### PR TITLE
Fix documentation formatting of core_arch

### DIFF
--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -1240,10 +1240,10 @@ pub unsafe fn __msa_adds_a_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Signed Saturated Add of Signed Values
 ///
-/// The elements in vector in `a` (sixteen signed  8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen signed  8-bit integer numbers).
+/// The elements in vector in `a` (sixteen signed 8-bit integer numbers)
+/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
-/// representable signed values before writing the result to vector (sixteen signed  8-bit integer numbers).
+/// representable signed values before writing the result to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1494,7 +1494,7 @@ pub unsafe fn __msa_and_v(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Immediate Logical And
 ///
-/// Each byte element of  vector `a` (sixteen unsigned 8-bit integer numbers)
+/// Each byte element of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the 8-bit immediate i8 (signed 8-bit integer number) in a bitwise logical AND operation.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -1514,8 +1514,8 @@ pub unsafe fn __msa_andi_b(a: v16u8, imm8: i32) -> v16u8 {
 /// Vector Absolute Values of Signed Subtract
 ///
 /// The signed elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are subtracted  from the signed elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// The absolute  value of the signed result is written to vector (sixteen signed 8-bit integer numbers).
+/// are subtracted from the signed elements in vector `b` (sixteen signed 8-bit integer numbers).
+/// The absolute value of the signed result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1527,8 +1527,8 @@ pub unsafe fn __msa_asub_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Absolute Values of Signed Subtract
 ///
 /// The signed elements in vector `a` (eight signed 16-bit integer numbers)
-/// are subtracted  from the signed elements in vector `b` (eight signed 16-bit integer numbers)
-/// The absolute  value of the signed result is written to vector (eight signed 16-bit integer numbers).
+/// are subtracted from the signed elements in vector `b` (eight signed 16-bit integer numbers).
+/// The absolute value of the signed result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1540,8 +1540,8 @@ pub unsafe fn __msa_asub_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Absolute Values of Signed Subtract
 ///
 /// The signed elements in vector `a` (four signed 32-bit integer numbers)
-/// are subtracted  from the signed elements in vector `b` (four signed 32-bit integer numbers)
-/// The absolute  value of the signed result is written to vector (four signed 32-bit integer numbers).
+/// are subtracted from the signed elements in vector `b` (four signed 32-bit integer numbers).
+/// The absolute value of the signed result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1553,8 +1553,8 @@ pub unsafe fn __msa_asub_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Absolute Values of Signed Subtract
 ///
 /// The signed elements in vector `a` (two signed 64-bit integer numbers)
-/// are subtracted  from the signed elements in vector `b` (two signed 64-bit integer numbers)
-/// The absolute  value of the signed result is written to vector (two signed 64-bit integer numbers).
+/// are subtracted from the signed elements in vector `b` (two signed 64-bit integer numbers).
+/// The absolute value of the signed result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1566,8 +1566,8 @@ pub unsafe fn __msa_asub_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Absolute Values of Unsigned Subtract
 ///
 /// The unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// are subtracted  from the unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// The absolute  value of the unsigned result is written to vector (sixteen unsigned 8-bit integer numbers).
+/// are subtracted from the unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers).
+/// The absolute value of the unsigned result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1579,8 +1579,8 @@ pub unsafe fn __msa_asub_u_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Absolute Values of Unsigned Subtract
 ///
 /// The unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// are subtracted  from the unsigned elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// The absolute  value of the unsigned result is written to vector (eight unsigned 16-bit integer numbers).
+/// are subtracted from the unsigned elements in vector `b` (eight unsigned 16-bit integer numbers).
+/// The absolute value of the unsigned result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1592,8 +1592,8 @@ pub unsafe fn __msa_asub_u_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Absolute Values of Unsigned Subtract
 ///
 /// The unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// are subtracted  from the unsigned elements in vector `b` (four unsigned 32-bit integer numbers)
-/// The absolute  value of the unsigned result is written to vector (four unsigned 32-bit integer numbers).
+/// are subtracted from the unsigned elements in vector `b` (four unsigned 32-bit integer numbers).
+/// The absolute value of the unsigned result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1605,8 +1605,8 @@ pub unsafe fn __msa_asub_u_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Absolute Values of Unsigned Subtract
 ///
 /// The unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// are subtracted  from the unsigned elements in vector `b` (two unsigned 64-bit integer numbers)
-/// The absolute  value of the unsigned result is written to vector (two unsigned 64-bit integer numbers).
+/// are subtracted from the unsigned elements in vector `b` (two unsigned 64-bit integer numbers).
+/// The absolute value of the unsigned result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1618,8 +1618,8 @@ pub unsafe fn __msa_asub_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Vector Signed Average
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// The addition is done signed with full precision, i.e.the result has one extra bit
+/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers).
+/// The addition is done signed with full precision, i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
 /// writing the result to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -1633,8 +1633,8 @@ pub unsafe fn __msa_ave_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Signed Average
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight signed 16-bit integer numbers)
-/// The addition is done signed with full precision, i.e.the result has one extra bit
+/// are added to the elements in vector `b` (eight signed 16-bit integer numbers).
+/// The addition is done signed with full precision, i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
 /// writing the result to vector (eight signed 16-bit integer numbers).
 ///
@@ -1648,8 +1648,8 @@ pub unsafe fn __msa_ave_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Signed Average
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are added to the elements in vector `b` (four signed 32-bit integer numbers)
-/// The addition is done signed with full precision, i.e.the result has one extra bit
+/// are added to the elements in vector `b` (four signed 32-bit integer numbers).
+/// The addition is done signed with full precision, i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
 /// writing the result to vector (four signed 32-bit integer numbers).
 ///
@@ -1663,8 +1663,8 @@ pub unsafe fn __msa_ave_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Signed Average
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are added to the elements in vector `b` (two signed 64-bit integer numbers)
-/// The addition is done signed with full precision, i.e.the result has one extra bit
+/// are added to the elements in vector `b` (two signed 64-bit integer numbers).
+/// The addition is done signed with full precision, i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
 /// writing the result to vector (two signed 64-bit integer numbers).
 ///
@@ -1678,9 +1678,9 @@ pub unsafe fn __msa_ave_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Unsigned Average
 ///
 /// The elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// The addition is done unsigned with full precision, i.e.the result has one extra bit
-/// Unsigned division by 2 (or logical shift right by one bit)  is performed before
+/// are added to the elements in vector `b` (sixteen unsigned 8-bit integer numbers).
+/// The addition is done unsigned with full precision, i.e. the result has one extra bit.
+/// Unsigned division by 2 (or logical shift right by one bit) is performed before
 /// writing the result to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
@@ -1693,9 +1693,9 @@ pub unsafe fn __msa_ave_u_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Unsigned Average
 ///
 /// The elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// The addition is done unsigned with full precision, i.e.the result has one extra bit
-/// Unsigned division by 2 (or logical shift right by one bit)  is performed before
+/// are added to the elements in vector `b` (eight unsigned 16-bit integer numbers).
+/// The addition is done unsigned with full precision, i.e. the result has one extra bit.
+/// Unsigned division by 2 (or logical shift right by one bit) is performed before
 /// writing the result to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
@@ -1708,9 +1708,9 @@ pub unsafe fn __msa_ave_u_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Unsigned Average
 ///
 /// The elements in vector `a` (four unsigned 32-bit integer numbers)
-/// are added to the elements in vector `b` (four unsigned 32-bit integer numbers)
-/// The addition is done unsigned with full precision, i.e.the result has one extra bit
-/// Unsigned division by 2 (or logical shift right by one bit)  is performed before
+/// are added to the elements in vector `b` (four unsigned 32-bit integer numbers).
+/// The addition is done unsigned with full precision, i.e. the result has one extra bit.
+/// Unsigned division by 2 (or logical shift right by one bit) is performed before
 /// writing the result to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
@@ -1723,9 +1723,9 @@ pub unsafe fn __msa_ave_u_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Unsigned Average
 ///
 /// The elements in vector `a` (two unsigned 64-bit integer numbers)
-/// are added to the elements in vector `b` (two unsigned 64-bit integer numbers)
-/// The addition is done unsigned with full precision, i.e.the result has one extra bit
-/// Unsigned division by 2 (or logical shift right by one bit)  is performed before
+/// are added to the elements in vector `b` (two unsigned 64-bit integer numbers).
+/// The addition is done unsigned with full precision, i.e. the result has one extra bit.
+/// Unsigned division by 2 (or logical shift right by one bit) is performed before
 /// writing the result to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
@@ -1738,7 +1738,7 @@ pub unsafe fn __msa_ave_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Vector Signed Average Rounded
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done signed with full precision,
 /// i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
@@ -1754,7 +1754,7 @@ pub unsafe fn __msa_aver_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Signed Average Rounded
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight signed 16-bit integer numbers)
+/// are added to the elements in vector `b` (eight signed 16-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done signed with full precision,
 /// i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
@@ -1770,7 +1770,7 @@ pub unsafe fn __msa_aver_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Signed Average Rounded
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are added to the elements in vector `b` (four signed 32-bit integer numbers)
+/// are added to the elements in vector `b` (four signed 32-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done signed with full precision,
 /// i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
@@ -1786,7 +1786,7 @@ pub unsafe fn __msa_aver_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Signed Average Rounded
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are added to the elements in vector `b` (two signed 64-bit integer numbers)
+/// are added to the elements in vector `b` (two signed 64-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done signed with full precision,
 /// i.e. the result has one extra bit.
 /// Signed division by 2 (or arithmetic shift right by one bit) is performed before
@@ -1802,7 +1802,7 @@ pub unsafe fn __msa_aver_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Unsigned Average Rounded
 ///
 /// The elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
+/// are added to the elements in vector `b` (sixteen unsigned 8-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done unsigned with full precision,
 /// i.e. the result has one extra bit.
 /// Unsigned division by 2 (or logical shift right by one bit) is performed before
@@ -1818,7 +1818,7 @@ pub unsafe fn __msa_aver_u_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Unsigned Average Rounded
 ///
 /// The elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight unsigned 16-bit integer numbers)
+/// are added to the elements in vector `b` (eight unsigned 16-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done unsigned with full precision,
 /// i.e. the result has one extra bit.
 /// Unsigned division by 2 (or logical shift right by one bit) is performed before
@@ -1834,7 +1834,7 @@ pub unsafe fn __msa_aver_u_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Unsigned Average Rounded
 ///
 /// The elements in vector `a` (four unsigned 32-bit integer numbers)
-/// are added to the elements in vector `b` (four unsigned 32-bit integer numbers)
+/// are added to the elements in vector `b` (four unsigned 32-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done unsigned with full precision,
 /// i.e. the result has one extra bit.
 /// Unsigned division by 2 (or logical shift right by one bit) is performed before
@@ -1850,7 +1850,7 @@ pub unsafe fn __msa_aver_u_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Unsigned Average Rounded
 ///
 /// The elements in vector `a` (two unsigned 64-bit integer numbers)
-/// are added to the elements in vector `b` (two unsigned 64-bit integer numbers)
+/// are added to the elements in vector `b` (two unsigned 64-bit integer numbers).
 /// The addition of the elements plus 1 (for rounding) is done unsigned with full precision,
 /// i.e. the result has one extra bit.
 /// Unsigned division by 2 (or logical shift right by one bit) is performed before
@@ -2263,7 +2263,7 @@ pub unsafe fn __msa_binsri_d(a: v2u64, b: v2u64, imm6: i32) -> v2u64 {
 ///
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
 /// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector `c`
-/// (sixteen unsigned 8-bit integer numbers)  are 1 and leaves unchanged all destination bits
+/// (sixteen unsigned 8-bit integer numbers) are 1 and leaves unchanged all destination bits
 /// for which the corresponding target bits are 0.
 ///
 #[inline]
@@ -2276,7 +2276,7 @@ pub unsafe fn __msa_bmnz_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 /// Immediate Bit Move If Not Zero
 ///
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from  from immediate imm8
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from from immediate imm8
 /// are 1 and leaves unchanged all destination bits for which the corresponding target bits are 0.
 ///
 #[inline]
@@ -2296,7 +2296,7 @@ pub unsafe fn __msa_bmnzi_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 ///
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
 /// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector `c`
-/// (sixteen unsigned 8-bit integer numbers)  are 0 and leaves unchanged all destination bits
+/// (sixteen unsigned 8-bit integer numbers) are 0 and leaves unchanged all destination bits
 /// for which the corresponding target bits are 1
 ///
 #[inline]
@@ -2309,7 +2309,7 @@ pub unsafe fn __msa_bmz_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 /// Immediate Bit Move If Zero
 ///
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from  from immediate imm8
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from from immediate imm8
 /// are 0 and leaves unchanged all destination bits for which the corresponding immediate bits are 1.
 ///
 #[inline]
@@ -2884,7 +2884,7 @@ pub unsafe fn __msa_cfcmsa(imm5: i32) -> i32 {
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
-/// are signed less than or equal to `b`  (sixteen signed 8-bit integer numbers) element.
+/// are signed less than or equal to `b` (sixteen signed 8-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2898,7 +2898,7 @@ pub unsafe fn __msa_cle_s_b(a: v16i8, b: v16i8) -> v16i8 {
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight signed 16-bit integer numbers) element
-/// are signed less than or equal to `b`  (eight signed 16-bit integer numbers) element.
+/// are signed less than or equal to `b` (eight signed 16-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2912,7 +2912,7 @@ pub unsafe fn __msa_cle_s_h(a: v8i16, b: v8i16) -> v8i16 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four signed 32-bit integer numbers) element
-/// are signed less than or equal to `b`  (four signed 32-bit integer numbers) element.
+/// are signed less than or equal to `b` (four signed 32-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2926,7 +2926,7 @@ pub unsafe fn __msa_cle_s_w(a: v4i32, b: v4i32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two signed 64-bit integer numbers) element
-/// are signed less than or equal to `b`  (two signed 64-bit integer numbers) element.
+/// are signed less than or equal to `b` (two signed 64-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2940,7 +2940,7 @@ pub unsafe fn __msa_cle_s_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
-/// are unsigned less than or equal to `b`  (sixteen unsigned 8-bit integer numbers) element.
+/// are unsigned less than or equal to `b` (sixteen unsigned 8-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2954,7 +2954,7 @@ pub unsafe fn __msa_cle_u_b(a: v16u8, b: v16u8) -> v16i8 {
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
-/// are unsigned less than or equal to `b`  (eight unsigned 16-bit integer numbers) element.
+/// are unsigned less than or equal to `b` (eight unsigned 16-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2968,7 +2968,7 @@ pub unsafe fn __msa_cle_u_h(a: v8u16, b: v8u16) -> v8i16 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four unsigned 32-bit integer numbers) element
-/// are unsigned less than or equal to `b`  (four unsigned 32-bit integer numbers) element.
+/// are unsigned less than or equal to `b` (four unsigned 32-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -2982,7 +2982,7 @@ pub unsafe fn __msa_cle_u_w(a: v4u32, b: v4u32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two unsigned 64-bit integer numbers) element
-/// are unsigned less than or equal to `b`  (two unsigned 64-bit integer numbers) element.
+/// are unsigned less than or equal to `b` (two unsigned 64-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3156,7 +3156,7 @@ pub unsafe fn __msa_clei_u_d(a: v2u64, imm5: i32) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
-/// are signed less than `b`  (sixteen signed 8-bit integer numbers) element.
+/// are signed less than `b` (sixteen signed 8-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3170,7 +3170,7 @@ pub unsafe fn __msa_clt_s_b(a: v16i8, b: v16i8) -> v16i8 {
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight signed 16-bit integer numbers) element
-/// are signed less than `b`  (eight signed 16-bit integer numbers) element.
+/// are signed less than `b` (eight signed 16-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3184,7 +3184,7 @@ pub unsafe fn __msa_clt_s_h(a: v8i16, b: v8i16) -> v8i16 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four signed 32-bit integer numbers) element
-/// are signed less than `b`  (four signed 32-bit integer numbers) element.
+/// are signed less than `b` (four signed 32-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3198,7 +3198,7 @@ pub unsafe fn __msa_clt_s_w(a: v4i32, b: v4i32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two signed 64-bit integer numbers) element
-/// are signed less than `b`  (two signed 64-bit integer numbers) element.
+/// are signed less than `b` (two signed 64-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3212,7 +3212,7 @@ pub unsafe fn __msa_clt_s_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
-/// are unsigned less than `b`  (sixteen unsigned 8-bit integer numbers) element.
+/// are unsigned less than `b` (sixteen unsigned 8-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3226,7 +3226,7 @@ pub unsafe fn __msa_clt_u_b(a: v16u8, b: v16u8) -> v16i8 {
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
-/// are unsigned less than `b`  (eight unsigned 16-bit integer numbers) element.
+/// are unsigned less than `b` (eight unsigned 16-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3240,7 +3240,7 @@ pub unsafe fn __msa_clt_u_h(a: v8u16, b: v8u16) -> v8i16 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four unsigned 32-bit integer numbers) element
-/// are unsigned less than `b`  (four unsigned 32-bit integer numbers) element.
+/// are unsigned less than `b` (four unsigned 32-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3254,7 +3254,7 @@ pub unsafe fn __msa_clt_u_w(a: v4u32, b: v4u32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two unsigned 64-bit integer numbers) element
-/// are unsigned less than `b`  (two unsigned 64-bit integer numbers) element.
+/// are unsigned less than `b` (two unsigned 64-bit integer numbers) element.
 /// Otherwise set all bits to 0.
 ///
 #[inline]
@@ -3569,7 +3569,7 @@ pub unsafe fn __msa_copy_u_d(a: v2i64, imm1: i32) -> u64 {
 }
 
 /// GPR Copy to MSA Control Register
-/// The content of the least significant 31 bits of  GPR imm1 is copied to
+/// The content of the least significant 31 bits of GPR imm1 is copied to
 /// MSA control register cd
 /// Can not be tested in user mode
 #[inline]
@@ -4039,7 +4039,7 @@ pub unsafe fn __msa_fceq_d(a: v2f64, b: v2f64) -> v2i64 {
 /// a bit mask reflecting the floating-point class of the corresponding element of vector
 /// `a` (four 32-bit floating point numbers).
 /// The mask has 10 bits as follows. Bits 0 and 1 indicate NaN values: signaling NaN (bit 0) and quiet NaN (bit 1).
-/// Bits 2, 3, 4, 5 classify  negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
+/// Bits 2, 3, 4, 5 classify negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
 /// Bits 6, 7, 8, 9 classify positive values: infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
 ///
 #[inline]
@@ -4055,7 +4055,7 @@ pub unsafe fn __msa_fclass_w(a: v4f32) -> v4i32 {
 /// a bit mask reflecting the floating-point class of the corresponding element of vector
 /// `a` (two 64-bit floating point numbers).
 /// The mask has 10 bits as follows. Bits 0 and 1 indicate NaN values: signaling NaN (bit 0) and quiet NaN (bit 1).
-/// Bits 2, 3, 4, 5 classify  negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
+/// Bits 2, 3, 4, 5 classify negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
 /// Bits 6, 7, 8, 9 classify positive values: infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
 ///
 #[inline]
@@ -4347,7 +4347,7 @@ pub unsafe fn __msa_fdiv_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Down-Convert Interchange Format
 ///
 /// The floating-point elements in vector `a` (four 64-bit floating point numbers)
-/// and  vector `b` (four 64-bit floating point numbers)  are down-converted
+/// and vector `b` (four 64-bit floating point numbers) are down-converted
 /// to a smaller interchange format, i.e. from 64-bit to 32-bit, or from 32-bit to 16-bit.
 /// The result is written to vector (8 16-bit floating point numbers).
 ///
@@ -4361,7 +4361,7 @@ pub unsafe fn __msa_fexdo_h(a: v4f32, b: v4f32) -> f16x8 {
 /// Vector Floating-Point Down-Convert Interchange Format
 ///
 /// The floating-point elements in vector `a` (two 64-bit floating point numbers)
-/// and  vector `b` (two 64-bit floating point numbers)  are down-converted
+/// and vector `b` (two 64-bit floating point numbers) are down-converted
 /// to a smaller interchange format, i.e. from 64-bit to 32-bit, or from 32-bit to 16-bit.
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
@@ -4832,7 +4832,7 @@ pub unsafe fn __msa_fmul_d(a: v2f64, b: v2f64) -> v2f64 {
 ///
 /// The floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are rounded to an integral valued floating-point number in the same format based
-/// on  the  rounding  mode  bits  RM  in  MSA  Control  and  Status  Register MSACSR.
+/// on the rounding mode bits RM in MSA Control and Status Register MSACSR.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4845,7 +4845,7 @@ pub unsafe fn __msa_frint_w(a: v4f32) -> v4f32 {
 ///
 /// The floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are rounded to an integral valued floating-point number in the same format based
-/// on  the  rounding  mode  bits  RM  in  MSA  Control  and  Status  Register MSACSR.
+/// on the rounding mode bits RM in MSA Control and Status Register MSACSR.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4854,7 +4854,7 @@ pub unsafe fn __msa_frint_d(a: v2f64) -> v2f64 {
     msa_frint_d(a)
 }
 
-/// Vector Approximate Floating-Point  Reciprocal
+/// Vector Approximate Floating-Point Reciprocal
 ///
 /// The reciprocals of floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are calculated and the result is written to vector (four 32-bit floating point numbers)
@@ -4866,7 +4866,7 @@ pub unsafe fn __msa_frcp_w(a: v4f32) -> v4f32 {
     msa_frcp_w(a)
 }
 
-/// Vector Approximate Floating-Point  Reciprocal
+/// Vector Approximate Floating-Point Reciprocal
 ///
 /// The reciprocals of floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are calculated and the result is written to vector (two 64-bit floating point numbers)
@@ -4880,7 +4880,7 @@ pub unsafe fn __msa_frcp_d(a: v2f64) -> v2f64 {
 
 /// Vector Approximate Floating-Point Reciprocal of Square Root
 ///
-/// The reciprocals of the square  roots of floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// The reciprocals of the square roots of floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are calculated and the result is written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4892,7 +4892,7 @@ pub unsafe fn __msa_frsqrt_w(a: v4f32) -> v4f32 {
 
 /// Vector Approximate Floating-Point Reciprocal of Square Root
 ///
-/// The reciprocals of the square  roots of floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// The reciprocals of the square roots of floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are calculated and the result is written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4904,9 +4904,9 @@ pub unsafe fn __msa_frsqrt_d(a: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Signaling Compare Always False
 ///
-/// Set all bits to 0 in  vector (four signed 32-bit integer numbers) elements.
+/// Set all bits to 0 in vector (four signed 32-bit integer numbers) elements.
 /// Signaling and quiet NaN elements in vector `a` (four 32-bit floating point numbers)
-/// or `b` (four 32-bit floating point numbers) signal  Invalid Operation exception.
+/// or `b` (four 32-bit floating point numbers) signal Invalid Operation exception.
 /// In case of a floating-point exception, the default result has all bits set to 0
 ///
 #[inline]
@@ -4918,9 +4918,9 @@ pub unsafe fn __msa_fsaf_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Always False
 ///
-/// Set all bits to 0 in  vector (two signed 64-bit integer numbers) elements.
+/// Set all bits to 0 in vector (two signed 64-bit integer numbers) elements.
 /// Signaling and quiet NaN elements in vector `a` (two 64-bit floating point numbers)
-/// or `b` (two 64-bit floating point numbers) signal  Invalid Operation exception.
+/// or `b` (two 64-bit floating point numbers) signal Invalid Operation exception.
 /// In case of a floating-point exception, the default result has all bits set to 0
 ///
 #[inline]
@@ -4932,7 +4932,7 @@ pub unsafe fn __msa_fsaf_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Equal
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers)
 /// and `b` (four 32-bit floating point numbers) elements are equal, otherwise set all bits to 0.
 ///
@@ -4971,7 +4971,7 @@ pub unsafe fn __msa_fsle_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Less or Equal
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) elements
 /// are less than or equal to `b` (two 64-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
@@ -4984,7 +4984,7 @@ pub unsafe fn __msa_fsle_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Less Than
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) elements
 /// are less than `b` (four 32-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
@@ -4997,7 +4997,7 @@ pub unsafe fn __msa_fslt_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Less Than
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) elements
 /// are less than `b` (two 64-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
@@ -5010,7 +5010,7 @@ pub unsafe fn __msa_fslt_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Not Equal
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) and
 /// `b` (four 32-bit floating point numbers) elements are not equal, otherwise set all bits to 0.
 ///
@@ -5023,7 +5023,7 @@ pub unsafe fn __msa_fsne_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Not Equal
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
 /// `b` (two 64-bit floating point numbers) elements are not equal, otherwise set all bits to 0.
 ///
@@ -5036,7 +5036,7 @@ pub unsafe fn __msa_fsne_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Ordered
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) and
 /// `b` (four 32-bit floating point numbers) elements are ordered,
 /// i.e. both elements are not NaN values, otherwise set all bits to 0.
@@ -5050,7 +5050,7 @@ pub unsafe fn __msa_fsor_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Ordered
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
 /// `b` (two 64-bit floating point numbers) elements are ordered,
 /// i.e. both elements are not NaN values, otherwise set all bits to 0.
@@ -5062,7 +5062,7 @@ pub unsafe fn __msa_fsor_d(a: v2f64, b: v2f64) -> v2i64 {
     msa_fsor_d(a, mem::transmute(b))
 }
 
-/// Vector Floating-Point  Square Root
+/// Vector Floating-Point Square Root
 ///
 /// The square roots of floating-point elements in vector `a`
 /// (four 32-bit floating point numbers) are written to vector
@@ -5075,7 +5075,7 @@ pub unsafe fn __msa_fsqrt_w(a: v4f32) -> v4f32 {
     msa_fsqrt_w(a)
 }
 
-/// Vector Floating-Point  Square Root
+/// Vector Floating-Point Square Root
 ///
 /// The square roots of floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) are written to vector
@@ -5118,7 +5118,7 @@ pub unsafe fn __msa_fsub_d(a: v2f64, b: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Signaling Compare Ordered
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) and
 /// `b` (four 32-bit floating point numbers) elements are unordered or equal,
 /// otherwise set all bits to 0.
@@ -5132,7 +5132,7 @@ pub unsafe fn __msa_fsueq_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Ordered
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
 /// `b` (two 64-bit floating point numbers) elements are unordered or equal,
 /// otherwise set all bits to 0.
@@ -5146,7 +5146,7 @@ pub unsafe fn __msa_fsueq_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Unordered or Less or Equal
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) elements are
 /// unordered or less than or equal to `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
@@ -5160,7 +5160,7 @@ pub unsafe fn __msa_fsule_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Unordered or Less or Equal
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) elements are
 /// unordered or less than or equal to `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
@@ -5174,7 +5174,7 @@ pub unsafe fn __msa_fsule_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Unordered or Less Than
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) elements
 /// are unordered or less than `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
@@ -5188,7 +5188,7 @@ pub unsafe fn __msa_fsult_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Unordered or Less Than
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) elements
 /// are unordered or less than `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
@@ -5202,7 +5202,7 @@ pub unsafe fn __msa_fsult_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Unordered
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) and
 /// `b` (four 32-bit floating point numbers) elements are unordered,
 /// i.e. at least one element is a NaN value, otherwise set all bits to 0.
@@ -5216,7 +5216,7 @@ pub unsafe fn __msa_fsun_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Unordered
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
 /// `b` (two 64-bit floating point numbers) elements are unordered,
 /// i.e. at least one element is a NaN value, otherwise set all bits to 0.
@@ -5230,7 +5230,7 @@ pub unsafe fn __msa_fsun_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Unordered or Not Equal
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers) and
 /// `b` (four 32-bit floating point numbers) elements are unordered or not equal,
 /// otherwise set all bits to 0.
@@ -5244,7 +5244,7 @@ pub unsafe fn __msa_fsune_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Unordered or Not Equal
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
 /// `b` (two 64-bit floating point numbers) elements are unordered or not equal,
 /// otherwise set all bits to 0.
@@ -5316,7 +5316,7 @@ pub unsafe fn __msa_ftint_u_d(a: v2f64) -> v2u64 {
 ///
 /// The elements in vector `a` (four 32-bit floating point numbers)
 /// and `b` (four 32-bit floating point numbers) are down-converted to a fixed-point
-/// representation,  i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
+/// representation, i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
 /// representation, or from 32-bit floating-point to 16-bit Q15 fixed-point representation.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -5331,7 +5331,7 @@ pub unsafe fn __msa_ftq_h(a: v4f32, b: v4f32) -> v8i16 {
 ///
 /// The elements in vector `a` (two 64-bit floating point numbers)
 /// and `b` (two 64-bit floating point numbers) are down-converted to a fixed-point
-/// representation,  i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
+/// representation, i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
 /// representation, or from 32-bit floating-point to 16-bit Q15 fixed-point representation.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -5564,7 +5564,7 @@ pub unsafe fn __msa_hsub_u_d(a: v4u32, b: v4u32) -> v2i64 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// Even elements in vectors `a` (sixteen signed 8-bit integer numbers)
 /// and vector `b` (sixteen signed 8-bit integer numbers) are copied to the result
 /// (sixteen signed 8-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5578,7 +5578,7 @@ pub unsafe fn __msa_ilvev_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// Even elements in vectors `a` (eight signed 16-bit integer numbers)
 /// and vector `b` (eight signed 16-bit integer numbers) are copied to the result
 /// (eight signed 16-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5592,7 +5592,7 @@ pub unsafe fn __msa_ilvev_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors `a` (four signed 32-bit integer numbers)
+/// Even elements in vectors `a` (four signed 32-bit integer numbers)
 /// and vector `b` (four signed 32-bit integer numbers) are copied to the result
 /// (four signed 32-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5606,7 +5606,7 @@ pub unsafe fn __msa_ilvev_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors `a` (two signed 64-bit integer numbers)
+/// Even elements in vectors `a` (two signed 64-bit integer numbers)
 /// and vector `b` (two signed 64-bit integer numbers) are copied to the result
 /// (two signed 64-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5676,7 +5676,7 @@ pub unsafe fn __msa_ilvl_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// Odd elements in vectors `a` (sixteen signed 8-bit integer numbers)
 /// and vector `b` (sixteen signed 8-bit integer numbers) are copied to the result
 /// (sixteen signed 8-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5690,7 +5690,7 @@ pub unsafe fn __msa_ilvod_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// Odd elements in vectors `a` (eight signed 16-bit integer numbers)
 /// and vector `b` (eight signed 16-bit integer numbers) are copied to the result
 /// (eight signed 16-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5704,7 +5704,7 @@ pub unsafe fn __msa_ilvod_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors `a` (four signed 32-bit integer numbers)
+/// Odd elements in vectors `a` (four signed 32-bit integer numbers)
 /// and vector `b` (four signed 32-bit integer numbers) are copied to the result
 /// (four signed 32-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5718,7 +5718,7 @@ pub unsafe fn __msa_ilvod_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors `a` (two signed 64-bit integer numbers)
+/// Odd elements in vectors `a` (two signed 64-bit integer numbers)
 /// and vector `b` (two signed 64-bit integer numbers) are copied to the result
 /// (two signed 64-bit integer numbers)
 /// alternating one element from `a` with one element from `b`.
@@ -5941,7 +5941,7 @@ pub unsafe fn __msa_insve_d(a: v2i64, imm1: i32, c: v2i64) -> v2i64 {
 /// Vector Load
 ///
 /// The WRLEN / 8 bytes at the effective memory location addressed by the base
-/// mem_addr and the 10-bit signed immediate offset imm_s10 are fetched and placed in
+/// `mem_addr` and the 10-bit signed immediate offset `imm_s10` are fetched and placed in
 /// the vector (sixteen signed 8-bit integer numbers) value.
 ///
 #[inline]
@@ -5960,7 +5960,7 @@ pub unsafe fn __msa_ld_b(mem_addr: *mut u8, imm_s10: i32) -> v16i8 {
 /// Vector Load
 ///
 /// The WRLEN / 8 bytes at the effective memory location addressed by the base
-/// mem_addr and the 10-bit signed immediate offset imm_s11 are fetched and placed in
+/// `mem_addr` and the 10-bit signed immediate offset `imm_s11` are fetched and placed in
 /// the vector (eight signed 16-bit integer numbers) value.
 ///
 #[inline]
@@ -5979,7 +5979,7 @@ pub unsafe fn __msa_ld_h(mem_addr: *mut u8, imm_s11: i32) -> v8i16 {
 /// Vector Load
 ///
 /// The WRLEN / 8 bytes at the effective memory location addressed by the base
-/// mem_addr and the 10-bit signed immediate offset imm_s12 are fetched and placed in
+/// `mem_addr` and the 10-bit signed immediate offset `imm_s12` are fetched and placed in
 /// the vector (four signed 32-bit integer numbers) value.
 ///
 #[inline]
@@ -5998,7 +5998,7 @@ pub unsafe fn __msa_ld_w(mem_addr: *mut u8, imm_s12: i32) -> v4i32 {
 /// Vector Load
 ///
 /// The WRLEN / 8 bytes at the effective memory location addressed by the base
-/// mem_addr and the 10-bit signed immediate offset imm_s13 are fetched and placed in
+/// `mem_addr` and the 10-bit signed immediate offset `imm_s13` are fetched and placed in
 /// the vector (two signed 64-bit integer numbers) value.
 ///
 #[inline]
@@ -6369,7 +6369,7 @@ pub unsafe fn __msa_max_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Immediate Signed Maximum
 ///
 /// Maximum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -6388,7 +6388,7 @@ pub unsafe fn __msa_maxi_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 /// Immediate Signed Maximum
 ///
 /// Maximum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -6407,7 +6407,7 @@ pub unsafe fn __msa_maxi_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 /// Immediate Signed Maximum
 ///
 /// Maximum values between signed elements in vector `a` (four signed 32-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -6426,7 +6426,7 @@ pub unsafe fn __msa_maxi_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 /// Immediate Signed Maximum
 ///
 /// Maximum values between signed elements in vector `a` (two signed 64-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -6445,7 +6445,7 @@ pub unsafe fn __msa_maxi_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -6464,7 +6464,7 @@ pub unsafe fn __msa_maxi_u_b(a: v16u8, imm5: i32) -> v16u8 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -6483,7 +6483,7 @@ pub unsafe fn __msa_maxi_u_h(a: v8u16, imm5: i32) -> v8u16 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -6502,7 +6502,7 @@ pub unsafe fn __msa_maxi_u_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -6629,7 +6629,7 @@ pub unsafe fn __msa_min_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Signed Minimum
 ///
 /// Minimum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -6648,7 +6648,7 @@ pub unsafe fn __msa_mini_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 /// Immediate Signed Minimum
 ///
 /// Minimum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -6667,7 +6667,7 @@ pub unsafe fn __msa_mini_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 /// Immediate Signed Minimum
 ///
 /// Minimum values between signed elements in vector `a` (four signed 32-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -6686,7 +6686,7 @@ pub unsafe fn __msa_mini_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 /// Immediate Signed Minimum
 ///
 /// Minimum values between signed elements in vector `a` (two signed 64-bit integer numbers)
-/// and  the 5-bit signed immediate imm_s5 are written to vector
+/// and the 5-bit signed immediate imm_s5 are written to vector
 /// (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -6757,7 +6757,7 @@ pub unsafe fn __msa_min_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -6776,7 +6776,7 @@ pub unsafe fn __msa_mini_u_b(a: v16u8, imm5: i32) -> v16u8 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -6795,7 +6795,7 @@ pub unsafe fn __msa_mini_u_h(a: v8u16, imm5: i32) -> v8u16 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -6814,7 +6814,7 @@ pub unsafe fn __msa_mini_u_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// and  the 5-bit unsigned immediate imm5 are written to vector
+/// and the 5-bit unsigned immediate imm5 are written to vector
 /// (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -7303,7 +7303,7 @@ pub unsafe fn __msa_nor_v(a: v16u8, b: v16u8) -> v16u8 {
 /// Immediate Logical Negated Or
 ///
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// is combined with the  8-bit immediate imm8
+/// is combined with the 8-bit immediate `imm8`
 /// in a bitwise logical NOR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -7337,7 +7337,7 @@ pub unsafe fn __msa_or_v(a: v16u8, b: v16u8) -> v16u8 {
 /// Immediate Logical Or
 ///
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// is combined with the  8-bit immediate imm8
+/// is combined with the 8-bit immediate `imm8`
 /// in a bitwise logical OR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -7356,7 +7356,7 @@ pub unsafe fn __msa_ori_b(a: v16u8, imm8: i32) -> v16u8 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// Even elements in vectors `a` (sixteen signed 8-bit integer numbers)
 /// are copied to the left half of the result vector and even elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7369,7 +7369,7 @@ pub unsafe fn __msa_pckev_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// Even elements in vectors `a` (eight signed 16-bit integer numbers)
 /// are copied to the left half of the result vector and even elements in vector `b`
 /// (eight signed 16-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7382,7 +7382,7 @@ pub unsafe fn __msa_pckev_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors `a` (four signed 32-bit integer numbers)
+/// Even elements in vectors `a` (four signed 32-bit integer numbers)
 /// are copied to the left half of the result vector and even elements in vector `b`
 /// (four signed 32-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7395,7 +7395,7 @@ pub unsafe fn __msa_pckev_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors `a` (two signed 64-bit integer numbers)
+/// Even elements in vectors `a` (two signed 64-bit integer numbers)
 /// are copied to the left half of the result vector and even elements in vector `b`
 /// (two signed 64-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7408,7 +7408,7 @@ pub unsafe fn __msa_pckev_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// Odd elements in vectors `a` (sixteen signed 8-bit integer numbers)
 /// are copied to the left half of the result vector and odd elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7421,7 +7421,7 @@ pub unsafe fn __msa_pckod_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// Odd elements in vectors `a` (eight signed 16-bit integer numbers)
 /// are copied to the left half of the result vector and odd elements in vector `b`
 /// (eight signed 16-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7434,7 +7434,7 @@ pub unsafe fn __msa_pckod_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors `a` (four signed 32-bit integer numbers)
+/// Odd elements in vectors `a` (four signed 32-bit integer numbers)
 /// are copied to the left half of the result vector and odd elements in vector `b`
 /// (four signed 32-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7447,7 +7447,7 @@ pub unsafe fn __msa_pckod_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors `a` (two signed 64-bit integer numbers)
+/// Odd elements in vectors `a` (two signed 64-bit integer numbers)
 /// are copied to the left half of the result vector and odd elements in vector `b`
 /// (two signed 64-bit integer numbers) are copied to the right half of the result vector.
 ///
@@ -7509,7 +7509,7 @@ pub unsafe fn __msa_pcnt_d(a: v2i64) -> v2i64 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are saturated to signed values of imm3+1 bits without changing the data width
+/// are saturated to signed values of `imm3+1` bits without changing the data width
 /// The result is stored in the vector (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -7528,7 +7528,7 @@ pub unsafe fn __msa_sat_s_b(a: v16i8, imm3: i32) -> v16i8 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (eight signed 16-bit integer numbers)
-/// are saturated to signed values of imm4+1 bits without changing the data width
+/// are saturated to signed values of `imm4+1` bits without changing the data width
 /// The result is stored in the vector (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -7547,7 +7547,7 @@ pub unsafe fn __msa_sat_s_h(a: v8i16, imm4: i32) -> v8i16 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (four signed 32-bit integer numbers)
-/// are saturated to signed values of imm5+1 bits without changing the data width
+/// are saturated to signed values of `imm5+1` bits without changing the data width
 /// The result is stored in the vector (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -7566,7 +7566,7 @@ pub unsafe fn __msa_sat_s_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (two signed 64-bit integer numbers)
-/// are saturated to signed values of imm6+1 bits without changing the data width
+/// are saturated to signed values of `imm6+1` bits without changing the data width
 /// The result is stored in the vector (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -7585,7 +7585,7 @@ pub unsafe fn __msa_sat_s_d(a: v2i64, imm6: i32) -> v2i64 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// are saturated to unsigned values of imm3+1 bits without changing the data width
+/// are saturated to unsigned values of `imm3+1` bits without changing the data width
 /// The result is stored in the vector (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -7604,7 +7604,7 @@ pub unsafe fn __msa_sat_u_b(a: v16u8, imm3: i32) -> v16u8 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// are saturated to unsigned values of imm4+1 bits without changing the data width
+/// are saturated to unsigned values of `imm4+1` bits without changing the data width
 /// The result is stored in the vector (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -7623,7 +7623,7 @@ pub unsafe fn __msa_sat_u_h(a: v8u16, imm4: i32) -> v8u16 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// are saturated to unsigned values of imm5+1 bits without changing the data width
+/// are saturated to unsigned values of `imm5+1` bits without changing the data width
 /// The result is stored in the vector (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -7642,7 +7642,7 @@ pub unsafe fn __msa_sat_u_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// are saturated to unsigned values of imm6+1 bits without changing the data width
+/// are saturated to unsigned values of `imm6+1` bits without changing the data width
 /// The result is stored in the vector (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -7806,7 +7806,7 @@ pub unsafe fn __msa_sld_d(a: v2i64, b: v2i64, c: i32) -> v2i64 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by imm1 columns
+/// by `imm1` columns
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -7830,7 +7830,7 @@ pub unsafe fn __msa_sldi_b(a: v16i8, b: v16i8, imm4: i32) -> v16i8 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by imm1 columns
+/// by `imm1` columns
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -7854,7 +7854,7 @@ pub unsafe fn __msa_sldi_h(a: v8i16, b: v8i16, imm3: i32) -> v8i16 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by imm1 columns
+/// by `imm1` columns
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -7878,7 +7878,7 @@ pub unsafe fn __msa_sldi_w(a: v4i32, b: v4i32, imm2: i32) -> v4i32 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by imm1 columns
+/// by `imm1` columns
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -8084,7 +8084,7 @@ pub unsafe fn __msa_splat_d(a: v2i64, b: i32) -> v2i64 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm4 in vector `a` (sixteen signed 8-bit integer numbers)
+/// Replicate element `imm4` in vector `a` (sixteen signed 8-bit integer numbers)
 /// to all elements in vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -8102,7 +8102,7 @@ pub unsafe fn __msa_splati_b(a: v16i8, imm4: i32) -> v16i8 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm3 in vector `a` (eight signed 16-bit integer numbers)
+/// Replicate element `imm3` in vector `a` (eight signed 16-bit integer numbers)
 /// to all elements in vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -8120,7 +8120,7 @@ pub unsafe fn __msa_splati_h(a: v8i16, imm3: i32) -> v8i16 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm2 in vector `a` (four signed 32-bit integer numbers)
+/// Replicate element `imm2` in vector `a` (four signed 32-bit integer numbers)
 /// to all elements in vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -8138,7 +8138,7 @@ pub unsafe fn __msa_splati_w(a: v4i32, imm2: i32) -> v4i32 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm1 in vector `a` (two signed 64-bit integer numbers)
+/// Replicate element `imm1` in vector `a` (two signed 64-bit integer numbers)
 /// to all elements in vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -8213,7 +8213,7 @@ pub unsafe fn __msa_sra_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Shift Right Arithmetic
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are shifted right arithmetic by imm3 bits.
+/// are shifted right arithmetic by `imm3` bits.
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -8232,7 +8232,7 @@ pub unsafe fn __msa_srai_b(a: v16i8, imm3: i32) -> v16i8 {
 /// Immediate Shift Right Arithmetic
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are shifted right arithmetic by imm4 bits.
+/// are shifted right arithmetic by `imm4` bits.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -8251,7 +8251,7 @@ pub unsafe fn __msa_srai_h(a: v8i16, imm4: i32) -> v8i16 {
 /// Immediate Shift Right Arithmetic
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are shifted right arithmetic by imm5 bits.
+/// are shifted right arithmetic by `imm5` bits.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -8270,7 +8270,7 @@ pub unsafe fn __msa_srai_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Shift Right Arithmetic
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are shifted right arithmetic by imm6 bits.
+/// are shifted right arithmetic by `imm6` bits.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -8349,7 +8349,7 @@ pub unsafe fn __msa_srar_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Shift Right Arithmetic Rounded
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are shifted right arithmetic by imm3 bits.The most significant
+/// are shifted right arithmetic by `imm3` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -8369,7 +8369,7 @@ pub unsafe fn __msa_srari_b(a: v16i8, imm3: i32) -> v16i8 {
 /// Immediate Shift Right Arithmetic Rounded
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are shifted right arithmetic by imm4 bits.The most significant
+/// are shifted right arithmetic by `imm4` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -8389,7 +8389,7 @@ pub unsafe fn __msa_srari_h(a: v8i16, imm4: i32) -> v8i16 {
 /// Immediate Shift Right Arithmetic Rounded
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are shifted right arithmetic by imm5 bits.The most significant
+/// are shifted right arithmetic by `imm5` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -8409,7 +8409,7 @@ pub unsafe fn __msa_srari_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Shift Right Arithmetic Rounded
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are shifted right arithmetic by imm6 bits.The most significant
+/// are shifted right arithmetic by `imm6` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -8485,7 +8485,7 @@ pub unsafe fn __msa_srl_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Shift Right Logical
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are shifted right logical by imm4 bits.
+/// are shifted right logical by `imm4` bits.
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -8504,7 +8504,7 @@ pub unsafe fn __msa_srli_b(a: v16i8, imm4: i32) -> v16i8 {
 /// Immediate Shift Right Logical
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are shifted right logical by imm3 bits.
+/// are shifted right logical by `imm3` bits.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -8523,7 +8523,7 @@ pub unsafe fn __msa_srli_h(a: v8i16, imm3: i32) -> v8i16 {
 /// Immediate Shift Right Logical
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are shifted right logical by imm2 bits.
+/// are shifted right logical by `imm2` bits.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -8542,7 +8542,7 @@ pub unsafe fn __msa_srli_w(a: v4i32, imm2: i32) -> v4i32 {
 /// Immediate Shift Right Logical
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are shifted right logical by imm1 bits.
+/// are shifted right logical by `imm1` bits.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -9128,8 +9128,8 @@ pub unsafe fn __msa_subvi_d(a: v2i64, imm5: i32) -> v2i64 {
 
 /// Vector Data Preserving Shuffle
 ///
-/// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors `b` (sixteen signed 8-bit integer numbers)
+/// The vector shuffle instructions selectively copy data elements from the
+/// concatenation of vectors `b` (sixteen signed 8-bit integer numbers)
 /// and `c` (sixteen signed 8-bit integer numbers) in to vector `a`
 /// (sixteen signed 8-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
@@ -9145,8 +9145,8 @@ pub unsafe fn __msa_vshf_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 
 /// Vector Data Preserving Shuffle
 ///
-/// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors `b` (eight signed 16-bit integer numbers)
+/// The vector shuffle instructions selectively copy data elements from the
+/// concatenation of vectors `b` (eight signed 16-bit integer numbers)
 /// and `c` (eight signed 16-bit integer numbers) in to vector `a`
 /// (eight signed 16-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
@@ -9162,8 +9162,8 @@ pub unsafe fn __msa_vshf_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Data Preserving Shuffle
 ///
-/// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors `b` (four signed 32-bit integer numbers)
+/// The vector shuffle instructions selectively copy data elements from the
+/// concatenation of vectors `b` (four signed 32-bit integer numbers)
 /// and `c` (four signed 32-bit integer numbers) in to vector `a`
 /// (four signed 32-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
@@ -9179,8 +9179,8 @@ pub unsafe fn __msa_vshf_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Data Preserving Shuffle
 ///
-/// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors `b` (two signed 64-bit integer numbers)
+/// The vector shuffle instructions selectively copy data elements from the
+/// concatenation of vectors `b` (two signed 64-bit integer numbers)
 /// and `c` (two signed 64-bit integer numbers) in to vector `a`
 /// (two signed 64-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in

--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -1404,7 +1404,7 @@ pub unsafe fn __msa_addv_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Add
 ///
-/// The 5-bit immediate unsigned value u5 is added to the elements
+/// The 5-bit immediate unsigned value `imm5` is added to the elements
 /// vector in `a` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -1423,7 +1423,7 @@ pub unsafe fn __msa_addvi_b(a: v16i8, imm5: i32) -> v16i8 {
 
 /// Immediate Add
 ///
-/// The 5-bit immediate unsigned value u5 is added to the elements
+/// The 5-bit immediate unsigned value `imm5` is added to the elements
 /// vector in `a` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -1442,7 +1442,7 @@ pub unsafe fn __msa_addvi_h(a: v8i16, imm5: i32) -> v8i16 {
 
 /// Immediate Add
 ///
-/// The 5-bit immediate unsigned value u5 is added to the elements
+/// The 5-bit immediate unsigned value `imm5` is added to the elements
 /// vector in `a` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -1461,7 +1461,7 @@ pub unsafe fn __msa_addvi_w(a: v4i32, imm5: i32) -> v4i32 {
 
 /// Immediate Add
 ///
-/// The 5-bit immediate unsigned value u5 is added to the elements
+/// The 5-bit immediate unsigned value `imm5` is added to the elements
 /// vector in `a` (two signed 64-bit integer numbers).
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -2329,7 +2329,7 @@ pub unsafe fn __msa_bmzi_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 ///
 /// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// The bit position is given by the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// modulo thesize of the element in bits.
+/// modulo the size of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -2343,7 +2343,7 @@ pub unsafe fn __msa_bneg_b(a: v16u8, b: v16u8) -> v16u8 {
 ///
 /// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
 /// The bit position is given by the elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// modulo thesize of the element in bits.
+/// modulo the size of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -2357,7 +2357,7 @@ pub unsafe fn __msa_bneg_h(a: v8u16, b: v8u16) -> v8u16 {
 ///
 /// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
 /// The bit position is given by the elements in vector `b` (four unsigned 32-bit integer numbers)
-/// modulo thesize of the element in bits.
+/// modulo the size of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -2371,7 +2371,7 @@ pub unsafe fn __msa_bneg_w(a: v4u32, b: v4u32) -> v4u32 {
 ///
 /// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
 /// The bit position is given by the elements in vector `b` (two unsigned 64-bit integer numbers)
-/// modulo thesize of the element in bits.
+/// modulo the size of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -2384,7 +2384,7 @@ pub unsafe fn __msa_bneg_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Immediate Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// The bit position is given by immediate imm3 modulo thesize of the element in bits.
+/// The bit position is given by immediate imm3 modulo the size of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -2403,7 +2403,7 @@ pub unsafe fn __msa_bnegi_b(a: v16u8, imm3: i32) -> v16u8 {
 /// Immediate Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
-/// The bit position is given by immediate imm4 modulo thesize of the element in bits.
+/// The bit position is given by immediate imm4 modulo the size of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -2422,7 +2422,7 @@ pub unsafe fn __msa_bnegi_h(a: v8u16, imm4: i32) -> v8u16 {
 /// Immediate Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
-/// The bit position is given by immediate imm5 modulo thesize of the element in bits.
+/// The bit position is given by immediate imm5 modulo the size of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -2441,7 +2441,7 @@ pub unsafe fn __msa_bnegi_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
-/// The bit position is given by immediate imm6 modulo thesize of the element in bits.
+/// The bit position is given by immediate imm6 modulo the size of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -2737,7 +2737,7 @@ pub unsafe fn __msa_bz_v(a: v16u8) -> i32 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding `a` (sixteen signed 8-bit integer numbers) and `b`  (sixteen signed 8-bit integer numbers)
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) and `b` (sixteen signed 8-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2750,7 +2750,7 @@ pub unsafe fn __msa_ceq_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding `a` (eight signed 16-bit integer numbers) and `b`  (eight signed 16-bit integer numbers)
+/// if the corresponding `a` (eight signed 16-bit integer numbers) and `b` (eight signed 16-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2763,7 +2763,7 @@ pub unsafe fn __msa_ceq_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four signed 32-bit integer numbers) and `b`  (four signed 32-bit integer numbers)
+/// if the corresponding `a` (four signed 32-bit integer numbers) and `b` (four signed 32-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2776,7 +2776,7 @@ pub unsafe fn __msa_ceq_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding `a` (two signed 64-bit integer numbers) and `b`  (two signed 64-bit integer numbers)
+/// if the corresponding `a` (two signed 64-bit integer numbers) and `b` (two signed 64-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2864,7 +2864,7 @@ pub unsafe fn __msa_ceqi_d(a: v2i64, imm_s5: i32) -> v2i64 {
 
 /// GPR Copy from MSA Control Register
 ///
-/// The sign extended content of MSA control register cs is copied to GPRrd.
+/// The sign extended content of MSA control register cs is copied to GPR rd.
 ///
 /// Can not be tested in user mode
 #[inline]
@@ -2885,7 +2885,7 @@ pub unsafe fn __msa_cfcmsa(imm5: i32) -> i32 {
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
 /// are signed less than or equal to `b`  (sixteen signed 8-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2899,7 +2899,7 @@ pub unsafe fn __msa_cle_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight signed 16-bit integer numbers) element
 /// are signed less than or equal to `b`  (eight signed 16-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2913,7 +2913,7 @@ pub unsafe fn __msa_cle_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four signed 32-bit integer numbers) element
 /// are signed less than or equal to `b`  (four signed 32-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2927,7 +2927,7 @@ pub unsafe fn __msa_cle_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two signed 64-bit integer numbers) element
 /// are signed less than or equal to `b`  (two signed 64-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2941,7 +2941,7 @@ pub unsafe fn __msa_cle_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
 /// are unsigned less than or equal to `b`  (sixteen unsigned 8-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2955,7 +2955,7 @@ pub unsafe fn __msa_cle_u_b(a: v16u8, b: v16u8) -> v16i8 {
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
 /// are unsigned less than or equal to `b`  (eight unsigned 16-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2969,7 +2969,7 @@ pub unsafe fn __msa_cle_u_h(a: v8u16, b: v8u16) -> v8i16 {
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four unsigned 32-bit integer numbers) element
 /// are unsigned less than or equal to `b`  (four unsigned 32-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2983,7 +2983,7 @@ pub unsafe fn __msa_cle_u_w(a: v4u32, b: v4u32) -> v4i32 {
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two unsigned 64-bit integer numbers) element
 /// are unsigned less than or equal to `b`  (two unsigned 64-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3157,7 +3157,7 @@ pub unsafe fn __msa_clei_u_d(a: v2u64, imm5: i32) -> v2i64 {
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
 /// are signed less than `b`  (sixteen signed 8-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3171,7 +3171,7 @@ pub unsafe fn __msa_clt_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight signed 16-bit integer numbers) element
 /// are signed less than `b`  (eight signed 16-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3185,7 +3185,7 @@ pub unsafe fn __msa_clt_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four signed 32-bit integer numbers) element
 /// are signed less than `b`  (four signed 32-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3199,7 +3199,7 @@ pub unsafe fn __msa_clt_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two signed 64-bit integer numbers) element
 /// are signed less than `b`  (two signed 64-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3213,7 +3213,7 @@ pub unsafe fn __msa_clt_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
 /// are unsigned less than `b`  (sixteen unsigned 8-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3227,7 +3227,7 @@ pub unsafe fn __msa_clt_u_b(a: v16u8, b: v16u8) -> v16i8 {
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
 /// are unsigned less than `b`  (eight unsigned 16-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3241,7 +3241,7 @@ pub unsafe fn __msa_clt_u_h(a: v8u16, b: v8u16) -> v8i16 {
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four unsigned 32-bit integer numbers) element
 /// are unsigned less than `b`  (four unsigned 32-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3255,7 +3255,7 @@ pub unsafe fn __msa_clt_u_w(a: v4u32, b: v4u32) -> v4i32 {
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two unsigned 64-bit integer numbers) element
 /// are unsigned less than `b`  (two unsigned 64-bit integer numbers) element.
-/// otherwise set all bits to 0.
+/// Otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3692,8 +3692,8 @@ pub unsafe fn __msa_div_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Vector Signed Dot Product
 ///
 /// The signed integer elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are multiplied by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers).
-/// producing a result the size of the input operands. The multiplication resultsof
+/// are multiplied by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// producing a result the size of the input operands. The multiplication results of
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (eight signed 16-bit integer numbers).
 ///
@@ -3707,8 +3707,8 @@ pub unsafe fn __msa_dotp_s_h(a: v16i8, b: v16i8) -> v8i16 {
 /// Vector Signed Dot Product
 ///
 /// The signed integer elements in vector `a` (eight signed 16-bit integer numbers)
-/// are multiplied by signed integer elements in vector `b` (eight signed 16-bit integer numbers).
-/// producing a result the size of the input operands. The multiplication resultsof
+/// are multiplied by signed integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// producing a result the size of the input operands. The multiplication results of
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (four signed 32-bit integer numbers).
 ///
@@ -3722,8 +3722,8 @@ pub unsafe fn __msa_dotp_s_w(a: v8i16, b: v8i16) -> v4i32 {
 /// Vector Signed Dot Product
 ///
 /// The signed integer elements in vector `a` (four signed 32-bit integer numbers)
-/// are multiplied by signed integer elements in vector `b` (four signed 32-bit integer numbers).
-/// producing a result the size of the input operands. The multiplication resultsof
+/// are multiplied by signed integer elements in vector `b` (four signed 32-bit integer numbers)
+/// producing a result the size of the input operands. The multiplication results of
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (two signed 64-bit integer numbers).
 ///
@@ -3737,8 +3737,8 @@ pub unsafe fn __msa_dotp_s_d(a: v4i32, b: v4i32) -> v2i64 {
 /// Vector Unsigned Dot Product
 ///
 /// The unsigned integer elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers).
-/// producing a result the size of the input operands. The multiplication resultsof
+/// are multiplied by unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers)
+/// producing a result the size of the input operands. The multiplication results of
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (eight unsigned 16-bit integer numbers).
 ///
@@ -3752,8 +3752,8 @@ pub unsafe fn __msa_dotp_u_h(a: v16u8, b: v16u8) -> v8u16 {
 /// Vector Unsigned Dot Product
 ///
 /// The unsigned integer elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers).
-/// producing a result the size of the input operands. The multiplication resultsof
+/// are multiplied by unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers)
+/// producing a result the size of the input operands. The multiplication results of
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (four unsigned 32-bit integer numbers).
 ///
@@ -3767,8 +3767,8 @@ pub unsafe fn __msa_dotp_u_w(a: v8u16, b: v8u16) -> v4u32 {
 /// Vector Unsigned Dot Product
 ///
 /// The unsigned integer elements in vector `a` (four unsigned 32-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers).
-/// producing a result the size of the input operands. The multiplication resultsof
+/// are multiplied by unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers)
+/// producing a result the size of the input operands. The multiplication results of
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (two unsigned 64-bit integer numbers).
 ///
@@ -3782,7 +3782,7 @@ pub unsafe fn __msa_dotp_u_d(a: v4u32, b: v4u32) -> v2u64 {
 /// Vector Signed Dot Product and Add
 ///
 /// The signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// are multiplied by signed integer elements in vector `c` (sixteen signed 8-bit integer numbers).
+/// are multiplied by signed integer elements in vector `c` (sixteen signed 8-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are added to the vector `a` (eight signed 16-bit integer numbers).
 ///
@@ -3796,7 +3796,7 @@ pub unsafe fn __msa_dpadd_s_h(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
 /// Vector Signed Dot Product and Add
 ///
 /// The signed integer elements in vector `b` (eight signed 16-bit integer numbers)
-/// are multiplied by signed integer elements in vector `c` (eight signed 16-bit integer numbers).
+/// are multiplied by signed integer elements in vector `c` (eight signed 16-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are added to the vector `a` (four signed 32-bit integer numbers).
 ///
@@ -3810,7 +3810,7 @@ pub unsafe fn __msa_dpadd_s_w(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
 /// Vector Signed Dot Product and Add
 ///
 /// The signed integer elements in vector `b` (four signed 32-bit integer numbers)
-/// are multiplied by signed integer elements in vector `c` (four signed 32-bit integer numbers).
+/// are multiplied by signed integer elements in vector `c` (four signed 32-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are added to the vector `a` (two signed 64-bit integer numbers).
 ///
@@ -3824,7 +3824,7 @@ pub unsafe fn __msa_dpadd_s_d(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
 /// Vector Unsigned Dot Product and Add
 ///
 /// The unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `c` (sixteen unsigned 8-bit integer numbers).
+/// are multiplied by unsigned integer elements in vector `c` (sixteen unsigned 8-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are added to the vector `a` (eight unsigned 16-bit integer numbers).
 ///
@@ -3838,7 +3838,7 @@ pub unsafe fn __msa_dpadd_u_h(a: v8u16, b: v16u8, c: v16u8) -> v8u16 {
 /// Vector Unsigned Dot Product and Add
 ///
 /// The unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `c` (eight unsigned 16-bit integer numbers).
+/// are multiplied by unsigned integer elements in vector `c` (eight unsigned 16-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are added to the vector `a` (four unsigned 32-bit integer numbers).
 ///
@@ -3852,7 +3852,7 @@ pub unsafe fn __msa_dpadd_u_w(a: v4u32, b: v8u16, c: v8u16) -> v4u32 {
 /// Vector Unsigned Dot Product and Add
 ///
 /// The unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `c` (four unsigned 32-bit integer numbers).
+/// are multiplied by unsigned integer elements in vector `c` (four unsigned 32-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are added to the vector `a` (two unsigned 64-bit integer numbers).
 ///
@@ -3866,7 +3866,7 @@ pub unsafe fn __msa_dpadd_u_d(a: v2u64, b: v4u32, c: v4u32) -> v2u64 {
 /// Vector Signed Dot Product and Add
 ///
 /// The signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// are multiplied by signed integer elements in vector `c` (sixteen signed 8-bit integer numbers).
+/// are multiplied by signed integer elements in vector `c` (sixteen signed 8-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (eight signed 16-bit integer numbers).
@@ -3881,7 +3881,7 @@ pub unsafe fn __msa_dpsub_s_h(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
 /// Vector Signed Dot Product and Add
 ///
 /// The signed integer elements in vector `b` (eight signed 16-bit integer numbers)
-/// are multiplied by signed integer elements in vector `c` (eight signed 16-bit integer numbers).
+/// are multiplied by signed integer elements in vector `c` (eight signed 16-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (four signed 32-bit integer numbers).
@@ -3896,7 +3896,7 @@ pub unsafe fn __msa_dpsub_s_w(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
 /// Vector Signed Dot Product and Add
 ///
 /// The signed integer elements in vector `b` (four signed 32-bit integer numbers)
-/// are multiplied by signed integer elements in vector `c` (four signed 32-bit integer numbers).
+/// are multiplied by signed integer elements in vector `c` (four signed 32-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (two signed 64-bit integer numbers).
@@ -3911,7 +3911,7 @@ pub unsafe fn __msa_dpsub_s_d(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
 /// Vector Unsigned Dot Product and Add
 ///
 /// The unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `c` (sixteen unsigned 8-bit integer numbers).
+/// are multiplied by unsigned integer elements in vector `c` (sixteen unsigned 8-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (eight signed 16-bit integer numbers).
@@ -3926,7 +3926,7 @@ pub unsafe fn __msa_dpsub_u_h(a: v8i16, b: v16u8, c: v16u8) -> v8i16 {
 /// Vector Unsigned Dot Product and Add
 ///
 /// The unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `c` (eight unsigned 16-bit integer numbers).
+/// are multiplied by unsigned integer elements in vector `c` (eight unsigned 16-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (four signed 32-bit integer numbers).
@@ -3941,7 +3941,7 @@ pub unsafe fn __msa_dpsub_u_w(a: v4i32, b: v8u16, c: v8u16) -> v4i32 {
 /// Vector Unsigned Dot Product and Add
 ///
 /// The unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector `c` (four unsigned 32-bit integer numbers).
+/// are multiplied by unsigned integer elements in vector `c` (four unsigned 32-bit integer numbers)
 /// producing a result twice the size of the input operands. The multiplication results
 /// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (two signed 64-bit integer numbers).
@@ -3983,7 +3983,7 @@ pub unsafe fn __msa_fadd_d(a: v2f64, b: v2f64) -> v2f64 {
 ///
 /// Set all bits to 0 in vector (four signed 32-bit integer numbers)
 /// Signaling NaN elements in `a` (four 32-bit floating point numbers)
-/// or `b` (four 32-bit floating point numbers)signal Invalid Operation exception.
+/// or `b` (four 32-bit floating point numbers) signal Invalid Operation exception.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4009,7 +4009,7 @@ pub unsafe fn __msa_fcaf_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
 /// elements if the corresponding in `a` (four 32-bit floating point numbers)
-/// and `b` (four 32-bit floating point numbers)elements are ordered and equal,
+/// and `b` (four 32-bit floating point numbers) elements are ordered and equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4023,7 +4023,7 @@ pub unsafe fn __msa_fceq_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
 /// elements if the corresponding in `a` (two 64-bit floating point numbers)
-/// and `b` (two 64-bit floating point numbers) elementsare ordered and equal,
+/// and `b` (two 64-bit floating point numbers) elements are ordered and equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4040,7 +4040,7 @@ pub unsafe fn __msa_fceq_d(a: v2f64, b: v2f64) -> v2i64 {
 /// `a` (four 32-bit floating point numbers).
 /// The mask has 10 bits as follows. Bits 0 and 1 indicate NaN values: signaling NaN (bit 0) and quiet NaN (bit 1).
 /// Bits 2, 3, 4, 5 classify  negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
-/// Bits 6, 7, 8, 9classify positive values:infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
+/// Bits 6, 7, 8, 9 classify positive values: infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4051,12 +4051,12 @@ pub unsafe fn __msa_fclass_w(a: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Class Mask
 ///
-/// Store in each element of vector (wto signed 64-bit integer numbers)
+/// Store in each element of vector (two signed 64-bit integer numbers)
 /// a bit mask reflecting the floating-point class of the corresponding element of vector
-/// `a` (wto 64-bit floating point numbers).
+/// `a` (two 64-bit floating point numbers).
 /// The mask has 10 bits as follows. Bits 0 and 1 indicate NaN values: signaling NaN (bit 0) and quiet NaN (bit 1).
 /// Bits 2, 3, 4, 5 classify  negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
-/// Bits 6, 7, 8, 9classify positive values:infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
+/// Bits 6, 7, 8, 9 classify positive values: infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4068,8 +4068,8 @@ pub unsafe fn __msa_fclass_d(a: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Less or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding `a` (four 32-bit floating point numbers)elements are ordered
-/// and either less than or equal to `b` (four 32-bit floating point numbers)elements
+/// elements if the corresponding `a` (four 32-bit floating point numbers) elements are ordered
+/// and either less than or equal to `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4082,8 +4082,8 @@ pub unsafe fn __msa_fcle_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Less or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding `a` (two 64-bit floating point numbers) elementsare ordered
-/// and either less than or equal to `b` (two 64-bit floating point numbers) elements
+/// elements if the corresponding `a` (two 64-bit floating point numbers) elements are ordered
+/// and either less than or equal to `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4096,8 +4096,8 @@ pub unsafe fn __msa_fcle_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding `a` (four 32-bit floating point numbers)elements are ordered
-/// and less than `b` (four 32-bit floating point numbers)elements
+/// elements if the corresponding `a` (four 32-bit floating point numbers) elements are ordered
+/// and less than `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4110,8 +4110,8 @@ pub unsafe fn __msa_fclt_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding `a` (two 64-bit floating point numbers) elementsare ordered
-/// and less than `b` (two 64-bit floating point numbers) elements
+/// elements if the corresponding `a` (two 64-bit floating point numbers) elements are ordered
+/// and less than `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4124,8 +4124,8 @@ pub unsafe fn __msa_fclt_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Not Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are ordered and not equal
+/// elements if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are ordered and not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4139,7 +4139,7 @@ pub unsafe fn __msa_fcne_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
 /// elements if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare ordered and not equal
+/// `b` (two 64-bit floating point numbers) elements are ordered and not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4152,8 +4152,8 @@ pub unsafe fn __msa_fcne_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Ordered
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are ordered, i.e. both elementsare not NaN values,
+/// elements if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are ordered, i.e. both elements are not NaN values,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4167,7 +4167,7 @@ pub unsafe fn __msa_fcor_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
 /// elements if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare ordered, i.e. both elementsare not NaN values,
+/// `b` (two 64-bit floating point numbers) elements are ordered, i.e. both elements are not NaN values,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4180,8 +4180,8 @@ pub unsafe fn __msa_fcor_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Unordered or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are unordered or equal,
+/// elements if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4195,7 +4195,7 @@ pub unsafe fn __msa_fcueq_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
 /// elements if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare unordered or equal,
+/// `b` (two 64-bit floating point numbers) elements are unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4209,7 +4209,7 @@ pub unsafe fn __msa_fcueq_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
 /// elements if the corresponding elements in `a` (four 32-bit floating point numbers)
-/// are unordered or less than or equal to `b` (four 32-bit floating point numbers)elements,
+/// are unordered or less than or equal to `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4237,7 +4237,7 @@ pub unsafe fn __msa_fcule_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
 /// elements if the corresponding elements in `a` (four 32-bit floating point numbers)
-/// are unordered or less than `b` (four 32-bit floating point numbers)elements,
+/// are unordered or less than `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4265,8 +4265,8 @@ pub unsafe fn __msa_fcult_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
 /// elements if the corresponding `a` (four 32-bit floating point numbers)
-/// and `b` (four 32-bit floating point numbers)elements are unordered,
-/// i.e. at least oneelement is a NaN value, otherwise set all bits to 0.
+/// and `b` (four 32-bit floating point numbers) elements are unordered,
+/// i.e. at least one element is a NaN value, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4279,8 +4279,8 @@ pub unsafe fn __msa_fcun_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
 /// elements if the corresponding `a` (two 64-bit floating point numbers)
-/// and `b` (two 64-bit floating point numbers) elementsare unordered,
-/// i.e. at least oneelement is a NaN value, otherwise set all bits to 0.
+/// and `b` (two 64-bit floating point numbers) elements are unordered,
+/// i.e. at least one element is a NaN value, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4293,7 +4293,7 @@ pub unsafe fn __msa_fcun_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
 /// elements if the corresponding `a` (four 32-bit floating point numbers)
-/// and `b` (four 32-bit floating point numbers)elements are unordered or not equal,
+/// and `b` (four 32-bit floating point numbers) elements are unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4307,7 +4307,7 @@ pub unsafe fn __msa_fcune_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
 /// elements if the corresponding `a` (two 64-bit floating point numbers)
-/// and `b` (two 64-bit floating point numbers) elementsare unordered or not equal,
+/// and `b` (two 64-bit floating point numbers) elements are unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4348,7 +4348,7 @@ pub unsafe fn __msa_fdiv_d(a: v2f64, b: v2f64) -> v2f64 {
 ///
 /// The floating-point elements in vector `a` (four 64-bit floating point numbers)
 /// and  vector `b` (four 64-bit floating point numbers)  are down-converted
-/// to a smaller interchange format, i.e. from 64-bitto 32-bit, or from 32-bit to 16-bit.
+/// to a smaller interchange format, i.e. from 64-bit to 32-bit, or from 32-bit to 16-bit.
 /// The result is written to vector (8 16-bit floating point numbers).
 ///
 #[inline]
@@ -4362,7 +4362,7 @@ pub unsafe fn __msa_fexdo_h(a: v4f32, b: v4f32) -> f16x8 {
 ///
 /// The floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// and  vector `b` (two 64-bit floating point numbers)  are down-converted
-/// to a smaller interchange format, i.e. from 64-bitto 32-bit, or from 32-bit to 16-bit.
+/// to a smaller interchange format, i.e. from 64-bit to 32-bit, or from 32-bit to 16-bit.
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
@@ -4621,7 +4621,7 @@ pub unsafe fn __msa_fill_d(a: i64) -> v2i64 {
 /// Vector Floating-Point Base 2 Logarithm
 ///
 /// The signed integral base 2 exponents of floating-point elements in vector `a`
-/// (four 32-bit floating point numbers)are written as floating-point values to vector elements
+/// (four 32-bit floating point numbers) are written as floating-point values to vector elements
 /// (four 32-bit floating point numbers).
 ///
 #[inline]
@@ -4673,7 +4673,7 @@ pub unsafe fn __msa_fmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
 /// Vector Floating-Point Maximum
 ///
 /// The largest values between corresponding floating-point elements in vector `a`
-/// (four 32-bit floating point numbers)andvector `b` (four 32-bit floating point numbers)
+/// (four 32-bit floating point numbers) and vector `b` (four 32-bit floating point numbers)
 /// are written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4727,7 +4727,7 @@ pub unsafe fn __msa_fmax_a_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Minimum
 ///
 /// The smallest values between corresponding floating-point elements in vector `a`
-/// (four 32-bit floating point numbers)andvector `b` (four 32-bit floating point numbers)
+/// (four 32-bit floating point numbers) and vector `b` (four 32-bit floating point numbers)
 /// are written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4806,7 +4806,7 @@ pub unsafe fn __msa_fmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Multiplication
 ///
-/// The floating-point elements in vector `a` (four 32-bit floating point numbers)are
+/// The floating-point elements in vector `a` (four 32-bit floating point numbers) are
 /// multiplied by floating-point elements in vector `b` (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4906,7 +4906,7 @@ pub unsafe fn __msa_frsqrt_d(a: v2f64) -> v2f64 {
 ///
 /// Set all bits to 0 in  vector (four signed 32-bit integer numbers) elements.
 /// Signaling and quiet NaN elements in vector `a` (four 32-bit floating point numbers)
-/// or `b` (four 32-bit floating point numbers)signal  Invalid Operation exception.
+/// or `b` (four 32-bit floating point numbers) signal  Invalid Operation exception.
 /// In case of a floating-point exception, the default result has all bits set to 0
 ///
 #[inline]
@@ -4934,7 +4934,7 @@ pub unsafe fn __msa_fsaf_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four 32-bit floating point numbers)
-/// and `b` (four 32-bit floating point numbers)elements are equal, otherwise set all bits to 0.
+/// and `b` (four 32-bit floating point numbers) elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4945,9 +4945,9 @@ pub unsafe fn __msa_fseq_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Signaling Compare Equal
 ///
-/// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
+/// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers)
-/// and `b` (two 64-bit floating point numbers) elementsare equal, otherwise set all bits to 0.
+/// and `b` (two 64-bit floating point numbers) elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4958,9 +4958,9 @@ pub unsafe fn __msa_fseq_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Signaling Compare Less or Equal
 ///
-/// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)elements
-/// are less than or equal to `b` (four 32-bit floating point numbers)elements, otherwise set all bits to 0.
+/// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
+/// if the corresponding `a` (four 32-bit floating point numbers) elements
+/// are less than or equal to `b` (four 32-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4985,8 +4985,8 @@ pub unsafe fn __msa_fsle_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Less Than
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)elements
-/// are less than `b` (four 32-bit floating point numbers)elements, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers) elements
+/// are less than `b` (four 32-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5011,8 +5011,8 @@ pub unsafe fn __msa_fslt_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Not Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are not equal, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are not equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5025,7 +5025,7 @@ pub unsafe fn __msa_fsne_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare not equal, otherwise set all bits to 0.
+/// `b` (two 64-bit floating point numbers) elements are not equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5037,9 +5037,9 @@ pub unsafe fn __msa_fsne_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Ordered
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are ordered,
-/// i.e. both elementsare not NaN values, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are ordered,
+/// i.e. both elements are not NaN values, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5052,8 +5052,8 @@ pub unsafe fn __msa_fsor_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare ordered,
-/// i.e. both elementsare not NaN values, otherwise set all bits to 0.
+/// `b` (two 64-bit floating point numbers) elements are ordered,
+/// i.e. both elements are not NaN values, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5065,8 +5065,8 @@ pub unsafe fn __msa_fsor_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point  Square Root
 ///
 /// The square roots of floating-point elements in vector `a`
-/// (four 32-bit floating point numbers)are written to vector
-/// (four 32-bit floating point numbers)elements are ordered,
+/// (four 32-bit floating point numbers) are written to vector
+/// (four 32-bit floating point numbers) elements are ordered,
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5079,7 +5079,7 @@ pub unsafe fn __msa_fsqrt_w(a: v4f32) -> v4f32 {
 ///
 /// The square roots of floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) are written to vector
-/// (two 64-bit floating point numbers) elementsare ordered,
+/// (two 64-bit floating point numbers) elements are ordered,
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5119,8 +5119,8 @@ pub unsafe fn __msa_fsub_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Signaling Compare Ordered
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are unordered or equal,
+/// if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5134,7 +5134,7 @@ pub unsafe fn __msa_fsueq_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare unordered or equal,
+/// `b` (two 64-bit floating point numbers) elements are unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5147,8 +5147,8 @@ pub unsafe fn __msa_fsueq_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered or Less or Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)elements are
-/// unordered or less than or equal to `b` (four 32-bit floating point numbers)elements
+/// if the corresponding `a` (four 32-bit floating point numbers) elements are
+/// unordered or less than or equal to `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5161,8 +5161,8 @@ pub unsafe fn __msa_fsule_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Unordered or Less or Equal
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding `a` (two 64-bit floating point numbers) elementsare
-/// unordered or less than or equal to `b` (two 64-bit floating point numbers) elements
+/// if the corresponding `a` (two 64-bit floating point numbers) elements are
+/// unordered or less than or equal to `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5175,8 +5175,8 @@ pub unsafe fn __msa_fsule_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered or Less Than
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)elements
-/// are unordered or less than `b` (four 32-bit floating point numbers)elements
+/// if the corresponding `a` (four 32-bit floating point numbers) elements
+/// are unordered or less than `b` (four 32-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5190,7 +5190,7 @@ pub unsafe fn __msa_fsult_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) elements
-/// are unordered or less than `b` (two 64-bit floating point numbers) elements
+/// are unordered or less than `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5203,9 +5203,9 @@ pub unsafe fn __msa_fsult_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are unordered,
-/// i.e. at least one element is a NaN value otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are unordered,
+/// i.e. at least one element is a NaN value, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5218,8 +5218,8 @@ pub unsafe fn __msa_fsun_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare unordered,
-/// i.e. at least one element is a NaN value otherwise set all bits to 0.
+/// `b` (two 64-bit floating point numbers) elements are unordered,
+/// i.e. at least one element is a NaN value, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5231,8 +5231,8 @@ pub unsafe fn __msa_fsun_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered or Not Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding `a` (four 32-bit floating point numbers)and
-/// `b` (four 32-bit floating point numbers)elements are unordered or not equal,
+/// if the corresponding `a` (four 32-bit floating point numbers) and
+/// `b` (four 32-bit floating point numbers) elements are unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5246,7 +5246,7 @@ pub unsafe fn __msa_fsune_w(a: v4f32, b: v4f32) -> v4i32 {
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two 64-bit floating point numbers) and
-/// `b` (two 64-bit floating point numbers) elementsare unordered or not equal,
+/// `b` (two 64-bit floating point numbers) elements are unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5315,7 +5315,7 @@ pub unsafe fn __msa_ftint_u_d(a: v2f64) -> v2u64 {
 /// Vector Floating-Point Convert to Fixed-Point
 ///
 /// The elements in vector `a` (four 32-bit floating point numbers)
-/// and `b` (four 32-bit floating point numbers)are down-converted to a fixed-point
+/// and `b` (four 32-bit floating point numbers) are down-converted to a fixed-point
 /// representation,  i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
 /// representation, or from 32-bit floating-point to 16-bit Q15 fixed-point representation.
 /// The result is written to vector (eight signed 16-bit integer numbers).
@@ -5398,7 +5398,7 @@ pub unsafe fn __msa_ftrunc_u_d(a: v2f64) -> v2u64 {
 ///
 /// The sign-extended odd elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are added to the sign-extended even elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -5412,7 +5412,7 @@ pub unsafe fn __msa_hadd_s_h(a: v16i8, b: v16i8) -> v8i16 {
 ///
 /// The sign-extended odd elements in vector `a` (eight signed 16-bit integer numbers)
 /// are added to the sign-extended even elements in vector `b` (eight signed 16-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -5426,7 +5426,7 @@ pub unsafe fn __msa_hadd_s_w(a: v8i16, b: v8i16) -> v4i32 {
 ///
 /// The sign-extended odd elements in vector `a` (four signed 32-bit integer numbers)
 /// are added to the sign-extended even elements in vector `b` (four signed 32-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -5440,7 +5440,7 @@ pub unsafe fn __msa_hadd_s_d(a: v4i32, b: v4i32) -> v2i64 {
 ///
 /// The zero-extended odd elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// are added to the zero-extended even elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
@@ -5454,7 +5454,7 @@ pub unsafe fn __msa_hadd_u_h(a: v16u8, b: v16u8) -> v8u16 {
 ///
 /// The zero-extended odd elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// are added to the zero-extended even elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
@@ -5468,7 +5468,7 @@ pub unsafe fn __msa_hadd_u_w(a: v8u16, b: v8u16) -> v4u32 {
 ///
 /// The zero-extended odd elements in vector `a` (four unsigned 32-bit integer numbers)
 /// are added to the zero-extended even elements in vector `b` (four unsigned 32-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
@@ -5482,7 +5482,7 @@ pub unsafe fn __msa_hadd_u_d(a: v4u32, b: v4u32) -> v2u64 {
 ///
 /// The sign-extended odd elements in vector `b` (sixteen signed 8-bit integer numbers)
 /// are subtracted from the sign-extended elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -5496,7 +5496,7 @@ pub unsafe fn __msa_hsub_s_h(a: v16i8, b: v16i8) -> v8i16 {
 ///
 /// The sign-extended odd elements in vector `b` (eight signed 16-bit integer numbers)
 /// are subtracted from the sign-extended elements in vector `a` (eight signed 16-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -5510,7 +5510,7 @@ pub unsafe fn __msa_hsub_s_w(a: v8i16, b: v8i16) -> v4i32 {
 ///
 /// The sign-extended odd elements in vector `b` (four signed 32-bit integer numbers)
 /// are subtracted from the sign-extended elements in vector `a` (four signed 32-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -5524,7 +5524,7 @@ pub unsafe fn __msa_hsub_s_d(a: v4i32, b: v4i32) -> v2i64 {
 ///
 /// The zero-extended odd elements in vector `b` (sixteen unsigned 8-bit integer numbers)
 /// are subtracted from the zero-extended elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -5538,7 +5538,7 @@ pub unsafe fn __msa_hsub_u_h(a: v16u8, b: v16u8) -> v8i16 {
 ///
 /// The zero-extended odd elements in vector `b` (eight unsigned 16-bit integer numbers)
 /// are subtracted from the zero-extended elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -5552,7 +5552,7 @@ pub unsafe fn __msa_hsub_u_w(a: v8u16, b: v8u16) -> v4i32 {
 ///
 /// The zero-extended odd elements in vector `b` (four unsigned 32-bit integer numbers)
 /// are subtracted from the zero-extended elements in vector `a` (four unsigned 32-bit integer numbers)
-/// producing aresult twice the size of the input operands.
+/// producing a result twice the size of the input operands.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -5940,7 +5940,7 @@ pub unsafe fn __msa_insve_d(a: v2i64, imm1: i32, c: v2i64) -> v2i64 {
 
 /// Vector Load
 ///
-/// The WRLEN / 8 bytes at the ef fective memory location addressed by the base
+/// The WRLEN / 8 bytes at the effective memory location addressed by the base
 /// mem_addr and the 10-bit signed immediate offset imm_s10 are fetched and placed in
 /// the vector (sixteen signed 8-bit integer numbers) value.
 ///
@@ -5959,7 +5959,7 @@ pub unsafe fn __msa_ld_b(mem_addr: *mut u8, imm_s10: i32) -> v16i8 {
 
 /// Vector Load
 ///
-/// The WRLEN / 8 bytes at the ef fective memory location addressed by the base
+/// The WRLEN / 8 bytes at the effective memory location addressed by the base
 /// mem_addr and the 10-bit signed immediate offset imm_s11 are fetched and placed in
 /// the vector (eight signed 16-bit integer numbers) value.
 ///
@@ -5978,7 +5978,7 @@ pub unsafe fn __msa_ld_h(mem_addr: *mut u8, imm_s11: i32) -> v8i16 {
 
 /// Vector Load
 ///
-/// The WRLEN / 8 bytes at the ef fective memory location addressed by the base
+/// The WRLEN / 8 bytes at the effective memory location addressed by the base
 /// mem_addr and the 10-bit signed immediate offset imm_s12 are fetched and placed in
 /// the vector (four signed 32-bit integer numbers) value.
 ///
@@ -5997,7 +5997,7 @@ pub unsafe fn __msa_ld_w(mem_addr: *mut u8, imm_s12: i32) -> v4i32 {
 
 /// Vector Load
 ///
-/// The WRLEN / 8 bytes at the ef fective memory location addressed by the base
+/// The WRLEN / 8 bytes at the effective memory location addressed by the base
 /// mem_addr and the 10-bit signed immediate offset imm_s13 are fetched and placed in
 /// the vector (two signed 64-bit integer numbers) value.
 ///
@@ -6833,9 +6833,9 @@ pub unsafe fn __msa_mini_u_d(a: v2u64, imm5: i32) -> v2u64 {
 /// Vector Signed Modulo
 ///
 /// The signed integer elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are divided by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// The remainder of thesame sign as the dividend is written to vector
-/// (sixteen signed 8-bit integer numbers).If a divisor element vectorwt is zero,
+/// are divided by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers).
+/// The remainder of the same sign as the dividend is written to vector
+/// (sixteen signed 8-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6848,9 +6848,9 @@ pub unsafe fn __msa_mod_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Signed Modulo
 ///
 /// The signed integer elements in vector `a` (eight signed 16-bit integer numbers)
-/// are divided by signed integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (eight signed 16-bit integer numbers).
 /// The remainder of the same sign as the dividend is written to vector
-/// (eight signed 16-bit integer numbers). If a divisor element vectorwt is zero,
+/// (eight signed 16-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6863,9 +6863,9 @@ pub unsafe fn __msa_mod_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Signed Modulo
 ///
 /// The signed integer elements in vector `a` (four signed 32-bit integer numbers)
-/// are divided by signed integer elements in vector `b` (four signed 32-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (four signed 32-bit integer numbers).
 /// The remainder of the same sign as the dividend is written to vector
-/// (four signed 32-bit integer numbers). If a divisor element vectorwt is zero,
+/// (four signed 32-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6880,7 +6880,7 @@ pub unsafe fn __msa_mod_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// The signed integer elements in vector `a` (two signed 64-bit integer numbers)
 /// are divided by signed integer elements in vector `b` (two signed 64-bit integer numbers).
 /// The remainder of the same sign as the dividend is written to vector
-/// (two signed 64-bit integer numbers). If a divisor element vectorwt is zero,
+/// (two signed 64-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6895,7 +6895,7 @@ pub unsafe fn __msa_mod_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// The unsigned integer elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// are divided by unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers).
 /// The remainder of the same sign as the dividend is written to vector
-/// (sixteen unsigned 8-bit integer numbers). If a divisor element vectorwt is zero,
+/// (sixteen unsigned 8-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6909,8 +6909,8 @@ pub unsafe fn __msa_mod_u_b(a: v16u8, b: v16u8) -> v16u8 {
 ///
 /// The unsigned integer elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// are divided by unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers).
-/// The remainder of thesame sign as the dividend is written to vector
-/// (eight unsigned 16-bit integer numbers).If a divisor element vectorwt is zero,
+/// The remainder of the same sign as the dividend is written to vector
+/// (eight unsigned 16-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6924,8 +6924,8 @@ pub unsafe fn __msa_mod_u_h(a: v8u16, b: v8u16) -> v8u16 {
 ///
 /// The unsigned integer elements in vector `a` (four unsigned 32-bit integer numbers)
 /// are divided by unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers).
-/// The remainder of thesame sign as the dividend is written to vector
-/// (four unsigned 32-bit integer numbers). If a divisor element vectorwt is zero,
+/// The remainder of the same sign as the dividend is written to vector
+/// (four unsigned 32-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6939,8 +6939,8 @@ pub unsafe fn __msa_mod_u_w(a: v4u32, b: v4u32) -> v4u32 {
 ///
 /// The unsigned integer elements in vector `a` (two unsigned 64-bit integer numbers)
 /// are divided by unsigned integer elements in vector `b` (two unsigned 64-bit integer numbers).
-/// The remainder of thesame sign as the dividend is written to vector
-/// (two unsigned 64-bit integer numbers).If a divisor element vectorwt is zero,
+/// The remainder of the same sign as the dividend is written to vector
+/// (two unsigned 64-bit integer numbers). If a divisor element vector `b` is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -7722,7 +7722,7 @@ pub unsafe fn __msa_shf_w(a: v4i32, imm8: i32) -> v4i32 {
 ///
 /// Vector registers `a` (sixteen signed 8-bit integer numbers) and `b`
 /// (sixteen signed 8-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7742,7 +7742,7 @@ pub unsafe fn __msa_sld_b(a: v16i8, b: v16i8, c: i32) -> v16i8 {
 ///
 /// Vector registers `a` (eight signed 16-bit integer numbers) and `b`
 /// (eight signed 16-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7762,7 +7762,7 @@ pub unsafe fn __msa_sld_h(a: v8i16, b: v8i16, c: i32) -> v8i16 {
 ///
 /// Vector registers `a` (four signed 32-bit integer numbers) and `b`
 /// (four signed 32-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7782,7 +7782,7 @@ pub unsafe fn __msa_sld_w(a: v4i32, b: v4i32, c: i32) -> v4i32 {
 ///
 /// Vector registers `a` (two signed 64-bit integer numbers) and `b`
 /// (two signed 64-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7802,7 +7802,7 @@ pub unsafe fn __msa_sld_d(a: v2i64, b: v2i64, c: i32) -> v2i64 {
 ///
 /// Vector registers `a` (sixteen signed 8-bit integer numbers) and `b`
 /// (sixteen signed 8-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7826,7 +7826,7 @@ pub unsafe fn __msa_sldi_b(a: v16i8, b: v16i8, imm4: i32) -> v16i8 {
 ///
 /// Vector registers `a` (eight signed 16-bit integer numbers) and `b`
 /// (eight signed 16-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7850,7 +7850,7 @@ pub unsafe fn __msa_sldi_h(a: v8i16, b: v8i16, imm3: i32) -> v8i16 {
 ///
 /// Vector registers `a` (four signed 32-bit integer numbers) and `b`
 /// (four signed 32-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7874,7 +7874,7 @@ pub unsafe fn __msa_sldi_w(a: v4i32, b: v4i32, imm2: i32) -> v4i32 {
 ///
 /// Vector registers `a` (two signed 64-bit integer numbers) and `b`
 /// (two signed 64-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
-/// stored row-wise with as many rows asbytes in integer data format df.
+/// stored row-wise with as many rows as bytes in integer data format df.
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
@@ -7899,7 +7899,7 @@ pub unsafe fn __msa_sldi_d(a: v2i64, b: v2i64, imm1: i32) -> v2i64 {
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted left by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector (sixteen signed 8-bit integer numbers).
+/// element in bits. The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7913,7 +7913,7 @@ pub unsafe fn __msa_sll_b(a: v16i8, b: v16i8) -> v16i8 {
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted left by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector (eight signed 16-bit integer numbers).
+/// element in bits. The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7927,7 +7927,7 @@ pub unsafe fn __msa_sll_h(a: v8i16, b: v8i16) -> v8i16 {
 /// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted left by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector (four signed 32-bit integer numbers).
+/// element in bits. The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7941,7 +7941,7 @@ pub unsafe fn __msa_sll_w(a: v4i32, b: v4i32) -> v4i32 {
 /// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted left by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(two signed 64-bit integer numbers).
+/// element in bits. The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7953,8 +7953,8 @@ pub unsafe fn __msa_sll_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Shift Left
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are shifted left by the imm4 bits.
-/// The result is written to vector(sixteen signed 8-bit integer numbers).
+/// are shifted left by `imm4` bits.
+/// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7972,8 +7972,8 @@ pub unsafe fn __msa_slli_b(a: v16i8, imm4: i32) -> v16i8 {
 /// Immediate Shift Left
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are shifted left by the imm3 bits.
-/// The result is written to vector(eight signed 16-bit integer numbers).
+/// are shifted left by `imm3` bits.
+/// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7991,8 +7991,8 @@ pub unsafe fn __msa_slli_h(a: v8i16, imm3: i32) -> v8i16 {
 /// Immediate Shift Left
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are shifted left by the imm2 bits.
-/// The result is written to vector(four signed 32-bit integer numbers).
+/// are shifted left by `imm2` bits.
+/// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8010,8 +8010,8 @@ pub unsafe fn __msa_slli_w(a: v4i32, imm2: i32) -> v4i32 {
 /// Immediate Shift Left
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are shifted left by the imm1 bits.
-/// The result is written to vector(two signed 64-bit integer numbers).
+/// are shifted left by `imm1` bits.
+/// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8159,7 +8159,7 @@ pub unsafe fn __msa_splati_d(a: v2i64, imm1: i32) -> v2i64 {
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(sixteen signed 8-bit integer numbers).
+/// element in bits.The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8173,7 +8173,7 @@ pub unsafe fn __msa_sra_b(a: v16i8, b: v16i8) -> v16i8 {
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(eight signed 16-bit integer numbers).
+/// element in bits.The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8187,7 +8187,7 @@ pub unsafe fn __msa_sra_h(a: v8i16, b: v8i16) -> v8i16 {
 /// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(four signed 32-bit integer numbers).
+/// element in bits.The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8201,7 +8201,7 @@ pub unsafe fn __msa_sra_w(a: v4i32, b: v4i32) -> v4i32 {
 /// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(two signed 64-bit integer numbers).
+/// element in bits.The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8214,7 +8214,7 @@ pub unsafe fn __msa_sra_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right arithmetic by imm3 bits.
-/// The result is written to vector(sixteen signed 8-bit integer numbers).
+/// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8233,7 +8233,7 @@ pub unsafe fn __msa_srai_b(a: v16i8, imm3: i32) -> v16i8 {
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right arithmetic by imm4 bits.
-/// The result is written to vector(eight signed 16-bit integer numbers).
+/// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8252,7 +8252,7 @@ pub unsafe fn __msa_srai_h(a: v8i16, imm4: i32) -> v8i16 {
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right arithmetic by imm5 bits.
-/// The result is written to vector(four signed 32-bit integer numbers).
+/// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8271,7 +8271,7 @@ pub unsafe fn __msa_srai_w(a: v4i32, imm5: i32) -> v4i32 {
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right arithmetic by imm6 bits.
-/// The result is written to vector(two signed 64-bit integer numbers).
+/// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8292,7 +8292,7 @@ pub unsafe fn __msa_srai_d(a: v2i64, imm6: i32) -> v2i64 {
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(sixteen signed 8-bit integer numbers).
+/// value (for rounding) and the result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8307,7 +8307,7 @@ pub unsafe fn __msa_srar_b(a: v16i8, b: v16i8) -> v16i8 {
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(eight signed 16-bit integer numbers).
+/// value (for rounding) and the result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8322,7 +8322,7 @@ pub unsafe fn __msa_srar_h(a: v8i16, b: v8i16) -> v8i16 {
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(four signed 32-bit integer numbers).
+/// value (for rounding) and the result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8337,7 +8337,7 @@ pub unsafe fn __msa_srar_w(a: v4i32, b: v4i32) -> v4i32 {
 /// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(two signed 64-bit integer numbers).
+/// value (for rounding) and the result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8351,7 +8351,7 @@ pub unsafe fn __msa_srar_d(a: v2i64, b: v2i64) -> v2i64 {
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right arithmetic by imm3 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(sixteen signed 8-bit integer numbers).
+/// the result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8371,7 +8371,7 @@ pub unsafe fn __msa_srari_b(a: v16i8, imm3: i32) -> v16i8 {
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right arithmetic by imm4 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(eight signed 16-bit integer numbers).
+/// the result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8391,7 +8391,7 @@ pub unsafe fn __msa_srari_h(a: v8i16, imm4: i32) -> v8i16 {
 /// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right arithmetic by imm5 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(four signed 32-bit integer numbers).
+/// the result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8411,7 +8411,7 @@ pub unsafe fn __msa_srari_w(a: v4i32, imm5: i32) -> v4i32 {
 /// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right arithmetic by imm6 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(two signed 64-bit integer numbers).
+/// the result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8431,7 +8431,7 @@ pub unsafe fn __msa_srari_d(a: v2i64, imm6: i32) -> v2i64 {
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(sixteen signed 8-bit integer numbers).
+/// element in bits.The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8445,7 +8445,7 @@ pub unsafe fn __msa_srl_b(a: v16i8, b: v16i8) -> v16i8 {
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(eight signed 16-bit integer numbers).
+/// element in bits.The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8459,7 +8459,7 @@ pub unsafe fn __msa_srl_h(a: v8i16, b: v8i16) -> v8i16 {
 /// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(four signed 32-bit integer numbers).
+/// element in bits.The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8473,7 +8473,7 @@ pub unsafe fn __msa_srl_w(a: v4i32, b: v4i32) -> v4i32 {
 /// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
-/// element in bits.The result is written to vector(two signed 64-bit integer numbers).
+/// element in bits.The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8486,7 +8486,7 @@ pub unsafe fn __msa_srl_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right logical by imm4 bits.
-/// The result is written to vector(sixteen signed 8-bit integer numbers).
+/// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8505,7 +8505,7 @@ pub unsafe fn __msa_srli_b(a: v16i8, imm4: i32) -> v16i8 {
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right logical by imm3 bits.
-/// The result is written to vector(eight signed 16-bit integer numbers).
+/// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8524,7 +8524,7 @@ pub unsafe fn __msa_srli_h(a: v8i16, imm3: i32) -> v8i16 {
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right logical by imm2 bits.
-/// The result is written to vector(four signed 32-bit integer numbers).
+/// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8543,7 +8543,7 @@ pub unsafe fn __msa_srli_w(a: v4i32, imm2: i32) -> v4i32 {
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right logical by imm1 bits.
-/// The result is written to vector(two signed 64-bit integer numbers).
+/// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8564,7 +8564,7 @@ pub unsafe fn __msa_srli_d(a: v2i64, imm1: i32) -> v2i64 {
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(sixteen signed 8-bit integer numbers).
+/// value (for rounding) and the result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8579,7 +8579,7 @@ pub unsafe fn __msa_srlr_b(a: v16i8, b: v16i8) -> v16i8 {
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(eight signed 16-bit integer numbers).
+/// value (for rounding) and the result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8594,7 +8594,7 @@ pub unsafe fn __msa_srlr_h(a: v8i16, b: v8i16) -> v8i16 {
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(four signed 32-bit integer numbers).
+/// value (for rounding) and the result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8609,7 +8609,7 @@ pub unsafe fn __msa_srlr_w(a: v4i32, b: v4i32) -> v4i32 {
 /// are shifted right logical by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
-/// value (for rounding) and the result is written to vector(two signed 64-bit integer numbers).
+/// value (for rounding) and the result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8621,9 +8621,9 @@ pub unsafe fn __msa_srlr_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Shift Right Logical Rounded
 ///
 /// The elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are shifted right logical by imm6 bits.The most significant
+/// are shifted right logical by `imm6` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(sixteen signed 8-bit integer numbers).
+/// the result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8641,9 +8641,9 @@ pub unsafe fn __msa_srlri_b(a: v16i8, imm3: i32) -> v16i8 {
 /// Immediate Shift Right Logical Rounded
 ///
 /// The elements in vector `a` (eight signed 16-bit integer numbers)
-/// are shifted right logical by imm6 bits.The most significant
+/// are shifted right logical by `imm6` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(eight signed 16-bit integer numbers).
+/// the result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8661,9 +8661,9 @@ pub unsafe fn __msa_srlri_h(a: v8i16, imm4: i32) -> v8i16 {
 /// Immediate Shift Right Logical Rounded
 ///
 /// The elements in vector `a` (four signed 32-bit integer numbers)
-/// are shifted right logical by imm6 bits.The most significant
+/// are shifted right logical by `imm6` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(four signed 32-bit integer numbers).
+/// the result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8681,9 +8681,9 @@ pub unsafe fn __msa_srlri_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Shift Right Logical Rounded
 ///
 /// The elements in vector `a` (two signed 64-bit integer numbers)
-/// are shifted right logical by imm6 bits.The most significant
+/// are shifted right logical by `imm6` bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
-/// the result is written to vector(two signed 64-bit integer numbers).
+/// the result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8700,9 +8700,9 @@ pub unsafe fn __msa_srlri_d(a: v2i64, imm6: i32) -> v2i64 {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector `a` (sixteen signed 8-bit integer numbers)
+/// The WRLEN / 8 bytes in vector `a` (sixteen signed 8-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base mem_addr and the 10-bit signed immediate offset imm_s10
+/// addressed by the base `mem_addr` and the 10-bit signed immediate offset `imm_s10`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8719,9 +8719,9 @@ pub unsafe fn __msa_st_b(a: v16i8, mem_addr: *mut u8, imm_s10: i32) -> () {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector `a` (eight signed 16-bit integer numbers)
+/// The WRLEN / 8 bytes in vector `a` (eight signed 16-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base mem_addr and the 11-bit signed immediate offset imm_s11
+/// addressed by the base `mem_addr` and the 11-bit signed immediate offset `imm_s11`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8738,9 +8738,9 @@ pub unsafe fn __msa_st_h(a: v8i16, mem_addr: *mut u8, imm_s11: i32) -> () {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector `a` (four signed 32-bit integer numbers)
+/// The WRLEN / 8 bytes in vector `a` (four signed 32-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base mem_addr and the 12-bit signed immediate offset imm_s12
+/// addressed by the base `mem_addr` and the 12-bit signed immediate offset `imm_s12`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8757,9 +8757,9 @@ pub unsafe fn __msa_st_w(a: v4i32, mem_addr: *mut u8, imm_s12: i32) -> () {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector `a` (two signed 64-bit integer numbers)
+/// The WRLEN / 8 bytes in vector `a` (two signed 64-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base mem_addr and the 13-bit signed immediate offset imm_s13
+/// addressed by the base `mem_addr` and the 13-bit signed immediate offset `imm_s13`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -9052,7 +9052,7 @@ pub unsafe fn __msa_subv_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Subtract
 ///
-/// The 5-bit immediate unsigned value imm5
+/// The 5-bit immediate unsigned value `imm5`
 /// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -9071,7 +9071,7 @@ pub unsafe fn __msa_subvi_b(a: v16i8, imm5: i32) -> v16i8 {
 
 /// Immediate Subtract
 ///
-/// The 5-bit immediate unsigned value imm5
+/// The 5-bit immediate unsigned value `imm5`
 /// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers)
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -9090,7 +9090,7 @@ pub unsafe fn __msa_subvi_h(a: v8i16, imm5: i32) -> v8i16 {
 
 /// Immediate Subtract
 ///
-/// The 5-bit immediate unsigned value imm5
+/// The 5-bit immediate unsigned value `imm5`
 /// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers)
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -9109,7 +9109,7 @@ pub unsafe fn __msa_subvi_w(a: v4i32, imm5: i32) -> v4i32 {
 
 /// Immediate Subtract
 ///
-/// The 5-bit immediate unsigned value imm5
+/// The 5-bit immediate unsigned value `imm5`
 /// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers)
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -9134,7 +9134,7 @@ pub unsafe fn __msa_subvi_d(a: v2i64, imm5: i32) -> v2i64 {
 /// (sixteen signed 8-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
-/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
+/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -9151,7 +9151,7 @@ pub unsafe fn __msa_vshf_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 /// (eight signed 16-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
-/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
+/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -9168,7 +9168,7 @@ pub unsafe fn __msa_vshf_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 /// (four signed 32-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
-/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
+/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -9185,7 +9185,7 @@ pub unsafe fn __msa_vshf_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 /// (two signed 64-bit integer numbers) based on the corresponding control element in `a`
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
-/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
+/// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -9211,7 +9211,7 @@ pub unsafe fn __msa_xor_v(a: v16u8, b: v16u8) -> v16u8 {
 /// Immediate Logical Exclusive Or
 ///
 /// Each byte of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// is combined with the 8-bit immediate imm8
+/// is combined with the 8-bit immediate `imm8`
 /// in a bitwise logical XOR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///

--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -1137,7 +1137,7 @@ extern "C" {
 /// Vector Add Absolute Values.
 ///
 /// The absolute values of the elements in vector in `a` (sixteen signed 8-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are added to the absolute values of the elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -1150,7 +1150,7 @@ pub unsafe fn __msa_add_a_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Add Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (eight signed 16-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (eight signed 16-bit integer numbers)
+/// are added to the absolute values of the elements in vector `b` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -1163,7 +1163,7 @@ pub unsafe fn __msa_add_a_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Add Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (four signed 32-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (four signed 32-bit integer numbers)
+/// are added to the absolute values of the elements in vector `b` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -1176,8 +1176,8 @@ pub unsafe fn __msa_add_a_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Add Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (two signed 64-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (two signed 64-bit integer numbers)
-// The result is written to vector (two signed 64-bit integer numbers).
+/// are added to the absolute values of the elements in vector `b` (two signed 64-bit integer numbers).
+/// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1189,7 +1189,7 @@ pub unsafe fn __msa_add_a_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Signed Saturated Vector Saturated Add of Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (sixteen signed 8-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are added to the absolute values of the elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// The saturated signed result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -1202,7 +1202,7 @@ pub unsafe fn __msa_adds_a_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Saturated Add of Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (eight signed 16-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (eight signed 16-bit integer numbers)
+/// are added to the absolute values of the elements in vector `b` (eight signed 16-bit integer numbers).
 /// The saturated signed result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -1215,7 +1215,7 @@ pub unsafe fn __msa_adds_a_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Saturated Add of Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (four signed 32-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (four signed 32-bit integer numbers)
+/// are added to the absolute values of the elements in vector `b` (four signed 32-bit integer numbers).
 /// The saturated signed result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -1228,8 +1228,8 @@ pub unsafe fn __msa_adds_a_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Saturated Add of Absolute Values
 ///
 /// The absolute values of the elements in vector in `a` (two signed 64-bit integer numbers)
-/// are added to the absolute values of the elements in vector `b` (two signed 64-bit integer numbers)
-// The saturated signed result is written to vector (two signed 64-bit integer numbers).
+/// are added to the absolute values of the elements in vector `b` (two signed 64-bit integer numbers).
+/// The saturated signed result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -1241,7 +1241,7 @@ pub unsafe fn __msa_adds_a_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Signed Saturated Add of Signed Values
 ///
 /// The elements in vector in `a` (sixteen signed  8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen signed  8-bit integer numbers)
+/// are added to the elements in vector `b` (sixteen signed  8-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (sixteen signed  8-bit integer numbers).
 ///
@@ -1255,7 +1255,7 @@ pub unsafe fn __msa_adds_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Signed Saturated Add of Signed Values
 ///
 /// The elements in vector in `a` (eight signed 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight signed 16-bit integer numbers)
+/// are added to the elements in vector `b` (eight signed 16-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (eight signed 16-bit integer numbers).
 ///
@@ -1269,7 +1269,7 @@ pub unsafe fn __msa_adds_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Signed Saturated Add of Signed Values
 ///
 /// The elements in vector in `a` (four signed 32-bit integer numbers)
-/// are added to the elements in vector `b` (four signed 32-bit integer numbers)
+/// are added to the elements in vector `b` (four signed 32-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (four signed 32-bit integer numbers).
 ///
@@ -1283,7 +1283,7 @@ pub unsafe fn __msa_adds_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Signed Saturated Add of Signed Values
 ///
 /// The elements in vector in `a` (two signed 64-bit integer numbers)
-/// are added to the elements in vector `b` (two signed 64-bit integer numbers)
+/// are added to the elements in vector `b` (two signed 64-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (two signed 64-bit integer numbers).
 ///
@@ -1297,7 +1297,7 @@ pub unsafe fn __msa_adds_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Unsigned Saturated Add of Unsigned Values
 ///
 /// The elements in vector in `a` (sixteen unsigned 8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
+/// are added to the elements in vector `b` (sixteen unsigned 8-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -1311,7 +1311,7 @@ pub unsafe fn __msa_adds_u_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Unsigned Saturated Add of Unsigned Values
 ///
 /// The elements in vector in `a` (eight unsigned 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight unsigned 16-bit integer numbers)
+/// are added to the elements in vector `b` (eight unsigned 16-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (eight unsigned 16-bit integer numbers).
 ///
@@ -1325,7 +1325,7 @@ pub unsafe fn __msa_adds_u_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Unsigned Saturated Add of Unsigned Values
 ///
 /// The elements in vector in `a` (four unsigned 32-bit integer numbers)
-/// are added to the elements in vector `b` (four unsigned 32-bit integer numbers)
+/// are added to the elements in vector `b` (four unsigned 32-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (four unsigned 32-bit integer numbers).
 ///
@@ -1339,7 +1339,7 @@ pub unsafe fn __msa_adds_u_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Unsigned Saturated Add of Unsigned Values
 ///
 /// The elements in vector in `a` (two unsigned 64-bit integer numbers)
-/// are added to the elements in vector `b` (two unsigned 64-bit integer numbers)
+/// are added to the elements in vector `b` (two unsigned 64-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (two unsigned 64-bit integer numbers).
 ///
@@ -1353,7 +1353,7 @@ pub unsafe fn __msa_adds_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Vector Add
 ///
 /// The elements in vector in `a` (sixteen signed 8-bit integer numbers)
-/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are added to the elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -1366,7 +1366,7 @@ pub unsafe fn __msa_addv_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Add
 ///
 /// The elements in vector in `a` (eight signed 16-bit integer numbers)
-/// are added to the elements in vector `b` (eight signed 16-bit integer numbers)
+/// are added to the elements in vector `b` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -1379,7 +1379,7 @@ pub unsafe fn __msa_addv_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Add
 ///
 /// The elements in vector in `a` (four signed 32-bit integer numbers)
-/// are added to the elements in vector `b` (four signed 32-bit integer numbers)
+/// are added to the elements in vector `b` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -1392,7 +1392,7 @@ pub unsafe fn __msa_addv_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Add
 ///
 /// The elements in vector in `a` (two signed 64-bit integer numbers)
-/// are added to the elements in vector `b` (two signed 64-bit integer numbers)
+/// are added to the elements in vector `b` (two signed 64-bit integer numbers).
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -1405,7 +1405,7 @@ pub unsafe fn __msa_addv_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Add
 ///
 /// The 5-bit immediate unsigned value u5 is added to the elements
-/// vector in `a` (sixteen signed 8-bit integer numbers)
+/// vector in `a` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -1424,7 +1424,7 @@ pub unsafe fn __msa_addvi_b(a: v16i8, imm5: i32) -> v16i8 {
 /// Immediate Add
 ///
 /// The 5-bit immediate unsigned value u5 is added to the elements
-/// vector in `a` (eight signed 16-bit integer numbers)
+/// vector in `a` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -1443,7 +1443,7 @@ pub unsafe fn __msa_addvi_h(a: v8i16, imm5: i32) -> v8i16 {
 /// Immediate Add
 ///
 /// The 5-bit immediate unsigned value u5 is added to the elements
-/// vector in `a` (four signed 32-bit integer numbers)
+/// vector in `a` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -1462,7 +1462,7 @@ pub unsafe fn __msa_addvi_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Add
 ///
 /// The 5-bit immediate unsigned value u5 is added to the elements
-/// vector in `a` (two signed 64-bit integer numbers)
+/// vector in `a` (two signed 64-bit integer numbers).
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -1481,7 +1481,7 @@ pub unsafe fn __msa_addvi_d(a: v2i64, imm5: i32) -> v2i64 {
 /// Vector Logical And
 ///
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// is combined with the corresponding bit of vector 'b' (sixteen unsigned 8-bit integer numbers).
+/// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical AND operation.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -1922,7 +1922,7 @@ pub unsafe fn __msa_bclr_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Immediate Bit Clear
 ///
 /// Clear (set to 0) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// The bit position is given by the immediate 'm' modulo the size of the element in bits.
+/// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
@@ -1941,7 +1941,7 @@ pub unsafe fn __msa_bclri_b(a: v16u8, imm3: i32) -> v16u8 {
 /// Immediate Bit Clear
 ///
 /// Clear (set to 0) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
-/// The bit position is given by the immediate 'm' modulo the size of the element in bits.
+/// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
@@ -1960,7 +1960,7 @@ pub unsafe fn __msa_bclri_h(a: v8u16, imm4: i32) -> v8u16 {
 /// Immediate Bit Clear
 ///
 /// Clear (set to 0) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
-/// The bit position is given by the immediate 'm' modulo the size of the element in bits.
+/// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
@@ -1979,7 +1979,7 @@ pub unsafe fn __msa_bclri_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Bit Clear
 ///
 /// Clear (set to 0) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
-/// The bit position is given by the immediate 'm' modulo the size of the element in bits.
+/// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
@@ -1998,9 +1998,9 @@ pub unsafe fn __msa_bclri_d(a: v2u64, imm6: i32) -> v2u64 {
 /// Vector Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (sixteen unsigned 8-bit integer numbers)
-/// to elements in vector 'a' (sixteen unsigned 8-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (sixteen unsigned 8-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (sixteen unsigned 8-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the elements in vector `c` (sixteen unsigned 8-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2012,9 +2012,9 @@ pub unsafe fn __msa_binsl_b(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 /// Vector Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (eight unsigned 16-bit integer numbers)
-/// to elements in vector 'a' (eight unsigned 16-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (eight unsigned 16-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (eight unsigned 16-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the elements in vector `c` (eight unsigned 16-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2026,9 +2026,9 @@ pub unsafe fn __msa_binsl_h(a: v8u16, b: v8u16, c: v8u16) -> v8u16 {
 /// Vector Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (four unsigned 32-bit integer numbers)
-/// to elements in vector 'a' (four unsigned 32-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (four unsigned 32-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (four unsigned 32-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the elements in vector `c` (four unsigned 32-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2040,9 +2040,9 @@ pub unsafe fn __msa_binsl_w(a: v4u32, b: v4u32, c: v4u32) -> v4u32 {
 /// Vector Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (two unsigned 64-bit integer numbers)
-/// to elements in vector 'a' (two unsigned 64-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (two unsigned 64-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (two unsigned 64-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the elements in vector `c` (two unsigned 64-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2054,8 +2054,8 @@ pub unsafe fn __msa_binsl_d(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
 /// Immediate Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (sixteen unsigned 8-bit integer numbers)
-/// to elements in vector 'a' (sixteen unsigned 8-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the immediate imm3 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (sixteen unsigned 8-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the immediate imm3 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2073,8 +2073,8 @@ pub unsafe fn __msa_binsli_b(a: v16u8, b: v16u8, imm3: i32) -> v16u8 {
 /// Immediate Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (eight unsigned 16-bit integer numbers)
-/// to elements in vector 'a' (eight unsigned 16-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the immediate imm4 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (eight unsigned 16-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the immediate imm4 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2092,8 +2092,8 @@ pub unsafe fn __msa_binsli_h(a: v8u16, b: v8u16, imm4: i32) -> v8u16 {
 /// Immediate Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (four unsigned 32-bit integer numbers)
-/// to elements in vector 'a' (four unsigned 32-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the immediate imm5 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (four unsigned 32-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the immediate imm5 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2111,8 +2111,8 @@ pub unsafe fn __msa_binsli_w(a: v4u32, b: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Bit Insert Left
 ///
 /// Copy most significant (left) bits in each element of vector `b` (two unsigned 64-bit integer numbers)
-/// to elements in vector 'a' (two unsigned 64-bit integer numbers) while preserving the least sig-nificant (right) bits.
-/// The number of bits to copy is given by the immediate imm6 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (two unsigned 64-bit integer numbers) while preserving the least significant (right) bits.
+/// The number of bits to copy is given by the immediate imm6 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2130,9 +2130,9 @@ pub unsafe fn __msa_binsli_d(a: v2u64, b: v2u64, imm6: i32) -> v2u64 {
 /// Vector Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (sixteen unsigned 8-bit integer numbers)
-/// to elements in vector 'a' (sixteen unsigned 8-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (sixteen unsigned 8-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (sixteen unsigned 8-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the elements in vector `c` (sixteen unsigned 8-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2144,9 +2144,9 @@ pub unsafe fn __msa_binsr_b(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 /// Vector Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (eight unsigned 16-bit integer numbers)
-/// to elements in vector 'a' (eight unsigned 16-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (eight unsigned 16-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (eight unsigned 16-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the elements in vector `c` (eight unsigned 16-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2158,9 +2158,9 @@ pub unsafe fn __msa_binsr_h(a: v8u16, b: v8u16, c: v8u16) -> v8u16 {
 /// Vector Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (four unsigned 32-bit integer numbers)
-/// to elements in vector 'a' (four unsigned 32-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (four unsigned 32-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (four unsigned 32-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the elements in vector `c` (four unsigned 32-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2172,9 +2172,9 @@ pub unsafe fn __msa_binsr_w(a: v4u32, b: v4u32, c: v4u32) -> v4u32 {
 /// Vector Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (two unsigned 64-bit integer numbers)
-/// to elements in vector 'a' (two unsigned 64-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the elements in vector 'c' (two unsigned 64-bit integer numbers)
-/// modulo the size of the element inbits plus 1.
+/// to elements in vector `a` (two unsigned 64-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the elements in vector `c` (two unsigned 64-bit integer numbers)
+/// modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2186,8 +2186,8 @@ pub unsafe fn __msa_binsr_d(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
 /// Immediate Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (sixteen unsigned 8-bit integer numbers)
-/// to elements in vector 'a' (sixteen unsigned 8-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the immediate imm3 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (sixteen unsigned 8-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the immediate imm3 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2205,8 +2205,8 @@ pub unsafe fn __msa_binsri_b(a: v16u8, b: v16u8, imm3: i32) -> v16u8 {
 /// Immediate Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (eight unsigned 16-bit integer numbers)
-/// to elements in vector 'a' (eight unsigned 16-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the immediate imm4 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (eight unsigned 16-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the immediate imm4 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2224,8 +2224,8 @@ pub unsafe fn __msa_binsri_h(a: v8u16, b: v8u16, imm4: i32) -> v8u16 {
 /// Immediate Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (four unsigned 32-bit integer numbers)
-/// to elements in vector 'a' (four unsigned 32-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the immediate imm5 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (four unsigned 32-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the immediate imm5 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2243,8 +2243,8 @@ pub unsafe fn __msa_binsri_w(a: v4u32, b: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Bit Insert Right
 ///
 /// Copy most significant (right) bits in each element of vector `b` (two unsigned 64-bit integer numbers)
-/// to elements in vector 'a' (two unsigned 64-bit integer numbers) while preserving the least sig-nificant (left) bits.
-/// The number of bits to copy is given by the immediate imm6 modulo the size of the element in bitsplus 1.
+/// to elements in vector `a` (two unsigned 64-bit integer numbers) while preserving the least significant (left) bits.
+/// The number of bits to copy is given by the immediate imm6 modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2261,8 +2261,8 @@ pub unsafe fn __msa_binsri_d(a: v2u64, b: v2u64, imm6: i32) -> v2u64 {
 
 /// Vector Bit Move If Not Zero
 ///
-/// Copy to destination vector 'a' (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// 'b' (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector 'c'
+/// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector `c`
 /// (sixteen unsigned 8-bit integer numbers)  are 1 and leaves unchanged all destination bits
 /// for which the corresponding target bits are 0.
 ///
@@ -2275,8 +2275,8 @@ pub unsafe fn __msa_bmnz_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 
 /// Immediate Bit Move If Not Zero
 ///
-/// Copy to destination vector 'a' (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// 'b' (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from  from immediate imm8
+/// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from  from immediate imm8
 /// are 1 and leaves unchanged all destination bits for which the corresponding target bits are 0.
 ///
 #[inline]
@@ -2294,8 +2294,8 @@ pub unsafe fn __msa_bmnzi_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 
 /// Vector Bit Move If Zero
 ///
-/// Copy to destination vector 'a' (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// 'b' (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector 'c'
+/// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector `c`
 /// (sixteen unsigned 8-bit integer numbers)  are 0 and leaves unchanged all destination bits
 /// for which the corresponding target bits are 1
 ///
@@ -2308,8 +2308,8 @@ pub unsafe fn __msa_bmz_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 
 /// Immediate Bit Move If Zero
 ///
-/// Copy to destination vector 'a' (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// 'b' (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from  from immediate imm8
+/// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from  from immediate imm8
 /// are 0 and leaves unchanged all destination bits for which the corresponding immediate bits are 1.
 ///
 #[inline]
@@ -2328,7 +2328,7 @@ pub unsafe fn __msa_bmzi_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 /// Vector Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (sixteen unsigned 8-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
 /// modulo thesize of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers)
 ///
@@ -2342,7 +2342,7 @@ pub unsafe fn __msa_bneg_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (eight unsigned 16-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (eight unsigned 16-bit integer numbers)
 /// modulo thesize of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers)
 ///
@@ -2356,7 +2356,7 @@ pub unsafe fn __msa_bneg_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (four unsigned 32-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (four unsigned 32-bit integer numbers)
 /// modulo thesize of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers)
 ///
@@ -2370,7 +2370,7 @@ pub unsafe fn __msa_bneg_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Bit Negate
 ///
 /// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (two unsigned 64-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (two unsigned 64-bit integer numbers)
 /// modulo thesize of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers)
 ///
@@ -2459,7 +2459,7 @@ pub unsafe fn __msa_bnegi_d(a: v2u64, imm6: i32) -> v2u64 {
 
 /// Immediate Branch If All Elements Are Not Zero
 ///
-/// PC-relative branch if all elements in 'a' (sixteen unsigned 8-bit integer numbers) are not zero.
+/// PC-relative branch if all elements in `a` (sixteen unsigned 8-bit integer numbers) are not zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2470,7 +2470,7 @@ pub unsafe fn __msa_bnz_b(a: v16u8) -> i32 {
 
 /// Immediate Branch If All Elements Are Not Zero
 ///
-/// PC-relative branch if all elements in 'a' (eight unsigned 16-bit integer numbers) are not zero.
+/// PC-relative branch if all elements in `a` (eight unsigned 16-bit integer numbers) are not zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2481,7 +2481,7 @@ pub unsafe fn __msa_bnz_h(a: v8u16) -> i32 {
 
 /// Immediate Branch If All Elements Are Not Zero
 ///
-/// PC-relative branch if all elements in 'a' (four unsigned 32-bit integer numbers) are not zero.
+/// PC-relative branch if all elements in `a` (four unsigned 32-bit integer numbers) are not zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2492,7 +2492,7 @@ pub unsafe fn __msa_bnz_w(a: v4u32) -> i32 {
 
 /// Immediate Branch If All Elements Are Not Zero
 ///
-/// PC-relative branch if all elements in 'a' (two unsigned 64-bit integer numbers) are not zero.
+/// PC-relative branch if all elements in `a` (two unsigned 64-bit integer numbers) are not zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2503,7 +2503,7 @@ pub unsafe fn __msa_bnz_d(a: v2u64) -> i32 {
 
 /// Immediate Branch If Not Zero (At Least One Element of Any Format Is Not Zero)
 ///
-/// PC-relative branch if at least one bit in 'a' (four unsigned 32-bit integer numbers) are not zero.
+/// PC-relative branch if at least one bit in `a` (four unsigned 32-bit integer numbers) are not zero.
 /// i.e at least one element is not zero regardless of the data format.
 ///
 #[inline]
@@ -2515,10 +2515,10 @@ pub unsafe fn __msa_bnz_v(a: v16u8) -> i32 {
 
 /// Vector Bit Select
 ///
-/// Selectively copy bits from the source vectors 'b' (eight unsigned 16-bit integer numbers)
-/// and 'c' (eight unsigned 16-bit integer numbers)
-/// into destination vector 'a' (eight unsigned 16-bit integer numbers) based on the corresponding bit in a:
-/// if 0 copies the bit from 'b', if 1 copies the bit from 'c'.
+/// Selectively copy bits from the source vectors `b` (eight unsigned 16-bit integer numbers)
+/// and `c` (eight unsigned 16-bit integer numbers)
+/// into destination vector `a` (eight unsigned 16-bit integer numbers) based on the corresponding bit in `a`:
+/// if 0 copies the bit from `b`, if 1 copies the bit from `c`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2529,9 +2529,9 @@ pub unsafe fn __msa_bsel_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 
 /// Immediate Bit Select
 ///
-/// Selectively copy bits from the 8-bit immediate imm8 and 'c' (eight unsigned 16-bit integer numbers)
-/// into destination vector 'a' (eight unsigned 16-bit integer numbers) based on the corresponding bit in a:
-/// if 0 copies the bit from 'b', if 1 copies the bit from 'c'.
+/// Selectively copy bits from the 8-bit immediate imm8 and `c` (eight unsigned 16-bit integer numbers)
+/// into destination vector `a` (eight unsigned 16-bit integer numbers) based on the corresponding bit in `a`:
+/// if 0 copies the bit from `b`, if 1 copies the bit from `c`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2549,7 +2549,7 @@ pub unsafe fn __msa_bseli_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 /// Vector Bit Set
 ///
 /// Set to 1 one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (sixteen unsigned 8-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers)
 ///
@@ -2563,7 +2563,7 @@ pub unsafe fn __msa_bset_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Bit Set
 ///
 /// Set to 1 one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (eight unsigned 16-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (eight unsigned 16-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers)
 ///
@@ -2577,7 +2577,7 @@ pub unsafe fn __msa_bset_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Bit Set
 ///
 /// Set to 1 one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (four unsigned 32-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (four unsigned 32-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers)
 ///
@@ -2591,7 +2591,7 @@ pub unsafe fn __msa_bset_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Bit Set
 ///
 /// Set to 1 one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
-/// The bit position is given by the elements in vector 'b' (two unsigned 64-bit integer numbers)
+/// The bit position is given by the elements in vector `b` (two unsigned 64-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers)
 ///
@@ -2606,7 +2606,7 @@ pub unsafe fn __msa_bset_d(a: v2u64, b: v2u64) -> v2u64 {
 ///
 /// Set to 1 one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// The bit position is given by immediate imm3.
-/// The result is written to vector 'a'(sixteen unsigned 8-bit integer numbers)
+/// The result is written to vector `a` (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2625,7 +2625,7 @@ pub unsafe fn __msa_bseti_b(a: v16u8, imm3: i32) -> v16u8 {
 ///
 /// Set to 1 one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
 /// The bit position is given by immediate imm4.
-/// The result is written to vector 'a'(eight unsigned 16-bit integer numbers)
+/// The result is written to vector `a` (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2644,7 +2644,7 @@ pub unsafe fn __msa_bseti_h(a: v8u16, imm4: i32) -> v8u16 {
 ///
 /// Set to 1 one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
 /// The bit position is given by immediate imm5.
-/// The result is written to vector 'a'(four unsigned 32-bit integer numbers)
+/// The result is written to vector `a` (four unsigned 32-bit integer numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2663,7 +2663,7 @@ pub unsafe fn __msa_bseti_w(a: v4u32, imm5: i32) -> v4u32 {
 ///
 /// Set to 1 one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
 /// The bit position is given by immediate imm6.
-/// The result is written to vector 'a'(two unsigned 64-bit integer numbers)
+/// The result is written to vector `a` (two unsigned 64-bit integer numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2680,7 +2680,7 @@ pub unsafe fn __msa_bseti_d(a: v2u64, imm6: i32) -> v2u64 {
 
 /// Immediate Branch If At Least One Element Is Zero
 ///
-/// PC-relative branch if at least one element in 'a' (sixteen unsigned 8-bit integer numbers) is zero.
+/// PC-relative branch if at least one element in `a` (sixteen unsigned 8-bit integer numbers) is zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2691,7 +2691,7 @@ pub unsafe fn __msa_bz_b(a: v16u8) -> i32 {
 
 /// Immediate Branch If At Least One Element Is Zero
 ///
-/// PC-relative branch if at least one element in 'a' (eight unsigned 16-bit integer numbers) is zero.
+/// PC-relative branch if at least one element in `a` (eight unsigned 16-bit integer numbers) is zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2702,7 +2702,7 @@ pub unsafe fn __msa_bz_h(a: v8u16) -> i32 {
 
 /// Immediate Branch If At Least One Element Is Zero
 ///
-/// PC-relative branch if at least one element in 'a' (four unsigned 32-bit integer numbers) is zero.
+/// PC-relative branch if at least one element in `a` (four unsigned 32-bit integer numbers) is zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2713,7 +2713,7 @@ pub unsafe fn __msa_bz_w(a: v4u32) -> i32 {
 
 /// Immediate Branch If At Least One Element Is Zero
 ///
-/// PC-relative branch if at least one element in 'a' (two unsigned 64-bit integer numbers) is zero.
+/// PC-relative branch if at least one element in `a` (two unsigned 64-bit integer numbers) is zero.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2724,7 +2724,7 @@ pub unsafe fn __msa_bz_d(a: v2u64) -> i32 {
 
 /// Immediate Branch If Zero (All Elements of Any Format Are Zero)
 ///
-/// PC-relative branch if all elements in 'a' (sixteen unsigned 8-bit integer numbers) bits are zero,
+/// PC-relative branch if all elements in `a` (sixteen unsigned 8-bit integer numbers) bits are zero,
 /// i.e. all elements are zero regardless of the data format
 ///
 #[inline]
@@ -2737,7 +2737,7 @@ pub unsafe fn __msa_bz_v(a: v16u8) -> i32 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen signed 8-bit integer numbers) and 'b'  (sixteen signed 8-bit integer numbers)
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) and `b`  (sixteen signed 8-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2750,7 +2750,7 @@ pub unsafe fn __msa_ceq_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight signed 16-bit integer numbers) and 'b'  (eight signed 16-bit integer numbers)
+/// if the corresponding `a` (eight signed 16-bit integer numbers) and `b`  (eight signed 16-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2763,7 +2763,7 @@ pub unsafe fn __msa_ceq_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four signed 32-bit integer numbers) and 'b'  (four signed 32-bit integer numbers)
+/// if the corresponding `a` (four signed 32-bit integer numbers) and `b`  (four signed 32-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2776,7 +2776,7 @@ pub unsafe fn __msa_ceq_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Compare Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two signed 64-bit integer numbers) and 'b'  (two signed 64-bit integer numbers)
+/// if the corresponding `a` (two signed 64-bit integer numbers) and `b`  (two signed 64-bit integer numbers)
 /// elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2789,7 +2789,7 @@ pub unsafe fn __msa_ceq_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Compare Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen signed 8-bit integer numbers) the 5-bit signed immediate imm_s5
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) the 5-bit signed immediate imm_s5
 /// are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2808,7 +2808,7 @@ pub unsafe fn __msa_ceqi_b(a: v16i8, imm_s5: i32) -> v16i8 {
 /// Immediate Compare Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight signed 16-bit integer numbers) the 5-bit signed immediate imm_s5
+/// if the corresponding `a` (eight signed 16-bit integer numbers) the 5-bit signed immediate imm_s5
 /// are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2827,7 +2827,7 @@ pub unsafe fn __msa_ceqi_h(a: v8i16, imm_s5: i32) -> v8i16 {
 /// Immediate Compare Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four signed 32-bit integer numbers) the 5-bit signed immediate imm_s5
+/// if the corresponding `a` (four signed 32-bit integer numbers) the 5-bit signed immediate imm_s5
 /// are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2846,7 +2846,7 @@ pub unsafe fn __msa_ceqi_w(a: v4i32, imm_s5: i32) -> v4i32 {
 /// Immediate Compare Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two signed 64-bit integer numbers) the 5-bit signed immediate imm_s5
+/// if the corresponding `a` (two signed 64-bit integer numbers) the 5-bit signed immediate imm_s5
 /// are equal, otherwise set all bits to 0.
 ///
 #[inline]
@@ -2883,8 +2883,8 @@ pub unsafe fn __msa_cfcmsa(imm5: i32) -> i32 {
 /// Vector Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen signed 8-bit integer numbers) element
-/// are signed less than or equal to 'b'  (sixteen signed 8-bit integer numbers) element.
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
+/// are signed less than or equal to `b`  (sixteen signed 8-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2897,8 +2897,8 @@ pub unsafe fn __msa_cle_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight signed 16-bit integer numbers) element
-/// are signed less than or equal to 'b'  (eight signed 16-bit integer numbers) element.
+/// if the corresponding `a` (eight signed 16-bit integer numbers) element
+/// are signed less than or equal to `b`  (eight signed 16-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2911,8 +2911,8 @@ pub unsafe fn __msa_cle_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four signed 32-bit integer numbers) element
-/// are signed less than or equal to 'b'  (four signed 32-bit integer numbers) element.
+/// if the corresponding `a` (four signed 32-bit integer numbers) element
+/// are signed less than or equal to `b`  (four signed 32-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2925,8 +2925,8 @@ pub unsafe fn __msa_cle_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two signed 64-bit integer numbers) element
-/// are signed less than or equal to 'b'  (two signed 64-bit integer numbers) element.
+/// if the corresponding `a` (two signed 64-bit integer numbers) element
+/// are signed less than or equal to `b`  (two signed 64-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2939,8 +2939,8 @@ pub unsafe fn __msa_cle_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen unsigned 8-bit integer numbers) element
-/// are unsigned less than or equal to 'b'  (sixteen unsigned 8-bit integer numbers) element.
+/// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
+/// are unsigned less than or equal to `b`  (sixteen unsigned 8-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2953,8 +2953,8 @@ pub unsafe fn __msa_cle_u_b(a: v16u8, b: v16u8) -> v16i8 {
 /// Vector Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight unsigned 16-bit integer numbers) element
-/// are unsigned less than or equal to 'b'  (eight unsigned 16-bit integer numbers) element.
+/// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
+/// are unsigned less than or equal to `b`  (eight unsigned 16-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2967,8 +2967,8 @@ pub unsafe fn __msa_cle_u_h(a: v8u16, b: v8u16) -> v8i16 {
 /// Vector Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four unsigned 32-bit integer numbers) element
-/// are unsigned less than or equal to 'b'  (four unsigned 32-bit integer numbers) element.
+/// if the corresponding `a` (four unsigned 32-bit integer numbers) element
+/// are unsigned less than or equal to `b`  (four unsigned 32-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2981,8 +2981,8 @@ pub unsafe fn __msa_cle_u_w(a: v4u32, b: v4u32) -> v4i32 {
 /// Vector Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two unsigned 64-bit integer numbers) element
-/// are unsigned less than or equal to 'b'  (two unsigned 64-bit integer numbers) element.
+/// if the corresponding `a` (two unsigned 64-bit integer numbers) element
+/// are unsigned less than or equal to `b`  (two unsigned 64-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -2995,7 +2995,7 @@ pub unsafe fn __msa_cle_u_d(a: v2u64, b: v2u64) -> v2i64 {
 /// Immediate Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen signed 8-bit integer numbers) element
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
 /// is less than or equal to the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3015,7 +3015,7 @@ pub unsafe fn __msa_clei_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 /// Immediate Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight signed 16-bit integer numbers) element
+/// if the corresponding `a` (eight signed 16-bit integer numbers) element
 /// is less than or equal to the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3035,7 +3035,7 @@ pub unsafe fn __msa_clei_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 /// Immediate Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four signed 32-bit integer numbers) element
+/// if the corresponding `a` (four signed 32-bit integer numbers) element
 /// is less than or equal to the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3055,7 +3055,7 @@ pub unsafe fn __msa_clei_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 /// Immediate Compare Signed Less Than or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two signed 64-bit integer numbers) element
+/// if the corresponding `a` (two signed 64-bit integer numbers) element
 /// is less than or equal to the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3075,7 +3075,7 @@ pub unsafe fn __msa_clei_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 /// Immediate Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen unsigned 8-bit integer numbers) element
+/// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
 /// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3095,7 +3095,7 @@ pub unsafe fn __msa_clei_u_b(a: v16u8, imm5: i32) -> v16i8 {
 /// Immediate Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight unsigned 16-bit integer numbers) element
+/// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
 /// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3115,7 +3115,7 @@ pub unsafe fn __msa_clei_u_h(a: v8u16, imm5: i32) -> v8i16 {
 /// Immediate Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four unsigned 32-bit integer numbers) element
+/// if the corresponding `a` (four unsigned 32-bit integer numbers) element
 /// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3135,7 +3135,7 @@ pub unsafe fn __msa_clei_u_w(a: v4u32, imm5: i32) -> v4i32 {
 /// Immediate Compare Unsigned Less Than or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two unsigned 64-bit integer numbers) element
+/// if the corresponding `a` (two unsigned 64-bit integer numbers) element
 /// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3155,8 +3155,8 @@ pub unsafe fn __msa_clei_u_d(a: v2u64, imm5: i32) -> v2i64 {
 /// Vector Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen signed 8-bit integer numbers) element
-/// are signed less than 'b'  (sixteen signed 8-bit integer numbers) element.
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
+/// are signed less than `b`  (sixteen signed 8-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3169,8 +3169,8 @@ pub unsafe fn __msa_clt_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight signed 16-bit integer numbers) element
-/// are signed less than 'b'  (eight signed 16-bit integer numbers) element.
+/// if the corresponding `a` (eight signed 16-bit integer numbers) element
+/// are signed less than `b`  (eight signed 16-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3183,8 +3183,8 @@ pub unsafe fn __msa_clt_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four signed 32-bit integer numbers) element
-/// are signed less than 'b'  (four signed 32-bit integer numbers) element.
+/// if the corresponding `a` (four signed 32-bit integer numbers) element
+/// are signed less than `b`  (four signed 32-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3197,8 +3197,8 @@ pub unsafe fn __msa_clt_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two signed 64-bit integer numbers) element
-/// are signed less than 'b'  (two signed 64-bit integer numbers) element.
+/// if the corresponding `a` (two signed 64-bit integer numbers) element
+/// are signed less than `b`  (two signed 64-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3211,8 +3211,8 @@ pub unsafe fn __msa_clt_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen unsigned 8-bit integer numbers) element
-/// are unsigned less than 'b'  (sixteen unsigned 8-bit integer numbers) element.
+/// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
+/// are unsigned less than `b`  (sixteen unsigned 8-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3225,8 +3225,8 @@ pub unsafe fn __msa_clt_u_b(a: v16u8, b: v16u8) -> v16i8 {
 /// Vector Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight unsigned 16-bit integer numbers) element
-/// are unsigned less than 'b'  (eight unsigned 16-bit integer numbers) element.
+/// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
+/// are unsigned less than `b`  (eight unsigned 16-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3239,8 +3239,8 @@ pub unsafe fn __msa_clt_u_h(a: v8u16, b: v8u16) -> v8i16 {
 /// Vector Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four unsigned 32-bit integer numbers) element
-/// are unsigned less than 'b'  (four unsigned 32-bit integer numbers) element.
+/// if the corresponding `a` (four unsigned 32-bit integer numbers) element
+/// are unsigned less than `b`  (four unsigned 32-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3253,8 +3253,8 @@ pub unsafe fn __msa_clt_u_w(a: v4u32, b: v4u32) -> v4i32 {
 /// Vector Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two unsigned 64-bit integer numbers) element
-/// are unsigned less than 'b'  (two unsigned 64-bit integer numbers) element.
+/// if the corresponding `a` (two unsigned 64-bit integer numbers) element
+/// are unsigned less than `b`  (two unsigned 64-bit integer numbers) element.
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3267,7 +3267,7 @@ pub unsafe fn __msa_clt_u_d(a: v2u64, b: v2u64) -> v2i64 {
 /// Immediate Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen signed 8-bit integer numbers) element
+/// if the corresponding `a` (sixteen signed 8-bit integer numbers) element
 /// is less than the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3287,7 +3287,7 @@ pub unsafe fn __msa_clti_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 /// Immediate Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight signed 16-bit integer numbers) element
+/// if the corresponding `a` (eight signed 16-bit integer numbers) element
 /// is less than the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3307,7 +3307,7 @@ pub unsafe fn __msa_clti_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 /// Immediate Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four signed 32-bit integer numbers) element
+/// if the corresponding `a` (four signed 32-bit integer numbers) element
 /// is less than the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3327,7 +3327,7 @@ pub unsafe fn __msa_clti_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 /// Immediate Compare Signed Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two signed 64-bit integer numbers) element
+/// if the corresponding `a` (two signed 64-bit integer numbers) element
 /// is less than the 5-bit signed immediate imm_s5,
 /// otherwise set all bits to 0.
 ///
@@ -3347,7 +3347,7 @@ pub unsafe fn __msa_clti_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 /// Immediate Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
-/// if the corresponding 'a' (sixteen unsigned 8-bit integer numbers) element
+/// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
 /// is unsigned less than the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3367,7 +3367,7 @@ pub unsafe fn __msa_clti_u_b(a: v16u8, imm5: i32) -> v16i8 {
 /// Immediate Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
-/// if the corresponding 'a' (eight unsigned 16-bit integer numbers) element
+/// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
 /// is unsigned less than the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3387,7 +3387,7 @@ pub unsafe fn __msa_clti_u_h(a: v8u16, imm5: i32) -> v8i16 {
 /// Immediate Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four unsigned 32-bit integer numbers) element
+/// if the corresponding `a` (four unsigned 32-bit integer numbers) element
 /// is unsigned less than the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3407,7 +3407,7 @@ pub unsafe fn __msa_clti_u_w(a: v4u32, imm5: i32) -> v4i32 {
 /// Immediate Compare Unsigned Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two unsigned 64-bit integer numbers) element
+/// if the corresponding `a` (two unsigned 64-bit integer numbers) element
 /// is unsigned less than the 5-bit unsigned immediate imm5,
 /// otherwise set all bits to 0.
 ///
@@ -3426,7 +3426,7 @@ pub unsafe fn __msa_clti_u_d(a: v2u64, imm5: i32) -> v2i64 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm4 of vector 'a' (sixteen signed 8-bit integer numbers)
+/// Sign-extend element imm4 of vector `a` (sixteen signed 8-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3444,7 +3444,7 @@ pub unsafe fn __msa_copy_s_b(a: v16i8, imm4: i32) -> i32 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm3 of vector 'a' (eight signed 16-bit integer numbers)
+/// Sign-extend element imm3 of vector `a` (eight signed 16-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3462,7 +3462,7 @@ pub unsafe fn __msa_copy_s_h(a: v8i16, imm3: i32) -> i32 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm2 of vector 'a' (four signed 32-bit integer numbers)
+/// Sign-extend element imm2 of vector `a` (four signed 32-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3480,7 +3480,7 @@ pub unsafe fn __msa_copy_s_w(a: v4i32, imm2: i32) -> i32 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm1 of vector 'a' (two signed 64-bit integer numbers)
+/// Sign-extend element imm1 of vector `a` (two signed 64-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3498,7 +3498,7 @@ pub unsafe fn __msa_copy_s_d(a: v2i64, imm1: i32) -> i64 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm4 of vector 'a' (sixteen signed 8-bit integer numbers)
+/// Zero-extend element imm4 of vector `a` (sixteen signed 8-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3516,7 +3516,7 @@ pub unsafe fn __msa_copy_u_b(a: v16i8, imm4: i32) -> u32 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm3 of vector 'a' (eight signed 16-bit integer numbers)
+/// Zero-extend element imm3 of vector `a` (eight signed 16-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3534,7 +3534,7 @@ pub unsafe fn __msa_copy_u_h(a: v8i16, imm3: i32) -> u32 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm2 of vector 'a' (four signed 32-bit integer numbers)
+/// Zero-extend element imm2 of vector `a` (four signed 32-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3552,7 +3552,7 @@ pub unsafe fn __msa_copy_u_w(a: v4i32, imm2: i32) -> u32 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm1 of vector 'a' (two signed 64-bit integer numbers)
+/// Zero-extend element imm1 of vector `a` (two signed 64-bit integer numbers)
 /// and copy the result to GPR rd
 ///
 #[inline]
@@ -3587,8 +3587,8 @@ pub unsafe fn __msa_ctcmsa(imm5: i32, a: i32) -> () {
 
 /// Vector Signed Divide
 ///
-/// The signed integer elements in vector 'a' (sixteen signed 8-bit integer numbers)
-/// are divided by signed integer elements in vector 'b' (sixteen signed 8-bit integer numbers).
+/// The signed integer elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -3600,8 +3600,8 @@ pub unsafe fn __msa_div_s_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Signed Divide
 ///
-/// The signed integer elements in vector 'a' (eight signed 16-bit integer numbers)
-/// are divided by signed integer elements in vector 'b' (eight signed 16-bit integer numbers).
+/// The signed integer elements in vector `a` (eight signed 16-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -3613,8 +3613,8 @@ pub unsafe fn __msa_div_s_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Signed Divide
 ///
-/// The signed integer elements in vector 'a' (four signed 32-bit integer numbers)
-/// are divided by signed integer elements in vector 'b' (four signed 32-bit integer numbers).
+/// The signed integer elements in vector `a` (four signed 32-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -3626,8 +3626,8 @@ pub unsafe fn __msa_div_s_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Signed Divide
 ///
-/// The signed integer elements in vector 'a' (two signed 64-bit integer numbers)
-/// are divided by signed integer elements in vector 'b' (two signed 64-bit integer numbers).
+/// The signed integer elements in vector `a` (two signed 64-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (two signed 64-bit integer numbers).
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -3639,8 +3639,8 @@ pub unsafe fn __msa_div_s_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Unsigned Divide
 ///
-/// The unsigned integer elements in vector 'a' (sixteen unsigned 8-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b' (sixteen unsigned 8-bit integer numbers).
+/// The unsigned integer elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers).
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
@@ -3652,8 +3652,8 @@ pub unsafe fn __msa_div_u_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Unsigned Divide
 ///
-/// The unsigned integer elements in vector 'a' (eight unsigned 16-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b' (eight unsigned 16-bit integer numbers).
+/// The unsigned integer elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers).
 /// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
@@ -3665,8 +3665,8 @@ pub unsafe fn __msa_div_u_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Unsigned Divide
 ///
-/// The unsigned integer elements in vector 'a' (four unsigned 32-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b' (four unsigned 32-bit integer numbers).
+/// The unsigned integer elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers).
 /// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
@@ -3678,8 +3678,8 @@ pub unsafe fn __msa_div_u_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Unsigned Divide
 ///
-/// The unsigned integer elements in vector 'a' (two unsigned 64-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b' (two unsigned 64-bit integer numbers).
+/// The unsigned integer elements in vector `a` (two unsigned 64-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (two unsigned 64-bit integer numbers).
 /// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
@@ -3691,8 +3691,8 @@ pub unsafe fn __msa_div_u_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Vector Signed Dot Product
 ///
-/// The signed integer elements in vector 'a' (sixteen signed 8-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'b' (sixteen signed 8-bit integer numbers).
+/// The signed integer elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are multiplied by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers).
 /// producing a result the size of the input operands. The multiplication resultsof
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (eight signed 16-bit integer numbers).
@@ -3706,8 +3706,8 @@ pub unsafe fn __msa_dotp_s_h(a: v16i8, b: v16i8) -> v8i16 {
 
 /// Vector Signed Dot Product
 ///
-/// The signed integer elements in vector 'a' (eight signed 16-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'b' (eight signed 16-bit integer numbers).
+/// The signed integer elements in vector `a` (eight signed 16-bit integer numbers)
+/// are multiplied by signed integer elements in vector `b` (eight signed 16-bit integer numbers).
 /// producing a result the size of the input operands. The multiplication resultsof
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (four signed 32-bit integer numbers).
@@ -3721,8 +3721,8 @@ pub unsafe fn __msa_dotp_s_w(a: v8i16, b: v8i16) -> v4i32 {
 
 /// Vector Signed Dot Product
 ///
-/// The signed integer elements in vector 'a' (four signed 32-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'b' (four signed 32-bit integer numbers).
+/// The signed integer elements in vector `a` (four signed 32-bit integer numbers)
+/// are multiplied by signed integer elements in vector `b` (four signed 32-bit integer numbers).
 /// producing a result the size of the input operands. The multiplication resultsof
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (two signed 64-bit integer numbers).
@@ -3736,8 +3736,8 @@ pub unsafe fn __msa_dotp_s_d(a: v4i32, b: v4i32) -> v2i64 {
 
 /// Vector Unsigned Dot Product
 ///
-/// The unsigned integer elements in vector 'a' (sixteen unsigned 8-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'b' (sixteen unsigned 8-bit integer numbers).
+/// The unsigned integer elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers).
 /// producing a result the size of the input operands. The multiplication resultsof
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (eight unsigned 16-bit integer numbers).
@@ -3751,8 +3751,8 @@ pub unsafe fn __msa_dotp_u_h(a: v16u8, b: v16u8) -> v8u16 {
 
 /// Vector Unsigned Dot Product
 ///
-/// The unsigned integer elements in vector 'a' (eight unsigned 16-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'b' (eight unsigned 16-bit integer numbers).
+/// The unsigned integer elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers).
 /// producing a result the size of the input operands. The multiplication resultsof
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (four unsigned 32-bit integer numbers).
@@ -3766,8 +3766,8 @@ pub unsafe fn __msa_dotp_u_w(a: v8u16, b: v8u16) -> v4u32 {
 
 /// Vector Unsigned Dot Product
 ///
-/// The unsigned integer elements in vector 'a' (four unsigned 32-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'b' (four unsigned 32-bit integer numbers).
+/// The unsigned integer elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers).
 /// producing a result the size of the input operands. The multiplication resultsof
 /// adjacent odd/even elements are added and stored to the destination
 /// vector (two unsigned 64-bit integer numbers).
@@ -3781,10 +3781,10 @@ pub unsafe fn __msa_dotp_u_d(a: v4u32, b: v4u32) -> v2u64 {
 
 /// Vector Signed Dot Product and Add
 ///
-/// The signed integer elements in vector 'b' (sixteen signed 8-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'c' (sixteen signed 8-bit integer numbers).
+/// The signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are multiplied by signed integer elements in vector `c` (sixteen signed 8-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are added to the vector 'a' (eight signed 16-bit integer numbers).
+/// of adjacent odd/even elements are added to the vector `a` (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3795,10 +3795,10 @@ pub unsafe fn __msa_dpadd_s_h(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
 
 /// Vector Signed Dot Product and Add
 ///
-/// The signed integer elements in vector 'b' (eight signed 16-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'c' (eight signed 16-bit integer numbers).
+/// The signed integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// are multiplied by signed integer elements in vector `c` (eight signed 16-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are added to the vector 'a' (four signed 32-bit integer numbers).
+/// of adjacent odd/even elements are added to the vector `a` (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3809,10 +3809,10 @@ pub unsafe fn __msa_dpadd_s_w(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
 
 /// Vector Signed Dot Product and Add
 ///
-/// The signed integer elements in vector 'b' (four signed 32-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'c' (four signed 32-bit integer numbers).
+/// The signed integer elements in vector `b` (four signed 32-bit integer numbers)
+/// are multiplied by signed integer elements in vector `c` (four signed 32-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are added to the vector 'a' (two signed 64-bit integer numbers).
+/// of adjacent odd/even elements are added to the vector `a` (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3823,10 +3823,10 @@ pub unsafe fn __msa_dpadd_s_d(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
 
 /// Vector Unsigned Dot Product and Add
 ///
-/// The unsigned integer elements in vector 'b' (sixteen unsigned 8-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'c' (sixteen unsigned 8-bit integer numbers).
+/// The unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `c` (sixteen unsigned 8-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are added to the vector 'a' (eight unsigned 16-bit integer numbers).
+/// of adjacent odd/even elements are added to the vector `a` (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3837,10 +3837,10 @@ pub unsafe fn __msa_dpadd_u_h(a: v8u16, b: v16u8, c: v16u8) -> v8u16 {
 
 /// Vector Unsigned Dot Product and Add
 ///
-/// The unsigned integer elements in vector 'b' (eight unsigned 16-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'c' (eight unsigned 16-bit integer numbers).
+/// The unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `c` (eight unsigned 16-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are added to the vector 'a' (four unsigned 32-bit integer numbers).
+/// of adjacent odd/even elements are added to the vector `a` (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3851,10 +3851,10 @@ pub unsafe fn __msa_dpadd_u_w(a: v4u32, b: v8u16, c: v8u16) -> v4u32 {
 
 /// Vector Unsigned Dot Product and Add
 ///
-/// The unsigned integer elements in vector 'b' (four unsigned 32-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'c' (four unsigned 32-bit integer numbers).
+/// The unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `c` (four unsigned 32-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are added to the vector 'a' (two unsigned 64-bit integer numbers).
+/// of adjacent odd/even elements are added to the vector `a` (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3865,10 +3865,10 @@ pub unsafe fn __msa_dpadd_u_d(a: v2u64, b: v4u32, c: v4u32) -> v2u64 {
 
 /// Vector Signed Dot Product and Add
 ///
-/// The signed integer elements in vector 'b' (sixteen signed 8-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'c' (sixteen signed 8-bit integer numbers).
+/// The signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are multiplied by signed integer elements in vector `c` (sixteen signed 8-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are sub-tracted from the integer elements in vector 'a'
+/// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -3880,10 +3880,10 @@ pub unsafe fn __msa_dpsub_s_h(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
 
 /// Vector Signed Dot Product and Add
 ///
-/// The signed integer elements in vector 'b' (eight signed 16-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'c' (eight signed 16-bit integer numbers).
+/// The signed integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// are multiplied by signed integer elements in vector `c` (eight signed 16-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are sub-tracted from the integer elements in vector 'a'
+/// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -3895,10 +3895,10 @@ pub unsafe fn __msa_dpsub_s_w(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
 
 /// Vector Signed Dot Product and Add
 ///
-/// The signed integer elements in vector 'b' (four signed 32-bit integer numbers)
-/// are multiplied by signed integer elements in vector 'c' (four signed 32-bit integer numbers).
+/// The signed integer elements in vector `b` (four signed 32-bit integer numbers)
+/// are multiplied by signed integer elements in vector `c` (four signed 32-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are sub-tracted from the integer elements in vector 'a'
+/// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -3910,10 +3910,10 @@ pub unsafe fn __msa_dpsub_s_d(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
 
 /// Vector Unsigned Dot Product and Add
 ///
-/// The unsigned integer elements in vector 'b' (sixteen unsigned 8-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'c' (sixteen unsigned 8-bit integer numbers).
+/// The unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `c` (sixteen unsigned 8-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are sub-tracted from the integer elements in vector 'a'
+/// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -3925,10 +3925,10 @@ pub unsafe fn __msa_dpsub_u_h(a: v8i16, b: v16u8, c: v16u8) -> v8i16 {
 
 /// Vector Unsigned Dot Product and Add
 ///
-/// The unsigned integer elements in vector 'b' (eight unsigned 16-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'c' (eight unsigned 16-bit integer numbers).
+/// The unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `c` (eight unsigned 16-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are sub-tracted from the integer elements in vector 'a'
+/// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -3940,10 +3940,10 @@ pub unsafe fn __msa_dpsub_u_w(a: v4i32, b: v8u16, c: v8u16) -> v4i32 {
 
 /// Vector Unsigned Dot Product and Add
 ///
-/// The unsigned integer elements in vector 'b' (four unsigned 32-bit integer numbers)
-/// are multiplied by unsigned integer elements in vector 'c' (four unsigned 32-bit integer numbers).
+/// The unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers)
+/// are multiplied by unsigned integer elements in vector `c` (four unsigned 32-bit integer numbers).
 /// producing a result twice the size of the input operands. The multiplication results
-/// of adjacent odd/even elements are sub-tracted from the integer elements in vector 'a'
+/// of adjacent odd/even elements are subtracted from the integer elements in vector `a`
 /// (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -3955,8 +3955,8 @@ pub unsafe fn __msa_dpsub_u_d(a: v2i64, b: v4u32, c: v4u32) -> v2i64 {
 
 /// Vector Floating-Point Addition
 ///
-/// The floating-point elements in vector 'a' (four 32-bit floating point numbers)
-/// are added to the floating-point elements in 'bc' (four 32-bit floating point numbers).
+/// The floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// are added to the floating-point elements in `bc` (four 32-bit floating point numbers).
 /// The result is written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -3968,8 +3968,8 @@ pub unsafe fn __msa_fadd_w(a: v4f32, b: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Addition
 ///
-/// The floating-point elements in vector 'a' (two 64-bit floating point numbers)
-/// are added to the floating-point elements in 'bc' (two 64-bit floating point numbers).
+/// The floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// are added to the floating-point elements in `bc` (two 64-bit floating point numbers).
 /// The result is written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -3982,8 +3982,8 @@ pub unsafe fn __msa_fadd_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Quiet Compare Always False
 ///
 /// Set all bits to 0 in vector (four signed 32-bit integer numbers)
-/// Signaling NaN elements in 'a' (four 32-bit floating point numbers)
-/// or 'b' (four 32-bit floating point numbers)signal Invalid Operation exception.
+/// Signaling NaN elements in `a` (four 32-bit floating point numbers)
+/// or `b` (four 32-bit floating point numbers)signal Invalid Operation exception.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3995,8 +3995,8 @@ pub unsafe fn __msa_fcaf_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Always False
 ///
 /// Set all bits to 0 in vector (two signed 64-bit integer numbers)
-/// Signaling NaN elements in 'a' (two 64-bit floating point numbers)
-/// or 'b' (two 64-bit floating point numbers) signal Invalid Operation exception.
+/// Signaling NaN elements in `a` (two 64-bit floating point numbers)
+/// or `b` (two 64-bit floating point numbers) signal Invalid Operation exception.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4008,8 +4008,8 @@ pub unsafe fn __msa_fcaf_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding in 'a' (four 32-bit floating point numbers)
-/// and 'b' (four 32-bit floating point numbers)elements are ordered and equal,
+/// elements if the corresponding in `a` (four 32-bit floating point numbers)
+/// and `b` (four 32-bit floating point numbers)elements are ordered and equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4022,8 +4022,8 @@ pub unsafe fn __msa_fceq_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding in 'a' (two 64-bit floating point numbers)
-/// and 'b' (two 64-bit floating point numbers) elementsare ordered and equal,
+/// elements if the corresponding in `a` (two 64-bit floating point numbers)
+/// and `b` (two 64-bit floating point numbers) elementsare ordered and equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4037,7 +4037,7 @@ pub unsafe fn __msa_fceq_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// Store in each element of vector (four signed 32-bit integer numbers)
 /// a bit mask reflecting the floating-point class of the corresponding element of vector
-/// 'a' (four 32-bit floating point numbers).
+/// `a` (four 32-bit floating point numbers).
 /// The mask has 10 bits as follows. Bits 0 and 1 indicate NaN values: signaling NaN (bit 0) and quiet NaN (bit 1).
 /// Bits 2, 3, 4, 5 classify  negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
 /// Bits 6, 7, 8, 9classify positive values:infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
@@ -4053,7 +4053,7 @@ pub unsafe fn __msa_fclass_w(a: v4f32) -> v4i32 {
 ///
 /// Store in each element of vector (wto signed 64-bit integer numbers)
 /// a bit mask reflecting the floating-point class of the corresponding element of vector
-/// 'a' (wto 64-bit floating point numbers).
+/// `a` (wto 64-bit floating point numbers).
 /// The mask has 10 bits as follows. Bits 0 and 1 indicate NaN values: signaling NaN (bit 0) and quiet NaN (bit 1).
 /// Bits 2, 3, 4, 5 classify  negative values: infinity (bit 2), normal (bit 3), subnormal (bit 4), and zero (bit 5).
 /// Bits 6, 7, 8, 9classify positive values:infinity (bit 6), normal (bit 7), subnormal (bit 8), and zero (bit 9).
@@ -4068,8 +4068,8 @@ pub unsafe fn __msa_fclass_d(a: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Less or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)elements are ordered
-/// and either less than or equal to 'b' (four 32-bit floating point numbers)elements
+/// elements if the corresponding `a` (four 32-bit floating point numbers)elements are ordered
+/// and either less than or equal to `b` (four 32-bit floating point numbers)elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4082,8 +4082,8 @@ pub unsafe fn __msa_fcle_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Less or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers) elementsare ordered
-/// and either less than or equal to 'b' (two 64-bit floating point numbers) elements
+/// elements if the corresponding `a` (two 64-bit floating point numbers) elementsare ordered
+/// and either less than or equal to `b` (two 64-bit floating point numbers) elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4096,8 +4096,8 @@ pub unsafe fn __msa_fcle_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)elements are ordered
-/// and less than 'b' (four 32-bit floating point numbers)elements
+/// elements if the corresponding `a` (four 32-bit floating point numbers)elements are ordered
+/// and less than `b` (four 32-bit floating point numbers)elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4110,8 +4110,8 @@ pub unsafe fn __msa_fclt_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers) elementsare ordered
-/// and less than 'b' (two 64-bit floating point numbers) elements
+/// elements if the corresponding `a` (two 64-bit floating point numbers) elementsare ordered
+/// and less than `b` (two 64-bit floating point numbers) elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4124,8 +4124,8 @@ pub unsafe fn __msa_fclt_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Not Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are ordered and not equal
+/// elements if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are ordered and not equal
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4138,8 +4138,8 @@ pub unsafe fn __msa_fcne_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Not Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare ordered and not equal
+/// elements if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare ordered and not equal
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4152,8 +4152,8 @@ pub unsafe fn __msa_fcne_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Ordered
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are ordered, i.e. both elementsare not NaN values,
+/// elements if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are ordered, i.e. both elementsare not NaN values,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4166,8 +4166,8 @@ pub unsafe fn __msa_fcor_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Ordered
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare ordered, i.e. both elementsare not NaN values,
+/// elements if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare ordered, i.e. both elementsare not NaN values,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4180,8 +4180,8 @@ pub unsafe fn __msa_fcor_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Unordered or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are unordered or equal,
+/// elements if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4194,8 +4194,8 @@ pub unsafe fn __msa_fcueq_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Unordered or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare unordered or equal,
+/// elements if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4208,8 +4208,8 @@ pub unsafe fn __msa_fcueq_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Unordered or Less or Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding elements in 'a' (four 32-bit floating point numbers)
-/// are unordered or less than or equal to 'b' (four 32-bit floating point numbers)elements,
+/// elements if the corresponding elements in `a` (four 32-bit floating point numbers)
+/// are unordered or less than or equal to `b` (four 32-bit floating point numbers)elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4222,8 +4222,8 @@ pub unsafe fn __msa_fcule_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Unordered or Less or Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding elements in 'a' (two 64-bit floating point numbers)
-/// are unordered or less than or equal to 'b' (two 64-bit floating point numbers) elements,
+/// elements if the corresponding elements in `a` (two 64-bit floating point numbers)
+/// are unordered or less than or equal to `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4236,8 +4236,8 @@ pub unsafe fn __msa_fcule_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Unordered or Less Than
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding elements in 'a' (four 32-bit floating point numbers)
-/// are unordered or less than 'b' (four 32-bit floating point numbers)elements,
+/// elements if the corresponding elements in `a` (four 32-bit floating point numbers)
+/// are unordered or less than `b` (four 32-bit floating point numbers)elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4250,8 +4250,8 @@ pub unsafe fn __msa_fcult_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Unordered or Less Than
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding elements in 'a' (two 64-bit floating point numbers)
-/// are unordered or less than 'b' (two 64-bit floating point numbers) elements,
+/// elements if the corresponding elements in `a` (two 64-bit floating point numbers)
+/// are unordered or less than `b` (two 64-bit floating point numbers) elements,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4264,8 +4264,8 @@ pub unsafe fn __msa_fcult_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Unordered
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)
-/// and 'b' (four 32-bit floating point numbers)elements are unordered,
+/// elements if the corresponding `a` (four 32-bit floating point numbers)
+/// and `b` (four 32-bit floating point numbers)elements are unordered,
 /// i.e. at least oneelement is a NaN value, otherwise set all bits to 0.
 ///
 #[inline]
@@ -4278,8 +4278,8 @@ pub unsafe fn __msa_fcun_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Unordered
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers)
-/// and 'b' (two 64-bit floating point numbers) elementsare unordered,
+/// elements if the corresponding `a` (two 64-bit floating point numbers)
+/// and `b` (two 64-bit floating point numbers) elementsare unordered,
 /// i.e. at least oneelement is a NaN value, otherwise set all bits to 0.
 ///
 #[inline]
@@ -4292,8 +4292,8 @@ pub unsafe fn __msa_fcun_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Quiet Compare Unordered or Not Equal
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers)
-/// elements if the corresponding 'a' (four 32-bit floating point numbers)
-/// and 'b' (four 32-bit floating point numbers)elements are unordered or not equal,
+/// elements if the corresponding `a` (four 32-bit floating point numbers)
+/// and `b` (four 32-bit floating point numbers)elements are unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4306,8 +4306,8 @@ pub unsafe fn __msa_fcune_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Quiet Compare Unordered or Not Equal
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers)
-/// elements if the corresponding 'a' (two 64-bit floating point numbers)
-/// and 'b' (two 64-bit floating point numbers) elementsare unordered or not equal,
+/// elements if the corresponding `a` (two 64-bit floating point numbers)
+/// and `b` (two 64-bit floating point numbers) elementsare unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -4319,8 +4319,8 @@ pub unsafe fn __msa_fcune_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Division
 ///
-/// The floating-point elements in vector 'a' (four 32-bit floating point numbers)
-/// are divided by the floating-point elements in vector 'b' (four 32-bit floating point numbers)
+/// The floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// are divided by the floating-point elements in vector `b` (four 32-bit floating point numbers)
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
@@ -4332,8 +4332,8 @@ pub unsafe fn __msa_fdiv_w(a: v4f32, b: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Division
 ///
-/// The floating-point elements in vector 'a' (two 64-bit floating point numbers)
-/// are divided by the floating-point elements in vector 'b' (two 64-bit floating point numbers)
+/// The floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// are divided by the floating-point elements in vector `b` (two 64-bit floating point numbers)
 /// The result is written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
@@ -4346,8 +4346,8 @@ pub unsafe fn __msa_fdiv_d(a: v2f64, b: v2f64) -> v2f64 {
 /* FIXME: 16-bit float
 /// Vector Floating-Point Down-Convert Interchange Format
 ///
-/// The floating-point elements in vector 'a' (four 64-bit floating point numbers)
-/// and  vector 'b' (four 64-bit floating point numbers)  are down-converted
+/// The floating-point elements in vector `a` (four 64-bit floating point numbers)
+/// and  vector `b` (four 64-bit floating point numbers)  are down-converted
 /// to a smaller interchange format, i.e. from 64-bitto 32-bit, or from 32-bit to 16-bit.
 /// The result is written to vector (8 16-bit floating point numbers).
 ///
@@ -4360,8 +4360,8 @@ pub unsafe fn __msa_fexdo_h(a: v4f32, b: v4f32) -> f16x8 {
 
 /// Vector Floating-Point Down-Convert Interchange Format
 ///
-/// The floating-point elements in vector 'a' (two 64-bit floating point numbers)
-/// and  vector 'b' (two 64-bit floating point numbers)  are down-converted
+/// The floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// and  vector `b` (two 64-bit floating point numbers)  are down-converted
 /// to a smaller interchange format, i.e. from 64-bitto 32-bit, or from 32-bit to 16-bit.
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
@@ -4374,8 +4374,8 @@ pub unsafe fn __msa_fexdo_w(a: v2f64, b: v2f64) -> v4f32 {
 
 /// Vector Floating-Point Down-Convert Interchange Format
 ///
-/// The floating-point elements in vector 'a' (four 32-bit floating point numbers)
-/// are scaled, i.e. multiplied, by 2 to the power of integer elements in vector 'b'
+/// The floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// are scaled, i.e. multiplied, by 2 to the power of integer elements in vector `b`
 /// (four signed 32-bit integer numbers).
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
@@ -4388,8 +4388,8 @@ pub unsafe fn __msa_fexp2_w(a: v4f32, b: v4i32) -> v4f32 {
 
 /// Vector Floating-Point Down-Convert Interchange Format
 ///
-/// The floating-point elements in vector 'a' (two 64-bit floating point numbers)
-/// are scaled, i.e. multiplied, by 2 to the power of integer elements in vector 'b'
+/// The floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// are scaled, i.e. multiplied, by 2 to the power of integer elements in vector `b`
 /// (two signed 64-bit integer numbers).
 /// The result is written to vector (two 64-bit floating point numbers).
 ///
@@ -4403,7 +4403,7 @@ pub unsafe fn __msa_fexp2_d(a: v2f64, b: v2i64) -> v2f64 {
 /* FIXME: 16-bit float
 /// Vector Floating-Point Up-Convert Interchange Format Left
 ///
-/// The left half floating-point elements in vector 'a' (two 16-bit floating point numbers)
+/// The left half floating-point elements in vector `a` (two 16-bit floating point numbers)
 /// are up-converted to a larger interchange format,
 /// i.e. from 16-bit to 32-bit, or from 32-bit to 64-bit.
 /// The result is written to vector (four 32-bit floating point numbers).
@@ -4417,7 +4417,7 @@ pub unsafe fn __msa_fexupl_w(a: f16x8) -> v4f32 {
 
 /// Vector Floating-Point Up-Convert Interchange Format Left
 ///
-/// The left half floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The left half floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are up-converted to a larger interchange format,
 /// i.e. from 16-bit to 32-bit, or from 32-bit to 64-bit.
 /// The result is written to vector (two 64-bit floating point numbers).
@@ -4432,7 +4432,7 @@ pub unsafe fn __msa_fexupl_d(a: v4f32) -> v2f64 {
 /* FIXME: 16-bit float
 /// Vector Floating-Point Up-Convert Interchange Format Left
 ///
-/// The right half floating-point elements in vector 'a' (two 16-bit floating point numbers)
+/// The right half floating-point elements in vector `a` (two 16-bit floating point numbers)
 /// are up-converted to a larger interchange format,
 /// i.e. from 16-bit to 32-bit, or from 32-bit to 64-bit.
 /// The result is written to vector (four 32-bit floating point numbers).
@@ -4446,7 +4446,7 @@ pub unsafe fn __msa_fexupr_w(a: f16x8) -> v4f32 {
 
 /// Vector Floating-Point Up-Convert Interchange Format Left
 ///
-/// The right half floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The right half floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are up-converted to a larger interchange format,
 /// i.e. from 16-bit to 32-bit, or from 32-bit to 64-bit.
 /// The result is written to vector (two 64-bit floating point numbers).
@@ -4460,7 +4460,7 @@ pub unsafe fn __msa_fexupr_d(a: v4f32) -> v2f64 {
 
 /// Vector Floating-Point Round and Convert from Signed Integer
 ///
-/// The signed integer elements in vector 'a' (four signed 32-bit integer numbers)
+/// The signed integer elements in vector `a` (four signed 32-bit integer numbers)
 /// are converted to floating-point values.
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
@@ -4473,7 +4473,7 @@ pub unsafe fn __msa_ffint_s_w(a: v4i32) -> v4f32 {
 
 /// Vector Floating-Point Round and Convert from Signed Integer
 ///
-/// The signed integer elements in vector 'a' (two signed 64-bit integer numbers)
+/// The signed integer elements in vector `a` (two signed 64-bit integer numbers)
 /// are converted to floating-point values.
 /// The result is written to vector (two 64-bit floating point numbers).
 ///
@@ -4486,7 +4486,7 @@ pub unsafe fn __msa_ffint_s_d(a: v2i64) -> v2f64 {
 
 /// Vector Floating-Point Round and Convert from Unsigned Integer
 ///
-/// The unsigned integer elements in vector 'a' (four unsigned 32-bit integer numbers)
+/// The unsigned integer elements in vector `a` (four unsigned 32-bit integer numbers)
 /// are converted to floating-point values.
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
@@ -4499,7 +4499,7 @@ pub unsafe fn __msa_ffint_u_w(a: v4u32) -> v4f32 {
 
 /// Vector Floating-Point Round and Convert from Unsigned Integer
 ///
-/// The unsigned integer elements in vector 'a' (two unsigned 64-bit integer numbers)
+/// The unsigned integer elements in vector `a` (two unsigned 64-bit integer numbers)
 /// are converted to floating-point values.
 /// The result is written to vector (two 64-bit floating point numbers).
 ///
@@ -4512,7 +4512,7 @@ pub unsafe fn __msa_ffint_u_d(a: v2u64) -> v2f64 {
 
 /// Vector Floating-Point Convert from Fixed-Point Left
 ///
-/// The left half fixed-point elements in vector 'a' (eight signed 16-bit integer numbers)
+/// The left half fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
 /// are up-converted to floating-point data format.
 /// i.e. from 16-bit Q15 to 32-bit floating-point, or from 32-bit Q31 to 64-bit floating-point.
 /// The result is written to vector (four 32-bit floating point numbers).
@@ -4526,7 +4526,7 @@ pub unsafe fn __msa_ffql_w(a: v8i16) -> v4f32 {
 
 /// Vector Floating-Point Convert from Fixed-Point Left
 ///
-/// The left half fixed-point elements in vector 'a' (four signed 32-bit integer numbers)
+/// The left half fixed-point elements in vector `a` (four signed 32-bit integer numbers)
 /// are up-converted to floating-point data format.
 /// i.e. from 16-bit Q15 to 32-bit floating-point, or from 32-bit Q31 to 64-bit floating-point.
 /// The result is written to vector (two 64-bit floating point numbers).
@@ -4540,7 +4540,7 @@ pub unsafe fn __msa_ffql_d(a: v4i32) -> v2f64 {
 
 /// Vector Floating-Point Convert from Fixed-Point Left
 ///
-/// The right half fixed-point elements in vector 'a' (eight signed 16-bit integer numbers)
+/// The right half fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
 /// are up-converted to floating-point data format.
 /// i.e. from 16-bit Q15 to 32-bit floating-point, or from 32-bit Q31 to 64-bit floating-point.
 /// The result is written to vector (four 32-bit floating point numbers).
@@ -4554,7 +4554,7 @@ pub unsafe fn __msa_ffqr_w(a: v8i16) -> v4f32 {
 
 /// Vector Floating-Point Convert from Fixed-Point Left
 ///
-/// The right half fixed-point elements in vector 'a' (four signed 32-bit integer numbers)
+/// The right half fixed-point elements in vector `a` (four signed 32-bit integer numbers)
 /// are up-converted to floating-point data format.
 /// i.e. from 16-bit Q15 to 32-bit floating-point, or from 32-bit Q31 to 64-bit floating-point.
 /// The result is written to vector (two 64-bit floating point numbers).
@@ -4620,7 +4620,7 @@ pub unsafe fn __msa_fill_d(a: i64) -> v2i64 {
 
 /// Vector Floating-Point Base 2 Logarithm
 ///
-/// The signed integral base 2 exponents of floating-point elements in vector 'a'
+/// The signed integral base 2 exponents of floating-point elements in vector `a`
 /// (four 32-bit floating point numbers)are written as floating-point values to vector elements
 /// (four 32-bit floating point numbers).
 ///
@@ -4633,7 +4633,7 @@ pub unsafe fn __msa_flog2_w(a: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Base 2 Logarithm
 ///
-/// The signed integral base 2 exponents of floating-point elements in vector 'a'
+/// The signed integral base 2 exponents of floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) are written as floating-point values to vector elements
 /// (two 64-bit floating point numbers).
 ///
@@ -4646,9 +4646,9 @@ pub unsafe fn __msa_flog2_d(a: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Multiply-Add
 ///
-/// The floating-point elements in vector 'b' (four 32-bit floating point numbers)
-/// multiplied by floating-point elements in vector 'c' (four 32-bit floating point numbers)
-/// are added to the floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The floating-point elements in vector `b` (four 32-bit floating point numbers)
+/// multiplied by floating-point elements in vector `c` (four 32-bit floating point numbers)
+/// are added to the floating-point elements in vector `a` (four 32-bit floating point numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4659,9 +4659,9 @@ pub unsafe fn __msa_fmadd_w(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Multiply-Add
 ///
-/// The floating-point elements in vector 'b' (two 64-bit floating point numbers)
-/// multiplied by floating-point elements in vector 'c' (two 64-bit floating point numbers)
-/// are added to the floating-point elements in vector 'a' (two 64-bit floating point numbers)
+/// The floating-point elements in vector `b` (two 64-bit floating point numbers)
+/// multiplied by floating-point elements in vector `c` (two 64-bit floating point numbers)
+/// are added to the floating-point elements in vector `a` (two 64-bit floating point numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4672,8 +4672,8 @@ pub unsafe fn __msa_fmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Maximum
 ///
-/// The largest values between corresponding floating-point elements in vector 'a'
-/// (four 32-bit floating point numbers)andvector 'b' (four 32-bit floating point numbers)
+/// The largest values between corresponding floating-point elements in vector `a`
+/// (four 32-bit floating point numbers)andvector `b` (four 32-bit floating point numbers)
 /// are written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4685,8 +4685,8 @@ pub unsafe fn __msa_fmax_w(a: v4f32, b: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Maximum
 ///
-/// The largest values between corresponding floating-point elements in vector 'a'
-/// (two 64-bit floating point numbers) and vector 'b' (two 64-bit floating point numbers)
+/// The largest values between corresponding floating-point elements in vector `a`
+/// (two 64-bit floating point numbers) and vector `b` (two 64-bit floating point numbers)
 /// are written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4699,8 +4699,8 @@ pub unsafe fn __msa_fmax_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Maximum Based on Absolute Values
 ///
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
-/// floating-point elements in vector 'a' (four 32-bit floating point numbers)
-/// and vector 'b' (four 32-bit floating point numbers)
+/// floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// and vector `b` (four 32-bit floating point numbers)
 /// are written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4713,8 +4713,8 @@ pub unsafe fn __msa_fmax_a_w(a: v4f32, b: v4f32) -> v4f32 {
 /// Vector Floating-Point Maximum Based on Absolute Values
 ///
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
-/// floating-point elements in vector 'a' (two 64-bit floating point numbers)
-/// and vector 'b' (two 64-bit floating point numbers)
+/// floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// and vector `b` (two 64-bit floating point numbers)
 /// are written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4726,8 +4726,8 @@ pub unsafe fn __msa_fmax_a_d(a: v2f64, b: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Minimum
 ///
-/// The smallest values between corresponding floating-point elements in vector 'a'
-/// (four 32-bit floating point numbers)andvector 'b' (four 32-bit floating point numbers)
+/// The smallest values between corresponding floating-point elements in vector `a`
+/// (four 32-bit floating point numbers)andvector `b` (four 32-bit floating point numbers)
 /// are written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4739,8 +4739,8 @@ pub unsafe fn __msa_fmin_w(a: v4f32, b: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Minimum
 ///
-/// The smallest values between corresponding floating-point elements in vector 'a'
-/// (two 64-bit floating point numbers) and vector 'b' (two 64-bit floating point numbers)
+/// The smallest values between corresponding floating-point elements in vector `a`
+/// (two 64-bit floating point numbers) and vector `b` (two 64-bit floating point numbers)
 /// are written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4753,8 +4753,8 @@ pub unsafe fn __msa_fmin_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Minimum Based on Absolute Values
 ///
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
-/// floating-point elements in vector 'a' (four 32-bit floating point numbers)
-/// and vector 'b' (four 32-bit floating point numbers)
+/// floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// and vector `b` (four 32-bit floating point numbers)
 /// are written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4767,8 +4767,8 @@ pub unsafe fn __msa_fmin_a_w(a: v4f32, b: v4f32) -> v4f32 {
 /// Vector Floating-Point Minimum Based on Absolute Values
 ///
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
-/// floating-point elements in vector 'a' (two 64-bit floating point numbers)
-/// and vector 'b' (two 64-bit floating point numbers)
+/// floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// and vector `b` (two 64-bit floating point numbers)
 /// are written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4780,9 +4780,9 @@ pub unsafe fn __msa_fmin_a_d(a: v2f64, b: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Multiply-Sub
 ///
-/// The floating-point elements in vector 'b' (four 32-bit floating point numbers)
-/// multiplied by floating-point elements in vector 'c' (four 32-bit floating point numbers)
-/// are subtracted from the floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The floating-point elements in vector `b` (four 32-bit floating point numbers)
+/// multiplied by floating-point elements in vector `c` (four 32-bit floating point numbers)
+/// are subtracted from the floating-point elements in vector `a` (four 32-bit floating point numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4793,9 +4793,9 @@ pub unsafe fn __msa_fmsub_w(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Multiply-Sub
 ///
-/// The floating-point elements in vector 'b' (two 64-bit floating point numbers)
-/// multiplied by floating-point elements in vector 'c' (two 64-bit floating point numbers)
-/// are subtracted from the floating-point elements in vector 'a' (two 64-bit floating point numbers)
+/// The floating-point elements in vector `b` (two 64-bit floating point numbers)
+/// multiplied by floating-point elements in vector `c` (two 64-bit floating point numbers)
+/// are subtracted from the floating-point elements in vector `a` (two 64-bit floating point numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4806,8 +4806,8 @@ pub unsafe fn __msa_fmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Multiplication
 ///
-/// The floating-point elements in vector 'a' (four 32-bit floating point numbers)are
-/// multiplied by floating-point elements in vector 'b' (four 32-bit floating point numbers)
+/// The floating-point elements in vector `a` (four 32-bit floating point numbers)are
+/// multiplied by floating-point elements in vector `b` (four 32-bit floating point numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4818,8 +4818,8 @@ pub unsafe fn __msa_fmul_w(a: v4f32, b: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Multiplication
 ///
-/// The floating-point elements in vector 'a' (two 64-bit floating point numbers) are
-/// multiplied by floating-point elements in vector 'b' (two 64-bit floating point numbers)
+/// The floating-point elements in vector `a` (two 64-bit floating point numbers) are
+/// multiplied by floating-point elements in vector `b` (two 64-bit floating point numbers)
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4830,7 +4830,7 @@ pub unsafe fn __msa_fmul_d(a: v2f64, b: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Round to Integer
 ///
-/// The floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are rounded to an integral valued floating-point number in the same format based
 /// on  the  rounding  mode  bits  RM  in  MSA  Control  and  Status  Register MSACSR.
 ///
@@ -4843,7 +4843,7 @@ pub unsafe fn __msa_frint_w(a: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Round to Integer
 ///
-/// The floating-point elements in vector 'a' (two 64-bit floating point numbers)
+/// The floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are rounded to an integral valued floating-point number in the same format based
 /// on  the  rounding  mode  bits  RM  in  MSA  Control  and  Status  Register MSACSR.
 ///
@@ -4856,7 +4856,7 @@ pub unsafe fn __msa_frint_d(a: v2f64) -> v2f64 {
 
 /// Vector Approximate Floating-Point  Reciprocal
 ///
-/// The reciprocals of floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The reciprocals of floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are calculated and the result is written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4868,7 +4868,7 @@ pub unsafe fn __msa_frcp_w(a: v4f32) -> v4f32 {
 
 /// Vector Approximate Floating-Point  Reciprocal
 ///
-/// The reciprocals of floating-point elements in vector 'a' (two 64-bit floating point numbers)
+/// The reciprocals of floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are calculated and the result is written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4880,7 +4880,7 @@ pub unsafe fn __msa_frcp_d(a: v2f64) -> v2f64 {
 
 /// Vector Approximate Floating-Point Reciprocal of Square Root
 ///
-/// The reciprocals of the square  roots of floating-point elements in vector 'a' (four 32-bit floating point numbers)
+/// The reciprocals of the square  roots of floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are calculated and the result is written to vector (four 32-bit floating point numbers)
 ///
 #[inline]
@@ -4892,7 +4892,7 @@ pub unsafe fn __msa_frsqrt_w(a: v4f32) -> v4f32 {
 
 /// Vector Approximate Floating-Point Reciprocal of Square Root
 ///
-/// The reciprocals of the square  roots of floating-point elements in vector 'a' (two 64-bit floating point numbers)
+/// The reciprocals of the square  roots of floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are calculated and the result is written to vector (two 64-bit floating point numbers)
 ///
 #[inline]
@@ -4905,8 +4905,8 @@ pub unsafe fn __msa_frsqrt_d(a: v2f64) -> v2f64 {
 /// Vector Floating-Point Signaling Compare Always False
 ///
 /// Set all bits to 0 in  vector (four signed 32-bit integer numbers) elements.
-/// Signaling and quiet NaN elements in vector 'a' (four 32-bit floating point numbers)
-/// or 'b' (four 32-bit floating point numbers)signal  Invalid Operation exception.
+/// Signaling and quiet NaN elements in vector `a` (four 32-bit floating point numbers)
+/// or `b` (four 32-bit floating point numbers)signal  Invalid Operation exception.
 /// In case of a floating-point exception, the default result has all bits set to 0
 ///
 #[inline]
@@ -4919,8 +4919,8 @@ pub unsafe fn __msa_fsaf_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Always False
 ///
 /// Set all bits to 0 in  vector (two signed 64-bit integer numbers) elements.
-/// Signaling and quiet NaN elements in vector 'a' (two 64-bit floating point numbers)
-/// or 'b' (two 64-bit floating point numbers) signal  Invalid Operation exception.
+/// Signaling and quiet NaN elements in vector `a` (two 64-bit floating point numbers)
+/// or `b` (two 64-bit floating point numbers) signal  Invalid Operation exception.
 /// In case of a floating-point exception, the default result has all bits set to 0
 ///
 #[inline]
@@ -4933,8 +4933,8 @@ pub unsafe fn __msa_fsaf_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)
-/// and 'b' (four 32-bit floating point numbers)elements are equal, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers)
+/// and `b` (four 32-bit floating point numbers)elements are equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4946,8 +4946,8 @@ pub unsafe fn __msa_fseq_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Equal
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers)
-/// and 'b' (two 64-bit floating point numbers) elementsare equal, otherwise set all bits to 0.
+/// if the corresponding `a` (two 64-bit floating point numbers)
+/// and `b` (two 64-bit floating point numbers) elementsare equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4959,8 +4959,8 @@ pub unsafe fn __msa_fseq_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Less or Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)elements
-/// are less than or equal to 'b' (four 32-bit floating point numbers)elements, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers)elements
+/// are less than or equal to `b` (four 32-bit floating point numbers)elements, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4972,8 +4972,8 @@ pub unsafe fn __msa_fsle_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Less or Equal
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) elements
-/// are less than or equal to 'b' (two 64-bit floating point numbers) elements, otherwise set all bits to 0.
+/// if the corresponding `a` (two 64-bit floating point numbers) elements
+/// are less than or equal to `b` (two 64-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4985,8 +4985,8 @@ pub unsafe fn __msa_fsle_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Less Than
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)elements
-/// are less than 'b' (four 32-bit floating point numbers)elements, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers)elements
+/// are less than `b` (four 32-bit floating point numbers)elements, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4998,8 +4998,8 @@ pub unsafe fn __msa_fslt_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Less Than
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) elements
-/// are less than 'b' (two 64-bit floating point numbers) elements, otherwise set all bits to 0.
+/// if the corresponding `a` (two 64-bit floating point numbers) elements
+/// are less than `b` (two 64-bit floating point numbers) elements, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5011,8 +5011,8 @@ pub unsafe fn __msa_fslt_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Not Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are not equal, otherwise set all bits to 0.
+/// if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are not equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5024,8 +5024,8 @@ pub unsafe fn __msa_fsne_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Not Equal
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare not equal, otherwise set all bits to 0.
+/// if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare not equal, otherwise set all bits to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5037,8 +5037,8 @@ pub unsafe fn __msa_fsne_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Ordered
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are ordered,
+/// if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are ordered,
 /// i.e. both elementsare not NaN values, otherwise set all bits to 0.
 ///
 #[inline]
@@ -5051,8 +5051,8 @@ pub unsafe fn __msa_fsor_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Ordered
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare ordered,
+/// if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare ordered,
 /// i.e. both elementsare not NaN values, otherwise set all bits to 0.
 ///
 #[inline]
@@ -5064,7 +5064,7 @@ pub unsafe fn __msa_fsor_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point  Square Root
 ///
-/// The square roots of floating-point elements in vector 'a'
+/// The square roots of floating-point elements in vector `a`
 /// (four 32-bit floating point numbers)are written to vector
 /// (four 32-bit floating point numbers)elements are ordered,
 ///
@@ -5077,7 +5077,7 @@ pub unsafe fn __msa_fsqrt_w(a: v4f32) -> v4f32 {
 
 /// Vector Floating-Point  Square Root
 ///
-/// The square roots of floating-point elements in vector 'a'
+/// The square roots of floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) are written to vector
 /// (two 64-bit floating point numbers) elementsare ordered,
 ///
@@ -5090,8 +5090,8 @@ pub unsafe fn __msa_fsqrt_d(a: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Subtraction
 ///
-/// The floating-point elements in vector 'b' (four 32-bit floating point numbers)
-/// are subtracted from the floating-point elements in vector 'a'
+/// The floating-point elements in vector `b` (four 32-bit floating point numbers)
+/// are subtracted from the floating-point elements in vector `a`
 /// (four 32-bit floating point numbers).
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
@@ -5104,8 +5104,8 @@ pub unsafe fn __msa_fsub_w(a: v4f32, b: v4f32) -> v4f32 {
 
 /// Vector Floating-Point Subtraction
 ///
-/// The floating-point elements in vector 'b' (two 64-bit floating point numbers)
-/// are subtracted from the floating-point elements in vector 'a'
+/// The floating-point elements in vector `b` (two 64-bit floating point numbers)
+/// are subtracted from the floating-point elements in vector `a`
 /// (two 64-bit floating point numbers).
 /// The result is written to vector (two 64-bit floating point numbers).
 ///
@@ -5119,8 +5119,8 @@ pub unsafe fn __msa_fsub_d(a: v2f64, b: v2f64) -> v2f64 {
 /// Vector Floating-Point Signaling Compare Ordered
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are unordered or equal,
+/// if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5133,8 +5133,8 @@ pub unsafe fn __msa_fsueq_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Ordered
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare unordered or equal,
+/// if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare unordered or equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5147,8 +5147,8 @@ pub unsafe fn __msa_fsueq_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered or Less or Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)elements are
-/// unordered or less than or equal to 'b' (four 32-bit floating point numbers)elements
+/// if the corresponding `a` (four 32-bit floating point numbers)elements are
+/// unordered or less than or equal to `b` (four 32-bit floating point numbers)elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5161,8 +5161,8 @@ pub unsafe fn __msa_fsule_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Unordered or Less or Equal
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) elementsare
-/// unordered or less than or equal to 'b' (two 64-bit floating point numbers) elements
+/// if the corresponding `a` (two 64-bit floating point numbers) elementsare
+/// unordered or less than or equal to `b` (two 64-bit floating point numbers) elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5175,8 +5175,8 @@ pub unsafe fn __msa_fsule_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered or Less Than
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)elements
-/// are unordered or less than 'b' (four 32-bit floating point numbers)elements
+/// if the corresponding `a` (four 32-bit floating point numbers)elements
+/// are unordered or less than `b` (four 32-bit floating point numbers)elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5189,8 +5189,8 @@ pub unsafe fn __msa_fsult_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Unordered or Less Than
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) elements
-/// are unordered or less than 'b' (two 64-bit floating point numbers) elements
+/// if the corresponding `a` (two 64-bit floating point numbers) elements
+/// are unordered or less than `b` (two 64-bit floating point numbers) elements
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5203,8 +5203,8 @@ pub unsafe fn __msa_fsult_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are unordered,
+/// if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are unordered,
 /// i.e. at least one element is a NaN value otherwise set all bits to 0.
 ///
 #[inline]
@@ -5217,8 +5217,8 @@ pub unsafe fn __msa_fsun_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Unordered
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare unordered,
+/// if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare unordered,
 /// i.e. at least one element is a NaN value otherwise set all bits to 0.
 ///
 #[inline]
@@ -5231,8 +5231,8 @@ pub unsafe fn __msa_fsun_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Signaling Compare Unordered or Not Equal
 ///
 /// Set all bits to 1 in  vector (four signed 32-bit integer numbers) elements
-/// if the corresponding 'a' (four 32-bit floating point numbers)and
-/// 'b' (four 32-bit floating point numbers)elements are unordered or not equal,
+/// if the corresponding `a` (four 32-bit floating point numbers)and
+/// `b` (four 32-bit floating point numbers)elements are unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5245,8 +5245,8 @@ pub unsafe fn __msa_fsune_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Vector Floating-Point Signaling Compare Unordered or Not Equal
 ///
 /// Set all bits to 1 in  vector (two signed 64-bit integer numbers) elements
-/// if the corresponding 'a' (two 64-bit floating point numbers) and
-/// 'b' (two 64-bit floating point numbers) elementsare unordered or not equal,
+/// if the corresponding `a` (two 64-bit floating point numbers) and
+/// `b` (two 64-bit floating point numbers) elementsare unordered or not equal,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -5258,7 +5258,7 @@ pub unsafe fn __msa_fsune_d(a: v2f64, b: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Convert to Signed Integer
 ///
-///The elements in vector 'a' (four 32-bit floating point numbers)
+///The elements in vector `a` (four 32-bit floating point numbers)
 /// are rounded and converted to signed integer values based on the
 /// rounding mode bits RM in MSA Control and Status Register MSACSR.
 /// The result is written to vector (four signed 32-bit integer numbers).
@@ -5272,7 +5272,7 @@ pub unsafe fn __msa_ftint_s_w(a: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Convert to Signed Integer
 ///
-///The elements in vector 'a' (two 64-bit floating point numbers)
+///The elements in vector `a` (two 64-bit floating point numbers)
 /// are rounded and converted to signed integer values based on the
 /// rounding mode bits RM in MSA Control and Status Register MSACSR.
 /// The result is written to vector (two signed 64-bit integer numbers).
@@ -5286,7 +5286,7 @@ pub unsafe fn __msa_ftint_s_d(a: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Convert to Unsigned Integer
 ///
-/// The elements in vector 'a' (four 32-bit floating point numbers)
+/// The elements in vector `a` (four 32-bit floating point numbers)
 /// are rounded and converted to signed integer values based on the
 /// rounding mode bits RM in MSA Control and Status Register MSACSR.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
@@ -5300,7 +5300,7 @@ pub unsafe fn __msa_ftint_u_w(a: v4f32) -> v4u32 {
 
 /// Vector Floating-Point Convert to Unsigned Integer
 ///
-/// The elements in vector 'a' (two 64-bit floating point numbers)
+/// The elements in vector `a` (two 64-bit floating point numbers)
 /// are rounded and converted to signed integer values based on the
 /// rounding mode bits RM in MSA Control and Status Register MSACSR.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
@@ -5314,8 +5314,8 @@ pub unsafe fn __msa_ftint_u_d(a: v2f64) -> v2u64 {
 
 /// Vector Floating-Point Convert to Fixed-Point
 ///
-/// The elements in vector 'a' (four 32-bit floating point numbers)
-/// and 'b' (four 32-bit floating point numbers)are down-converted to a fixed-point
+/// The elements in vector `a` (four 32-bit floating point numbers)
+/// and `b` (four 32-bit floating point numbers)are down-converted to a fixed-point
 /// representation,  i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
 /// representation, or from 32-bit floating-point to 16-bit Q15 fixed-point representation.
 /// The result is written to vector (eight signed 16-bit integer numbers).
@@ -5329,8 +5329,8 @@ pub unsafe fn __msa_ftq_h(a: v4f32, b: v4f32) -> v8i16 {
 
 /// Vector Floating-Point Convert to Fixed-Point
 ///
-/// The elements in vector 'a' (two 64-bit floating point numbers)
-/// and 'b' (two 64-bit floating point numbers) are down-converted to a fixed-point
+/// The elements in vector `a` (two 64-bit floating point numbers)
+/// and `b` (two 64-bit floating point numbers) are down-converted to a fixed-point
 /// representation,  i.e. from 64-bit floating-point to 32-bit Q31 fixed-point
 /// representation, or from 32-bit floating-point to 16-bit Q15 fixed-point representation.
 /// The result is written to vector (four signed 32-bit integer numbers).
@@ -5344,7 +5344,7 @@ pub unsafe fn __msa_ftq_w(a: v2f64, b: v2f64) -> v4i32 {
 
 /// Vector Floating-Point Truncate and Convert to Signed Integer
 ///
-/// The elements in vector 'a' (four 32-bit floating point numbers)
+/// The elements in vector `a` (four 32-bit floating point numbers)
 /// are truncated, i.e. rounded toward zero, to signed integer values.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -5357,7 +5357,7 @@ pub unsafe fn __msa_ftrunc_s_w(a: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Truncate and Convert to Signed Integer
 ///
-/// The elements in vector 'a' (two 64-bit floating point numbers)
+/// The elements in vector `a` (two 64-bit floating point numbers)
 /// are truncated, i.e. rounded toward zero, to signed integer values.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -5370,7 +5370,7 @@ pub unsafe fn __msa_ftrunc_s_d(a: v2f64) -> v2i64 {
 
 /// Vector Floating-Point Truncate and Convert to Unsigned Integer
 ///
-/// The elements in vector 'a' (four 32-bit floating point numbers)
+/// The elements in vector `a` (four 32-bit floating point numbers)
 /// are truncated, i.e. rounded toward zero, to unsigned integer values.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
@@ -5383,7 +5383,7 @@ pub unsafe fn __msa_ftrunc_u_w(a: v4f32) -> v4u32 {
 
 /// Vector Floating-Point Truncate and Convert to Unsigned Integer
 ///
-/// The elements in vector 'a' (two 64-bit floating point numbers)
+/// The elements in vector `a` (two 64-bit floating point numbers)
 /// are truncated, i.e. rounded toward zero, to unsigned integer values.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
@@ -5396,8 +5396,8 @@ pub unsafe fn __msa_ftrunc_u_d(a: v2f64) -> v2u64 {
 
 /// Vector Signed Horizontal Add
 ///
-/// The sign-extended odd elements in vector 'a' (sixteen signed 8-bit integer numbers)
-/// are added to the sign-extended even elements in vector 'b' (sixteen signed 8-bit integer numbers)
+/// The sign-extended odd elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are added to the sign-extended even elements in vector `b` (sixteen signed 8-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -5410,8 +5410,8 @@ pub unsafe fn __msa_hadd_s_h(a: v16i8, b: v16i8) -> v8i16 {
 
 /// Vector Signed Horizontal Add
 ///
-/// The sign-extended odd elements in vector 'a' (eight signed 16-bit integer numbers)
-/// are added to the sign-extended even elements in vector 'b' (eight signed 16-bit integer numbers)
+/// The sign-extended odd elements in vector `a` (eight signed 16-bit integer numbers)
+/// are added to the sign-extended even elements in vector `b` (eight signed 16-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -5424,8 +5424,8 @@ pub unsafe fn __msa_hadd_s_w(a: v8i16, b: v8i16) -> v4i32 {
 
 /// Vector Signed Horizontal Add
 ///
-/// The sign-extended odd elements in vector 'a' (four signed 32-bit integer numbers)
-/// are added to the sign-extended even elements in vector 'b' (four signed 32-bit integer numbers)
+/// The sign-extended odd elements in vector `a` (four signed 32-bit integer numbers)
+/// are added to the sign-extended even elements in vector `b` (four signed 32-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -5438,8 +5438,8 @@ pub unsafe fn __msa_hadd_s_d(a: v4i32, b: v4i32) -> v2i64 {
 
 /// Vector Unsigned Horizontal Add
 ///
-/// The zero-extended odd elements in vector 'a' (sixteen unsigned 8-bit integer numbers)
-/// are added to the zero-extended even elements in vector 'b' (sixteen unsigned 8-bit integer numbers)
+/// The zero-extended odd elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are added to the zero-extended even elements in vector `b` (sixteen unsigned 8-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
@@ -5452,8 +5452,8 @@ pub unsafe fn __msa_hadd_u_h(a: v16u8, b: v16u8) -> v8u16 {
 
 /// Vector Unsigned Horizontal Add
 ///
-/// The zero-extended odd elements in vector 'a' (eight unsigned 16-bit integer numbers)
-/// are added to the zero-extended even elements in vector 'b' (eight unsigned 16-bit integer numbers)
+/// The zero-extended odd elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are added to the zero-extended even elements in vector `b` (eight unsigned 16-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
@@ -5466,8 +5466,8 @@ pub unsafe fn __msa_hadd_u_w(a: v8u16, b: v8u16) -> v4u32 {
 
 /// Vector Unsigned Horizontal Add
 ///
-/// The zero-extended odd elements in vector 'a' (four unsigned 32-bit integer numbers)
-/// are added to the zero-extended even elements in vector 'b' (four unsigned 32-bit integer numbers)
+/// The zero-extended odd elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are added to the zero-extended even elements in vector `b` (four unsigned 32-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
@@ -5480,8 +5480,8 @@ pub unsafe fn __msa_hadd_u_d(a: v4u32, b: v4u32) -> v2u64 {
 
 /// Vector Signed Horizontal Subtract
 ///
-/// The sign-extended odd elements in vector 'b' (sixteen signed 8-bit integer numbers)
-/// are subtracted from the sign-extended elements in vector 'a' (sixteen signed 8-bit integer numbers)
+/// The sign-extended odd elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are subtracted from the sign-extended elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -5494,8 +5494,8 @@ pub unsafe fn __msa_hsub_s_h(a: v16i8, b: v16i8) -> v8i16 {
 
 /// Vector Signed Horizontal Subtract
 ///
-/// The sign-extended odd elements in vector 'b' (eight signed 16-bit integer numbers)
-/// are subtracted from the sign-extended elements in vector 'a' (eight signed 16-bit integer numbers)
+/// The sign-extended odd elements in vector `b` (eight signed 16-bit integer numbers)
+/// are subtracted from the sign-extended elements in vector `a` (eight signed 16-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -5508,8 +5508,8 @@ pub unsafe fn __msa_hsub_s_w(a: v8i16, b: v8i16) -> v4i32 {
 
 /// Vector Signed Horizontal Subtract
 ///
-/// The sign-extended odd elements in vector 'b' (four signed 32-bit integer numbers)
-/// are subtracted from the sign-extended elements in vector 'a' (four signed 32-bit integer numbers)
+/// The sign-extended odd elements in vector `b` (four signed 32-bit integer numbers)
+/// are subtracted from the sign-extended elements in vector `a` (four signed 32-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -5522,8 +5522,8 @@ pub unsafe fn __msa_hsub_s_d(a: v4i32, b: v4i32) -> v2i64 {
 
 /// Vector Unsigned Horizontal Subtract
 ///
-/// The zero-extended odd elements in vector 'b' (sixteen unsigned 8-bit integer numbers)
-/// are subtracted from the zero-extended elements in vector 'a' (sixteen unsigned 8-bit integer numbers)
+/// The zero-extended odd elements in vector `b` (sixteen unsigned 8-bit integer numbers)
+/// are subtracted from the zero-extended elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -5536,8 +5536,8 @@ pub unsafe fn __msa_hsub_u_h(a: v16u8, b: v16u8) -> v8i16 {
 
 /// Vector Unsigned Horizontal Subtract
 ///
-/// The zero-extended odd elements in vector 'b' (eight unsigned 16-bit integer numbers)
-/// are subtracted from the zero-extended elements in vector 'a' (eight unsigned 16-bit integer numbers)
+/// The zero-extended odd elements in vector `b` (eight unsigned 16-bit integer numbers)
+/// are subtracted from the zero-extended elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -5550,8 +5550,8 @@ pub unsafe fn __msa_hsub_u_w(a: v8u16, b: v8u16) -> v4i32 {
 
 /// Vector Unsigned Horizontal Subtract
 ///
-/// The zero-extended odd elements in vector 'b' (four unsigned 32-bit integer numbers)
-/// are subtracted from the zero-extended elements in vector 'a' (four unsigned 32-bit integer numbers)
+/// The zero-extended odd elements in vector `b` (four unsigned 32-bit integer numbers)
+/// are subtracted from the zero-extended elements in vector `a` (four unsigned 32-bit integer numbers)
 /// producing aresult twice the size of the input operands.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -5564,10 +5564,10 @@ pub unsafe fn __msa_hsub_u_d(a: v4u32, b: v4u32) -> v2i64 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors 'a' (sixteen signed 8-bit integer numbers)
-/// and vector 'b' (sixteen signed 8-bit integer numbers) are copied to the result
+/// Even  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// and vector `b` (sixteen signed 8-bit integer numbers) are copied to the result
 /// (sixteen signed 8-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5578,10 +5578,10 @@ pub unsafe fn __msa_ilvev_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors 'a' (eight signed 16-bit integer numbers)
-/// and vector 'b' (eight signed 16-bit integer numbers) are copied to the result
+/// Even  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// and vector `b` (eight signed 16-bit integer numbers) are copied to the result
 /// (eight signed 16-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5592,10 +5592,10 @@ pub unsafe fn __msa_ilvev_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors 'a' (four signed 32-bit integer numbers)
-/// and vector 'b' (four signed 32-bit integer numbers) are copied to the result
+/// Even  elements in vectors `a` (four signed 32-bit integer numbers)
+/// and vector `b` (four signed 32-bit integer numbers) are copied to the result
 /// (four signed 32-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5606,10 +5606,10 @@ pub unsafe fn __msa_ilvev_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Interleave Even
 ///
-/// Even  elements in vectors 'a' (two signed 64-bit integer numbers)
-/// and vector 'b' (two signed 64-bit integer numbers) are copied to the result
+/// Even  elements in vectors `a` (two signed 64-bit integer numbers)
+/// and vector `b` (two signed 64-bit integer numbers) are copied to the result
 /// (two signed 64-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5620,10 +5620,10 @@ pub unsafe fn __msa_ilvev_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Interleave Left
 ///
-/// The left half elements in vectors 'a' (sixteen signed 8-bit integer numbers)
-/// and vector 'b' (sixteen signed 8-bit integer numbers) are copied to the result
+/// The left half elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// and vector `b` (sixteen signed 8-bit integer numbers) are copied to the result
 /// (sixteen signed 8-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5634,10 +5634,10 @@ pub unsafe fn __msa_ilvl_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Interleave Left
 ///
-/// The left half elements in vectors 'a' (eight signed 16-bit integer numbers)
-/// and vector 'b' (eight signed 16-bit integer numbers) are copied to the result
+/// The left half elements in vectors `a` (eight signed 16-bit integer numbers)
+/// and vector `b` (eight signed 16-bit integer numbers) are copied to the result
 /// (eight signed 16-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5648,10 +5648,10 @@ pub unsafe fn __msa_ilvl_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Interleave Left
 ///
-/// The left half elements in vectors 'a' (four signed 32-bit integer numbers)
-/// and vector 'b' (four signed 32-bit integer numbers) are copied to the result
+/// The left half elements in vectors `a` (four signed 32-bit integer numbers)
+/// and vector `b` (four signed 32-bit integer numbers) are copied to the result
 /// (four signed 32-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5662,10 +5662,10 @@ pub unsafe fn __msa_ilvl_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Interleave Left
 ///
-/// The left half elements in vectors 'a' (two signed 64-bit integer numbers)
-/// and vector 'b' (two signed 64-bit integer numbers) are copied to the result
+/// The left half elements in vectors `a` (two signed 64-bit integer numbers)
+/// and vector `b` (two signed 64-bit integer numbers) are copied to the result
 /// (two signed 64-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5676,10 +5676,10 @@ pub unsafe fn __msa_ilvl_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors 'a' (sixteen signed 8-bit integer numbers)
-/// and vector 'b' (sixteen signed 8-bit integer numbers) are copied to the result
+/// Odd  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// and vector `b` (sixteen signed 8-bit integer numbers) are copied to the result
 /// (sixteen signed 8-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5690,10 +5690,10 @@ pub unsafe fn __msa_ilvod_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors 'a' (eight signed 16-bit integer numbers)
-/// and vector 'b' (eight signed 16-bit integer numbers) are copied to the result
+/// Odd  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// and vector `b` (eight signed 16-bit integer numbers) are copied to the result
 /// (eight signed 16-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5704,10 +5704,10 @@ pub unsafe fn __msa_ilvod_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors 'a' (four signed 32-bit integer numbers)
-/// and vector 'b' (four signed 32-bit integer numbers) are copied to the result
+/// Odd  elements in vectors `a` (four signed 32-bit integer numbers)
+/// and vector `b` (four signed 32-bit integer numbers) are copied to the result
 /// (four signed 32-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5718,10 +5718,10 @@ pub unsafe fn __msa_ilvod_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Interleave Odd
 ///
-/// Odd  elements in vectors 'a' (two signed 64-bit integer numbers)
-/// and vector 'b' (two signed 64-bit integer numbers) are copied to the result
+/// Odd  elements in vectors `a` (two signed 64-bit integer numbers)
+/// and vector `b` (two signed 64-bit integer numbers) are copied to the result
 /// (two signed 64-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5732,10 +5732,10 @@ pub unsafe fn __msa_ilvod_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Interleave Right
 ///
-/// The right half elements in vectors 'a' (sixteen signed 8-bit integer numbers)
-/// and vector 'b' (sixteen signed 8-bit integer numbers) are copied to the result
+/// The right half elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// and vector `b` (sixteen signed 8-bit integer numbers) are copied to the result
 /// (sixteen signed 8-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5746,10 +5746,10 @@ pub unsafe fn __msa_ilvr_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Interleave Right
 ///
-/// The right half elements in vectors 'a' (eight signed 16-bit integer numbers)
-/// and vector 'b' (eight signed 16-bit integer numbers) are copied to the result
+/// The right half elements in vectors `a` (eight signed 16-bit integer numbers)
+/// and vector `b` (eight signed 16-bit integer numbers) are copied to the result
 /// (eight signed 16-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5760,10 +5760,10 @@ pub unsafe fn __msa_ilvr_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Interleave Right
 ///
-/// The right half elements in vectors 'a' (four signed 32-bit integer numbers)
-/// and vector 'b' (four signed 32-bit integer numbers) are copied to the result
+/// The right half elements in vectors `a` (four signed 32-bit integer numbers)
+/// and vector `b` (four signed 32-bit integer numbers) are copied to the result
 /// (four signed 32-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5774,10 +5774,10 @@ pub unsafe fn __msa_ilvr_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Interleave Right
 ///
-/// The right half elements in vectors 'a' (two signed 64-bit integer numbers)
-/// and vector 'b' (two signed 64-bit integer numbers) are copied to the result
+/// The right half elements in vectors `a` (two signed 64-bit integer numbers)
+/// and vector `b` (two signed 64-bit integer numbers) are copied to the result
 /// (two signed 64-bit integer numbers)
-/// alternating one element from 'a' with one element from 'b'.
+/// alternating one element from `a` with one element from `b`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5788,8 +5788,8 @@ pub unsafe fn __msa_ilvr_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// GPR Insert Element
 ///
-/// Set element imm4 in vector 'a' (sixteen signed 8-bit integer numbers) to GPR 'c' value.
-/// All other elements in vector 'a' are unchanged. If the source GPR is wider than the
+/// Set element imm4 in vector `a` (sixteen signed 8-bit integer numbers) to GPR `c` value.
+/// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
 #[inline]
@@ -5807,8 +5807,8 @@ pub unsafe fn __msa_insert_b(a: v16i8, imm4: i32, c: i32) -> v16i8 {
 
 /// GPR Insert Element
 ///
-/// Set element imm3 in vector 'a' (eight signed 16-bit integer numbers) to GPR 'c' value.
-/// All other elements in vector 'a' are unchanged. If the source GPR is wider than the
+/// Set element imm3 in vector `a` (eight signed 16-bit integer numbers) to GPR `c` value.
+/// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
 #[inline]
@@ -5826,8 +5826,8 @@ pub unsafe fn __msa_insert_h(a: v8i16, imm3: i32, c: i32) -> v8i16 {
 
 /// GPR Insert Element
 ///
-/// Set element imm2 in vector 'a' (four signed 32-bit integer numbers) to GPR 'c' value.
-/// All other elements in vector 'a' are unchanged. If the source GPR is wider than the
+/// Set element imm2 in vector `a` (four signed 32-bit integer numbers) to GPR `c` value.
+/// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
 #[inline]
@@ -5845,8 +5845,8 @@ pub unsafe fn __msa_insert_w(a: v4i32, imm2: i32, c: i32) -> v4i32 {
 
 /// GPR Insert Element
 ///
-/// Set element imm1 in vector 'a' (two signed 64-bit integer numbers) to GPR 'c' value.
-/// All other elements in vector 'a' are unchanged. If the source GPR is wider than the
+/// Set element imm1 in vector `a` (two signed 64-bit integer numbers) to GPR `c` value.
+/// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
 #[inline]
@@ -5864,9 +5864,9 @@ pub unsafe fn __msa_insert_d(a: v2i64, imm1: i32, c: i64) -> v2i64 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector 'a' (sixteen signed 8-bit integer numbers) to element 0
-/// in vector 'c' (sixteen signed 8-bit integer numbers) value.
-/// All other elements in vector 'a' are unchanged.
+/// Set element imm1 in the result vector `a` (sixteen signed 8-bit integer numbers) to element 0
+/// in vector `c` (sixteen signed 8-bit integer numbers) value.
+/// All other elements in vector `a` are unchanged.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5883,9 +5883,9 @@ pub unsafe fn __msa_insve_b(a: v16i8, imm4: i32, c: v16i8) -> v16i8 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector 'a' (eight signed 16-bit integer numbers) to element 0
-/// in vector 'c' (eight signed 16-bit integer numbers) value.
-/// All other elements in vector 'a' are unchanged.
+/// Set element imm1 in the result vector `a` (eight signed 16-bit integer numbers) to element 0
+/// in vector `c` (eight signed 16-bit integer numbers) value.
+/// All other elements in vector `a` are unchanged.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5902,9 +5902,9 @@ pub unsafe fn __msa_insve_h(a: v8i16, imm3: i32, c: v8i16) -> v8i16 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector 'a' (four signed 32-bit integer numbers) to element 0
-/// in vector 'c' (four signed 32-bit integer numbers) value.
-/// All other elements in vector 'a' are unchanged.
+/// Set element imm1 in the result vector `a` (four signed 32-bit integer numbers) to element 0
+/// in vector `c` (four signed 32-bit integer numbers) value.
+/// All other elements in vector `a` are unchanged.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5921,9 +5921,9 @@ pub unsafe fn __msa_insve_w(a: v4i32, imm2: i32, c: v4i32) -> v4i32 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector 'a' (two signed 64-bit integer numbers) to element 0
-/// in vector 'c' (two signed 64-bit integer numbers) value.
-/// All other elements in vector 'a' are unchanged.
+/// Set element imm1 in the result vector `a` (two signed 64-bit integer numbers) to element 0
+/// in vector `c` (two signed 64-bit integer numbers) value.
+/// All other elements in vector `a` are unchanged.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6092,11 +6092,11 @@ pub unsafe fn __msa_ldi_d(imm_s10: i32) -> v2i64 {
 
 /// Vector Fixed-Point Multiply and Add
 ///
-/// The products of fixed-point elements in 'b' (eight signed 16-bit integer numbers)
-/// by fixed-point elements in vector 'c' (eight signed 16-bit integer numbers)
-/// are added to the fixed-pointelements in vector 'a' (eight signed 16-bit integer numbers)
+/// The products of fixed-point elements in `b` (eight signed 16-bit integer numbers)
+/// by fixed-point elements in vector `c` (eight signed 16-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The saturated fixed-point results are stored to vector 'a'
+/// The saturated fixed-point results are stored to vector `a`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6107,11 +6107,11 @@ pub unsafe fn __msa_madd_q_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Fixed-Point Multiply and Add
 ///
-/// The products of fixed-point elements in 'b' (four signed 32-bit integer numbers)
-/// by fixed-point elements in vector 'c' (four signed 32-bit integer numbers)
-/// are added to the fixed-pointelements in vector 'a' (four signed 32-bit integer numbers)
+/// The products of fixed-point elements in `b` (four signed 32-bit integer numbers)
+/// by fixed-point elements in vector `c` (four signed 32-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (four signed 32-bit integer numbers)
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The saturated fixed-point results are stored to vector 'a'
+/// The saturated fixed-point results are stored to vector `a`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6122,11 +6122,11 @@ pub unsafe fn __msa_madd_q_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Fixed-Point Multiply and Add Rounded
 ///
-/// The products of fixed-point elements in 'b' (eight signed 16-bit integer numbers)
-/// by fixed-point elements in vector 'c' (eight signed 16-bit integer numbers)
-/// are added to the fixed-pointelements in vector 'a' (eight signed 16-bit integer numbers)
+/// The products of fixed-point elements in `b` (eight signed 16-bit integer numbers)
+/// by fixed-point elements in vector `c` (eight signed 16-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The rounded and saturated fixed-point results are stored to vector 'a'
+/// The rounded and saturated fixed-point results are stored to vector `a`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6137,11 +6137,11 @@ pub unsafe fn __msa_maddr_q_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Fixed-Point Multiply and Add Rounded
 ///
-/// The products of fixed-point elements in 'b' (four signed 32-bit integer numbers)
-/// by fixed-point elements in vector 'c' (four signed 32-bit integer numbers)
-/// are added to the fixed-pointelements in vector 'a' (four signed 32-bit integer numbers)
+/// The products of fixed-point elements in `b` (four signed 32-bit integer numbers)
+/// by fixed-point elements in vector `c` (four signed 32-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (four signed 32-bit integer numbers)
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The rounded and saturated fixed-point results are stored to vector 'a'
+/// The rounded and saturated fixed-point results are stored to vector `a`
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6152,9 +6152,9 @@ pub unsafe fn __msa_maddr_q_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Multiply and Add
 ///
-/// The integer elements in vector 'b' (sixteen signed 8-bit integer numbers)
-/// are multiplied by integer elements in vector 'c' (sixteen signed 8-bit integer numbers)
-/// and added to the integer elements in vector 'a' (sixteen signed 8-bit integer numbers)
+/// The integer elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// are multiplied by integer elements in vector `c` (sixteen signed 8-bit integer numbers)
+/// and added to the integer elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6166,9 +6166,9 @@ pub unsafe fn __msa_maddv_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 
 /// Vector Multiply and Add
 ///
-/// The integer elements in vector 'b' (eight signed 16-bit integer numbers)
-/// are multiplied by integer elements in vector 'c' (eight signed 16-bit integer numbers)
-/// and added to the integer elements in vector 'a' (eight signed 16-bit integer numbers)
+/// The integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// are multiplied by integer elements in vector `c` (eight signed 16-bit integer numbers)
+/// and added to the integer elements in vector `a` (eight signed 16-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6180,9 +6180,9 @@ pub unsafe fn __msa_maddv_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Multiply and Add
 ///
-/// The integer elements in vector 'b' (four signed 32-bit integer numbers)
-/// are multiplied by integer elements in vector 'c' (four signed 32-bit integer numbers)
-/// and added to the integer elements in vector 'a' (four signed 32-bit integer numbers)
+/// The integer elements in vector `b` (four signed 32-bit integer numbers)
+/// are multiplied by integer elements in vector `c` (four signed 32-bit integer numbers)
+/// and added to the integer elements in vector `a` (four signed 32-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6194,9 +6194,9 @@ pub unsafe fn __msa_maddv_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Multiply and Add
 ///
-/// The integer elements in vector 'b' (two signed 64-bit integer numbers)
-/// are multiplied by integer elements in vector 'c' (two signed 64-bit integer numbers)
-/// and added to the integer elements in vector 'a' (two signed 64-bit integer numbers)
+/// The integer elements in vector `b` (two signed 64-bit integer numbers)
+/// are multiplied by integer elements in vector `c` (two signed 64-bit integer numbers)
+/// and added to the integer elements in vector `a` (two signed 64-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6209,8 +6209,8 @@ pub unsafe fn __msa_maddv_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
 /// Vector Maximum Based on Absolute Values
 ///
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(sixteen signed 8-bit integer numbers) and
-/// 'b'(sixteen signed 8-bit integer numbers) are written to vector
+/// signed elements in vector `a` (sixteen signed 8-bit integer numbers) and
+/// `b` (sixteen signed 8-bit integer numbers) are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -6223,8 +6223,8 @@ pub unsafe fn __msa_max_a_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Maximum Based on Absolute Values
 ///
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(eight signed 16-bit integer numbers) and
-/// 'b'(eight signed 16-bit integer numbers) are written to vector
+/// signed elements in vector `a` (eight signed 16-bit integer numbers) and
+/// `b` (eight signed 16-bit integer numbers) are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -6237,8 +6237,8 @@ pub unsafe fn __msa_max_a_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Maximum Based on Absolute Values
 ///
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(four signed 32-bit integer numbers) and
-/// 'b'(four signed 32-bit integer numbers) are written to vector
+/// signed elements in vector `a` (four signed 32-bit integer numbers) and
+/// `b` (four signed 32-bit integer numbers) are written to vector
 /// (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -6251,8 +6251,8 @@ pub unsafe fn __msa_max_a_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Maximum Based on Absolute Values
 ///
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(two signed 64-bit integer numbers) and
-/// 'b'(two signed 64-bit integer numbers) are written to vector
+/// signed elements in vector `a` (two signed 64-bit integer numbers) and
+/// `b` (two signed 64-bit integer numbers) are written to vector
 /// (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -6264,8 +6264,8 @@ pub unsafe fn __msa_max_a_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// and signed elements in vector 'b'(sixteen signed 8-bit integer numbers) are written to vector
+/// Maximum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// and signed elements in vector `b` (sixteen signed 8-bit integer numbers) are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -6277,8 +6277,8 @@ pub unsafe fn __msa_max_s_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(eight signed 16-bit integer numbers)
-/// and signed elements in vector 'b'(eight signed 16-bit integer numbers) are written to vector
+/// Maximum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
+/// and signed elements in vector `b` (eight signed 16-bit integer numbers) are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -6290,8 +6290,8 @@ pub unsafe fn __msa_max_s_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(four signed 32-bit integer numbers)
-/// and signed elements in vector 'b'(four signed 32-bit integer numbers) are written to vector
+/// Maximum values between signed elements in vector `a` (four signed 32-bit integer numbers)
+/// and signed elements in vector `b` (four signed 32-bit integer numbers) are written to vector
 /// (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -6303,8 +6303,8 @@ pub unsafe fn __msa_max_s_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(two signed 64-bit integer numbers)
-/// and signed elements in vector 'b'(two signed 64-bit integer numbers) are written to vector
+/// Maximum values between signed elements in vector `a` (two signed 64-bit integer numbers)
+/// and signed elements in vector `b` (two signed 64-bit integer numbers) are written to vector
 /// (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -6316,8 +6316,8 @@ pub unsafe fn __msa_max_s_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(sixteen unsigned 8-bit integer numbers)
-/// and unsigned elements in vector 'b'(sixteen unsigned 8-bit integer numbers) are written to vector
+/// Maximum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// and unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers) are written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -6329,8 +6329,8 @@ pub unsafe fn __msa_max_u_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(eight unsigned 16-bit integer numbers)
-/// and unsigned elements in vector 'b'(eight unsigned 16-bit integer numbers) are written to vector
+/// Maximum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// and unsigned elements in vector `b` (eight unsigned 16-bit integer numbers) are written to vector
 /// (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -6342,8 +6342,8 @@ pub unsafe fn __msa_max_u_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(four unsigned 32-bit integer numbers)
-/// and unsigned elements in vector 'b'(four unsigned 32-bit integer numbers) are written to vector
+/// Maximum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
+/// and unsigned elements in vector `b` (four unsigned 32-bit integer numbers) are written to vector
 /// (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -6355,8 +6355,8 @@ pub unsafe fn __msa_max_u_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(two unsigned 64-bit integer numbers)
-/// and unsigned elements in vector 'b'(two unsigned 64-bit integer numbers) are written to vector
+/// Maximum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
+/// and unsigned elements in vector `b` (two unsigned 64-bit integer numbers) are written to vector
 /// (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -6368,7 +6368,7 @@ pub unsafe fn __msa_max_u_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Immediate Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// Maximum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
@@ -6387,7 +6387,7 @@ pub unsafe fn __msa_maxi_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 
 /// Immediate Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(eight signed 16-bit integer numbers)
+/// Maximum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
@@ -6406,7 +6406,7 @@ pub unsafe fn __msa_maxi_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 
 /// Immediate Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(four signed 32-bit integer numbers)
+/// Maximum values between signed elements in vector `a` (four signed 32-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (four signed 32-bit integer numbers)
 ///
@@ -6425,7 +6425,7 @@ pub unsafe fn __msa_maxi_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 
 /// Immediate Signed Maximum
 ///
-/// Maximum values between signed elements in vector 'a'(two signed 64-bit integer numbers)
+/// Maximum values between signed elements in vector `a` (two signed 64-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (two signed 64-bit integer numbers)
 ///
@@ -6444,7 +6444,7 @@ pub unsafe fn __msa_maxi_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 
 /// Immediate Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(sixteen unsigned 8-bit integer numbers)
+/// Maximum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -6463,7 +6463,7 @@ pub unsafe fn __msa_maxi_u_b(a: v16u8, imm5: i32) -> v16u8 {
 
 /// Immediate Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(eight unsigned 16-bit integer numbers)
+/// Maximum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (eight unsigned 16-bit integer numbers)
 ///
@@ -6482,7 +6482,7 @@ pub unsafe fn __msa_maxi_u_h(a: v8u16, imm5: i32) -> v8u16 {
 
 /// Immediate Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(four unsigned 32-bit integer numbers)
+/// Maximum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (four unsigned 32-bit integer numbers)
 ///
@@ -6501,7 +6501,7 @@ pub unsafe fn __msa_maxi_u_w(a: v4u32, imm5: i32) -> v4u32 {
 
 /// Immediate Unsigned Maximum
 ///
-/// Maximum values between unsigned elements in vector 'a'(two unsigned 64-bit integer numbers)
+/// Maximum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (two unsigned 64-bit integer numbers)
 ///
@@ -6521,8 +6521,8 @@ pub unsafe fn __msa_maxi_u_d(a: v2u64, imm5: i32) -> v2u64 {
 /// Vector Minimum Based on Absolute Value
 ///
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(sixteen signed 8-bit integer numbers) and
-/// 'b'(sixteen signed 8-bit integer numbers) are written to vector
+/// signed elements in vector `a` (sixteen signed 8-bit integer numbers) and
+/// `b` (sixteen signed 8-bit integer numbers) are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -6535,8 +6535,8 @@ pub unsafe fn __msa_min_a_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Minimum Based on Absolute Value
 ///
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(eight signed 16-bit integer numbers) and
-/// 'b'(eight signed 16-bit integer numbers) are written to vector
+/// signed elements in vector `a` (eight signed 16-bit integer numbers) and
+/// `b` (eight signed 16-bit integer numbers) are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -6549,8 +6549,8 @@ pub unsafe fn __msa_min_a_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Minimum Based on Absolute Value
 ///
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(four signed 32-bit integer numbers) and
-/// 'b'(four signed 32-bit integer numbers) are written to vector
+/// signed elements in vector `a` (four signed 32-bit integer numbers) and
+/// `b` (four signed 32-bit integer numbers) are written to vector
 /// (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -6563,8 +6563,8 @@ pub unsafe fn __msa_min_a_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Minimum Based on Absolute Value
 ///
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
-/// signed elements in vector 'a'(two signed 64-bit integer numbers) and
-/// 'b'(two signed 64-bit integer numbers) are written to vector
+/// signed elements in vector `a` (two signed 64-bit integer numbers) and
+/// `b` (two signed 64-bit integer numbers) are written to vector
 /// (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -6576,8 +6576,8 @@ pub unsafe fn __msa_min_a_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// and signed elements in vector 'b'(sixteen signed 8-bit integer numbers) are written to vector
+/// Minimum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// and signed elements in vector `b` (sixteen signed 8-bit integer numbers) are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -6589,8 +6589,8 @@ pub unsafe fn __msa_min_s_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(eight signed 16-bit integer numbers)
-/// and signed elements in vector 'b'(eight signed 16-bit integer numbers) are written to vector
+/// Minimum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
+/// and signed elements in vector `b` (eight signed 16-bit integer numbers) are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -6602,8 +6602,8 @@ pub unsafe fn __msa_min_s_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(four signed 32-bit integer numbers)
-/// and signed elements in vector 'b'(four signed 32-bit integer numbers) are written to vector
+/// Minimum values between signed elements in vector `a` (four signed 32-bit integer numbers)
+/// and signed elements in vector `b` (four signed 32-bit integer numbers) are written to vector
 /// (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -6615,8 +6615,8 @@ pub unsafe fn __msa_min_s_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(two signed 64-bit integer numbers)
-/// and signed elements in vector 'b'(two signed 64-bit integer numbers) are written to vector
+/// Minimum values between signed elements in vector `a` (two signed 64-bit integer numbers)
+/// and signed elements in vector `b` (two signed 64-bit integer numbers) are written to vector
 /// (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -6628,7 +6628,7 @@ pub unsafe fn __msa_min_s_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// Minimum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (sixteen signed 8-bit integer numbers)
 ///
@@ -6647,7 +6647,7 @@ pub unsafe fn __msa_mini_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 
 /// Immediate Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(eight signed 16-bit integer numbers)
+/// Minimum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (eight signed 16-bit integer numbers)
 ///
@@ -6666,7 +6666,7 @@ pub unsafe fn __msa_mini_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 
 /// Immediate Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(four signed 32-bit integer numbers)
+/// Minimum values between signed elements in vector `a` (four signed 32-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (four signed 32-bit integer numbers)
 ///
@@ -6685,7 +6685,7 @@ pub unsafe fn __msa_mini_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 
 /// Immediate Signed Minimum
 ///
-/// Minimum values between signed elements in vector 'a'(two signed 64-bit integer numbers)
+/// Minimum values between signed elements in vector `a` (two signed 64-bit integer numbers)
 /// and  the 5-bit signed immediate imm_s5 are written to vector
 /// (two signed 64-bit integer numbers)
 ///
@@ -6704,8 +6704,8 @@ pub unsafe fn __msa_mini_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 
 /// Vector Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(sixteen unsigned 8-bit integer numbers)
-/// and unsigned elements in vector 'b'(sixteen unsigned 8-bit integer numbers) are written to vector
+/// Minimum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// and unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers) are written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
 #[inline]
@@ -6717,8 +6717,8 @@ pub unsafe fn __msa_min_u_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(eight unsigned 16-bit integer numbers)
-/// and unsigned elements in vector 'b'(eight unsigned 16-bit integer numbers) are written to vector
+/// Minimum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// and unsigned elements in vector `b` (eight unsigned 16-bit integer numbers) are written to vector
 /// (eight unsigned 16-bit integer numbers)
 ///
 #[inline]
@@ -6730,8 +6730,8 @@ pub unsafe fn __msa_min_u_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(four unsigned 32-bit integer numbers)
-/// and unsigned elements in vector 'b'(four unsigned 32-bit integer numbers) are written to vector
+/// Minimum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
+/// and unsigned elements in vector `b` (four unsigned 32-bit integer numbers) are written to vector
 /// (four unsigned 32-bit integer numbers)
 ///
 #[inline]
@@ -6743,8 +6743,8 @@ pub unsafe fn __msa_min_u_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(two unsigned 64-bit integer numbers)
-/// and unsigned elements in vector 'b'(two unsigned 64-bit integer numbers) are written to vector
+/// Minimum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
+/// and unsigned elements in vector `b` (two unsigned 64-bit integer numbers) are written to vector
 /// (two unsigned 64-bit integer numbers)
 ///
 #[inline]
@@ -6756,7 +6756,7 @@ pub unsafe fn __msa_min_u_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Immediate Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(sixteen unsigned 8-bit integer numbers)
+/// Minimum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -6775,7 +6775,7 @@ pub unsafe fn __msa_mini_u_b(a: v16u8, imm5: i32) -> v16u8 {
 
 /// Immediate Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(eight unsigned 16-bit integer numbers)
+/// Minimum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (eight unsigned 16-bit integer numbers)
 ///
@@ -6794,7 +6794,7 @@ pub unsafe fn __msa_mini_u_h(a: v8u16, imm5: i32) -> v8u16 {
 
 /// Immediate Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(four unsigned 32-bit integer numbers)
+/// Minimum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (four unsigned 32-bit integer numbers)
 ///
@@ -6813,7 +6813,7 @@ pub unsafe fn __msa_mini_u_w(a: v4u32, imm5: i32) -> v4u32 {
 
 /// Immediate Unsigned Minimum
 ///
-/// Minimum values between unsigned elements in vector 'a'(two unsigned 64-bit integer numbers)
+/// Minimum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
 /// and  the 5-bit unsigned immediate imm5 are written to vector
 /// (two unsigned 64-bit integer numbers)
 ///
@@ -6832,8 +6832,8 @@ pub unsafe fn __msa_mini_u_d(a: v2u64, imm5: i32) -> v2u64 {
 
 /// Vector Signed Modulo
 ///
-/// The signed integer elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are divided by signed integer elements in vector 'b'(sixteen signed 8-bit integer numbers)
+/// The signed integer elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (sixteen signed 8-bit integer numbers)
 /// The remainder of thesame sign as the dividend is written to vector
 /// (sixteen signed 8-bit integer numbers).If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
@@ -6847,10 +6847,10 @@ pub unsafe fn __msa_mod_s_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Signed Modulo
 ///
-/// The signed integer elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are divided by signed integer elements in vector 'b'(eight signed 16-bit integer numbers)
-/// The remainder of thesame sign as the dividend is written to vector
-/// (eight signed 16-bit integer numbers).If a divisor element vectorwt is zero,
+/// The signed integer elements in vector `a` (eight signed 16-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// The remainder of the same sign as the dividend is written to vector
+/// (eight signed 16-bit integer numbers). If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6862,10 +6862,10 @@ pub unsafe fn __msa_mod_s_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Signed Modulo
 ///
-/// The signed integer elements in vector 'a'(four signed 32-bit integer numbers)
-/// are divided by signed integer elements in vector 'b'(four signed 32-bit integer numbers)
-/// The remainder of thesame sign as the dividend is written to vector
-/// (four signed 32-bit integer numbers).If a divisor element vectorwt is zero,
+/// The signed integer elements in vector `a` (four signed 32-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (four signed 32-bit integer numbers)
+/// The remainder of the same sign as the dividend is written to vector
+/// (four signed 32-bit integer numbers). If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6877,10 +6877,10 @@ pub unsafe fn __msa_mod_s_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Signed Modulo
 ///
-/// The signed integer elements in vector 'a'(two signed 64-bit integer numbers)
-/// are divided by signed integer elements in vector 'b'(two signed 64-bit integer numbers)
-/// The remainder of thesame sign as the dividend is written to vector
-/// (two signed 64-bit integer numbers).If a divisor element vectorwt is zero,
+/// The signed integer elements in vector `a` (two signed 64-bit integer numbers)
+/// are divided by signed integer elements in vector `b` (two signed 64-bit integer numbers).
+/// The remainder of the same sign as the dividend is written to vector
+/// (two signed 64-bit integer numbers). If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6892,10 +6892,10 @@ pub unsafe fn __msa_mod_s_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Unsigned Modulo
 ///
-/// The unsigned integer elements in vector 'a'(sixteen unsigned 8-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b'(sixteen unsigned 8-bit integer numbers)
-/// The remainder of thesame sign as the dividend is written to vector
-/// (sixteen unsigned 8-bit integer numbers).If a divisor element vectorwt is zero,
+/// The unsigned integer elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (sixteen unsigned 8-bit integer numbers).
+/// The remainder of the same sign as the dividend is written to vector
+/// (sixteen unsigned 8-bit integer numbers). If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6907,8 +6907,8 @@ pub unsafe fn __msa_mod_u_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Unsigned Modulo
 ///
-/// The unsigned integer elements in vector 'a'(eight unsigned 16-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b'(eight unsigned 16-bit integer numbers)
+/// The unsigned integer elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (eight unsigned 16-bit integer numbers).
 /// The remainder of thesame sign as the dividend is written to vector
 /// (eight unsigned 16-bit integer numbers).If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
@@ -6922,10 +6922,10 @@ pub unsafe fn __msa_mod_u_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Unsigned Modulo
 ///
-/// The unsigned integer elements in vector 'a'(four unsigned 32-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b'(four unsigned 32-bit integer numbers)
+/// The unsigned integer elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (four unsigned 32-bit integer numbers).
 /// The remainder of thesame sign as the dividend is written to vector
-/// (four unsigned 32-bit integer numbers).If a divisor element vectorwt is zero,
+/// (four unsigned 32-bit integer numbers). If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
 ///
 #[inline]
@@ -6937,8 +6937,8 @@ pub unsafe fn __msa_mod_u_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Unsigned Modulo
 ///
-/// The unsigned integer elements in vector 'a'(two unsigned 64-bit integer numbers)
-/// are divided by unsigned integer elements in vector 'b'(two unsigned 64-bit integer numbers)
+/// The unsigned integer elements in vector `a` (two unsigned 64-bit integer numbers)
+/// are divided by unsigned integer elements in vector `b` (two unsigned 64-bit integer numbers).
 /// The remainder of thesame sign as the dividend is written to vector
 /// (two unsigned 64-bit integer numbers).If a divisor element vectorwt is zero,
 /// the result value is UNPREDICTABLE.
@@ -6952,7 +6952,7 @@ pub unsafe fn __msa_mod_u_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Vector Move
 ///
-/// Copy all WRLEN bits in vector 'a'(eight signed 16-bit integer numbers)
+/// Copy all WRLEN bits in vector `a` (eight signed 16-bit integer numbers)
 /// to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -6964,12 +6964,12 @@ pub unsafe fn __msa_move_v(a: v16i8) -> v16i8 {
 
 /// Vector Fixed-Point Multiply and Subtract
 ///
-/// The product of fixed-point elements in vector 'c'(eight signed 16-bit integer numbers)
-/// by fixed-point elements in vector 'b'(eight signed 16-bit integer numbers)
-/// are subtracted from the fixed-point elements in vector 'a'
-/// (eight signed 16-bit integer numbers).The multiplication result is not saturated,
+/// The product of fixed-point elements in vector `c` (eight signed 16-bit integer numbers)
+/// by fixed-point elements in vector `b` (eight signed 16-bit integer numbers)
+/// are subtracted from the fixed-point elements in vector `a`
+/// (eight signed 16-bit integer numbers). The multiplication result is not saturated,
 /// i.e. exact (-1) * (-1) = 1 is subtracted from the destination.
-/// The saturated fixed-point results are stored back to vector 'a'
+/// The saturated fixed-point results are stored back to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6980,12 +6980,12 @@ pub unsafe fn __msa_msub_q_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Fixed-Point Multiply and Subtract
 ///
-/// The product of fixed-point elements in vector 'c'(four signed 32-bit integer numbers)
-/// by fixed-point elements in vector 'b'(four signed 32-bit integer numbers)
-/// are subtracted from the fixed-point elements in vector 'a'
-/// (four signed 32-bit integer numbers).The multiplication result is not saturated,
+/// The product of fixed-point elements in vector `c` (four signed 32-bit integer numbers)
+/// by fixed-point elements in vector `b` (four signed 32-bit integer numbers)
+/// are subtracted from the fixed-point elements in vector `a`
+/// (four signed 32-bit integer numbers). The multiplication result is not saturated,
 /// i.e. exact (-1) * (-1) = 1 is subtracted from the destination.
-/// The saturated fixed-point results are stored back to vector 'a'
+/// The saturated fixed-point results are stored back to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6996,12 +6996,12 @@ pub unsafe fn __msa_msub_q_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Fixed-Point Multiply and Subtract Rounded
 ///
-/// The product of fixed-point elements in vector 'c'(eight signed 16-bit integer numbers)
-/// by fixed-point elements in vector 'b'(eight signed 16-bit integer numbers)
-/// are subtracted from the fixed-point elements in vector 'a'
-/// (eight signed 16-bit integer numbers).The multiplication result is not saturated,
+/// The product of fixed-point elements in vector `c` (eight signed 16-bit integer numbers)
+/// by fixed-point elements in vector `b` (eight signed 16-bit integer numbers)
+/// are subtracted from the fixed-point elements in vector `a`
+/// (eight signed 16-bit integer numbers). The multiplication result is not saturated,
 /// i.e. exact (-1) * (-1) = 1 is subtracted from the destination.
-/// The rounded and saturated fixed-point results are stored back to vector 'a'
+/// The rounded and saturated fixed-point results are stored back to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7012,12 +7012,12 @@ pub unsafe fn __msa_msubr_q_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Fixed-Point Multiply and Subtract Rounded
 ///
-/// The product of fixed-point elements in vector 'c'(four signed 32-bit integer numbers)
-/// by fixed-point elements in vector 'b'(four signed 32-bit integer numbers)
-/// are subtracted from the fixed-point elements in vector 'a'
-/// (four signed 32-bit integer numbers).The multiplication result is not saturated,
+/// The product of fixed-point elements in vector `c` (four signed 32-bit integer numbers)
+/// by fixed-point elements in vector `b` (four signed 32-bit integer numbers)
+/// are subtracted from the fixed-point elements in vector `a`
+/// (four signed 32-bit integer numbers). The multiplication result is not saturated,
 /// i.e. exact (-1) * (-1) = 1 is subtracted from the destination.
-/// The rounded and saturated fixed-point results are stored back to vector 'a'
+/// The rounded and saturated fixed-point results are stored back to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7028,9 +7028,9 @@ pub unsafe fn __msa_msubr_q_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Multiply and Subtract
 ///
-/// The integer elements in vector 'c'(sixteen signed 8-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(sixteen signed 8-bit integer numbers)
-/// and subtracted from the integer elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The integer elements in vector `c` (sixteen signed 8-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (sixteen signed 8-bit integer numbers)
+/// and subtracted from the integer elements in vector `a` (sixteen signed 8-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7042,9 +7042,9 @@ pub unsafe fn __msa_msubv_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 
 /// Vector Multiply and Subtract
 ///
-/// The integer elements in vector 'c'(eight signed 16-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(eight signed 16-bit integer numbers)
-/// and subtracted from the integer elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The integer elements in vector `c` (eight signed 16-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (eight signed 16-bit integer numbers)
+/// and subtracted from the integer elements in vector `a` (eight signed 16-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7056,9 +7056,9 @@ pub unsafe fn __msa_msubv_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 
 /// Vector Multiply and Subtract
 ///
-/// The integer elements in vector 'c'(four signed 32-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(four signed 32-bit integer numbers)
-/// and subtracted from the integer elements in vector 'a'(four signed 32-bit integer numbers)
+/// The integer elements in vector `c` (four signed 32-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (four signed 32-bit integer numbers)
+/// and subtracted from the integer elements in vector `a` (four signed 32-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7070,9 +7070,9 @@ pub unsafe fn __msa_msubv_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 
 /// Vector Multiply and Subtract
 ///
-/// The integer elements in vector 'c'(two signed 64-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(two signed 64-bit integer numbers)
-/// and subtracted from the integer elements in vector 'a'(two signed 64-bit integer numbers)
+/// The integer elements in vector `c` (two signed 64-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (two signed 64-bit integer numbers)
+/// and subtracted from the integer elements in vector `a` (two signed 64-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7084,9 +7084,9 @@ pub unsafe fn __msa_msubv_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
 
 /// Vector Fixed-Point Multiply
 ///
-/// The fixed-point elements in vector 'a'(eight signed 16-bit integer numbers)
-/// multiplied by fixed-point elements in vector 'b'(eight signed 16-bit integer numbers)
-/// The result is written to vector (eight signed 16-bit integer numbers)
+/// The fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
+/// multiplied by fixed-point elements in vector `b` (eight signed 16-bit integer numbers).
+/// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7097,9 +7097,9 @@ pub unsafe fn __msa_mul_q_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Fixed-Point Multiply
 ///
-/// The fixed-point elements in vector 'a'(four signed 32-bit integer numbers)
-/// multiplied by fixed-point elements in vector 'b'(four signed 32-bit integer numbers)
-/// The result is written to vector (four signed 32-bit integer numbers)
+/// The fixed-point elements in vector `a` (four signed 32-bit integer numbers)
+/// multiplied by fixed-point elements in vector `b` (four signed 32-bit integer numbers).
+/// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7110,9 +7110,9 @@ pub unsafe fn __msa_mul_q_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Fixed-Point Multiply Rounded
 ///
-/// The fixed-point elements in vector 'a'(eight signed 16-bit integer numbers)
-/// multiplied by fixed-point elements in vector 'b'(eight signed 16-bit integer numbers)
-/// The rounded result is written to vector (eight signed 16-bit integer numbers)
+/// The fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
+/// multiplied by fixed-point elements in vector `b` (eight signed 16-bit integer numbers).
+/// The rounded result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7123,9 +7123,9 @@ pub unsafe fn __msa_mulr_q_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Fixed-Point Multiply Rounded
 ///
-/// The fixed-point elements in vector 'a'(four signed 32-bit integer numbers)
-/// multiplied by fixed-point elements in vector 'b'(four signed 32-bit integer numbers)
-/// The rounded result is written to vector (four signed 32-bit integer numbers)
+/// The fixed-point elements in vector `a` (four signed 32-bit integer numbers)
+/// multiplied by fixed-point elements in vector `b` (four signed 32-bit integer numbers).
+/// The rounded result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7136,8 +7136,8 @@ pub unsafe fn __msa_mulr_q_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Multiply
 ///
-/// The integer elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(sixteen signed 8-bit integer numbers)
+/// The integer elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (sixteen signed 8-bit integer numbers)
 /// The result is written to vector (sixteen signed 8-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
@@ -7150,8 +7150,8 @@ pub unsafe fn __msa_mulv_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Multiply
 ///
-/// The integer elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(eight signed 16-bit integer numbers)
+/// The integer elements in vector `a` (eight signed 16-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (eight signed 16-bit integer numbers)
 /// The result is written to vector (eight signed 16-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
@@ -7164,8 +7164,8 @@ pub unsafe fn __msa_mulv_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Multiply
 ///
-/// The integer elements in vector 'a'(four signed 32-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(four signed 32-bit integer numbers)
+/// The integer elements in vector `a` (four signed 32-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (four signed 32-bit integer numbers)
 /// The result is written to vector (four signed 32-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
@@ -7178,8 +7178,8 @@ pub unsafe fn __msa_mulv_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Multiply
 ///
-/// The integer elements in vector 'a'(two signed 64-bit integer numbers)
-/// are multiplied by integer elements in vector 'b'(two signed 64-bit integer numbers)
+/// The integer elements in vector `a` (two signed 64-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (two signed 64-bit integer numbers)
 /// The result is written to vector (two signed 64-bit integer numbers)
 /// The most significant half of the multiplication result is discarded.
 ///
@@ -7192,7 +7192,7 @@ pub unsafe fn __msa_mulv_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Leading Ones Count
 ///
-/// The number of leading ones for elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The number of leading ones for elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// is stored to the elements in vector (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -7204,7 +7204,7 @@ pub unsafe fn __msa_nloc_b(a: v16i8) -> v16i8 {
 
 /// Vector Leading Ones Count
 ///
-/// The number of leading ones for elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The number of leading ones for elements in vector `a` (eight signed 16-bit integer numbers)
 /// is stored to the elements in vector (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -7216,7 +7216,7 @@ pub unsafe fn __msa_nloc_h(a: v8i16) -> v8i16 {
 
 /// Vector Leading Ones Count
 ///
-/// The number of leading ones for elements in vector 'a'(four signed 32-bit integer numbers)
+/// The number of leading ones for elements in vector `a` (four signed 32-bit integer numbers)
 /// is stored to the elements in vector (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -7228,7 +7228,7 @@ pub unsafe fn __msa_nloc_w(a: v4i32) -> v4i32 {
 
 /// Vector Leading Ones Count
 ///
-/// The number of leading ones for elements in vector 'a'(two signed 64-bit integer numbers)
+/// The number of leading ones for elements in vector `a` (two signed 64-bit integer numbers)
 /// is stored to the elements in vector (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -7240,7 +7240,7 @@ pub unsafe fn __msa_nloc_d(a: v2i64) -> v2i64 {
 
 /// Vector Leading Zeros Count
 ///
-/// The number of leading zeros for elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The number of leading zeros for elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// is stored to the elements in vector (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -7252,7 +7252,7 @@ pub unsafe fn __msa_nlzc_b(a: v16i8) -> v16i8 {
 
 /// Vector Leading Zeros Count
 ///
-/// The number of leading zeros for elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The number of leading zeros for elements in vector `a` (eight signed 16-bit integer numbers)
 /// is stored to the elements in vector (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -7264,7 +7264,7 @@ pub unsafe fn __msa_nlzc_h(a: v8i16) -> v8i16 {
 
 /// Vector Leading Zeros Count
 ///
-/// The number of leading zeros for elements in vector 'a'(four signed 32-bit integer numbers)
+/// The number of leading zeros for elements in vector `a` (four signed 32-bit integer numbers)
 /// is stored to the elements in vector (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -7276,7 +7276,7 @@ pub unsafe fn __msa_nlzc_w(a: v4i32) -> v4i32 {
 
 /// Vector Leading Zeros Count
 ///
-/// The number of leading zeros for elements in vector 'a'(two signed 64-bit integer numbers)
+/// The number of leading zeros for elements in vector `a` (two signed 64-bit integer numbers)
 /// is stored to the elements in vector (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -7288,8 +7288,8 @@ pub unsafe fn __msa_nlzc_d(a: v2i64) -> v2i64 {
 
 /// Vector Logical Negated Or
 ///
-/// Each bit of vector 'a'(sixteen unsigned 8-bit integer numbers)
-/// is combined with the corresponding bit of vector 'b' (sixteen unsigned 8-bit integer numbers)
+/// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical NOR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -7302,7 +7302,7 @@ pub unsafe fn __msa_nor_v(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Immediate Logical Negated Or
 ///
-/// Each bit of vector 'a'(sixteen unsigned 8-bit integer numbers)
+/// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the  8-bit immediate imm8
 /// in a bitwise logical NOR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
@@ -7322,8 +7322,8 @@ pub unsafe fn __msa_nori_b(a: v16u8, imm8: i32) -> v16u8 {
 
 /// Vector Logical Or
 ///
-/// Each bit of vector 'a'(sixteen unsigned 8-bit integer numbers)
-/// is combined with the corresponding bit of vector 'b' (sixteen unsigned 8-bit integer numbers)
+/// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical OR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -7336,7 +7336,7 @@ pub unsafe fn __msa_or_v(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Immediate Logical Or
 ///
-/// Each bit of vector 'a'(sixteen unsigned 8-bit integer numbers)
+/// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the  8-bit immediate imm8
 /// in a bitwise logical OR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
@@ -7356,8 +7356,8 @@ pub unsafe fn __msa_ori_b(a: v16u8, imm8: i32) -> v16u8 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors 'a' (sixteen signed 8-bit integer numbers)
-/// are copied to the left half of the result vector and even elements in vector 'b'
+/// Even  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// are copied to the left half of the result vector and even elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7369,8 +7369,8 @@ pub unsafe fn __msa_pckev_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors 'a' (eight signed 16-bit integer numbers)
-/// are copied to the left half of the result vector and even elements in vector 'b'
+/// Even  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// are copied to the left half of the result vector and even elements in vector `b`
 /// (eight signed 16-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7382,8 +7382,8 @@ pub unsafe fn __msa_pckev_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors 'a' (four signed 32-bit integer numbers)
-/// are copied to the left half of the result vector and even elements in vector 'b'
+/// Even  elements in vectors `a` (four signed 32-bit integer numbers)
+/// are copied to the left half of the result vector and even elements in vector `b`
 /// (four signed 32-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7395,8 +7395,8 @@ pub unsafe fn __msa_pckev_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Pack Even
 ///
-/// Even  elements in vectors 'a' (two signed 64-bit integer numbers)
-/// are copied to the left half of the result vector and even elements in vector 'b'
+/// Even  elements in vectors `a` (two signed 64-bit integer numbers)
+/// are copied to the left half of the result vector and even elements in vector `b`
 /// (two signed 64-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7408,8 +7408,8 @@ pub unsafe fn __msa_pckev_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors 'a' (sixteen signed 8-bit integer numbers)
-/// are copied to the left half of the result vector and odd elements in vector 'b'
+/// Odd  elements in vectors `a` (sixteen signed 8-bit integer numbers)
+/// are copied to the left half of the result vector and odd elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7421,8 +7421,8 @@ pub unsafe fn __msa_pckod_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors 'a' (eight signed 16-bit integer numbers)
-/// are copied to the left half of the result vector and odd elements in vector 'b'
+/// Odd  elements in vectors `a` (eight signed 16-bit integer numbers)
+/// are copied to the left half of the result vector and odd elements in vector `b`
 /// (eight signed 16-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7434,8 +7434,8 @@ pub unsafe fn __msa_pckod_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors 'a' (four signed 32-bit integer numbers)
-/// are copied to the left half of the result vector and odd elements in vector 'b'
+/// Odd  elements in vectors `a` (four signed 32-bit integer numbers)
+/// are copied to the left half of the result vector and odd elements in vector `b`
 /// (four signed 32-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7447,8 +7447,8 @@ pub unsafe fn __msa_pckod_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Pack Odd
 ///
-/// Odd  elements in vectors 'a' (two signed 64-bit integer numbers)
-/// are copied to the left half of the result vector and odd elements in vector 'b'
+/// Odd  elements in vectors `a` (two signed 64-bit integer numbers)
+/// are copied to the left half of the result vector and odd elements in vector `b`
 /// (two signed 64-bit integer numbers) are copied to the right half of the result vector.
 ///
 #[inline]
@@ -7460,7 +7460,7 @@ pub unsafe fn __msa_pckod_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Vector Population Count
 ///
-/// The number of bits set to 1 for elements in vector 'a' (sixteen signed 8-bit integer numbers)
+/// The number of bits set to 1 for elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// is stored to the elements in the result vector (sixteen signed 8-bit integer numbers)
 ///
 #[inline]
@@ -7472,7 +7472,7 @@ pub unsafe fn __msa_pcnt_b(a: v16i8) -> v16i8 {
 
 /// Vector Population Count
 ///
-/// The number of bits set to 1 for elements in vector 'a' (eight signed 16-bit integer numbers)
+/// The number of bits set to 1 for elements in vector `a` (eight signed 16-bit integer numbers)
 /// is stored to the elements in the result vector (eight signed 16-bit integer numbers)
 ///
 #[inline]
@@ -7484,7 +7484,7 @@ pub unsafe fn __msa_pcnt_h(a: v8i16) -> v8i16 {
 
 /// Vector Population Count
 ///
-/// The number of bits set to 1 for elements in vector 'a' (four signed 32-bit integer numbers)
+/// The number of bits set to 1 for elements in vector `a` (four signed 32-bit integer numbers)
 /// is stored to the elements in the result vector (four signed 32-bit integer numbers)
 ///
 #[inline]
@@ -7496,7 +7496,7 @@ pub unsafe fn __msa_pcnt_w(a: v4i32) -> v4i32 {
 
 /// Vector Population Count
 ///
-/// The number of bits set to 1 for elements in vector 'a' (two signed 64-bit integer numbers)
+/// The number of bits set to 1 for elements in vector `a` (two signed 64-bit integer numbers)
 /// is stored to the elements in the result vector (two signed 64-bit integer numbers)
 ///
 #[inline]
@@ -7508,7 +7508,7 @@ pub unsafe fn __msa_pcnt_d(a: v2i64) -> v2i64 {
 
 /// Immediate Signed Saturate
 ///
-/// Signed elements in vector 'a' (sixteen signed 8-bit integer numbers)
+/// Signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are saturated to signed values of imm3+1 bits without changing the data width
 /// The result is stored in the vector (sixteen signed 8-bit integer numbers)
 ///
@@ -7527,7 +7527,7 @@ pub unsafe fn __msa_sat_s_b(a: v16i8, imm3: i32) -> v16i8 {
 
 /// Immediate Signed Saturate
 ///
-/// Signed elements in vector 'a' (eight signed 16-bit integer numbers)
+/// Signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// are saturated to signed values of imm4+1 bits without changing the data width
 /// The result is stored in the vector (eight signed 16-bit integer numbers)
 ///
@@ -7546,7 +7546,7 @@ pub unsafe fn __msa_sat_s_h(a: v8i16, imm4: i32) -> v8i16 {
 
 /// Immediate Signed Saturate
 ///
-/// Signed elements in vector 'a' (four signed 32-bit integer numbers)
+/// Signed elements in vector `a` (four signed 32-bit integer numbers)
 /// are saturated to signed values of imm5+1 bits without changing the data width
 /// The result is stored in the vector (four signed 32-bit integer numbers)
 ///
@@ -7565,7 +7565,7 @@ pub unsafe fn __msa_sat_s_w(a: v4i32, imm5: i32) -> v4i32 {
 
 /// Immediate Signed Saturate
 ///
-/// Signed elements in vector 'a' (two signed 64-bit integer numbers)
+/// Signed elements in vector `a` (two signed 64-bit integer numbers)
 /// are saturated to signed values of imm6+1 bits without changing the data width
 /// The result is stored in the vector (two signed 64-bit integer numbers)
 ///
@@ -7584,7 +7584,7 @@ pub unsafe fn __msa_sat_s_d(a: v2i64, imm6: i32) -> v2i64 {
 
 /// Immediate Unsigned Saturate
 ///
-/// Unsigned elements in vector 'a' (sixteen unsigned 8-bit integer numbers)
+/// Unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// are saturated to unsigned values of imm3+1 bits without changing the data width
 /// The result is stored in the vector (sixteen unsigned 8-bit integer numbers)
 ///
@@ -7603,7 +7603,7 @@ pub unsafe fn __msa_sat_u_b(a: v16u8, imm3: i32) -> v16u8 {
 
 /// Immediate Unsigned Saturate
 ///
-/// Unsigned elements in vector 'a' (eight unsigned 16-bit integer numbers)
+/// Unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// are saturated to unsigned values of imm4+1 bits without changing the data width
 /// The result is stored in the vector (eight unsigned 16-bit integer numbers)
 ///
@@ -7622,7 +7622,7 @@ pub unsafe fn __msa_sat_u_h(a: v8u16, imm4: i32) -> v8u16 {
 
 /// Immediate Unsigned Saturate
 ///
-/// Unsigned elements in vector 'a' (four unsigned 32-bit integer numbers)
+/// Unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
 /// are saturated to unsigned values of imm5+1 bits without changing the data width
 /// The result is stored in the vector (four unsigned 32-bit integer numbers)
 ///
@@ -7641,7 +7641,7 @@ pub unsafe fn __msa_sat_u_w(a: v4u32, imm5: i32) -> v4u32 {
 
 /// Immediate Unsigned Saturate
 ///
-/// Unsigned elements in vector 'a' (two unsigned 64-bit integer numbers)
+/// Unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
 /// are saturated to unsigned values of imm6+1 bits without changing the data width
 /// The result is stored in the vector (two unsigned 64-bit integer numbers)
 ///
@@ -7661,7 +7661,7 @@ pub unsafe fn __msa_sat_u_d(a: v2u64, imm6: i32) -> v2u64 {
 /// Immediate Set Shuffle Elements
 ///
 /// The set shuffle instruction works on 4-element sets.
-/// All sets are shuffled in the same way: the element i82i+1..2i in 'a'
+/// All sets are shuffled in the same way: the element i82i+1..2i in `a`
 /// (sixteen signed 8-bit integer numbers) is copied over the element i in result vector
 /// (sixteen signed 8-bit integer numbers), where i is 0, 1, 2, 3.
 ///
@@ -7681,7 +7681,7 @@ pub unsafe fn __msa_shf_b(a: v16i8, imm8: i32) -> v16i8 {
 /// Immediate Set Shuffle Elements
 ///
 /// The set shuffle instruction works on 4-element sets.
-/// All sets are shuffled in the same way: the element i82i+1..2i in 'a'
+/// All sets are shuffled in the same way: the element i82i+1..2i in `a`
 /// (eight signed 16-bit integer numbers) is copied over the element i in result vector
 /// (eight signed 16-bit integer numbers), where i is 0, 1, 2, 3.
 ///
@@ -7701,7 +7701,7 @@ pub unsafe fn __msa_shf_h(a: v8i16, imm8: i32) -> v8i16 {
 /// Immediate Set Shuffle Elements
 ///
 /// The set shuffle instruction works on 4-element sets.
-/// All sets are shuffled in the same way: the element i82i+1..2i in 'a'
+/// All sets are shuffled in the same way: the element i82i+1..2i in `a`
 /// (four signed 32-bit integer numbers) is copied over the element i in result vector
 /// (four signed 32-bit integer numbers), where i is 0, 1, 2, 3.
 ///
@@ -7720,15 +7720,15 @@ pub unsafe fn __msa_shf_w(a: v4i32, imm8: i32) -> v4i32 {
 
 /// GPR Columns Slide
 ///
-/// Vector registers 'a' (sixteen signed 8-bit integer numbers) and 'b'
+/// Vector registers `a` (sixteen signed 8-bit integer numbers) and `b`
 /// (sixteen signed 8-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
-/// by the number of columns given in GPR 'c'.
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
+/// by the number of columns given in GPR `c`.
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
-/// GPR 'c' value is interpreted modulo the number of columns in destination rectangle,
+/// GPR `c` value is interpreted modulo the number of columns in destination rectangle,
 /// or equivalently, the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -7740,15 +7740,15 @@ pub unsafe fn __msa_sld_b(a: v16i8, b: v16i8, c: i32) -> v16i8 {
 
 /// GPR Columns Slide
 ///
-/// Vector registers 'a' (eight signed 16-bit integer numbers) and 'b'
+/// Vector registers `a` (eight signed 16-bit integer numbers) and `b`
 /// (eight signed 16-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
-/// by the number of columns given in GPR 'c'.
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
+/// by the number of columns given in GPR `c`.
 /// The result is written to vector (eight signed 16-bit integer numbers).
-/// GPR 'c' value is interpreted modulo the number of columns in destination rectangle,
+/// GPR `c` value is interpreted modulo the number of columns in destination rectangle,
 /// or equivalently, the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -7760,15 +7760,15 @@ pub unsafe fn __msa_sld_h(a: v8i16, b: v8i16, c: i32) -> v8i16 {
 
 /// GPR Columns Slide
 ///
-/// Vector registers 'a' (four signed 32-bit integer numbers) and 'b'
+/// Vector registers `a` (four signed 32-bit integer numbers) and `b`
 /// (four signed 32-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
-/// by the number of columns given in GPR 'c'.
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
+/// by the number of columns given in GPR `c`.
 /// The result is written to vector (four signed 32-bit integer numbers).
-/// GPR 'c' value is interpreted modulo the number of columns in destination rectangle,
+/// GPR `c` value is interpreted modulo the number of columns in destination rectangle,
 /// or equivalently, the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -7780,15 +7780,15 @@ pub unsafe fn __msa_sld_w(a: v4i32, b: v4i32, c: i32) -> v4i32 {
 
 /// GPR Columns Slide
 ///
-/// Vector registers 'a' (two signed 64-bit integer numbers) and 'b'
+/// Vector registers `a` (two signed 64-bit integer numbers) and `b`
 /// (two signed 64-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
-/// by the number of columns given in GPR 'c'.
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
+/// by the number of columns given in GPR `c`.
 /// The result is written to vector (two signed 64-bit integer numbers).
-/// GPR 'c' value is interpreted modulo the number of columns in destination rectangle,
+/// GPR `c` value is interpreted modulo the number of columns in destination rectangle,
 /// or equivalently, the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -7800,12 +7800,12 @@ pub unsafe fn __msa_sld_d(a: v2i64, b: v2i64, c: i32) -> v2i64 {
 
 /// Immediate Columns Slide
 ///
-/// Vector registers 'a' (sixteen signed 8-bit integer numbers) and 'b'
+/// Vector registers `a` (sixteen signed 8-bit integer numbers) and `b`
 /// (sixteen signed 8-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
 /// by imm1 columns
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -7824,12 +7824,12 @@ pub unsafe fn __msa_sldi_b(a: v16i8, b: v16i8, imm4: i32) -> v16i8 {
 
 /// Immediate Columns Slide
 ///
-/// Vector registers 'a' (eight signed 16-bit integer numbers) and 'b'
+/// Vector registers `a` (eight signed 16-bit integer numbers) and `b`
 /// (eight signed 16-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
 /// by imm1 columns
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -7848,12 +7848,12 @@ pub unsafe fn __msa_sldi_h(a: v8i16, b: v8i16, imm3: i32) -> v8i16 {
 
 /// Immediate Columns Slide
 ///
-/// Vector registers 'a' (four signed 32-bit integer numbers) and 'b'
+/// Vector registers `a` (four signed 32-bit integer numbers) and `b`
 /// (four signed 32-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
 /// by imm1 columns
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -7872,12 +7872,12 @@ pub unsafe fn __msa_sldi_w(a: v4i32, b: v4i32, imm2: i32) -> v4i32 {
 
 /// Immediate Columns Slide
 ///
-/// Vector registers 'a' (two signed 64-bit integer numbers) and 'b'
+/// Vector registers `a` (two signed 64-bit integer numbers) and `b`
 /// (two signed 64-bit integer numbers) contain 2-dimensional byte arrays (rectangles)
 /// stored row-wise with as many rows asbytes in integer data format df.
-/// The two source rectangles 'b' and 'a' are concatenated horizontally in the order
-/// they appear in the syntax, i.e. first 'a' and then 'b'. Place a new destination
-/// rectangle over 'b' and then slide it to the left over the concatenation of 'a' and 'b'
+/// The two source rectangles `b` and `a` are concatenated horizontally in the order
+/// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
+/// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
 /// by imm1 columns
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
@@ -7896,8 +7896,8 @@ pub unsafe fn __msa_sldi_d(a: v2i64, b: v2i64, imm1: i32) -> v2i64 {
 
 /// Vector Shift Left
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are shifted left by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are shifted left by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -7910,8 +7910,8 @@ pub unsafe fn __msa_sll_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Shift Left
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are shifted left by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
+/// are shifted left by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector (eight signed 16-bit integer numbers).
 ///
@@ -7924,8 +7924,8 @@ pub unsafe fn __msa_sll_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Shift Left
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
-/// are shifted left by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (four signed 32-bit integer numbers)
+/// are shifted left by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector (four signed 32-bit integer numbers).
 ///
@@ -7938,8 +7938,8 @@ pub unsafe fn __msa_sll_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Shift Left
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
-/// are shifted left by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (two signed 64-bit integer numbers)
+/// are shifted left by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(two signed 64-bit integer numbers).
 ///
@@ -7952,7 +7952,7 @@ pub unsafe fn __msa_sll_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Shift Left
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted left by the imm4 bits.
 /// The result is written to vector(sixteen signed 8-bit integer numbers).
 ///
@@ -7971,7 +7971,7 @@ pub unsafe fn __msa_slli_b(a: v16i8, imm4: i32) -> v16i8 {
 
 /// Immediate Shift Left
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted left by the imm3 bits.
 /// The result is written to vector(eight signed 16-bit integer numbers).
 ///
@@ -7990,7 +7990,7 @@ pub unsafe fn __msa_slli_h(a: v8i16, imm3: i32) -> v8i16 {
 
 /// Immediate Shift Left
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
+/// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted left by the imm2 bits.
 /// The result is written to vector(four signed 32-bit integer numbers).
 ///
@@ -8009,7 +8009,7 @@ pub unsafe fn __msa_slli_w(a: v4i32, imm2: i32) -> v4i32 {
 
 /// Immediate Shift Left
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
+/// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted left by the imm1 bits.
 /// The result is written to vector(two signed 64-bit integer numbers).
 ///
@@ -8028,9 +8028,9 @@ pub unsafe fn __msa_slli_d(a: v2i64, imm1: i32) -> v2i64 {
 
 /// GPR Element Splat
 ///
-/// Replicate vector 'a'(sixteen signed 8-bit integer numbers)
-/// element with index given by GPR 'b' to all elements in vector
-/// (sixteen signed 8-bit integer numbers) GPR 'b' value is interpreted
+/// Replicate vector `a` (sixteen signed 8-bit integer numbers)
+/// element with index given by GPR `b` to all elements in vector
+/// (sixteen signed 8-bit integer numbers) GPR `b` value is interpreted
 /// modulo the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -8042,9 +8042,9 @@ pub unsafe fn __msa_splat_b(a: v16i8, b: i32) -> v16i8 {
 
 /// GPR Element Splat
 ///
-/// Replicate vector 'a'(eight signed 16-bit integer numbers)
-/// element with index given by GPR 'b' to all elements in vector
-/// (eight signed 16-bit integer numbers) GPR 'b' value is interpreted
+/// Replicate vector `a` (eight signed 16-bit integer numbers)
+/// element with index given by GPR `b` to all elements in vector
+/// (eight signed 16-bit integer numbers) GPR `b` value is interpreted
 /// modulo the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -8056,9 +8056,9 @@ pub unsafe fn __msa_splat_h(a: v8i16, b: i32) -> v8i16 {
 
 /// GPR Element Splat
 ///
-/// Replicate vector 'a'(four signed 32-bit integer numbers)
-/// element with index given by GPR 'b' to all elements in vector
-/// (four signed 32-bit integer numbers) GPR 'b' value is interpreted
+/// Replicate vector `a` (four signed 32-bit integer numbers)
+/// element with index given by GPR `b` to all elements in vector
+/// (four signed 32-bit integer numbers) GPR `b` value is interpreted
 /// modulo the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -8070,9 +8070,9 @@ pub unsafe fn __msa_splat_w(a: v4i32, b: i32) -> v4i32 {
 
 /// GPR Element Splat
 ///
-/// Replicate vector 'a'(two signed 64-bit integer numbers)
-/// element with index given by GPR 'b' to all elements in vector
-/// (two signed 64-bit integer numbers) GPR 'b' value is interpreted
+/// Replicate vector `a` (two signed 64-bit integer numbers)
+/// element with index given by GPR `b` to all elements in vector
+/// (two signed 64-bit integer numbers) GPR `b` value is interpreted
 /// modulo the number of data format df elements in the destination vector.
 ///
 #[inline]
@@ -8084,7 +8084,7 @@ pub unsafe fn __msa_splat_d(a: v2i64, b: i32) -> v2i64 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm4 in vector 'a'(sixteen signed 8-bit integer numbers)
+/// Replicate element imm4 in vector `a` (sixteen signed 8-bit integer numbers)
 /// to all elements in vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -8102,7 +8102,7 @@ pub unsafe fn __msa_splati_b(a: v16i8, imm4: i32) -> v16i8 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm3 in vector 'a'(eight signed 16-bit integer numbers)
+/// Replicate element imm3 in vector `a` (eight signed 16-bit integer numbers)
 /// to all elements in vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -8120,7 +8120,7 @@ pub unsafe fn __msa_splati_h(a: v8i16, imm3: i32) -> v8i16 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm2 in vector 'a'(four signed 32-bit integer numbers)
+/// Replicate element imm2 in vector `a` (four signed 32-bit integer numbers)
 /// to all elements in vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -8138,7 +8138,7 @@ pub unsafe fn __msa_splati_w(a: v4i32, imm2: i32) -> v4i32 {
 
 /// Immediate Element Splat
 ///
-/// Replicate element imm1 in vector 'a'(two signed 64-bit integer numbers)
+/// Replicate element imm1 in vector `a` (two signed 64-bit integer numbers)
 /// to all elements in vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -8156,8 +8156,8 @@ pub unsafe fn __msa_splati_d(a: v2i64, imm1: i32) -> v2i64 {
 
 /// Vector Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(sixteen signed 8-bit integer numbers).
 ///
@@ -8170,8 +8170,8 @@ pub unsafe fn __msa_sra_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(eight signed 16-bit integer numbers).
 ///
@@ -8184,8 +8184,8 @@ pub unsafe fn __msa_sra_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (four signed 32-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(four signed 32-bit integer numbers).
 ///
@@ -8198,8 +8198,8 @@ pub unsafe fn __msa_sra_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (two signed 64-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(two signed 64-bit integer numbers).
 ///
@@ -8212,7 +8212,7 @@ pub unsafe fn __msa_sra_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right arithmetic by imm3 bits.
 /// The result is written to vector(sixteen signed 8-bit integer numbers).
 ///
@@ -8231,7 +8231,7 @@ pub unsafe fn __msa_srai_b(a: v16i8, imm3: i32) -> v16i8 {
 
 /// Immediate Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right arithmetic by imm4 bits.
 /// The result is written to vector(eight signed 16-bit integer numbers).
 ///
@@ -8250,7 +8250,7 @@ pub unsafe fn __msa_srai_h(a: v8i16, imm4: i32) -> v8i16 {
 
 /// Immediate Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
+/// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right arithmetic by imm5 bits.
 /// The result is written to vector(four signed 32-bit integer numbers).
 ///
@@ -8269,7 +8269,7 @@ pub unsafe fn __msa_srai_w(a: v4i32, imm5: i32) -> v4i32 {
 
 /// Immediate Shift Right Arithmetic
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
+/// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right arithmetic by imm6 bits.
 /// The result is written to vector(two signed 64-bit integer numbers).
 ///
@@ -8288,8 +8288,8 @@ pub unsafe fn __msa_srai_d(a: v2i64, imm6: i32) -> v2i64 {
 
 /// Vector Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(sixteen signed 8-bit integer numbers).
@@ -8303,8 +8303,8 @@ pub unsafe fn __msa_srar_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(eight signed 16-bit integer numbers).
@@ -8318,8 +8318,8 @@ pub unsafe fn __msa_srar_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (four signed 32-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(four signed 32-bit integer numbers).
@@ -8333,8 +8333,8 @@ pub unsafe fn __msa_srar_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
-/// are shifted right arithmetic by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (two signed 64-bit integer numbers)
+/// are shifted right arithmetic by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(two signed 64-bit integer numbers).
@@ -8348,7 +8348,7 @@ pub unsafe fn __msa_srar_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right arithmetic by imm3 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(sixteen signed 8-bit integer numbers).
@@ -8368,7 +8368,7 @@ pub unsafe fn __msa_srari_b(a: v16i8, imm3: i32) -> v16i8 {
 
 /// Immediate Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right arithmetic by imm4 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(eight signed 16-bit integer numbers).
@@ -8388,7 +8388,7 @@ pub unsafe fn __msa_srari_h(a: v8i16, imm4: i32) -> v8i16 {
 
 /// Immediate Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
+/// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right arithmetic by imm5 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(four signed 32-bit integer numbers).
@@ -8408,7 +8408,7 @@ pub unsafe fn __msa_srari_w(a: v4i32, imm5: i32) -> v4i32 {
 
 /// Immediate Shift Right Arithmetic Rounded
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
+/// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right arithmetic by imm6 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(two signed 64-bit integer numbers).
@@ -8428,8 +8428,8 @@ pub unsafe fn __msa_srari_d(a: v2i64, imm6: i32) -> v2i64 {
 
 /// Vector Shift Right Logical
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(sixteen signed 8-bit integer numbers).
 ///
@@ -8442,8 +8442,8 @@ pub unsafe fn __msa_srl_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Shift Right Logical
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(eight signed 16-bit integer numbers).
 ///
@@ -8456,8 +8456,8 @@ pub unsafe fn __msa_srl_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Shift Right Logical
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (four signed 32-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(four signed 32-bit integer numbers).
 ///
@@ -8470,8 +8470,8 @@ pub unsafe fn __msa_srl_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Shift Right Logical
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (two signed 64-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The result is written to vector(two signed 64-bit integer numbers).
 ///
@@ -8484,7 +8484,7 @@ pub unsafe fn __msa_srl_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Shift Right Logical
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right logical by imm4 bits.
 /// The result is written to vector(sixteen signed 8-bit integer numbers).
 ///
@@ -8503,7 +8503,7 @@ pub unsafe fn __msa_srli_b(a: v16i8, imm4: i32) -> v16i8 {
 
 /// Immediate Shift Right Logical
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right logical by imm3 bits.
 /// The result is written to vector(eight signed 16-bit integer numbers).
 ///
@@ -8522,7 +8522,7 @@ pub unsafe fn __msa_srli_h(a: v8i16, imm3: i32) -> v8i16 {
 
 /// Immediate Shift Right Logical
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
+/// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right logical by imm2 bits.
 /// The result is written to vector(four signed 32-bit integer numbers).
 ///
@@ -8541,7 +8541,7 @@ pub unsafe fn __msa_srli_w(a: v4i32, imm2: i32) -> v4i32 {
 
 /// Immediate Shift Right Logical
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
+/// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right logical by imm1 bits.
 /// The result is written to vector(two signed 64-bit integer numbers).
 ///
@@ -8560,8 +8560,8 @@ pub unsafe fn __msa_srli_d(a: v2i64, imm1: i32) -> v2i64 {
 
 /// Vector Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (sixteen signed 8-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(sixteen signed 8-bit integer numbers).
@@ -8575,8 +8575,8 @@ pub unsafe fn __msa_srlr_b(a: v16i8, b: v16i8) -> v16i8 {
 
 /// Vector Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (eight signed 16-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(eight signed 16-bit integer numbers).
@@ -8590,8 +8590,8 @@ pub unsafe fn __msa_srlr_h(a: v8i16, b: v8i16) -> v8i16 {
 
 /// Vector Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (four signed 32-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (four signed 32-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(four signed 32-bit integer numbers).
@@ -8605,8 +8605,8 @@ pub unsafe fn __msa_srlr_w(a: v4i32, b: v4i32) -> v4i32 {
 
 /// Vector Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
-/// are shifted right logical by the number of bits the elements in vector 'b'
+/// The elements in vector `a` (two signed 64-bit integer numbers)
+/// are shifted right logical by the number of bits the elements in vector `b`
 /// (two signed 64-bit integer numbers) specify modulo the size of the
 /// element in bits.The most significant discarded bit is added to the shifted
 /// value (for rounding) and the result is written to vector(two signed 64-bit integer numbers).
@@ -8620,7 +8620,7 @@ pub unsafe fn __msa_srlr_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// Immediate Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(sixteen signed 8-bit integer numbers)
+/// The elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// are shifted right logical by imm6 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(sixteen signed 8-bit integer numbers).
@@ -8640,7 +8640,7 @@ pub unsafe fn __msa_srlri_b(a: v16i8, imm3: i32) -> v16i8 {
 
 /// Immediate Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(eight signed 16-bit integer numbers)
+/// The elements in vector `a` (eight signed 16-bit integer numbers)
 /// are shifted right logical by imm6 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(eight signed 16-bit integer numbers).
@@ -8660,7 +8660,7 @@ pub unsafe fn __msa_srlri_h(a: v8i16, imm4: i32) -> v8i16 {
 
 /// Immediate Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(four signed 32-bit integer numbers)
+/// The elements in vector `a` (four signed 32-bit integer numbers)
 /// are shifted right logical by imm6 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(four signed 32-bit integer numbers).
@@ -8680,7 +8680,7 @@ pub unsafe fn __msa_srlri_w(a: v4i32, imm5: i32) -> v4i32 {
 
 /// Immediate Shift Right Logical Rounded
 ///
-/// The elements in vector 'a'(two signed 64-bit integer numbers)
+/// The elements in vector `a` (two signed 64-bit integer numbers)
 /// are shifted right logical by imm6 bits.The most significant
 /// discarded bit is added to the shifted value (for rounding) and
 /// the result is written to vector(two signed 64-bit integer numbers).
@@ -8700,7 +8700,7 @@ pub unsafe fn __msa_srlri_d(a: v2i64, imm6: i32) -> v2i64 {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector 'a'(sixteen signed 8-bit integer numbers)
+/// TheWRLEN / 8 bytes in vector `a` (sixteen signed 8-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
 /// addressed by the base mem_addr and the 10-bit signed immediate offset imm_s10
 ///
@@ -8719,7 +8719,7 @@ pub unsafe fn __msa_st_b(a: v16i8, mem_addr: *mut u8, imm_s10: i32) -> () {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector 'a'(eight signed 16-bit integer numbers)
+/// TheWRLEN / 8 bytes in vector `a` (eight signed 16-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
 /// addressed by the base mem_addr and the 11-bit signed immediate offset imm_s11
 ///
@@ -8738,7 +8738,7 @@ pub unsafe fn __msa_st_h(a: v8i16, mem_addr: *mut u8, imm_s11: i32) -> () {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector 'a'(four signed 32-bit integer numbers)
+/// TheWRLEN / 8 bytes in vector `a` (four signed 32-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
 /// addressed by the base mem_addr and the 12-bit signed immediate offset imm_s12
 ///
@@ -8757,7 +8757,7 @@ pub unsafe fn __msa_st_w(a: v4i32, mem_addr: *mut u8, imm_s12: i32) -> () {
 
 /// Vector Store
 ///
-/// TheWRLEN / 8 bytes in vector 'a'(two signed 64-bit integer numbers)
+/// TheWRLEN / 8 bytes in vector `a` (two signed 64-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
 /// addressed by the base mem_addr and the 13-bit signed immediate offset imm_s13
 ///
@@ -9129,11 +9129,11 @@ pub unsafe fn __msa_subvi_d(a: v2i64, imm5: i32) -> v2i64 {
 /// Vector Data Preserving Shuffle
 ///
 /// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors 'b' (sixteen signed 8-bit integer numbers)
-/// and `c` (sixteen signed 8-bit integer numbers) in to vector 'a'
-/// (sixteen signed 8-bit integer numbers) based on the corresponding control element in 'a'
-/// The least significant 6 bits in 'a' control elements modulo the number of elements in
-/// the concatenated vectors 'b','a' specify the index of the source element.
+/// concatenation  of  vectors `b` (sixteen signed 8-bit integer numbers)
+/// and `c` (sixteen signed 8-bit integer numbers) in to vector `a`
+/// (sixteen signed 8-bit integer numbers) based on the corresponding control element in `a`
+/// The least significant 6 bits in `a` control elements modulo the number of elements in
+/// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
 ///
 #[inline]
@@ -9146,11 +9146,11 @@ pub unsafe fn __msa_vshf_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 /// Vector Data Preserving Shuffle
 ///
 /// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors 'b' (eight signed 16-bit integer numbers)
-/// and `c` (eight signed 16-bit integer numbers) in to vector 'a'
-/// (eight signed 16-bit integer numbers) based on the corresponding control element in 'a'
-/// The least significant 6 bits in 'a' control elements modulo the number of elements in
-/// the concatenated vectors 'b','a' specify the index of the source element.
+/// concatenation  of  vectors `b` (eight signed 16-bit integer numbers)
+/// and `c` (eight signed 16-bit integer numbers) in to vector `a`
+/// (eight signed 16-bit integer numbers) based on the corresponding control element in `a`
+/// The least significant 6 bits in `a` control elements modulo the number of elements in
+/// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
 ///
 #[inline]
@@ -9163,11 +9163,11 @@ pub unsafe fn __msa_vshf_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 /// Vector Data Preserving Shuffle
 ///
 /// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors 'b' (four signed 32-bit integer numbers)
-/// and `c` (four signed 32-bit integer numbers) in to vector 'a'
-/// (four signed 32-bit integer numbers) based on the corresponding control element in 'a'
-/// The least significant 6 bits in 'a' control elements modulo the number of elements in
-/// the concatenated vectors 'b','a' specify the index of the source element.
+/// concatenation  of  vectors `b` (four signed 32-bit integer numbers)
+/// and `c` (four signed 32-bit integer numbers) in to vector `a`
+/// (four signed 32-bit integer numbers) based on the corresponding control element in `a`
+/// The least significant 6 bits in `a` control elements modulo the number of elements in
+/// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
 ///
 #[inline]
@@ -9180,11 +9180,11 @@ pub unsafe fn __msa_vshf_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 /// Vector Data Preserving Shuffle
 ///
 /// The  vector  shuffle  instructions  selectively  copy data  elements from the
-/// concatenation  of  vectors 'b' (two signed 64-bit integer numbers)
-/// and `c` (two signed 64-bit integer numbers) in to vector 'a'
-/// (two signed 64-bit integer numbers) based on the corresponding control element in 'a'
-/// The least significant 6 bits in 'a' control elements modulo the number of elements in
-/// the concatenated vectors 'b','a' specify the index of the source element.
+/// concatenation  of  vectors `b` (two signed 64-bit integer numbers)
+/// and `c` (two signed 64-bit integer numbers) in to vector `a`
+/// (two signed 64-bit integer numbers) based on the corresponding control element in `a`
+/// The least significant 6 bits in `a` control elements modulo the number of elements in
+/// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination elementis set to 0.
 ///
 #[inline]
@@ -9196,8 +9196,8 @@ pub unsafe fn __msa_vshf_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
 
 /// Vector Logical Exclusive Or
 ///
-/// Each bit of vector 'a'(sixteen unsigned 8-bit integer numbers)
-/// is combined with the corresponding bit of vector 'b' (sixteen unsigned 8-bit integer numbers)
+/// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical XOR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
 ///
@@ -9210,7 +9210,7 @@ pub unsafe fn __msa_xor_v(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Immediate Logical Exclusive Or
 ///
-/// Each byte of vector 'a'(sixteen unsigned 8-bit integer numbers)
+/// Each byte of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the 8-bit immediate imm8
 /// in a bitwise logical XOR operation. The result is written to vector
 /// (sixteen unsigned 8-bit integer numbers)
@@ -11417,7 +11417,7 @@ mod tests {
 
     // FIXME: https://reviews.llvm.org/D59884
     // If target type is i64, negative immediate loses the sign
-    // Test passes if 4294967293 is used instead -3 in vector 'a'
+    // Test passes if 4294967293 is used instead -3 in vector `a`
     // #[simd_test(enable = "msa")]
     // unsafe fn test_msa_ceqi_d() {
     //     #[rustfmt::skip]
@@ -14880,7 +14880,7 @@ mod tests {
 
     // FIXME: https://reviews.llvm.org/D59884
     // If target type is i64, negative immediate loses the sign
-    // Test passes if 4294967185 is used instead -111 in vector 'r'
+    // Test passes if 4294967185 is used instead -111 in vector `r`
     // #[simd_test(enable = "msa")]
     // unsafe fn test_msa_ldi_d() {
     //     let r = i64x2::new(-111, -111);
@@ -15361,7 +15361,7 @@ mod tests {
 
     // FIXME: https://reviews.llvm.org/D59884
     // If target type is i64, negative immediate loses the sign
-    // Test passes if 4294967293 is used instead -3 in vector 'r'
+    // Test passes if 4294967293 is used instead -3 in vector `r`
     // #[simd_test(enable = "msa")]
     // unsafe fn test_msa_maxi_s_d() {
     //     #[rustfmt::skip]

--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -1865,7 +1865,7 @@ pub unsafe fn __msa_aver_u_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Vector Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers).
 /// The bit position is given by the elements in `b` (sixteen unsigned 8-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers).
@@ -1879,7 +1879,7 @@ pub unsafe fn __msa_bclr_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers).
 /// The bit position is given by the elements in `b` (eight unsigned 16-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers).
@@ -1893,7 +1893,7 @@ pub unsafe fn __msa_bclr_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (four unsigned 32-bit integer numbers).
 /// The bit position is given by the elements in `b` (four unsigned 32-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
@@ -1907,7 +1907,7 @@ pub unsafe fn __msa_bclr_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (two unsigned 64-bit integer numbers).
 /// The bit position is given by the elements in `b` (two unsigned 64-bit integer numbers)
 /// modulo the size of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
@@ -1921,7 +1921,7 @@ pub unsafe fn __msa_bclr_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Immediate Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers).
 /// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -1940,7 +1940,7 @@ pub unsafe fn __msa_bclri_b(a: v16u8, imm3: i32) -> v16u8 {
 
 /// Immediate Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers).
 /// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
@@ -1959,7 +1959,7 @@ pub unsafe fn __msa_bclri_h(a: v8u16, imm4: i32) -> v8u16 {
 
 /// Immediate Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (four unsigned 32-bit integer numbers).
 /// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
@@ -1978,7 +1978,7 @@ pub unsafe fn __msa_bclri_w(a: v4u32, imm5: i32) -> v4u32 {
 
 /// Immediate Bit Clear
 ///
-/// Clear (set to 0) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
+/// Clear (set to 0) one bit in each element of vector `a` (two unsigned 64-bit integer numbers).
 /// The bit position is given by the immediate `m` modulo the size of the element in bits.
 /// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
@@ -2055,7 +2055,7 @@ pub unsafe fn __msa_binsl_d(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
 ///
 /// Copy most significant (left) bits in each element of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// to elements in vector `a` (sixteen unsigned 8-bit integer numbers) while preserving the least significant (right) bits.
-/// The number of bits to copy is given by the immediate imm3 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm3` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2074,7 +2074,7 @@ pub unsafe fn __msa_binsli_b(a: v16u8, b: v16u8, imm3: i32) -> v16u8 {
 ///
 /// Copy most significant (left) bits in each element of vector `b` (eight unsigned 16-bit integer numbers)
 /// to elements in vector `a` (eight unsigned 16-bit integer numbers) while preserving the least significant (right) bits.
-/// The number of bits to copy is given by the immediate imm4 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm4` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2093,7 +2093,7 @@ pub unsafe fn __msa_binsli_h(a: v8u16, b: v8u16, imm4: i32) -> v8u16 {
 ///
 /// Copy most significant (left) bits in each element of vector `b` (four unsigned 32-bit integer numbers)
 /// to elements in vector `a` (four unsigned 32-bit integer numbers) while preserving the least significant (right) bits.
-/// The number of bits to copy is given by the immediate imm5 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm5` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2112,7 +2112,7 @@ pub unsafe fn __msa_binsli_w(a: v4u32, b: v4u32, imm5: i32) -> v4u32 {
 ///
 /// Copy most significant (left) bits in each element of vector `b` (two unsigned 64-bit integer numbers)
 /// to elements in vector `a` (two unsigned 64-bit integer numbers) while preserving the least significant (right) bits.
-/// The number of bits to copy is given by the immediate imm6 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm6` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2187,7 +2187,7 @@ pub unsafe fn __msa_binsr_d(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
 ///
 /// Copy most significant (right) bits in each element of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// to elements in vector `a` (sixteen unsigned 8-bit integer numbers) while preserving the least significant (left) bits.
-/// The number of bits to copy is given by the immediate imm3 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm3` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2206,7 +2206,7 @@ pub unsafe fn __msa_binsri_b(a: v16u8, b: v16u8, imm3: i32) -> v16u8 {
 ///
 /// Copy most significant (right) bits in each element of vector `b` (eight unsigned 16-bit integer numbers)
 /// to elements in vector `a` (eight unsigned 16-bit integer numbers) while preserving the least significant (left) bits.
-/// The number of bits to copy is given by the immediate imm4 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm4` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2225,7 +2225,7 @@ pub unsafe fn __msa_binsri_h(a: v8u16, b: v8u16, imm4: i32) -> v8u16 {
 ///
 /// Copy most significant (right) bits in each element of vector `b` (four unsigned 32-bit integer numbers)
 /// to elements in vector `a` (four unsigned 32-bit integer numbers) while preserving the least significant (left) bits.
-/// The number of bits to copy is given by the immediate imm5 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm5` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2244,7 +2244,7 @@ pub unsafe fn __msa_binsri_w(a: v4u32, b: v4u32, imm5: i32) -> v4u32 {
 ///
 /// Copy most significant (right) bits in each element of vector `b` (two unsigned 64-bit integer numbers)
 /// to elements in vector `a` (two unsigned 64-bit integer numbers) while preserving the least significant (left) bits.
-/// The number of bits to copy is given by the immediate imm6 modulo the size of the element in bits plus 1.
+/// The number of bits to copy is given by the immediate `imm6` modulo the size of the element in bits plus 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2276,7 +2276,7 @@ pub unsafe fn __msa_bmnz_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 /// Immediate Bit Move If Not Zero
 ///
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from from immediate imm8
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from from immediate `imm8`
 /// are 1 and leaves unchanged all destination bits for which the corresponding target bits are 0.
 ///
 #[inline]
@@ -2297,7 +2297,7 @@ pub unsafe fn __msa_bmnzi_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
 /// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from target vector `c`
 /// (sixteen unsigned 8-bit integer numbers) are 0 and leaves unchanged all destination bits
-/// for which the corresponding target bits are 1
+/// for which the corresponding target bits are 1.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2309,7 +2309,7 @@ pub unsafe fn __msa_bmz_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 /// Immediate Bit Move If Zero
 ///
 /// Copy to destination vector `a` (sixteen unsigned 8-bit integer numbers) all bits from source vector
-/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from from immediate imm8
+/// `b` (sixteen unsigned 8-bit integer numbers) for which the corresponding bits from from immediate `imm8`
 /// are 0 and leaves unchanged all destination bits for which the corresponding immediate bits are 1.
 ///
 #[inline]
@@ -2327,10 +2327,10 @@ pub unsafe fn __msa_bmzi_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 
 /// Vector Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (sixteen unsigned 8-bit integer numbers)
+/// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2341,10 +2341,10 @@ pub unsafe fn __msa_bneg_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (eight unsigned 16-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (eight unsigned 16-bit integer numbers)
+/// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2355,10 +2355,10 @@ pub unsafe fn __msa_bneg_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (four unsigned 32-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (four unsigned 32-bit integer numbers)
+/// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2369,10 +2369,10 @@ pub unsafe fn __msa_bneg_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (two unsigned 64-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (two unsigned 64-bit integer numbers)
+/// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2383,9 +2383,9 @@ pub unsafe fn __msa_bneg_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Immediate Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// The bit position is given by immediate imm3 modulo the size of the element in bits.
-/// The result is written to vector (sixteen unsigned 8-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers).
+/// The bit position is given by immediate `imm3` modulo the size of the element in bits.
+/// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2402,9 +2402,9 @@ pub unsafe fn __msa_bnegi_b(a: v16u8, imm3: i32) -> v16u8 {
 
 /// Immediate Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
-/// The bit position is given by immediate imm4 modulo the size of the element in bits.
-/// The result is written to vector (eight unsigned 16-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (eight unsigned 16-bit integer numbers).
+/// The bit position is given by immediate `imm4` modulo the size of the element in bits.
+/// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2421,9 +2421,9 @@ pub unsafe fn __msa_bnegi_h(a: v8u16, imm4: i32) -> v8u16 {
 
 /// Immediate Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
-/// The bit position is given by immediate imm5 modulo the size of the element in bits.
-/// The result is written to vector (four unsigned 32-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (four unsigned 32-bit integer numbers).
+/// The bit position is given by immediate `imm5` modulo the size of the element in bits.
+/// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2440,9 +2440,9 @@ pub unsafe fn __msa_bnegi_w(a: v4u32, imm5: i32) -> v4u32 {
 
 /// Immediate Bit Negate
 ///
-/// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
-/// The bit position is given by immediate imm6 modulo the size of the element in bits.
-/// The result is written to vector (two unsigned 64-bit integer numbers)
+/// Negate (complement) one bit in each element of vector `a` (two unsigned 64-bit integer numbers).
+/// The bit position is given by immediate `imm6` modulo the size of the element in bits.
+/// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2529,7 +2529,7 @@ pub unsafe fn __msa_bsel_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
 
 /// Immediate Bit Select
 ///
-/// Selectively copy bits from the 8-bit immediate imm8 and `c` (eight unsigned 16-bit integer numbers)
+/// Selectively copy bits from the 8-bit immediate `imm8` and `c` (eight unsigned 16-bit integer numbers)
 /// into destination vector `a` (eight unsigned 16-bit integer numbers) based on the corresponding bit in `a`:
 /// if 0 copies the bit from `b`, if 1 copies the bit from `c`.
 ///
@@ -2548,10 +2548,10 @@ pub unsafe fn __msa_bseli_b(a: v16u8, b: v16u8, imm8: i32) -> v16u8 {
 
 /// Vector Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (sixteen unsigned 8-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (sixteen unsigned 8-bit integer numbers)
+/// The result is written to vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2562,10 +2562,10 @@ pub unsafe fn __msa_bset_b(a: v16u8, b: v16u8) -> v16u8 {
 
 /// Vector Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (eight unsigned 16-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (eight unsigned 16-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (eight unsigned 16-bit integer numbers)
+/// The result is written to vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2576,10 +2576,10 @@ pub unsafe fn __msa_bset_h(a: v8u16, b: v8u16) -> v8u16 {
 
 /// Vector Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (four unsigned 32-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (four unsigned 32-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (four unsigned 32-bit integer numbers)
+/// The result is written to vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2590,10 +2590,10 @@ pub unsafe fn __msa_bset_w(a: v4u32, b: v4u32) -> v4u32 {
 
 /// Vector Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (two unsigned 64-bit integer numbers).
 /// The bit position is given by the elements in vector `b` (two unsigned 64-bit integer numbers)
 /// modulo the size of the element in bits.
-/// The result is written to vector (two unsigned 64-bit integer numbers)
+/// The result is written to vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2604,9 +2604,9 @@ pub unsafe fn __msa_bset_d(a: v2u64, b: v2u64) -> v2u64 {
 
 /// Immediate Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers)
-/// The bit position is given by immediate imm3.
-/// The result is written to vector `a` (sixteen unsigned 8-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (sixteen unsigned 8-bit integer numbers).
+/// The bit position is given by immediate `imm3`.
+/// The result is written to vector `a` (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2623,9 +2623,9 @@ pub unsafe fn __msa_bseti_b(a: v16u8, imm3: i32) -> v16u8 {
 
 /// Immediate Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (eight unsigned 16-bit integer numbers)
-/// The bit position is given by immediate imm4.
-/// The result is written to vector `a` (eight unsigned 16-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (eight unsigned 16-bit integer numbers).
+/// The bit position is given by immediate `imm4`.
+/// The result is written to vector `a` (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2642,9 +2642,9 @@ pub unsafe fn __msa_bseti_h(a: v8u16, imm4: i32) -> v8u16 {
 
 /// Immediate Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (four unsigned 32-bit integer numbers)
-/// The bit position is given by immediate imm5.
-/// The result is written to vector `a` (four unsigned 32-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (four unsigned 32-bit integer numbers).
+/// The bit position is given by immediate `imm5`.
+/// The result is written to vector `a` (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2661,9 +2661,9 @@ pub unsafe fn __msa_bseti_w(a: v4u32, imm5: i32) -> v4u32 {
 
 /// Immediate Bit Set
 ///
-/// Set to 1 one bit in each element of vector `a` (two unsigned 64-bit integer numbers)
-/// The bit position is given by immediate imm6.
-/// The result is written to vector `a` (two unsigned 64-bit integer numbers)
+/// Set to 1 one bit in each element of vector `a` (two unsigned 64-bit integer numbers).
+/// The bit position is given by immediate `imm6`.
+/// The result is written to vector `a` (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -2725,7 +2725,7 @@ pub unsafe fn __msa_bz_d(a: v2u64) -> i32 {
 /// Immediate Branch If Zero (All Elements of Any Format Are Zero)
 ///
 /// PC-relative branch if all elements in `a` (sixteen unsigned 8-bit integer numbers) bits are zero,
-/// i.e. all elements are zero regardless of the data format
+/// i.e. all elements are zero regardless of the data format.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3076,7 +3076,7 @@ pub unsafe fn __msa_clei_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
-/// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
+/// is unsigned less than or equal to the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3096,7 +3096,7 @@ pub unsafe fn __msa_clei_u_b(a: v16u8, imm5: i32) -> v16i8 {
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
-/// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
+/// is unsigned less than or equal to the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3116,7 +3116,7 @@ pub unsafe fn __msa_clei_u_h(a: v8u16, imm5: i32) -> v8i16 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four unsigned 32-bit integer numbers) element
-/// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
+/// is unsigned less than or equal to the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3136,7 +3136,7 @@ pub unsafe fn __msa_clei_u_w(a: v4u32, imm5: i32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two unsigned 64-bit integer numbers) element
-/// is unsigned less than or equal to the 5-bit unsigned immediate imm5,
+/// is unsigned less than or equal to the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3348,7 +3348,7 @@ pub unsafe fn __msa_clti_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 ///
 /// Set all bits to 1 in vector (sixteen signed 8-bit integer numbers) elements
 /// if the corresponding `a` (sixteen unsigned 8-bit integer numbers) element
-/// is unsigned less than the 5-bit unsigned immediate imm5,
+/// is unsigned less than the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3368,7 +3368,7 @@ pub unsafe fn __msa_clti_u_b(a: v16u8, imm5: i32) -> v16i8 {
 ///
 /// Set all bits to 1 in vector (eight signed 16-bit integer numbers) elements
 /// if the corresponding `a` (eight unsigned 16-bit integer numbers) element
-/// is unsigned less than the 5-bit unsigned immediate imm5,
+/// is unsigned less than the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3388,7 +3388,7 @@ pub unsafe fn __msa_clti_u_h(a: v8u16, imm5: i32) -> v8i16 {
 ///
 /// Set all bits to 1 in vector (four signed 32-bit integer numbers) elements
 /// if the corresponding `a` (four unsigned 32-bit integer numbers) element
-/// is unsigned less than the 5-bit unsigned immediate imm5,
+/// is unsigned less than the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3408,7 +3408,7 @@ pub unsafe fn __msa_clti_u_w(a: v4u32, imm5: i32) -> v4i32 {
 ///
 /// Set all bits to 1 in vector (two signed 64-bit integer numbers) elements
 /// if the corresponding `a` (two unsigned 64-bit integer numbers) element
-/// is unsigned less than the 5-bit unsigned immediate imm5,
+/// is unsigned less than the 5-bit unsigned immediate `imm5`,
 /// otherwise set all bits to 0.
 ///
 #[inline]
@@ -3426,8 +3426,8 @@ pub unsafe fn __msa_clti_u_d(a: v2u64, imm5: i32) -> v2i64 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm4 of vector `a` (sixteen signed 8-bit integer numbers)
-/// and copy the result to GPR rd
+/// Sign-extend element `imm4` of vector `a` (sixteen signed 8-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3444,8 +3444,8 @@ pub unsafe fn __msa_copy_s_b(a: v16i8, imm4: i32) -> i32 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm3 of vector `a` (eight signed 16-bit integer numbers)
-/// and copy the result to GPR rd
+/// Sign-extend element `imm3` of vector `a` (eight signed 16-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3462,8 +3462,8 @@ pub unsafe fn __msa_copy_s_h(a: v8i16, imm3: i32) -> i32 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm2 of vector `a` (four signed 32-bit integer numbers)
-/// and copy the result to GPR rd
+/// Sign-extend element `imm2` of vector `a` (four signed 32-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3480,8 +3480,8 @@ pub unsafe fn __msa_copy_s_w(a: v4i32, imm2: i32) -> i32 {
 
 /// Element Copy to GPR Signed
 ///
-/// Sign-extend element imm1 of vector `a` (two signed 64-bit integer numbers)
-/// and copy the result to GPR rd
+/// Sign-extend element `imm1` of vector `a` (two signed 64-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3498,8 +3498,8 @@ pub unsafe fn __msa_copy_s_d(a: v2i64, imm1: i32) -> i64 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm4 of vector `a` (sixteen signed 8-bit integer numbers)
-/// and copy the result to GPR rd
+/// Zero-extend element `imm4` of vector `a` (sixteen signed 8-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3516,8 +3516,8 @@ pub unsafe fn __msa_copy_u_b(a: v16i8, imm4: i32) -> u32 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm3 of vector `a` (eight signed 16-bit integer numbers)
-/// and copy the result to GPR rd
+/// Zero-extend element `imm3` of vector `a` (eight signed 16-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3534,8 +3534,8 @@ pub unsafe fn __msa_copy_u_h(a: v8i16, imm3: i32) -> u32 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm2 of vector `a` (four signed 32-bit integer numbers)
-/// and copy the result to GPR rd
+/// Zero-extend element `imm2` of vector `a` (four signed 32-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3552,8 +3552,8 @@ pub unsafe fn __msa_copy_u_w(a: v4i32, imm2: i32) -> u32 {
 
 /// Element Copy to GPR Unsigned
 ///
-/// Zero-extend element imm1 of vector `a` (two signed 64-bit integer numbers)
-/// and copy the result to GPR rd
+/// Zero-extend element `imm1` of vector `a` (two signed 64-bit integer numbers)
+/// and copy the result to GPR rd.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3569,9 +3569,12 @@ pub unsafe fn __msa_copy_u_d(a: v2i64, imm1: i32) -> u64 {
 }
 
 /// GPR Copy to MSA Control Register
-/// The content of the least significant 31 bits of GPR imm1 is copied to
-/// MSA control register cd
+///
+/// The content of the least significant 31 bits of GPR `imm1` is copied to
+/// MSA control register cd.
+///
 /// Can not be tested in user mode
+///
 #[inline]
 #[target_feature(enable = "msa")]
 #[cfg_attr(test, assert_instr(ctcmsa, imm1 = 0b1))]
@@ -3957,7 +3960,7 @@ pub unsafe fn __msa_dpsub_u_d(a: v2i64, b: v4u32, c: v4u32) -> v2i64 {
 ///
 /// The floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// are added to the floating-point elements in `bc` (four 32-bit floating point numbers).
-/// The result is written to vector (four 32-bit floating point numbers)
+/// The result is written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3970,7 +3973,7 @@ pub unsafe fn __msa_fadd_w(a: v4f32, b: v4f32) -> v4f32 {
 ///
 /// The floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// are added to the floating-point elements in `bc` (two 64-bit floating point numbers).
-/// The result is written to vector (two 64-bit floating point numbers)
+/// The result is written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -3981,7 +3984,7 @@ pub unsafe fn __msa_fadd_d(a: v2f64, b: v2f64) -> v2f64 {
 
 /// Vector Floating-Point Quiet Compare Always False
 ///
-/// Set all bits to 0 in vector (four signed 32-bit integer numbers)
+/// Set all bits to 0 in vector (four signed 32-bit integer numbers).
 /// Signaling NaN elements in `a` (four 32-bit floating point numbers)
 /// or `b` (four 32-bit floating point numbers) signal Invalid Operation exception.
 ///
@@ -3994,7 +3997,7 @@ pub unsafe fn __msa_fcaf_w(a: v4f32, b: v4f32) -> v4i32 {
 
 /// Vector Floating-Point Quiet Compare Always False
 ///
-/// Set all bits to 0 in vector (two signed 64-bit integer numbers)
+/// Set all bits to 0 in vector (two signed 64-bit integer numbers).
 /// Signaling NaN elements in `a` (two 64-bit floating point numbers)
 /// or `b` (two 64-bit floating point numbers) signal Invalid Operation exception.
 ///
@@ -4320,7 +4323,7 @@ pub unsafe fn __msa_fcune_d(a: v2f64, b: v2f64) -> v2i64 {
 /// Vector Floating-Point Division
 ///
 /// The floating-point elements in vector `a` (four 32-bit floating point numbers)
-/// are divided by the floating-point elements in vector `b` (four 32-bit floating point numbers)
+/// are divided by the floating-point elements in vector `b` (four 32-bit floating point numbers).
 /// The result is written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
@@ -4333,7 +4336,7 @@ pub unsafe fn __msa_fdiv_w(a: v4f32, b: v4f32) -> v4f32 {
 /// Vector Floating-Point Division
 ///
 /// The floating-point elements in vector `a` (two 64-bit floating point numbers)
-/// are divided by the floating-point elements in vector `b` (two 64-bit floating point numbers)
+/// are divided by the floating-point elements in vector `b` (two 64-bit floating point numbers).
 /// The result is written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
@@ -4570,7 +4573,7 @@ pub unsafe fn __msa_ffqr_d(a: v4i32) -> v2f64 {
 ///
 /// Replicate GPR rs value to all elements in vector (sixteen signed 8-bit integer numbers).
 /// If the source GPR is wider than the destination data format, the destination's elements
-/// will be set to the least significant bits of the GPR
+/// will be set to the least significant bits of the GPR.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4583,7 +4586,7 @@ pub unsafe fn __msa_fill_b(a: i32) -> v16i8 {
 ///
 /// Replicate GPR rs value to all elements in vector (eight signed 16-bit integer numbers).
 /// If the source GPR is wider than the destination data format, the destination's elements
-/// will be set to the least significant bits of the GPR
+/// will be set to the least significant bits of the GPR.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4596,7 +4599,7 @@ pub unsafe fn __msa_fill_h(a: i32) -> v8i16 {
 ///
 /// Replicate GPR rs value to all elements in vector (four signed 32-bit integer numbers).
 /// If the source GPR is wider than the destination data format, the destination's elements
-/// will be set to the least significant bits of the GPR
+/// will be set to the least significant bits of the GPR.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4609,7 +4612,7 @@ pub unsafe fn __msa_fill_w(a: i32) -> v4i32 {
 ///
 /// Replicate GPR rs value to all elements in vector (two signed 64-bit integer numbers).
 /// If the source GPR is wider than the destination data format, the destination's elements
-/// will be set to the least significant bits of the GPR
+/// will be set to the least significant bits of the GPR.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4648,7 +4651,7 @@ pub unsafe fn __msa_flog2_d(a: v2f64) -> v2f64 {
 ///
 /// The floating-point elements in vector `b` (four 32-bit floating point numbers)
 /// multiplied by floating-point elements in vector `c` (four 32-bit floating point numbers)
-/// are added to the floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// are added to the floating-point elements in vector `a` (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4661,7 +4664,7 @@ pub unsafe fn __msa_fmadd_w(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
 ///
 /// The floating-point elements in vector `b` (two 64-bit floating point numbers)
 /// multiplied by floating-point elements in vector `c` (two 64-bit floating point numbers)
-/// are added to the floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// are added to the floating-point elements in vector `a` (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4674,7 +4677,7 @@ pub unsafe fn __msa_fmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
 ///
 /// The largest values between corresponding floating-point elements in vector `a`
 /// (four 32-bit floating point numbers) and vector `b` (four 32-bit floating point numbers)
-/// are written to vector (four 32-bit floating point numbers)
+/// are written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4687,7 +4690,7 @@ pub unsafe fn __msa_fmax_w(a: v4f32, b: v4f32) -> v4f32 {
 ///
 /// The largest values between corresponding floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) and vector `b` (two 64-bit floating point numbers)
-/// are written to vector (two 64-bit floating point numbers)
+/// are written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4701,7 +4704,7 @@ pub unsafe fn __msa_fmax_d(a: v2f64, b: v2f64) -> v2f64 {
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
 /// floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// and vector `b` (four 32-bit floating point numbers)
-/// are written to vector (four 32-bit floating point numbers)
+/// are written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4715,7 +4718,7 @@ pub unsafe fn __msa_fmax_a_w(a: v4f32, b: v4f32) -> v4f32 {
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
 /// floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// and vector `b` (two 64-bit floating point numbers)
-/// are written to vector (two 64-bit floating point numbers)
+/// are written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4728,7 +4731,7 @@ pub unsafe fn __msa_fmax_a_d(a: v2f64, b: v2f64) -> v2f64 {
 ///
 /// The smallest values between corresponding floating-point elements in vector `a`
 /// (four 32-bit floating point numbers) and vector `b` (four 32-bit floating point numbers)
-/// are written to vector (four 32-bit floating point numbers)
+/// are written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4741,7 +4744,7 @@ pub unsafe fn __msa_fmin_w(a: v4f32, b: v4f32) -> v4f32 {
 ///
 /// The smallest values between corresponding floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) and vector `b` (two 64-bit floating point numbers)
-/// are written to vector (two 64-bit floating point numbers)
+/// are written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4755,7 +4758,7 @@ pub unsafe fn __msa_fmin_d(a: v2f64, b: v2f64) -> v2f64 {
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
 /// floating-point elements in vector `a` (four 32-bit floating point numbers)
 /// and vector `b` (four 32-bit floating point numbers)
-/// are written to vector (four 32-bit floating point numbers)
+/// are written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4769,7 +4772,7 @@ pub unsafe fn __msa_fmin_a_w(a: v4f32, b: v4f32) -> v4f32 {
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
 /// floating-point elements in vector `a` (two 64-bit floating point numbers)
 /// and vector `b` (two 64-bit floating point numbers)
-/// are written to vector (two 64-bit floating point numbers)
+/// are written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4782,7 +4785,7 @@ pub unsafe fn __msa_fmin_a_d(a: v2f64, b: v2f64) -> v2f64 {
 ///
 /// The floating-point elements in vector `b` (four 32-bit floating point numbers)
 /// multiplied by floating-point elements in vector `c` (four 32-bit floating point numbers)
-/// are subtracted from the floating-point elements in vector `a` (four 32-bit floating point numbers)
+/// are subtracted from the floating-point elements in vector `a` (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4795,7 +4798,7 @@ pub unsafe fn __msa_fmsub_w(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
 ///
 /// The floating-point elements in vector `b` (two 64-bit floating point numbers)
 /// multiplied by floating-point elements in vector `c` (two 64-bit floating point numbers)
-/// are subtracted from the floating-point elements in vector `a` (two 64-bit floating point numbers)
+/// are subtracted from the floating-point elements in vector `a` (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4807,7 +4810,7 @@ pub unsafe fn __msa_fmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
 /// Vector Floating-Point Multiplication
 ///
 /// The floating-point elements in vector `a` (four 32-bit floating point numbers) are
-/// multiplied by floating-point elements in vector `b` (four 32-bit floating point numbers)
+/// multiplied by floating-point elements in vector `b` (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4819,7 +4822,7 @@ pub unsafe fn __msa_fmul_w(a: v4f32, b: v4f32) -> v4f32 {
 /// Vector Floating-Point Multiplication
 ///
 /// The floating-point elements in vector `a` (two 64-bit floating point numbers) are
-/// multiplied by floating-point elements in vector `b` (two 64-bit floating point numbers)
+/// multiplied by floating-point elements in vector `b` (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4857,7 +4860,7 @@ pub unsafe fn __msa_frint_d(a: v2f64) -> v2f64 {
 /// Vector Approximate Floating-Point Reciprocal
 ///
 /// The reciprocals of floating-point elements in vector `a` (four 32-bit floating point numbers)
-/// are calculated and the result is written to vector (four 32-bit floating point numbers)
+/// are calculated and the result is written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4869,7 +4872,7 @@ pub unsafe fn __msa_frcp_w(a: v4f32) -> v4f32 {
 /// Vector Approximate Floating-Point Reciprocal
 ///
 /// The reciprocals of floating-point elements in vector `a` (two 64-bit floating point numbers)
-/// are calculated and the result is written to vector (two 64-bit floating point numbers)
+/// are calculated and the result is written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4881,7 +4884,7 @@ pub unsafe fn __msa_frcp_d(a: v2f64) -> v2f64 {
 /// Vector Approximate Floating-Point Reciprocal of Square Root
 ///
 /// The reciprocals of the square roots of floating-point elements in vector `a` (four 32-bit floating point numbers)
-/// are calculated and the result is written to vector (four 32-bit floating point numbers)
+/// are calculated and the result is written to vector (four 32-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4893,7 +4896,7 @@ pub unsafe fn __msa_frsqrt_w(a: v4f32) -> v4f32 {
 /// Vector Approximate Floating-Point Reciprocal of Square Root
 ///
 /// The reciprocals of the square roots of floating-point elements in vector `a` (two 64-bit floating point numbers)
-/// are calculated and the result is written to vector (two 64-bit floating point numbers)
+/// are calculated and the result is written to vector (two 64-bit floating point numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4907,7 +4910,7 @@ pub unsafe fn __msa_frsqrt_d(a: v2f64) -> v2f64 {
 /// Set all bits to 0 in vector (four signed 32-bit integer numbers) elements.
 /// Signaling and quiet NaN elements in vector `a` (four 32-bit floating point numbers)
 /// or `b` (four 32-bit floating point numbers) signal Invalid Operation exception.
-/// In case of a floating-point exception, the default result has all bits set to 0
+/// In case of a floating-point exception, the default result has all bits set to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -4921,7 +4924,7 @@ pub unsafe fn __msa_fsaf_w(a: v4f32, b: v4f32) -> v4i32 {
 /// Set all bits to 0 in vector (two signed 64-bit integer numbers) elements.
 /// Signaling and quiet NaN elements in vector `a` (two 64-bit floating point numbers)
 /// or `b` (two 64-bit floating point numbers) signal Invalid Operation exception.
-/// In case of a floating-point exception, the default result has all bits set to 0
+/// In case of a floating-point exception, the default result has all bits set to 0.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5066,7 +5069,7 @@ pub unsafe fn __msa_fsor_d(a: v2f64, b: v2f64) -> v2i64 {
 ///
 /// The square roots of floating-point elements in vector `a`
 /// (four 32-bit floating point numbers) are written to vector
-/// (four 32-bit floating point numbers) elements are ordered,
+/// (four 32-bit floating point numbers) elements are ordered,.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5079,7 +5082,7 @@ pub unsafe fn __msa_fsqrt_w(a: v4f32) -> v4f32 {
 ///
 /// The square roots of floating-point elements in vector `a`
 /// (two 64-bit floating point numbers) are written to vector
-/// (two 64-bit floating point numbers) elements are ordered,
+/// (two 64-bit floating point numbers) elements are ordered,.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -5788,7 +5791,7 @@ pub unsafe fn __msa_ilvr_d(a: v2i64, b: v2i64) -> v2i64 {
 
 /// GPR Insert Element
 ///
-/// Set element imm4 in vector `a` (sixteen signed 8-bit integer numbers) to GPR `c` value.
+/// Set element `imm4` in vector `a` (sixteen signed 8-bit integer numbers) to GPR `c` value.
 /// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
@@ -5807,7 +5810,7 @@ pub unsafe fn __msa_insert_b(a: v16i8, imm4: i32, c: i32) -> v16i8 {
 
 /// GPR Insert Element
 ///
-/// Set element imm3 in vector `a` (eight signed 16-bit integer numbers) to GPR `c` value.
+/// Set element `imm3` in vector `a` (eight signed 16-bit integer numbers) to GPR `c` value.
 /// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
@@ -5826,7 +5829,7 @@ pub unsafe fn __msa_insert_h(a: v8i16, imm3: i32, c: i32) -> v8i16 {
 
 /// GPR Insert Element
 ///
-/// Set element imm2 in vector `a` (four signed 32-bit integer numbers) to GPR `c` value.
+/// Set element `imm2` in vector `a` (four signed 32-bit integer numbers) to GPR `c` value.
 /// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
@@ -5845,7 +5848,7 @@ pub unsafe fn __msa_insert_w(a: v4i32, imm2: i32, c: i32) -> v4i32 {
 
 /// GPR Insert Element
 ///
-/// Set element imm1 in vector `a` (two signed 64-bit integer numbers) to GPR `c` value.
+/// Set element `imm1` in vector `a` (two signed 64-bit integer numbers) to GPR `c` value.
 /// All other elements in vector `a` are unchanged. If the source GPR is wider than the
 /// destination data format, the destination's elements will be set to the least significant bits of the GPR.
 ///
@@ -5864,7 +5867,7 @@ pub unsafe fn __msa_insert_d(a: v2i64, imm1: i32, c: i64) -> v2i64 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector `a` (sixteen signed 8-bit integer numbers) to element 0
+/// Set element `imm1` in the result vector `a` (sixteen signed 8-bit integer numbers) to element 0
 /// in vector `c` (sixteen signed 8-bit integer numbers) value.
 /// All other elements in vector `a` are unchanged.
 ///
@@ -5883,7 +5886,7 @@ pub unsafe fn __msa_insve_b(a: v16i8, imm4: i32, c: v16i8) -> v16i8 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector `a` (eight signed 16-bit integer numbers) to element 0
+/// Set element `imm1` in the result vector `a` (eight signed 16-bit integer numbers) to element 0
 /// in vector `c` (eight signed 16-bit integer numbers) value.
 /// All other elements in vector `a` are unchanged.
 ///
@@ -5902,7 +5905,7 @@ pub unsafe fn __msa_insve_h(a: v8i16, imm3: i32, c: v8i16) -> v8i16 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector `a` (four signed 32-bit integer numbers) to element 0
+/// Set element `imm1` in the result vector `a` (four signed 32-bit integer numbers) to element 0
 /// in vector `c` (four signed 32-bit integer numbers) value.
 /// All other elements in vector `a` are unchanged.
 ///
@@ -5921,7 +5924,7 @@ pub unsafe fn __msa_insve_w(a: v4i32, imm2: i32, c: v4i32) -> v4i32 {
 
 /// Element Insert Element
 ///
-/// Set element imm1 in the result vector `a` (two signed 64-bit integer numbers) to element 0
+/// Set element `imm1` in the result vector `a` (two signed 64-bit integer numbers) to element 0
 /// in vector `c` (two signed 64-bit integer numbers) value.
 /// All other elements in vector `a` are unchanged.
 ///
@@ -6094,9 +6097,9 @@ pub unsafe fn __msa_ldi_d(imm_s10: i32) -> v2i64 {
 ///
 /// The products of fixed-point elements in `b` (eight signed 16-bit integer numbers)
 /// by fixed-point elements in vector `c` (eight signed 16-bit integer numbers)
-/// are added to the fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (eight signed 16-bit integer numbers).
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The saturated fixed-point results are stored to vector `a`
+/// The saturated fixed-point results are stored to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6109,9 +6112,9 @@ pub unsafe fn __msa_madd_q_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 ///
 /// The products of fixed-point elements in `b` (four signed 32-bit integer numbers)
 /// by fixed-point elements in vector `c` (four signed 32-bit integer numbers)
-/// are added to the fixed-point elements in vector `a` (four signed 32-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (four signed 32-bit integer numbers).
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The saturated fixed-point results are stored to vector `a`
+/// The saturated fixed-point results are stored to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6124,9 +6127,9 @@ pub unsafe fn __msa_madd_q_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 ///
 /// The products of fixed-point elements in `b` (eight signed 16-bit integer numbers)
 /// by fixed-point elements in vector `c` (eight signed 16-bit integer numbers)
-/// are added to the fixed-point elements in vector `a` (eight signed 16-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (eight signed 16-bit integer numbers).
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The rounded and saturated fixed-point results are stored to vector `a`
+/// The rounded and saturated fixed-point results are stored to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6139,9 +6142,9 @@ pub unsafe fn __msa_maddr_q_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 ///
 /// The products of fixed-point elements in `b` (four signed 32-bit integer numbers)
 /// by fixed-point elements in vector `c` (four signed 32-bit integer numbers)
-/// are added to the fixed-point elements in vector `a` (four signed 32-bit integer numbers)
+/// are added to the fixed-point elements in vector `a` (four signed 32-bit integer numbers).
 /// The multiplication result is not saturated, i.e. exact (-1) * (-1) = 1 is added to the destination.
-/// The rounded and saturated fixed-point results are stored to vector `a`
+/// The rounded and saturated fixed-point results are stored to vector `a`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6154,7 +6157,7 @@ pub unsafe fn __msa_maddr_q_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 ///
 /// The integer elements in vector `b` (sixteen signed 8-bit integer numbers)
 /// are multiplied by integer elements in vector `c` (sixteen signed 8-bit integer numbers)
-/// and added to the integer elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// and added to the integer elements in vector `a` (sixteen signed 8-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6168,7 +6171,7 @@ pub unsafe fn __msa_maddv_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 ///
 /// The integer elements in vector `b` (eight signed 16-bit integer numbers)
 /// are multiplied by integer elements in vector `c` (eight signed 16-bit integer numbers)
-/// and added to the integer elements in vector `a` (eight signed 16-bit integer numbers)
+/// and added to the integer elements in vector `a` (eight signed 16-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6182,7 +6185,7 @@ pub unsafe fn __msa_maddv_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 ///
 /// The integer elements in vector `b` (four signed 32-bit integer numbers)
 /// are multiplied by integer elements in vector `c` (four signed 32-bit integer numbers)
-/// and added to the integer elements in vector `a` (four signed 32-bit integer numbers)
+/// and added to the integer elements in vector `a` (four signed 32-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6196,7 +6199,7 @@ pub unsafe fn __msa_maddv_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 ///
 /// The integer elements in vector `b` (two signed 64-bit integer numbers)
 /// are multiplied by integer elements in vector `c` (two signed 64-bit integer numbers)
-/// and added to the integer elements in vector `a` (two signed 64-bit integer numbers)
+/// and added to the integer elements in vector `a` (two signed 64-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -6211,7 +6214,7 @@ pub unsafe fn __msa_maddv_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (sixteen signed 8-bit integer numbers) and
 /// `b` (sixteen signed 8-bit integer numbers) are written to vector
-/// (sixteen signed 8-bit integer numbers)
+/// (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6225,7 +6228,7 @@ pub unsafe fn __msa_max_a_b(a: v16i8, b: v16i8) -> v16i8 {
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (eight signed 16-bit integer numbers) and
 /// `b` (eight signed 16-bit integer numbers) are written to vector
-/// (eight signed 16-bit integer numbers)
+/// (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6239,7 +6242,7 @@ pub unsafe fn __msa_max_a_h(a: v8i16, b: v8i16) -> v8i16 {
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (four signed 32-bit integer numbers) and
 /// `b` (four signed 32-bit integer numbers) are written to vector
-/// (four signed 32-bit integer numbers)
+/// (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6253,7 +6256,7 @@ pub unsafe fn __msa_max_a_w(a: v4i32, b: v4i32) -> v4i32 {
 /// The value with the largest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (two signed 64-bit integer numbers) and
 /// `b` (two signed 64-bit integer numbers) are written to vector
-/// (two signed 64-bit integer numbers)
+/// (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6266,7 +6269,7 @@ pub unsafe fn __msa_max_a_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// Maximum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// and signed elements in vector `b` (sixteen signed 8-bit integer numbers) are written to vector
-/// (sixteen signed 8-bit integer numbers)
+/// (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6279,7 +6282,7 @@ pub unsafe fn __msa_max_s_b(a: v16i8, b: v16i8) -> v16i8 {
 ///
 /// Maximum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// and signed elements in vector `b` (eight signed 16-bit integer numbers) are written to vector
-/// (eight signed 16-bit integer numbers)
+/// (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6292,7 +6295,7 @@ pub unsafe fn __msa_max_s_h(a: v8i16, b: v8i16) -> v8i16 {
 ///
 /// Maximum values between signed elements in vector `a` (four signed 32-bit integer numbers)
 /// and signed elements in vector `b` (four signed 32-bit integer numbers) are written to vector
-/// (four signed 32-bit integer numbers)
+/// (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6305,7 +6308,7 @@ pub unsafe fn __msa_max_s_w(a: v4i32, b: v4i32) -> v4i32 {
 ///
 /// Maximum values between signed elements in vector `a` (two signed 64-bit integer numbers)
 /// and signed elements in vector `b` (two signed 64-bit integer numbers) are written to vector
-/// (two signed 64-bit integer numbers)
+/// (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6318,7 +6321,7 @@ pub unsafe fn __msa_max_s_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// Maximum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// and unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers) are written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6331,7 +6334,7 @@ pub unsafe fn __msa_max_u_b(a: v16u8, b: v16u8) -> v16u8 {
 ///
 /// Maximum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// and unsigned elements in vector `b` (eight unsigned 16-bit integer numbers) are written to vector
-/// (eight unsigned 16-bit integer numbers)
+/// (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6344,7 +6347,7 @@ pub unsafe fn __msa_max_u_h(a: v8u16, b: v8u16) -> v8u16 {
 ///
 /// Maximum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
 /// and unsigned elements in vector `b` (four unsigned 32-bit integer numbers) are written to vector
-/// (four unsigned 32-bit integer numbers)
+/// (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6357,7 +6360,7 @@ pub unsafe fn __msa_max_u_w(a: v4u32, b: v4u32) -> v4u32 {
 ///
 /// Maximum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
 /// and unsigned elements in vector `b` (two unsigned 64-bit integer numbers) are written to vector
-/// (two unsigned 64-bit integer numbers)
+/// (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6370,7 +6373,7 @@ pub unsafe fn __msa_max_u_d(a: v2u64, b: v2u64) -> v2u64 {
 ///
 /// Maximum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (sixteen signed 8-bit integer numbers)
+/// (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6389,7 +6392,7 @@ pub unsafe fn __msa_maxi_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 ///
 /// Maximum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (eight signed 16-bit integer numbers)
+/// (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6408,7 +6411,7 @@ pub unsafe fn __msa_maxi_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 ///
 /// Maximum values between signed elements in vector `a` (four signed 32-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (four signed 32-bit integer numbers)
+/// (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6427,7 +6430,7 @@ pub unsafe fn __msa_maxi_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 ///
 /// Maximum values between signed elements in vector `a` (two signed 64-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (two signed 64-bit integer numbers)
+/// (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6445,8 +6448,8 @@ pub unsafe fn __msa_maxi_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6464,8 +6467,8 @@ pub unsafe fn __msa_maxi_u_b(a: v16u8, imm5: i32) -> v16u8 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (eight unsigned 16-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6483,8 +6486,8 @@ pub unsafe fn __msa_maxi_u_h(a: v8u16, imm5: i32) -> v8u16 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (four unsigned 32-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6502,8 +6505,8 @@ pub unsafe fn __msa_maxi_u_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Unsigned Maximum
 ///
 /// Maximum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (two unsigned 64-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6523,7 +6526,7 @@ pub unsafe fn __msa_maxi_u_d(a: v2u64, imm5: i32) -> v2u64 {
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (sixteen signed 8-bit integer numbers) and
 /// `b` (sixteen signed 8-bit integer numbers) are written to vector
-/// (sixteen signed 8-bit integer numbers)
+/// (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6537,7 +6540,7 @@ pub unsafe fn __msa_min_a_b(a: v16i8, b: v16i8) -> v16i8 {
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (eight signed 16-bit integer numbers) and
 /// `b` (eight signed 16-bit integer numbers) are written to vector
-/// (eight signed 16-bit integer numbers)
+/// (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6551,7 +6554,7 @@ pub unsafe fn __msa_min_a_h(a: v8i16, b: v8i16) -> v8i16 {
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (four signed 32-bit integer numbers) and
 /// `b` (four signed 32-bit integer numbers) are written to vector
-/// (four signed 32-bit integer numbers)
+/// (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6565,7 +6568,7 @@ pub unsafe fn __msa_min_a_w(a: v4i32, b: v4i32) -> v4i32 {
 /// The value with the smallest magnitude, i.e. absolute value, between corresponding
 /// signed elements in vector `a` (two signed 64-bit integer numbers) and
 /// `b` (two signed 64-bit integer numbers) are written to vector
-/// (two signed 64-bit integer numbers)
+/// (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6578,7 +6581,7 @@ pub unsafe fn __msa_min_a_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// Minimum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// and signed elements in vector `b` (sixteen signed 8-bit integer numbers) are written to vector
-/// (sixteen signed 8-bit integer numbers)
+/// (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6591,7 +6594,7 @@ pub unsafe fn __msa_min_s_b(a: v16i8, b: v16i8) -> v16i8 {
 ///
 /// Minimum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// and signed elements in vector `b` (eight signed 16-bit integer numbers) are written to vector
-/// (eight signed 16-bit integer numbers)
+/// (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6604,7 +6607,7 @@ pub unsafe fn __msa_min_s_h(a: v8i16, b: v8i16) -> v8i16 {
 ///
 /// Minimum values between signed elements in vector `a` (four signed 32-bit integer numbers)
 /// and signed elements in vector `b` (four signed 32-bit integer numbers) are written to vector
-/// (four signed 32-bit integer numbers)
+/// (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6617,7 +6620,7 @@ pub unsafe fn __msa_min_s_w(a: v4i32, b: v4i32) -> v4i32 {
 ///
 /// Minimum values between signed elements in vector `a` (two signed 64-bit integer numbers)
 /// and signed elements in vector `b` (two signed 64-bit integer numbers) are written to vector
-/// (two signed 64-bit integer numbers)
+/// (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6630,7 +6633,7 @@ pub unsafe fn __msa_min_s_d(a: v2i64, b: v2i64) -> v2i64 {
 ///
 /// Minimum values between signed elements in vector `a` (sixteen signed 8-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (sixteen signed 8-bit integer numbers)
+/// (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6649,7 +6652,7 @@ pub unsafe fn __msa_mini_s_b(a: v16i8, imm_s5: i32) -> v16i8 {
 ///
 /// Minimum values between signed elements in vector `a` (eight signed 16-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (eight signed 16-bit integer numbers)
+/// (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6668,7 +6671,7 @@ pub unsafe fn __msa_mini_s_h(a: v8i16, imm_s5: i32) -> v8i16 {
 ///
 /// Minimum values between signed elements in vector `a` (four signed 32-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (four signed 32-bit integer numbers)
+/// (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6687,7 +6690,7 @@ pub unsafe fn __msa_mini_s_w(a: v4i32, imm_s5: i32) -> v4i32 {
 ///
 /// Minimum values between signed elements in vector `a` (two signed 64-bit integer numbers)
 /// and the 5-bit signed immediate imm_s5 are written to vector
-/// (two signed 64-bit integer numbers)
+/// (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6706,7 +6709,7 @@ pub unsafe fn __msa_mini_s_d(a: v2i64, imm_s5: i32) -> v2i64 {
 ///
 /// Minimum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
 /// and unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers) are written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6719,7 +6722,7 @@ pub unsafe fn __msa_min_u_b(a: v16u8, b: v16u8) -> v16u8 {
 ///
 /// Minimum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
 /// and unsigned elements in vector `b` (eight unsigned 16-bit integer numbers) are written to vector
-/// (eight unsigned 16-bit integer numbers)
+/// (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6732,7 +6735,7 @@ pub unsafe fn __msa_min_u_h(a: v8u16, b: v8u16) -> v8u16 {
 ///
 /// Minimum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
 /// and unsigned elements in vector `b` (four unsigned 32-bit integer numbers) are written to vector
-/// (four unsigned 32-bit integer numbers)
+/// (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6745,7 +6748,7 @@ pub unsafe fn __msa_min_u_w(a: v4u32, b: v4u32) -> v4u32 {
 ///
 /// Minimum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
 /// and unsigned elements in vector `b` (two unsigned 64-bit integer numbers) are written to vector
-/// (two unsigned 64-bit integer numbers)
+/// (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6757,8 +6760,8 @@ pub unsafe fn __msa_min_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6776,8 +6779,8 @@ pub unsafe fn __msa_mini_u_b(a: v16u8, imm5: i32) -> v16u8 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (eight unsigned 16-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6795,8 +6798,8 @@ pub unsafe fn __msa_mini_u_h(a: v8u16, imm5: i32) -> v8u16 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (four unsigned 32-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -6814,8 +6817,8 @@ pub unsafe fn __msa_mini_u_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Unsigned Minimum
 ///
 /// Minimum values between unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// and the 5-bit unsigned immediate imm5 are written to vector
-/// (two unsigned 64-bit integer numbers)
+/// and the 5-bit unsigned immediate `imm5` are written to vector
+/// (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7137,8 +7140,8 @@ pub unsafe fn __msa_mulr_q_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Multiply
 ///
 /// The integer elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are multiplied by integer elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// The result is written to vector (sixteen signed 8-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (sixteen signed 8-bit integer numbers).
+/// The result is written to vector (sixteen signed 8-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7151,8 +7154,8 @@ pub unsafe fn __msa_mulv_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Multiply
 ///
 /// The integer elements in vector `a` (eight signed 16-bit integer numbers)
-/// are multiplied by integer elements in vector `b` (eight signed 16-bit integer numbers)
-/// The result is written to vector (eight signed 16-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (eight signed 16-bit integer numbers).
+/// The result is written to vector (eight signed 16-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7165,8 +7168,8 @@ pub unsafe fn __msa_mulv_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Multiply
 ///
 /// The integer elements in vector `a` (four signed 32-bit integer numbers)
-/// are multiplied by integer elements in vector `b` (four signed 32-bit integer numbers)
-/// The result is written to vector (four signed 32-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (four signed 32-bit integer numbers).
+/// The result is written to vector (four signed 32-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7179,8 +7182,8 @@ pub unsafe fn __msa_mulv_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Multiply
 ///
 /// The integer elements in vector `a` (two signed 64-bit integer numbers)
-/// are multiplied by integer elements in vector `b` (two signed 64-bit integer numbers)
-/// The result is written to vector (two signed 64-bit integer numbers)
+/// are multiplied by integer elements in vector `b` (two signed 64-bit integer numbers).
+/// The result is written to vector (two signed 64-bit integer numbers).
 /// The most significant half of the multiplication result is discarded.
 ///
 #[inline]
@@ -7193,7 +7196,7 @@ pub unsafe fn __msa_mulv_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Leading Ones Count
 ///
 /// The number of leading ones for elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// is stored to the elements in vector (sixteen signed 8-bit integer numbers)
+/// is stored to the elements in vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7205,7 +7208,7 @@ pub unsafe fn __msa_nloc_b(a: v16i8) -> v16i8 {
 /// Vector Leading Ones Count
 ///
 /// The number of leading ones for elements in vector `a` (eight signed 16-bit integer numbers)
-/// is stored to the elements in vector (eight signed 16-bit integer numbers)
+/// is stored to the elements in vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7217,7 +7220,7 @@ pub unsafe fn __msa_nloc_h(a: v8i16) -> v8i16 {
 /// Vector Leading Ones Count
 ///
 /// The number of leading ones for elements in vector `a` (four signed 32-bit integer numbers)
-/// is stored to the elements in vector (four signed 32-bit integer numbers)
+/// is stored to the elements in vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7229,7 +7232,7 @@ pub unsafe fn __msa_nloc_w(a: v4i32) -> v4i32 {
 /// Vector Leading Ones Count
 ///
 /// The number of leading ones for elements in vector `a` (two signed 64-bit integer numbers)
-/// is stored to the elements in vector (two signed 64-bit integer numbers)
+/// is stored to the elements in vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7241,7 +7244,7 @@ pub unsafe fn __msa_nloc_d(a: v2i64) -> v2i64 {
 /// Vector Leading Zeros Count
 ///
 /// The number of leading zeros for elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// is stored to the elements in vector (sixteen signed 8-bit integer numbers)
+/// is stored to the elements in vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7253,7 +7256,7 @@ pub unsafe fn __msa_nlzc_b(a: v16i8) -> v16i8 {
 /// Vector Leading Zeros Count
 ///
 /// The number of leading zeros for elements in vector `a` (eight signed 16-bit integer numbers)
-/// is stored to the elements in vector (eight signed 16-bit integer numbers)
+/// is stored to the elements in vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7265,7 +7268,7 @@ pub unsafe fn __msa_nlzc_h(a: v8i16) -> v8i16 {
 /// Vector Leading Zeros Count
 ///
 /// The number of leading zeros for elements in vector `a` (four signed 32-bit integer numbers)
-/// is stored to the elements in vector (four signed 32-bit integer numbers)
+/// is stored to the elements in vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7277,7 +7280,7 @@ pub unsafe fn __msa_nlzc_w(a: v4i32) -> v4i32 {
 /// Vector Leading Zeros Count
 ///
 /// The number of leading zeros for elements in vector `a` (two signed 64-bit integer numbers)
-/// is stored to the elements in vector (two signed 64-bit integer numbers)
+/// is stored to the elements in vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7291,7 +7294,7 @@ pub unsafe fn __msa_nlzc_d(a: v2i64) -> v2i64 {
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical NOR operation. The result is written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7305,7 +7308,7 @@ pub unsafe fn __msa_nor_v(a: v16u8, b: v16u8) -> v16u8 {
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the 8-bit immediate `imm8`
 /// in a bitwise logical NOR operation. The result is written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7325,7 +7328,7 @@ pub unsafe fn __msa_nori_b(a: v16u8, imm8: i32) -> v16u8 {
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical OR operation. The result is written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7339,7 +7342,7 @@ pub unsafe fn __msa_or_v(a: v16u8, b: v16u8) -> v16u8 {
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the 8-bit immediate `imm8`
 /// in a bitwise logical OR operation. The result is written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7461,7 +7464,7 @@ pub unsafe fn __msa_pckod_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Population Count
 ///
 /// The number of bits set to 1 for elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// is stored to the elements in the result vector (sixteen signed 8-bit integer numbers)
+/// is stored to the elements in the result vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7473,7 +7476,7 @@ pub unsafe fn __msa_pcnt_b(a: v16i8) -> v16i8 {
 /// Vector Population Count
 ///
 /// The number of bits set to 1 for elements in vector `a` (eight signed 16-bit integer numbers)
-/// is stored to the elements in the result vector (eight signed 16-bit integer numbers)
+/// is stored to the elements in the result vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7485,7 +7488,7 @@ pub unsafe fn __msa_pcnt_h(a: v8i16) -> v8i16 {
 /// Vector Population Count
 ///
 /// The number of bits set to 1 for elements in vector `a` (four signed 32-bit integer numbers)
-/// is stored to the elements in the result vector (four signed 32-bit integer numbers)
+/// is stored to the elements in the result vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7497,7 +7500,7 @@ pub unsafe fn __msa_pcnt_w(a: v4i32) -> v4i32 {
 /// Vector Population Count
 ///
 /// The number of bits set to 1 for elements in vector `a` (two signed 64-bit integer numbers)
-/// is stored to the elements in the result vector (two signed 64-bit integer numbers)
+/// is stored to the elements in the result vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7509,8 +7512,8 @@ pub unsafe fn __msa_pcnt_d(a: v2i64) -> v2i64 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (sixteen signed 8-bit integer numbers)
-/// are saturated to signed values of `imm3+1` bits without changing the data width
-/// The result is stored in the vector (sixteen signed 8-bit integer numbers)
+/// are saturated to signed values of `imm3+1` bits without changing the data width.
+/// The result is stored in the vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7528,8 +7531,8 @@ pub unsafe fn __msa_sat_s_b(a: v16i8, imm3: i32) -> v16i8 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (eight signed 16-bit integer numbers)
-/// are saturated to signed values of `imm4+1` bits without changing the data width
-/// The result is stored in the vector (eight signed 16-bit integer numbers)
+/// are saturated to signed values of `imm4+1` bits without changing the data width.
+/// The result is stored in the vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7547,8 +7550,8 @@ pub unsafe fn __msa_sat_s_h(a: v8i16, imm4: i32) -> v8i16 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (four signed 32-bit integer numbers)
-/// are saturated to signed values of `imm5+1` bits without changing the data width
-/// The result is stored in the vector (four signed 32-bit integer numbers)
+/// are saturated to signed values of `imm5+1` bits without changing the data width.
+/// The result is stored in the vector (four signed 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7566,8 +7569,8 @@ pub unsafe fn __msa_sat_s_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Signed Saturate
 ///
 /// Signed elements in vector `a` (two signed 64-bit integer numbers)
-/// are saturated to signed values of `imm6+1` bits without changing the data width
-/// The result is stored in the vector (two signed 64-bit integer numbers)
+/// are saturated to signed values of `imm6+1` bits without changing the data width.
+/// The result is stored in the vector (two signed 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7585,8 +7588,8 @@ pub unsafe fn __msa_sat_s_d(a: v2i64, imm6: i32) -> v2i64 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
-/// are saturated to unsigned values of `imm3+1` bits without changing the data width
-/// The result is stored in the vector (sixteen unsigned 8-bit integer numbers)
+/// are saturated to unsigned values of `imm3+1` bits without changing the data width.
+/// The result is stored in the vector (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7604,8 +7607,8 @@ pub unsafe fn __msa_sat_u_b(a: v16u8, imm3: i32) -> v16u8 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
-/// are saturated to unsigned values of `imm4+1` bits without changing the data width
-/// The result is stored in the vector (eight unsigned 16-bit integer numbers)
+/// are saturated to unsigned values of `imm4+1` bits without changing the data width.
+/// The result is stored in the vector (eight unsigned 16-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7623,8 +7626,8 @@ pub unsafe fn __msa_sat_u_h(a: v8u16, imm4: i32) -> v8u16 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
-/// are saturated to unsigned values of `imm5+1` bits without changing the data width
-/// The result is stored in the vector (four unsigned 32-bit integer numbers)
+/// are saturated to unsigned values of `imm5+1` bits without changing the data width.
+/// The result is stored in the vector (four unsigned 32-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7642,8 +7645,8 @@ pub unsafe fn __msa_sat_u_w(a: v4u32, imm5: i32) -> v4u32 {
 /// Immediate Unsigned Saturate
 ///
 /// Unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
-/// are saturated to unsigned values of `imm6+1` bits without changing the data width
-/// The result is stored in the vector (two unsigned 64-bit integer numbers)
+/// are saturated to unsigned values of `imm6+1` bits without changing the data width.
+/// The result is stored in the vector (two unsigned 64-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -7806,7 +7809,7 @@ pub unsafe fn __msa_sld_d(a: v2i64, b: v2i64, c: i32) -> v2i64 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by `imm1` columns
+/// by `imm1` columns.
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -7830,7 +7833,7 @@ pub unsafe fn __msa_sldi_b(a: v16i8, b: v16i8, imm4: i32) -> v16i8 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by `imm1` columns
+/// by `imm1` columns.
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -7854,7 +7857,7 @@ pub unsafe fn __msa_sldi_h(a: v8i16, b: v8i16, imm3: i32) -> v8i16 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by `imm1` columns
+/// by `imm1` columns.
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -7878,7 +7881,7 @@ pub unsafe fn __msa_sldi_w(a: v4i32, b: v4i32, imm2: i32) -> v4i32 {
 /// The two source rectangles `b` and `a` are concatenated horizontally in the order
 /// they appear in the syntax, i.e. first `a` and then `b`. Place a new destination
 /// rectangle over `b` and then slide it to the left over the concatenation of `a` and `b`
-/// by `imm1` columns
+/// by `imm1` columns.
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -8702,7 +8705,7 @@ pub unsafe fn __msa_srlri_d(a: v2i64, imm6: i32) -> v2i64 {
 ///
 /// The WRLEN / 8 bytes in vector `a` (sixteen signed 8-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base `mem_addr` and the 10-bit signed immediate offset `imm_s10`
+/// addressed by the base `mem_addr` and the 10-bit signed immediate offset `imm_s10`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8721,7 +8724,7 @@ pub unsafe fn __msa_st_b(a: v16i8, mem_addr: *mut u8, imm_s10: i32) -> () {
 ///
 /// The WRLEN / 8 bytes in vector `a` (eight signed 16-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base `mem_addr` and the 11-bit signed immediate offset `imm_s11`
+/// addressed by the base `mem_addr` and the 11-bit signed immediate offset `imm_s11`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8740,7 +8743,7 @@ pub unsafe fn __msa_st_h(a: v8i16, mem_addr: *mut u8, imm_s11: i32) -> () {
 ///
 /// The WRLEN / 8 bytes in vector `a` (four signed 32-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base `mem_addr` and the 12-bit signed immediate offset `imm_s12`
+/// addressed by the base `mem_addr` and the 12-bit signed immediate offset `imm_s12`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8759,7 +8762,7 @@ pub unsafe fn __msa_st_w(a: v4i32, mem_addr: *mut u8, imm_s12: i32) -> () {
 ///
 /// The WRLEN / 8 bytes in vector `a` (two signed 64-bit integer numbers)
 /// are stored as elements of data format df at the effective memory location
-/// addressed by the base `mem_addr` and the 13-bit signed immediate offset `imm_s13`
+/// addressed by the base `mem_addr` and the 13-bit signed immediate offset `imm_s13`.
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -8777,7 +8780,7 @@ pub unsafe fn __msa_st_d(a: v2i64, mem_addr: *mut u8, imm_s13: i32) -> () {
 /// Vector Signed Saturated Subtract of Signed Values
 ///
 /// The elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (sixteen signed 8-bit integer numbers).
 ///
@@ -8791,7 +8794,7 @@ pub unsafe fn __msa_subs_s_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Signed Saturated Subtract of Signed Values
 ///
 /// The elements in vector `b` (eight signed 16-bit integer numbers)
-/// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers)
+/// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (eight signed 16-bit integer numbers).
 ///
@@ -8805,7 +8808,7 @@ pub unsafe fn __msa_subs_s_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Signed Saturated Subtract of Signed Values
 ///
 /// The elements in vector `b` (four signed 32-bit integer numbers)
-/// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers)
+/// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (four signed 32-bit integer numbers).
 ///
@@ -8819,7 +8822,7 @@ pub unsafe fn __msa_subs_s_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Signed Saturated Subtract of Signed Values
 ///
 /// The elements in vector `b` (two signed 64-bit integer numbers)
-/// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers)
+/// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers).
 /// Signed arithmetic is performed and overflows clamp to the largest and/or smallest
 /// representable signed values before writing the result to vector (two signed 64-bit integer numbers).
 ///
@@ -8833,7 +8836,7 @@ pub unsafe fn __msa_subs_s_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Vector Unsigned Saturated Subtract of Unsigned Values
 ///
 /// The elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// are subtracted from the elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are subtracted from the elements in vector `a` (sixteen unsigned 8-bit integer numbers).
 /// Unsigned arithmetic is performed and under-flows clamp to 0 before writing
 /// the result to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -8847,7 +8850,7 @@ pub unsafe fn __msa_subs_u_b(a: v16u8, b: v16u8) -> v16u8 {
 /// Vector Unsigned Saturated Subtract of Unsigned Values
 ///
 /// The elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// are subtracted from the elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are subtracted from the elements in vector `a` (eight unsigned 16-bit integer numbers).
 /// Unsigned arithmetic is performed and under-flows clamp to 0 before writing
 /// the result to vector (eight unsigned 16-bit integer numbers).
 ///
@@ -8861,7 +8864,7 @@ pub unsafe fn __msa_subs_u_h(a: v8u16, b: v8u16) -> v8u16 {
 /// Vector Unsigned Saturated Subtract of Unsigned Values
 ///
 /// The elements in vector `b` (four unsigned 32-bit integer numbers)
-/// are subtracted from the elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are subtracted from the elements in vector `a` (four unsigned 32-bit integer numbers).
 /// Unsigned arithmetic is performed and under-flows clamp to 0 before writing
 /// the result to vector (four unsigned 32-bit integer numbers).
 ///
@@ -8875,7 +8878,7 @@ pub unsafe fn __msa_subs_u_w(a: v4u32, b: v4u32) -> v4u32 {
 /// Vector Unsigned Saturated Subtract of Unsigned Values
 ///
 /// The elements in vector `b` (two unsigned 64-bit integer numbers)
-/// are subtracted from the elements in vector `a` (two unsigned 64-bit integer numbers)
+/// are subtracted from the elements in vector `a` (two unsigned 64-bit integer numbers).
 /// Unsigned arithmetic is performed and under-flows clamp to 0 before writing
 /// the result to vector (two unsigned 64-bit integer numbers).
 ///
@@ -8889,7 +8892,7 @@ pub unsafe fn __msa_subs_u_d(a: v2u64, b: v2u64) -> v2u64 {
 /// Vector Unsigned Saturated Subtract of Signed from Unsigned
 ///
 /// The signed elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers).
 /// The signed result is unsigned saturated and written to
 /// to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -8903,7 +8906,7 @@ pub unsafe fn __msa_subsus_u_b(a: v16u8, b: v16i8) -> v16u8 {
 /// Vector Unsigned Saturated Subtract of Signed from Unsigned
 ///
 /// The signed elements in vector `b` (eight signed 16-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (eight unsigned 16-bit integer numbers).
 /// The signed result is unsigned saturated and written to
 /// to vector (eight unsigned 16-bit integer numbers).
 ///
@@ -8917,7 +8920,7 @@ pub unsafe fn __msa_subsus_u_h(a: v8u16, b: v8i16) -> v8u16 {
 /// Vector Unsigned Saturated Subtract of Signed from Unsigned
 ///
 /// The signed elements in vector `b` (four signed 6432it integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (four unsigned 32-bit integer numbers).
 /// The signed result is unsigned saturated and written to
 /// to vector (four unsigned 32-bit integer numbers).
 ///
@@ -8931,7 +8934,7 @@ pub unsafe fn __msa_subsus_u_w(a: v4u32, b: v4i32) -> v4u32 {
 /// Vector Unsigned Saturated Subtract of Signed from Unsigned
 ///
 /// The signed elements in vector `b` (two signed 64-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (two unsigned 64-bit integer numbers).
 /// The signed result is unsigned saturated and written to
 /// to vector (two unsigned 64-bit integer numbers).
 ///
@@ -8945,7 +8948,7 @@ pub unsafe fn __msa_subsus_u_d(a: v2u64, b: v2i64) -> v2u64 {
 /// Vector Signed Saturated Subtract of Unsigned Values
 ///
 /// The unsigned elements in vector `b` (sixteen unsigned 8-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (sixteen unsigned 8-bit integer numbers).
 /// The signed result is signed saturated and written to
 /// to vector (sixteen unsigned 8-bit integer numbers).
 ///
@@ -8959,7 +8962,7 @@ pub unsafe fn __msa_subsuu_s_b(a: v16u8, b: v16u8) -> v16i8 {
 /// Vector Signed Saturated Subtract of Unsigned Values
 ///
 /// The unsigned elements in vector `b` (eight unsigned 16-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (eight unsigned 16-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (eight unsigned 16-bit integer numbers).
 /// The signed result is signed saturated and written to
 /// to vector (eight unsigned 16-bit integer numbers).
 ///
@@ -8973,7 +8976,7 @@ pub unsafe fn __msa_subsuu_s_h(a: v8u16, b: v8u16) -> v8i16 {
 /// Vector Signed Saturated Subtract of Unsigned Values
 ///
 /// The unsigned elements in vector `b` (four unsigned 32-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (four unsigned 32-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (four unsigned 32-bit integer numbers).
 /// The signed result is signed saturated and written to
 /// to vector (four unsigned 32-bit integer numbers).
 ///
@@ -8987,7 +8990,7 @@ pub unsafe fn __msa_subsuu_s_w(a: v4u32, b: v4u32) -> v4i32 {
 /// Vector Signed Saturated Subtract of Unsigned Values
 ///
 /// The unsigned elements in vector `b` (two unsigned 64-bit integer numbers)
-/// are subtracted from the unsigned elements in vector `a` (two unsigned 64-bit integer numbers)
+/// are subtracted from the unsigned elements in vector `a` (two unsigned 64-bit integer numbers).
 /// The signed result is signed saturated and written to
 /// to vector (two unsigned 64-bit integer numbers).
 ///
@@ -9001,7 +9004,7 @@ pub unsafe fn __msa_subsuu_s_d(a: v2u64, b: v2u64) -> v2i64 {
 /// Vector Subtract
 ///
 /// The elements in vector `b` (sixteen signed 8-bit integer numbers)
-/// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -9014,7 +9017,7 @@ pub unsafe fn __msa_subv_b(a: v16i8, b: v16i8) -> v16i8 {
 /// Vector Subtract
 ///
 /// The elements in vector `b` (eight signed 16-bit integer numbers)
-/// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers)
+/// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -9027,7 +9030,7 @@ pub unsafe fn __msa_subv_h(a: v8i16, b: v8i16) -> v8i16 {
 /// Vector Subtract
 ///
 /// The elements in vector `b` (four signed 32-bit integer numbers)
-/// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers)
+/// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -9040,7 +9043,7 @@ pub unsafe fn __msa_subv_w(a: v4i32, b: v4i32) -> v4i32 {
 /// Vector Subtract
 ///
 /// The elements in vector `b` (two signed 64-bit integer numbers)
-/// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers)
+/// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers).
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -9053,7 +9056,7 @@ pub unsafe fn __msa_subv_d(a: v2i64, b: v2i64) -> v2i64 {
 /// Immediate Subtract
 ///
 /// The 5-bit immediate unsigned value `imm5`
-/// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers)
+/// are subtracted from the elements in vector `a` (sixteen signed 8-bit integer numbers).
 /// The result is written to vector (sixteen signed 8-bit integer numbers).
 ///
 #[inline]
@@ -9072,7 +9075,7 @@ pub unsafe fn __msa_subvi_b(a: v16i8, imm5: i32) -> v16i8 {
 /// Immediate Subtract
 ///
 /// The 5-bit immediate unsigned value `imm5`
-/// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers)
+/// are subtracted from the elements in vector `a` (eight signed 16-bit integer numbers).
 /// The result is written to vector (eight signed 16-bit integer numbers).
 ///
 #[inline]
@@ -9091,7 +9094,7 @@ pub unsafe fn __msa_subvi_h(a: v8i16, imm5: i32) -> v8i16 {
 /// Immediate Subtract
 ///
 /// The 5-bit immediate unsigned value `imm5`
-/// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers)
+/// are subtracted from the elements in vector `a` (four signed 32-bit integer numbers).
 /// The result is written to vector (four signed 32-bit integer numbers).
 ///
 #[inline]
@@ -9110,7 +9113,7 @@ pub unsafe fn __msa_subvi_w(a: v4i32, imm5: i32) -> v4i32 {
 /// Immediate Subtract
 ///
 /// The 5-bit immediate unsigned value `imm5`
-/// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers)
+/// are subtracted from the elements in vector `a` (two signed 64-bit integer numbers).
 /// The result is written to vector (two signed 64-bit integer numbers).
 ///
 #[inline]
@@ -9131,7 +9134,7 @@ pub unsafe fn __msa_subvi_d(a: v2i64, imm5: i32) -> v2i64 {
 /// The vector shuffle instructions selectively copy data elements from the
 /// concatenation of vectors `b` (sixteen signed 8-bit integer numbers)
 /// and `c` (sixteen signed 8-bit integer numbers) in to vector `a`
-/// (sixteen signed 8-bit integer numbers) based on the corresponding control element in `a`
+/// (sixteen signed 8-bit integer numbers) based on the corresponding control element in `a`.
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
@@ -9148,7 +9151,7 @@ pub unsafe fn __msa_vshf_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
 /// The vector shuffle instructions selectively copy data elements from the
 /// concatenation of vectors `b` (eight signed 16-bit integer numbers)
 /// and `c` (eight signed 16-bit integer numbers) in to vector `a`
-/// (eight signed 16-bit integer numbers) based on the corresponding control element in `a`
+/// (eight signed 16-bit integer numbers) based on the corresponding control element in `a`.
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
@@ -9165,7 +9168,7 @@ pub unsafe fn __msa_vshf_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
 /// The vector shuffle instructions selectively copy data elements from the
 /// concatenation of vectors `b` (four signed 32-bit integer numbers)
 /// and `c` (four signed 32-bit integer numbers) in to vector `a`
-/// (four signed 32-bit integer numbers) based on the corresponding control element in `a`
+/// (four signed 32-bit integer numbers) based on the corresponding control element in `a`.
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
@@ -9182,7 +9185,7 @@ pub unsafe fn __msa_vshf_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
 /// The vector shuffle instructions selectively copy data elements from the
 /// concatenation of vectors `b` (two signed 64-bit integer numbers)
 /// and `c` (two signed 64-bit integer numbers) in to vector `a`
-/// (two signed 64-bit integer numbers) based on the corresponding control element in `a`
+/// (two signed 64-bit integer numbers) based on the corresponding control element in `a`.
 /// The least significant 6 bits in `a` control elements modulo the number of elements in
 /// the concatenated vectors `b`, `a` specify the index of the source element.
 /// If bit 6 or bit 7 is 1, there will be no copy, but rather the destination element is set to 0.
@@ -9199,7 +9202,7 @@ pub unsafe fn __msa_vshf_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
 /// Each bit of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the corresponding bit of vector `b` (sixteen unsigned 8-bit integer numbers)
 /// in a bitwise logical XOR operation. The result is written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]
@@ -9213,7 +9216,7 @@ pub unsafe fn __msa_xor_v(a: v16u8, b: v16u8) -> v16u8 {
 /// Each byte of vector `a` (sixteen unsigned 8-bit integer numbers)
 /// is combined with the 8-bit immediate `imm8`
 /// in a bitwise logical XOR operation. The result is written to vector
-/// (sixteen unsigned 8-bit integer numbers)
+/// (sixteen unsigned 8-bit integer numbers).
 ///
 #[inline]
 #[target_feature(enable = "msa")]

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1913,7 +1913,7 @@ pub unsafe fn _mm256_moveldup_ps(a: __m256) -> __m256 {
 }
 
 /// Duplicate even-indexed double-precision (64-bit) floating-point elements
-/// from "a", and returns the results.
+/// from `a`, and returns the results.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_movedup_pd)
 #[inline]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2315,7 +2315,7 @@ pub unsafe fn _mm_ucomineq_sd(a: __m128d, b: __m128d) -> i32 {
     ucomineqsd(a, b)
 }
 
-/// Converts packed double-precision (64-bit) floating-point elements in "a" to
+/// Converts packed double-precision (64-bit) floating-point elements in `a` to
 /// packed single-precision (32-bit) floating-point elements
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cvtpd_ps)
@@ -2378,7 +2378,7 @@ pub unsafe fn _mm_cvtsd_ss(a: __m128, b: __m128d) -> __m128 {
     cvtsd2ss(a, b)
 }
 
-/// Returns the lower double-precision (64-bit) floating-point element of "a".
+/// Returns the lower double-precision (64-bit) floating-point element of `a`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cvtsd_f64)
 #[inline]


### PR DESCRIPTION
Initiated by https://github.com/rust-lang/rust/issues/62454, this includes many formatting fixes to the intrinsic functions documentation, especially in MIPS MSA.