### PR TITLE
remove unused features; formatting

### DIFF
--- a/coresimd/arm/mod.rs
+++ b/coresimd/arm/mod.rs
@@ -20,36 +20,28 @@ mod v7;
 #[cfg(any(target_arch = "aarch64", target_feature = "v7"))]
 pub use self::v7::*;
 
-#[cfg(
-    any(
-        all(target_feature = "v7", not(target_feature = "mclass")),
-        dox
-    )
-)]
+#[cfg(any(
+    all(target_feature = "v7", not(target_feature = "mclass")),
+    dox
+))]
 mod dsp;
-#[cfg(
-    any(
-        all(target_feature = "v7", not(target_feature = "mclass")),
-        dox
-    )
-)]
+#[cfg(any(
+    all(target_feature = "v7", not(target_feature = "mclass")),
+    dox
+))]
 pub use self::dsp::*;
 
 // NEON is supported on AArch64, and on ARM when built with the v7 and neon
 // features. Building ARM without neon produces incorrect codegen.
-#[cfg(
-    any(
-        target_arch = "aarch64",
-        all(target_feature = "v7", target_feature = "neon"),
-        dox
-    )
-)]
+#[cfg(any(
+    target_arch = "aarch64",
+    all(target_feature = "v7", target_feature = "neon"),
+    dox
+))]
 mod neon;
-#[cfg(
-    any(
-        target_arch = "aarch64",
-        all(target_feature = "v7", target_feature = "neon"),
-        dox
-    )
-)]
+#[cfg(any(
+    target_arch = "aarch64",
+    all(target_feature = "v7", target_feature = "neon"),
+    dox
+))]
 pub use self::neon::*;

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -26,8 +26,6 @@
     rustc_attrs,
     stdsimd,
     staged_api,
-    core_float,
-    core_slice_ext,
     align_offset,
     doc_cfg,
     mmx_target_feature,
@@ -43,7 +41,6 @@
     feature(
         use_extern_macros,
         test,
-        attr_literals,
         abi_vectorcall,
         untagged_unions
     )

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -137,8 +137,7 @@ fn parse_objdump(output: &str) -> HashMap<String, Vec<Function>> {
                 .skip_while(|s| {
                     s.len() == expected_len
                         && usize::from_str_radix(s, 16).is_ok()
-                })
-                .map(|s| s.to_string())
+                }).map(|s| s.to_string())
                 .collect::<Vec<String>>();
             instructions.push(Instruction { parts });
         }
@@ -232,8 +231,7 @@ fn parse_dumpbin(output: &str) -> HashMap<String, Vec<Function>> {
                 .skip(1)
                 .skip_while(|s| {
                     s.len() == 2 && usize::from_str_radix(s, 16).is_ok()
-                })
-                .map(|s| s.to_string())
+                }).map(|s| s.to_string())
                 .collect::<Vec<String>>();
             instructions.push(Instruction { parts });
         }

--- a/crates/stdsimd/src/lib.rs
+++ b/crates/stdsimd/src/lib.rs
@@ -1,7 +1,7 @@
 //! SIMD and vendor intrinsics support library.
 //!
 //! This crate defines the vendor intrinsics and types primarily used for SIMD
-//! in Rust. 
+//! in Rust.
 
 #![feature(const_fn, integer_atomics, staged_api, stdsimd)]
 #![feature(doc_cfg, allow_internal_unstable)]
@@ -30,6 +30,6 @@ use __do_not_use_this_import::fs;
 #[allow(unused_imports)]
 use __do_not_use_this_import::io;
 #[allow(unused_imports)]
-use __do_not_use_this_import::prelude;
-#[allow(unused_imports)]
 use __do_not_use_this_import::mem;
+#[allow(unused_imports)]
+use __do_not_use_this_import::prelude;

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -5,38 +5,32 @@
     allow(option_unwrap_used, use_debug, print_stdout)
 )]
 
-#[cfg(
-    any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "powerpc",
-        target_arch = "powerpc64"
-    )
-)]
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "powerpc",
+    target_arch = "powerpc64"
+))]
 #[macro_use]
 extern crate stdsimd;
 
 #[test]
-#[cfg(
-    all(
-        target_arch = "arm",
-        any(target_os = "linux", target_os = "android")
-    )
-)]
+#[cfg(all(
+    target_arch = "arm",
+    any(target_os = "linux", target_os = "android")
+))]
 fn arm_linux() {
     println!("neon: {}", is_arm_feature_detected!("neon"));
     println!("pmull: {}", is_arm_feature_detected!("pmull"));
 }
 
 #[test]
-#[cfg(
-    all(
-        target_arch = "aarch64",
-        any(target_os = "linux", target_os = "android")
-    )
-)]
+#[cfg(all(
+    target_arch = "aarch64",
+    any(target_os = "linux", target_os = "android")
+))]
 fn aarch64_linux() {
     println!("fp: {}", is_aarch64_feature_detected!("fp"));
     println!("fp16: {}", is_aarch64_feature_detected!("fp16"));


### PR DESCRIPTION
Removes `core_float` and `core_slice_ext` features and re-formats the library.