### PR TITLE
Adjust #[doc(include)] paths for rustdoc change

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -9,10 +9,10 @@ mod acle;
 mod simd;
 
 #[cfg_attr(
-    not(core_arch_docs),
+    bootstrap,
     doc(include = "../stdarch/crates/core_arch/src/core_arch_docs.md")
 )]
-#[cfg_attr(core_arch_docs, doc(include = "core_arch_docs.md"))]
+#[cfg_attr(not(bootstrap), doc(include = "core_arch_docs.md"))]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
     /// Platform-specific intrinsics for the `x86` platform.


### PR DESCRIPTION
The same as https://github.com/rust-lang/stdarch/pull/769, needed due to the revert in b881a2d124cb0eea09d137300eb4a35829b517fb, in order to land https://github.com/rust-lang/rust/pull/60938.