### PR TITLE
Fix typo in `core::arch::x86_64::_mm_prefetch`

### DIFF
--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1817,7 +1817,7 @@ pub const _MM_HINT_NTA: i32 = 0;
 /// The `strategy` must be one of:
 ///
 /// * [`_MM_HINT_T0`](constant._MM_HINT_T0.html): Fetch into all levels of the
-///   cache hierachy.
+///   cache hierarchy.
 ///
 /// * [`_MM_HINT_T1`](constant._MM_HINT_T1.html): Fetch into L2 and higher.
 ///


### PR DESCRIPTION
Pointed out in https://github.com/rust-lang/rust/issues/62488