### PR TITLE
Use more simd_* intrinsics

### DIFF
--- a/crates/core_arch/src/simd_llvm.rs
+++ b/crates/core_arch/src/simd_llvm.rs
@@ -61,5 +61,7 @@ extern "platform-intrinsic" {
     pub fn simd_fmax<T>(a: T, b: T) -> T;
 
     pub fn simd_fsqrt<T>(a: T) -> T;
+    pub fn simd_floor<T>(a: T) -> T;
+    pub fn simd_ceil<T>(a: T) -> T;
     pub fn simd_fma<T>(a: T, b: T, c: T) -> T;
 }

--- a/crates/core_arch/src/simd_llvm.rs
+++ b/crates/core_arch/src/simd_llvm.rs
@@ -3,6 +3,7 @@
 //! TODO: should use `link_llvm_intrinsic` instead: issue #112
 
 extern "platform-intrinsic" {
+    //pub fn simd_select_bitmask
     pub fn simd_eq<T, U>(x: T, y: T) -> U;
     pub fn simd_ne<T, U>(x: T, y: T) -> U;
     pub fn simd_lt<T, U>(x: T, y: T) -> U;
@@ -27,6 +28,8 @@ extern "platform-intrinsic" {
 
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
     pub fn simd_extract<T, U>(x: T, idx: u32) -> U;
+    //pub fn simd_select
+    pub fn simd_bitmask<T, U>(x: T) -> U;
 
     pub fn simd_cast<T, U>(x: T) -> U;
 
@@ -39,6 +42,12 @@ extern "platform-intrinsic" {
     pub fn simd_and<T>(x: T, y: T) -> T;
     pub fn simd_or<T>(x: T, y: T) -> T;
     pub fn simd_xor<T>(x: T, y: T) -> T;
+
+    pub fn simd_saturating_add<T>(x: T, y: T) -> T;
+    pub fn simd_saturating_sub<T>(x: T, y: T) -> T;
+
+    pub fn simd_gather<T, U, V>(values: T, pointers: U, mask: V) -> T;
+    pub fn simd_scatter<T, U, V>(values: T, pointers: U, mask: V);
 
     pub fn simd_reduce_add_unordered<T, U>(x: T) -> U;
     pub fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
@@ -61,7 +70,17 @@ extern "platform-intrinsic" {
     pub fn simd_fmax<T>(a: T, b: T) -> T;
 
     pub fn simd_fsqrt<T>(a: T) -> T;
+    pub fn simd_fsin<T>(a: T) -> T;
+    pub fn simd_fcos<T>(a: T) -> T;
+    pub fn simd_fabs<T>(a: T) -> T;
     pub fn simd_floor<T>(a: T) -> T;
     pub fn simd_ceil<T>(a: T) -> T;
+    pub fn simd_fexp<T>(a: T) -> T;
+    pub fn simd_fexp2<T>(a: T) -> T;
+    pub fn simd_flog10<T>(a: T) -> T;
+    pub fn simd_flog2<T>(a: T) -> T;
+    pub fn simd_flog<T>(a: T) -> T;
+    //pub fn simd_fpowi
+    //pub fn simd_fpow
     pub fn simd_fma<T>(a: T, b: T, c: T) -> T;
 }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -513,7 +513,7 @@ pub unsafe fn _mm256_sqrt_ps(a: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vsqrtpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_sqrt_pd(a: __m256d) -> __m256d {
-    sqrtpd256(a)
+    simd_fsqrt(a)
 }
 
 /// Blends packed double-precision (64-bit) floating-point elements from

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -426,7 +426,7 @@ pub unsafe fn _mm256_round_pd(a: __m256d, b: i32) -> __m256d {
 #[cfg_attr(test, assert_instr(vroundpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_ceil_pd(a: __m256d) -> __m256d {
-    roundpd256(a, 0x02)
+    simd_ceil(a)
 }
 
 /// Rounds packed double-precision (64-bit) floating point elements in `a`
@@ -438,7 +438,7 @@ pub unsafe fn _mm256_ceil_pd(a: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vroundpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_floor_pd(a: __m256d) -> __m256d {
-    roundpd256(a, 0x01)
+    simd_floor(a)
 }
 
 /// Rounds packed single-precision (32-bit) floating point elements in `a`
@@ -477,7 +477,7 @@ pub unsafe fn _mm256_round_ps(a: __m256, b: i32) -> __m256 {
 #[cfg_attr(test, assert_instr(vroundps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_ceil_ps(a: __m256) -> __m256 {
-    roundps256(a, 0x02)
+    simd_ceil(a)
 }
 
 /// Rounds packed single-precision (32-bit) floating point elements in `a`
@@ -489,7 +489,7 @@ pub unsafe fn _mm256_ceil_ps(a: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vroundps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_floor_ps(a: __m256) -> __m256 {
-    roundps256(a, 0x01)
+    simd_floor(a)
 }
 
 /// Returns the square root of packed single-precision (32-bit) floating point

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -255,7 +255,7 @@ pub unsafe fn _mm256_andnot_ps(a: __m256, b: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vmaxpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_max_pd(a: __m256d, b: __m256d) -> __m256d {
-    maxpd256(a, b)
+    simd_fmax(a, b)
 }
 
 /// Compares packed single-precision (32-bit) floating-point elements in `a`
@@ -267,7 +267,7 @@ pub unsafe fn _mm256_max_pd(a: __m256d, b: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vmaxps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_max_ps(a: __m256, b: __m256) -> __m256 {
-    maxps256(a, b)
+    simd_fmax(a, b)
 }
 
 /// Compares packed double-precision (64-bit) floating-point elements
@@ -279,7 +279,7 @@ pub unsafe fn _mm256_max_ps(a: __m256, b: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vminpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_min_pd(a: __m256d, b: __m256d) -> __m256d {
-    minpd256(a, b)
+    simd_fmin(a, b)
 }
 
 /// Compares packed single-precision (32-bit) floating-point elements in `a`
@@ -291,7 +291,7 @@ pub unsafe fn _mm256_min_pd(a: __m256d, b: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vminps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_min_ps(a: __m256, b: __m256) -> __m256 {
-    minps256(a, b)
+    simd_fmin(a, b)
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements
@@ -3166,20 +3166,10 @@ extern "C" {
     fn addsubpd256(a: __m256d, b: __m256d) -> __m256d;
     #[link_name = "llvm.x86.avx.addsub.ps.256"]
     fn addsubps256(a: __m256, b: __m256) -> __m256;
-    #[link_name = "llvm.x86.avx.max.pd.256"]
-    fn maxpd256(a: __m256d, b: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.avx.max.ps.256"]
-    fn maxps256(a: __m256, b: __m256) -> __m256;
-    #[link_name = "llvm.x86.avx.min.pd.256"]
-    fn minpd256(a: __m256d, b: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.avx.min.ps.256"]
-    fn minps256(a: __m256, b: __m256) -> __m256;
     #[link_name = "llvm.x86.avx.round.pd.256"]
     fn roundpd256(a: __m256d, b: i32) -> __m256d;
     #[link_name = "llvm.x86.avx.round.ps.256"]
     fn roundps256(a: __m256, b: i32) -> __m256;
-    #[link_name = "llvm.x86.avx.sqrt.pd.256"]
-    fn sqrtpd256(a: __m256d) -> __m256d;
     #[link_name = "llvm.x86.avx.sqrt.ps.256"]
     fn sqrtps256(a: __m256) -> __m256;
     #[link_name = "llvm.x86.avx.blendv.pd.256"]

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -111,7 +111,7 @@ pub unsafe fn _mm256_add_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpaddsb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_adds_epi8(a: __m256i, b: __m256i) -> __m256i {
-    transmute(paddsb(a.as_i8x32(), b.as_i8x32()))
+    transmute(simd_saturating_add(a.as_i8x32(), b.as_i8x32()))
 }
 
 /// Adds packed 16-bit integers in `a` and `b` using saturation.
@@ -122,7 +122,7 @@ pub unsafe fn _mm256_adds_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpaddsw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_adds_epi16(a: __m256i, b: __m256i) -> __m256i {
-    transmute(paddsw(a.as_i16x16(), b.as_i16x16()))
+    transmute(simd_saturating_add(a.as_i16x16(), b.as_i16x16()))
 }
 
 /// Adds packed unsigned 8-bit integers in `a` and `b` using saturation.
@@ -133,7 +133,7 @@ pub unsafe fn _mm256_adds_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpaddusb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_adds_epu8(a: __m256i, b: __m256i) -> __m256i {
-    transmute(paddusb(a.as_u8x32(), b.as_u8x32()))
+    transmute(simd_saturating_add(a.as_u8x32(), b.as_u8x32()))
 }
 
 /// Adds packed unsigned 16-bit integers in `a` and `b` using saturation.
@@ -144,7 +144,7 @@ pub unsafe fn _mm256_adds_epu8(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpaddusw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_adds_epu16(a: __m256i, b: __m256i) -> __m256i {
-    transmute(paddusw(a.as_u16x16(), b.as_u16x16()))
+    transmute(simd_saturating_add(a.as_u16x16(), b.as_u16x16()))
 }
 
 /// Concatenates pairs of 16-byte blocks in `a` and `b` into a 32-byte temporary
@@ -3331,7 +3331,7 @@ pub unsafe fn _mm256_sub_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpsubsw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_subs_epi16(a: __m256i, b: __m256i) -> __m256i {
-    transmute(psubsw(a.as_i16x16(), b.as_i16x16()))
+    transmute(simd_saturating_sub(a.as_i16x16(), b.as_i16x16()))
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in
@@ -3343,7 +3343,7 @@ pub unsafe fn _mm256_subs_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpsubsb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_subs_epi8(a: __m256i, b: __m256i) -> __m256i {
-    transmute(psubsb(a.as_i8x32(), b.as_i8x32()))
+    transmute(simd_saturating_sub(a.as_i8x32(), b.as_i8x32()))
 }
 
 /// Subtract packed unsigned 16-bit integers in `b` from packed 16-bit
@@ -3355,7 +3355,7 @@ pub unsafe fn _mm256_subs_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpsubusw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_subs_epu16(a: __m256i, b: __m256i) -> __m256i {
-    transmute(psubusw(a.as_u16x16(), b.as_u16x16()))
+    transmute(simd_saturating_sub(a.as_u16x16(), b.as_u16x16()))
 }
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed 8-bit
@@ -3367,7 +3367,7 @@ pub unsafe fn _mm256_subs_epu16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpsubusb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_subs_epu8(a: __m256i, b: __m256i) -> __m256i {
-    transmute(psubusb(a.as_u8x32(), b.as_u8x32()))
+    transmute(simd_saturating_sub(a.as_u8x32(), b.as_u8x32()))
 }
 
 /// Unpacks and interleave 8-bit integers from the high half of each
@@ -3807,14 +3807,6 @@ extern "C" {
     fn pabsw(a: i16x16) -> u16x16;
     #[link_name = "llvm.x86.avx2.pabs.d"]
     fn pabsd(a: i32x8) -> u32x8;
-    #[link_name = "llvm.x86.avx2.padds.b"]
-    fn paddsb(a: i8x32, b: i8x32) -> i8x32;
-    #[link_name = "llvm.x86.avx2.padds.w"]
-    fn paddsw(a: i16x16, b: i16x16) -> i16x16;
-    #[link_name = "llvm.x86.avx2.paddus.b"]
-    fn paddusb(a: u8x32, b: u8x32) -> u8x32;
-    #[link_name = "llvm.x86.avx2.paddus.w"]
-    fn paddusw(a: u16x16, b: u16x16) -> u16x16;
     #[link_name = "llvm.x86.avx2.pavg.b"]
     fn pavgb(a: u8x32, b: u8x32) -> u8x32;
     #[link_name = "llvm.x86.avx2.pavg.w"]
@@ -3959,14 +3951,6 @@ extern "C" {
     fn psrlvq(a: i64x2, count: i64x2) -> i64x2;
     #[link_name = "llvm.x86.avx2.psrlv.q.256"]
     fn psrlvq256(a: i64x4, count: i64x4) -> i64x4;
-    #[link_name = "llvm.x86.avx2.psubs.b"]
-    fn psubsb(a: i8x32, b: i8x32) -> i8x32;
-    #[link_name = "llvm.x86.avx2.psubs.w"]
-    fn psubsw(a: i16x16, b: i16x16) -> i16x16;
-    #[link_name = "llvm.x86.avx2.psubus.b"]
-    fn psubusb(a: u8x32, b: u8x32) -> u8x32;
-    #[link_name = "llvm.x86.avx2.psubus.w"]
-    fn psubusw(a: u16x16, b: u16x16) -> u16x16;
     #[link_name = "llvm.x86.avx2.pshuf.b"]
     fn pshufb(a: u8x32, b: u8x32) -> u8x32;
     #[link_name = "llvm.x86.avx2.permd"]

--- a/crates/core_arch/src/x86/bswap.rs
+++ b/crates/core_arch/src/x86/bswap.rs
@@ -11,13 +11,7 @@ use stdarch_test::assert_instr;
 #[cfg_attr(test, assert_instr(bswap))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _bswap(x: i32) -> i32 {
-    bswap_i32(x)
-}
-
-#[allow(improper_ctypes)]
-extern "C" {
-    #[link_name = "llvm.bswap.i32"]
-    fn bswap_i32(x: i32) -> i32;
+    x.swap_bytes()
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -440,14 +440,6 @@ pub unsafe fn _mm_fnmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.x86.fma.vfmadd.pd"]
-    fn vfmaddpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfmadd.pd.256"]
-    fn vfmaddpd256(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.fma.vfmadd.ps"]
-    fn vfmaddps(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfmadd.ps.256"]
-    fn vfmaddps256(a: __m256, b: __m256, c: __m256) -> __m256;
     #[link_name = "llvm.x86.fma.vfmadd.sd"]
     fn vfmaddsd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
     #[link_name = "llvm.x86.fma.vfmadd.ss"]

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -18,8 +18,8 @@
 //! [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
-use crate::core_arch::x86::*;
 use crate::core_arch::simd_llvm::simd_fma;
+use crate::core_arch::x86::*;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -19,6 +19,7 @@
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
 use crate::core_arch::x86::*;
+use crate::core_arch::simd_llvm::simd_fma;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;
@@ -32,7 +33,7 @@ use stdarch_test::assert_instr;
 #[cfg_attr(test, assert_instr(vfmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfmaddpd(a, b, c)
+    simd_fma(a, b, c)
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -44,7 +45,7 @@ pub unsafe fn _mm_fmadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
-    vfmaddpd256(a, b, c)
+    simd_fma(a, b, c)
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -56,7 +57,7 @@ pub unsafe fn _mm256_fmadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vfmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmadd_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfmaddps(a, b, c)
+    simd_fma(a, b, c)
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -68,7 +69,7 @@ pub unsafe fn _mm_fmadd_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmadd_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
-    vfmaddps256(a, b, c)
+    simd_fma(a, b, c)
 }
 
 /// Multiplies the lower double-precision (64-bit) floating-point elements in

--- a/crates/core_arch/src/x86/mmx.rs
+++ b/crates/core_arch/src/x86/mmx.rs
@@ -9,7 +9,7 @@
 //! [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
 
 use crate::{
-    core_arch::{simd::*, x86::*},
+    core_arch::{simd::*, simd_llvm::*, x86::*},
     mem::transmute,
 };
 
@@ -31,7 +31,7 @@ pub unsafe fn _mm_setzero_si64() -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddb))]
 pub unsafe fn _mm_add_pi8(a: __m64, b: __m64) -> __m64 {
-    paddb(a, b)
+    transmute(simd_add(a.as_i8x8(), b.as_i8x8()))
 }
 
 /// Adds packed 8-bit integers in `a` and `b`.
@@ -47,7 +47,7 @@ pub unsafe fn _m_paddb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddw))]
 pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
-    paddw(a, b)
+    transmute(simd_add(a.as_i16x4(), b.as_i16x4()))
 }
 
 /// Adds packed 16-bit integers in `a` and `b`.
@@ -63,7 +63,7 @@ pub unsafe fn _m_paddw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddd))]
 pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
-    paddd(a, b)
+    transmute(simd_add(a.as_i32x2(), b.as_i32x2()))
 }
 
 /// Adds packed 32-bit integers in `a` and `b`.
@@ -79,7 +79,7 @@ pub unsafe fn _m_paddd(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddsb))]
 pub unsafe fn _mm_adds_pi8(a: __m64, b: __m64) -> __m64 {
-    paddsb(a, b)
+    transmute(simd_saturating_add(a.as_i8x8(), b.as_i8x8()))
 }
 
 /// Adds packed 8-bit integers in `a` and `b` using saturation.
@@ -95,7 +95,7 @@ pub unsafe fn _m_paddsb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddsw))]
 pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
-    paddsw(a, b)
+    transmute(simd_saturating_add(a.as_i16x4(), b.as_i16x4()))
 }
 
 /// Adds packed 16-bit integers in `a` and `b` using saturation.
@@ -111,7 +111,7 @@ pub unsafe fn _m_paddsw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddusb))]
 pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
-    paddusb(a, b)
+    transmute(simd_saturating_add(a.as_u8x8(), b.as_u8x8()))
 }
 
 /// Adds packed unsigned 8-bit integers in `a` and `b` using saturation.
@@ -127,7 +127,7 @@ pub unsafe fn _m_paddusb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddusw))]
 pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {
-    paddusw(a, b)
+    transmute(simd_saturating_add(a.as_u16x4(), b.as_u16x4()))
 }
 
 /// Adds packed unsigned 16-bit integers in `a` and `b` using saturation.
@@ -143,7 +143,7 @@ pub unsafe fn _m_paddusw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubb))]
 pub unsafe fn _mm_sub_pi8(a: __m64, b: __m64) -> __m64 {
-    psubb(a, b)
+    transmute(simd_sub(a.as_i8x8(), b.as_i8x8()))
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`.
@@ -159,7 +159,7 @@ pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubw))]
 pub unsafe fn _mm_sub_pi16(a: __m64, b: __m64) -> __m64 {
-    psubw(a, b)
+    transmute(simd_sub(a.as_i16x4(), b.as_i16x4()))
 }
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`.
@@ -175,7 +175,7 @@ pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubd))]
 pub unsafe fn _mm_sub_pi32(a: __m64, b: __m64) -> __m64 {
-    psubd(a, b)
+    transmute(simd_sub(a.as_i32x2(), b.as_i32x2()))
 }
 
 /// Subtract packed 32-bit integers in `b` from packed 32-bit integers in `a`.
@@ -192,7 +192,7 @@ pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubsb))]
 pub unsafe fn _mm_subs_pi8(a: __m64, b: __m64) -> __m64 {
-    psubsb(a, b)
+    transmute(simd_saturating_sub(a.as_i8x8(), b.as_i8x8()))
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`
@@ -210,7 +210,7 @@ pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubsw))]
 pub unsafe fn _mm_subs_pi16(a: __m64, b: __m64) -> __m64 {
-    psubsw(a, b)
+    transmute(simd_saturating_sub(a.as_i16x4(), b.as_i16x4()))
 }
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
@@ -228,7 +228,7 @@ pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubusb))]
 pub unsafe fn _mm_subs_pu8(a: __m64, b: __m64) -> __m64 {
-    psubusb(a, b)
+    transmute(simd_saturating_sub(a.as_u8x8(), b.as_u8x8()))
 }
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
@@ -246,7 +246,7 @@ pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubusw))]
 pub unsafe fn _mm_subs_pu16(a: __m64, b: __m64) -> __m64 {
-    psubusw(a, b)
+    transmute(simd_saturating_sub(a.as_u16x4(), b.as_u16x4()))
 }
 
 /// Subtract packed unsigned 16-bit integers in `b` from packed unsigned
@@ -475,34 +475,6 @@ pub unsafe fn _mm_cvtsi64_si32(a: __m64) -> i32 {
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.x86.mmx.padd.b"]
-    fn paddb(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.padd.w"]
-    fn paddw(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.padd.d"]
-    fn paddd(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.padds.b"]
-    fn paddsb(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.padds.w"]
-    fn paddsw(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.paddus.b"]
-    fn paddusb(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.paddus.w"]
-    fn paddusw(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psub.b"]
-    fn psubb(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psub.w"]
-    fn psubw(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psub.d"]
-    fn psubd(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psubs.b"]
-    fn psubsb(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psubs.w"]
-    fn psubsw(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psubus.b"]
-    fn psubusb(a: __m64, b: __m64) -> __m64;
-    #[link_name = "llvm.x86.mmx.psubus.w"]
-    fn psubusw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]

--- a/crates/core_arch/src/x86/mmx.rs
+++ b/crates/core_arch/src/x86/mmx.rs
@@ -9,7 +9,7 @@
 //! [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
 
 use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
+    core_arch::{simd::*, x86::*},
     mem::transmute,
 };
 
@@ -31,7 +31,7 @@ pub unsafe fn _mm_setzero_si64() -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddb))]
 pub unsafe fn _mm_add_pi8(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_add(a.as_i8x8(), b.as_i8x8()))
+    paddb(a, b)
 }
 
 /// Adds packed 8-bit integers in `a` and `b`.
@@ -47,7 +47,7 @@ pub unsafe fn _m_paddb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddw))]
 pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_add(a.as_i16x4(), b.as_i16x4()))
+    paddw(a, b)
 }
 
 /// Adds packed 16-bit integers in `a` and `b`.
@@ -63,7 +63,7 @@ pub unsafe fn _m_paddw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddd))]
 pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_add(a.as_i32x2(), b.as_i32x2()))
+    paddd(a, b)
 }
 
 /// Adds packed 32-bit integers in `a` and `b`.
@@ -79,7 +79,7 @@ pub unsafe fn _m_paddd(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddsb))]
 pub unsafe fn _mm_adds_pi8(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_add(a.as_i8x8(), b.as_i8x8()))
+    paddsb(a, b)
 }
 
 /// Adds packed 8-bit integers in `a` and `b` using saturation.
@@ -95,7 +95,7 @@ pub unsafe fn _m_paddsb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddsw))]
 pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_add(a.as_i16x4(), b.as_i16x4()))
+    paddsw(a, b)
 }
 
 /// Adds packed 16-bit integers in `a` and `b` using saturation.
@@ -111,7 +111,7 @@ pub unsafe fn _m_paddsw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddusb))]
 pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_add(a.as_u8x8(), b.as_u8x8()))
+    paddusb(a, b)
 }
 
 /// Adds packed unsigned 8-bit integers in `a` and `b` using saturation.
@@ -127,7 +127,7 @@ pub unsafe fn _m_paddusb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddusw))]
 pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_add(a.as_u16x4(), b.as_u16x4()))
+    paddusw(a, b)
 }
 
 /// Adds packed unsigned 16-bit integers in `a` and `b` using saturation.
@@ -143,7 +143,7 @@ pub unsafe fn _m_paddusw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubb))]
 pub unsafe fn _mm_sub_pi8(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_sub(a.as_i8x8(), b.as_i8x8()))
+    psubb(a, b)
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`.
@@ -159,7 +159,7 @@ pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubw))]
 pub unsafe fn _mm_sub_pi16(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_sub(a.as_i16x4(), b.as_i16x4()))
+    psubw(a, b)
 }
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`.
@@ -175,7 +175,7 @@ pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubd))]
 pub unsafe fn _mm_sub_pi32(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_sub(a.as_i32x2(), b.as_i32x2()))
+    psubd(a, b)
 }
 
 /// Subtract packed 32-bit integers in `b` from packed 32-bit integers in `a`.
@@ -192,7 +192,7 @@ pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubsb))]
 pub unsafe fn _mm_subs_pi8(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_sub(a.as_i8x8(), b.as_i8x8()))
+    psubsb(a, b)
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`
@@ -210,7 +210,7 @@ pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubsw))]
 pub unsafe fn _mm_subs_pi16(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_sub(a.as_i16x4(), b.as_i16x4()))
+    psubsw(a, b)
 }
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
@@ -228,7 +228,7 @@ pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubusb))]
 pub unsafe fn _mm_subs_pu8(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_sub(a.as_u8x8(), b.as_u8x8()))
+    psubusb(a, b)
 }
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
@@ -246,7 +246,7 @@ pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(psubusw))]
 pub unsafe fn _mm_subs_pu16(a: __m64, b: __m64) -> __m64 {
-    transmute(simd_saturating_sub(a.as_u16x4(), b.as_u16x4()))
+    psubusw(a, b)
 }
 
 /// Subtract packed unsigned 16-bit integers in `b` from packed unsigned
@@ -475,6 +475,34 @@ pub unsafe fn _mm_cvtsi64_si32(a: __m64) -> i32 {
 
 #[allow(improper_ctypes)]
 extern "C" {
+    #[link_name = "llvm.x86.mmx.padd.b"]
+    fn paddb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padd.w"]
+    fn paddw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padd.d"]
+    fn paddd(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padds.b"]
+    fn paddsb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padds.w"]
+    fn paddsw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.paddus.b"]
+    fn paddusb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.paddus.w"]
+    fn paddusw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psub.b"]
+    fn psubb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psub.w"]
+    fn psubw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psub.d"]
+    fn psubd(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubs.b"]
+    fn psubsb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubs.w"]
+    fn psubsw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubus.b"]
+    fn psubusb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubus.w"]
+    fn psubusw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]

--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -353,6 +353,49 @@ pub use self::test::*;
 
 #[allow(non_camel_case_types)]
 #[unstable(feature = "stdimd_internal", issue = "0")]
+pub(crate) trait m64Ext: Sized {
+    fn as_m64(self) -> __m64;
+
+    #[inline]
+    fn as_u8x8(self) -> crate::core_arch::simd::u8x8 {
+        unsafe { transmute(self.as_m64()) }
+    }
+
+    #[inline]
+    fn as_u16x4(self) -> crate::core_arch::simd::u16x4 {
+        unsafe { transmute(self.as_m64()) }
+    }
+
+    #[inline]
+    fn as_u32x2(self) -> crate::core_arch::simd::u32x2 {
+        unsafe { transmute(self.as_m64()) }
+    }
+
+    #[inline]
+    fn as_i8x8(self) -> crate::core_arch::simd::i8x8 {
+        unsafe { transmute(self.as_m64()) }
+    }
+
+    #[inline]
+    fn as_i16x4(self) -> crate::core_arch::simd::i16x4 {
+        unsafe { transmute(self.as_m64()) }
+    }
+
+    #[inline]
+    fn as_i32x2(self) -> crate::core_arch::simd::i32x2 {
+        unsafe { transmute(self.as_m64()) }
+    }
+}
+
+impl m64Ext for __m64 {
+    #[inline]
+    fn as_m64(self) -> Self {
+        self
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[unstable(feature = "stdimd_internal", issue = "0")]
 pub(crate) trait m128iExt: Sized {
     fn as_m128i(self) -> __m128i;
 

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -194,7 +194,7 @@ pub unsafe fn _mm_min_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(minps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_min_ps(a: __m128, b: __m128) -> __m128 {
-    minps(a, b)
+    simd_fmin(a, b)
 }
 
 /// Compares the first single-precision (32-bit) floating-point element of `a`
@@ -219,7 +219,7 @@ pub unsafe fn _mm_max_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(maxps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_max_ps(a: __m128, b: __m128) -> __m128 {
-    maxps(a, b)
+    simd_fmax(a, b)
 }
 
 /// Bitwise AND of packed single-precision (32-bit) floating-point elements.
@@ -1915,12 +1915,8 @@ extern "C" {
     fn rsqrtps(a: __m128) -> __m128;
     #[link_name = "llvm.x86.sse.min.ss"]
     fn minss(a: __m128, b: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.min.ps"]
-    fn minps(a: __m128, b: __m128) -> __m128;
     #[link_name = "llvm.x86.sse.max.ss"]
     fn maxss(a: __m128, b: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.max.ps"]
-    fn maxps(a: __m128, b: __m128) -> __m128;
     #[link_name = "llvm.x86.sse.movmsk.ps"]
     fn movmskps(a: __m128) -> i32;
     #[link_name = "llvm.x86.sse.cmp.ps"]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -121,7 +121,7 @@ pub unsafe fn _mm_add_epi64(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(paddsb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_adds_epi8(a: __m128i, b: __m128i) -> __m128i {
-    transmute(paddsb(a.as_i8x16(), b.as_i8x16()))
+    transmute(simd_saturating_add(a.as_i8x16(), b.as_i8x16()))
 }
 
 /// Adds packed 16-bit integers in `a` and `b` using saturation.
@@ -132,7 +132,7 @@ pub unsafe fn _mm_adds_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(paddsw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_adds_epi16(a: __m128i, b: __m128i) -> __m128i {
-    transmute(paddsw(a.as_i16x8(), b.as_i16x8()))
+    transmute(simd_saturating_add(a.as_i16x8(), b.as_i16x8()))
 }
 
 /// Adds packed unsigned 8-bit integers in `a` and `b` using saturation.
@@ -143,7 +143,7 @@ pub unsafe fn _mm_adds_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(paddusb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_adds_epu8(a: __m128i, b: __m128i) -> __m128i {
-    transmute(paddsub(a.as_u8x16(), b.as_u8x16()))
+    transmute(simd_saturating_add(a.as_u8x16(), b.as_u8x16()))
 }
 
 /// Adds packed unsigned 16-bit integers in `a` and `b` using saturation.
@@ -154,7 +154,7 @@ pub unsafe fn _mm_adds_epu8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(paddusw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_adds_epu16(a: __m128i, b: __m128i) -> __m128i {
-    transmute(paddsuw(a.as_u16x8(), b.as_u16x8()))
+    transmute(simd_saturating_add(a.as_u16x8(), b.as_u16x8()))
 }
 
 /// Averages packed unsigned 8-bit integers in `a` and `b`.
@@ -367,7 +367,7 @@ pub unsafe fn _mm_sub_epi64(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(psubsb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_subs_epi8(a: __m128i, b: __m128i) -> __m128i {
-    transmute(psubsb(a.as_i8x16(), b.as_i8x16()))
+    transmute(simd_saturating_sub(a.as_i8x16(), b.as_i8x16()))
 }
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
@@ -379,7 +379,7 @@ pub unsafe fn _mm_subs_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(psubsw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_subs_epi16(a: __m128i, b: __m128i) -> __m128i {
-    transmute(psubsw(a.as_i16x8(), b.as_i16x8()))
+    transmute(simd_saturating_sub(a.as_i16x8(), b.as_i16x8()))
 }
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
@@ -391,7 +391,7 @@ pub unsafe fn _mm_subs_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(psubusb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_subs_epu8(a: __m128i, b: __m128i) -> __m128i {
-    transmute(psubusb(a.as_u8x16(), b.as_u8x16()))
+    transmute(simd_saturating_sub(a.as_u8x16(), b.as_u8x16()))
 }
 
 /// Subtract packed unsigned 16-bit integers in `b` from packed unsigned 16-bit
@@ -403,7 +403,7 @@ pub unsafe fn _mm_subs_epu8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(psubusw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_subs_epu16(a: __m128i, b: __m128i) -> __m128i {
-    transmute(psubusw(a.as_u16x8(), b.as_u16x8()))
+    transmute(simd_saturating_sub(a.as_u16x8(), b.as_u16x8()))
 }
 
 /// Shifts `a` left by `imm8` bytes while shifting in zeros.
@@ -3021,14 +3021,6 @@ extern "C" {
     fn lfence();
     #[link_name = "llvm.x86.sse2.mfence"]
     fn mfence();
-    #[link_name = "llvm.x86.sse2.padds.b"]
-    fn paddsb(a: i8x16, b: i8x16) -> i8x16;
-    #[link_name = "llvm.x86.sse2.padds.w"]
-    fn paddsw(a: i16x8, b: i16x8) -> i16x8;
-    #[link_name = "llvm.x86.sse2.paddus.b"]
-    fn paddsub(a: u8x16, b: u8x16) -> u8x16;
-    #[link_name = "llvm.x86.sse2.paddus.w"]
-    fn paddsuw(a: u16x8, b: u16x8) -> u16x8;
     #[link_name = "llvm.x86.sse2.pavg.b"]
     fn pavgb(a: u8x16, b: u8x16) -> u8x16;
     #[link_name = "llvm.x86.sse2.pavg.w"]
@@ -3051,14 +3043,6 @@ extern "C" {
     fn pmuludq(a: u32x4, b: u32x4) -> u64x2;
     #[link_name = "llvm.x86.sse2.psad.bw"]
     fn psadbw(a: u8x16, b: u8x16) -> u64x2;
-    #[link_name = "llvm.x86.sse2.psubs.b"]
-    fn psubsb(a: i8x16, b: i8x16) -> i8x16;
-    #[link_name = "llvm.x86.sse2.psubs.w"]
-    fn psubsw(a: i16x8, b: i16x8) -> i16x8;
-    #[link_name = "llvm.x86.sse2.psubus.b"]
-    fn psubusb(a: u8x16, b: u8x16) -> u8x16;
-    #[link_name = "llvm.x86.sse2.psubus.w"]
-    fn psubusw(a: u16x8, b: u16x8) -> u16x8;
     #[link_name = "llvm.x86.sse2.pslli.w"]
     fn pslliw(a: i16x8, imm8: i32) -> i16x8;
     #[link_name = "llvm.x86.sse2.psll.w"]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1823,7 +1823,7 @@ pub unsafe fn _mm_sqrt_sd(a: __m128d, b: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(sqrtpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sqrt_pd(a: __m128d) -> __m128d {
-    sqrtpd(a)
+    simd_fsqrt(a)
 }
 
 /// Returns a new vector with the low element of `a` replaced by subtracting the

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -601,7 +601,7 @@ pub unsafe fn _mm_dp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
 #[cfg_attr(test, assert_instr(roundpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_floor_pd(a: __m128d) -> __m128d {
-    roundpd(a, _MM_FROUND_FLOOR)
+    simd_floor(a)
 }
 
 /// Round the packed single-precision (32-bit) floating-point elements in `a`
@@ -614,7 +614,7 @@ pub unsafe fn _mm_floor_pd(a: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(roundps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_floor_ps(a: __m128) -> __m128 {
-    roundps(a, _MM_FROUND_FLOOR)
+    simd_floor(a)
 }
 
 /// Round the lower double-precision (64-bit) floating-point element in `b`
@@ -657,7 +657,7 @@ pub unsafe fn _mm_floor_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(roundpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_ceil_pd(a: __m128d) -> __m128d {
-    roundpd(a, _MM_FROUND_CEIL)
+    simd_ceil(a)
 }
 
 /// Round the packed single-precision (32-bit) floating-point elements in `a`
@@ -670,7 +670,7 @@ pub unsafe fn _mm_ceil_pd(a: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(roundps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_ceil_ps(a: __m128) -> __m128 {
-    roundps(a, _MM_FROUND_CEIL)
+    simd_ceil(a)
 }
 
 /// Round the lower double-precision (64-bit) floating-point element in `b`

--- a/crates/core_arch/src/x86_64/bswap.rs
+++ b/crates/core_arch/src/x86_64/bswap.rs
@@ -12,13 +12,7 @@ use stdarch_test::assert_instr;
 #[cfg_attr(test, assert_instr(bswap))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _bswap64(x: i64) -> i64 {
-    bswap_i64(x)
-}
-
-#[allow(improper_ctypes)]
-extern "C" {
-    #[link_name = "llvm.bswap.i64"]
-    fn bswap_i64(x: i64) -> i64;
+   x.swap_bytes()
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86_64/bswap.rs
+++ b/crates/core_arch/src/x86_64/bswap.rs
@@ -12,7 +12,7 @@ use stdarch_test::assert_instr;
 #[cfg_attr(test, assert_instr(bswap))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _bswap64(x: i64) -> i64 {
-   x.swap_bytes()
+    x.swap_bytes()
 }
 
 #[cfg(test)]

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -90,7 +90,7 @@ pub fn assert(_fnptr: usize, fnname: &str, expected: &str) {
 
     // Look for `expected` as the first part of any instruction in this
     // function, e.g., tzcntl in tzcntl %rax,%rax.
-    let found = instrs.iter().any(|s| s.contains(expected));
+    let found = instrs.iter().any(|s| s.starts_with(expected));
 
     // Look for `call` instructions in the disassembly to detect whether
     // inlining failed: all intrinsics are `#[inline(always)]`, so


### PR DESCRIPTION
I currently only did this for x86. Also I skipped `_mm_sqrt_ps` and some more, as llvm emitted `rsqrtps` combined with a lot of extra instructions instead of `sqrtps`, causing slight rounding errors and non optimal codegen.

cc #788