### PR TITLE
Soundness fix on 32-bit to cache.rs

### DIFF
--- a/crates/std_detect/src/detect/cache.rs
+++ b/crates/std_detect/src/detect/cache.rs
@@ -178,7 +178,7 @@ cfg_if! {
 }
 
 /// Tests the `bit` of the storage. If the storage has not been initialized,
-/// initializes it with the result of `f()`.
+/// initializes it with the result of `os::detect_features()`.
 ///
 /// On its first invocation, it detects the CPU features and caches them in the
 /// `CACHE` global variable as an `AtomicU64`.
@@ -190,12 +190,9 @@ cfg_if! {
 /// variable `RUST_STD_DETECT_UNSTABLE` and uses its its content to disable
 /// Features that would had been otherwise detected.
 #[inline]
-pub(crate) fn test<F>(bit: u32, f: F) -> bool
-where
-    F: FnOnce() -> Initializer,
-{
+pub(crate) fn test(bit: u32) -> bool {
     if CACHE.is_uninitialized() {
-        initialize(f());
+        initialize(crate::detect::os::detect_features());
     }
     CACHE.test(bit)
 }

--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -113,7 +113,7 @@ cfg_if! {
 /// Performs run-time feature detection.
 #[inline]
 fn check_for(x: Feature) -> bool {
-    cache::test(x as u32, self::os::detect_features)
+    cache::test(x as u32)
 }
 
 /// Returns an `Iterator<Item=(&'static str, bool)>` where


### PR DESCRIPTION
This PR fixes a soundness issue on 32-bit.

The problem is that on 32-bit relaxed semantics are not good enough as the code is currently written. The problem is that it is possible for a thread to observe the initialized value for CACHE.1 while still observing the uninitialized value for CACHE.0.

The way I fixed it was by putting a bit in both of the `AtomicU32` values that shows whether it has been initialized or not.

While changing the code, I also changed it so only a single atomic load is needed on the fast path on both 32 and 64 bit.