### PR TITLE
Apply snap of bootstrap compiler in rust-lang/rust

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -8,11 +8,7 @@ mod acle;
 
 mod simd;
 
-#[cfg_attr(
-    bootstrap,
-    doc(include = "../stdarch/crates/core_arch/src/core_arch_docs.md")
-)]
-#[cfg_attr(not(bootstrap), doc(include = "core_arch_docs.md"))]
+#[doc(include = "core_arch_docs.md")]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
     /// Platform-specific intrinsics for the `x86` platform.


### PR DESCRIPTION
FWIW, in the future we should try to avoid this as I'm assuming we'll break CI trying to land this here (and we can't swap bootstrap compilers in Rust until this lands).