### PR TITLE
Factor out check_for

### DIFF
--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -90,4 +90,9 @@ cfg_if! {
         mod os;
     }
 }
-pub use self::os::check_for;
+
+/// Performs run-time feature detection.
+#[inline]
+pub fn check_for(x: Feature) -> bool {
+    cache::test(x as u32, self::os::detect_features)
+}

--- a/crates/std_detect/src/detect/os/freebsd/aarch64.rs
+++ b/crates/std_detect/src/detect/os/freebsd/aarch64.rs
@@ -1,13 +1,6 @@
 //! Run-time feature detection for Aarch64 on FreeBSD.
 
-use crate::detect::{Feature, cache};
-use super::super::aarch64::detect_features;
-
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
+pub use super::super::aarch64::detect_features;
 
 #[cfg(test)]
 mod tests {

--- a/crates/std_detect/src/detect/os/freebsd/arm.rs
+++ b/crates/std_detect/src/detect/os/freebsd/arm.rs
@@ -3,14 +3,8 @@
 use crate::detect::{Feature, cache};
 use super::{auxvec};
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
 /// Try to read the features from the auxiliary vector
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
     let enable_feature = |value: &mut cache::Initializer, f, enable| {
         if enable {

--- a/crates/std_detect/src/detect/os/freebsd/powerpc.rs
+++ b/crates/std_detect/src/detect/os/freebsd/powerpc.rs
@@ -3,13 +3,7 @@
 use crate::detect::{Feature, cache};
 use super::{auxvec};
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
     let enable_feature = |value: &mut cache::Initializer, f, enable| {
         if enable {

--- a/crates/std_detect/src/detect/os/linux/aarch64.rs
+++ b/crates/std_detect/src/detect/os/linux/aarch64.rs
@@ -3,15 +3,9 @@
 use crate::detect::{Feature, cache, bit};
 use super::{auxvec, cpuinfo};
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
 /// Try to read the features from the auxiliary vector, and if that fails, try
 /// to read them from /proc/cpuinfo.
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     if let Ok(auxv) = auxvec::auxv() {
         let hwcap: AtHwcap = auxv.into();
         return hwcap.cache();

--- a/crates/std_detect/src/detect/os/linux/arm.rs
+++ b/crates/std_detect/src/detect/os/linux/arm.rs
@@ -3,15 +3,9 @@
 use crate::detect::{Feature, cache, bit};
 use super::{auxvec, cpuinfo};
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
 /// Try to read the features from the auxiliary vector, and if that fails, try
 /// to read them from /proc/cpuinfo.
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
     let enable_feature = |value: &mut cache::Initializer, f, enable| {
         if enable {

--- a/crates/std_detect/src/detect/os/linux/mips.rs
+++ b/crates/std_detect/src/detect/os/linux/mips.rs
@@ -3,15 +3,9 @@
 use crate::detect::{Feature, cache, bit};
 use super::auxvec;
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
 /// Try to read the features from the auxiliary vector, and if that fails, try
 /// to read them from `/proc/cpuinfo`.
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
     let enable_feature = |value: &mut cache::Initializer, f, enable| {
         if enable {

--- a/crates/std_detect/src/detect/os/linux/powerpc.rs
+++ b/crates/std_detect/src/detect/os/linux/powerpc.rs
@@ -3,15 +3,9 @@
 use crate::detect::{Feature, cache};
 use super::{auxvec, cpuinfo};
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
 /// Try to read the features from the auxiliary vector, and if that fails, try
 /// to read them from /proc/cpuinfo.
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
     let enable_feature = |value: &mut cache::Initializer, f, enable| {
         if enable {

--- a/crates/std_detect/src/detect/os/other.rs
+++ b/crates/std_detect/src/detect/os/other.rs
@@ -1,9 +1,7 @@
 //! Other operating systems
 
-use crate::detect::Feature;
+use crate::detect::cache;
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(_x: Feature) -> bool {
-    false
+pub(crate) fn detect_features() -> cache::Initializer {
+    cache::Initializer::default()
 }

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -9,12 +9,6 @@ use crate::mem;
 
 use crate::detect::{Feature, cache, bit};
 
-/// Performs run-time feature detection.
-#[inline]
-pub fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, detect_features)
-}
-
 /// Run-time feature detection on x86 works by using the CPUID instruction.
 ///
 /// The [CPUID Wikipedia page][wiki_cpuid] contains
@@ -31,7 +25,7 @@ pub fn check_for(x: Feature) -> bool {
 /// [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
 /// [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
 #[allow(clippy::similar_names)]
-fn detect_features() -> cache::Initializer {
+pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
 
     // If the x86 CPU does not support the CPUID instruction then it is too


### PR DESCRIPTION
All the os-specific code implements a `check_for` and a `detect_features`.

Move the always identical check_for in the mod.rs and use
`os::detect_features` there.