### PR TITLE
Fix assert_instr tests

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,6 +8,7 @@ set -ex
 # having only one thread increases debuggability to be worth it.
 #export RUST_BACKTRACE=full
 #export RUST_TEST_NOCAPTURE=1
+#export RUST_TEST_THREADS=1
 
 RUSTFLAGS="$RUSTFLAGS --cfg stdsimd_strict"
 
@@ -49,7 +50,6 @@ cargo_test() {
 CORE_ARCH="--manifest-path=crates/core_arch/Cargo.toml"
 STD_DETECT="--manifest-path=crates/std_detect/Cargo.toml"
 STDSIMD_EXAMPLES="--manifest-path=examples/Cargo.toml"
-cargo_test "${CORE_ARCH}"
 cargo_test "${CORE_ARCH} --release"
 
 if [ "$NOSTD" != "1" ]; then

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -29,7 +29,7 @@ stdsimd-test = { version = "0.*", path = "../stdsimd-test" }
 std_detect = { version = "0.*", path = "../std_detect" }
 
 [target.wasm32-unknown-unknown.dev-dependencies]
-wasm-bindgen-test = "0.2.42"
+wasm-bindgen-test = "0.2.47"
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--cfg", "dox" ]

--- a/crates/stdsimd-test/Cargo.toml
+++ b/crates/stdsimd-test/Cargo.toml
@@ -6,14 +6,13 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 [dependencies]
 assert-instr-macro = { path = "../assert-instr-macro" }
 simd-test-macro = { path = "../simd-test-macro" }
-backtrace = "0.3"
 cc = "1.0"
 lazy_static = "1.0"
 rustc-demangle = "0.1.8"
 cfg-if = "0.1"
 
 [target.wasm32-unknown-unknown.dependencies]
-wasm-bindgen = "0.2.39"
+wasm-bindgen = "0.2.47"
 js-sys = "0.3"
 console_error_panic_hook = "0.1"
 


### PR DESCRIPTION
This fixes the assert_instr tests, at least on macosx. It's WIP because it will need a bit of code golf till it works everywhere else.

I have no idea what was wrong before, nor what was the code actually doing. 

What we do now is the following: dump the binary with the appropriate tool (e.g. objdump), parse the instruction dumps of the shims into a hashset of (function_name -> instructions), and then query this hashset for the shim name. 

I have no idea what was `backtrace` used for. We know the name of the shim we want to disassembly, so there is no need for us to inspect the backtrace AFAICT. 