### PR TITLE
Revert PR 769

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -9,10 +9,10 @@ mod acle;
 mod simd;
 
 #[cfg_attr(
-    bootstrap,
+    not(core_arch_docs),
     doc(include = "../stdarch/crates/core_arch/src/core_arch_docs.md")
 )]
-#[cfg_attr(not(bootstrap), doc(include = "core_arch_docs.md"))]
+#[cfg_attr(core_arch_docs, doc(include = "core_arch_docs.md"))]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
     /// Platform-specific intrinsics for the `x86` platform.


### PR DESCRIPTION
This is required for https://github.com/rust-lang/rust/pull/62687 to land, which has to happen before https://github.com/rust-lang/rust/pull/60938 lands, which would be required for the original change to stdarch to land. 