### PR TITLE
Remove const_str_as_bytes feature gate

### DIFF
--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -3,7 +3,6 @@
 //! This basically just disassembles the current executable and then parses the
 //! output once globally and then provides the `assert` function which makes
 //! assertions about the disassembly of a function.
-#![feature(const_str_as_bytes)]
 #![feature(const_transmute)]
 #![feature(vec_leak)]
 #![allow(clippy::missing_docs_in_private_items, clippy::print_stdout)]


### PR DESCRIPTION
`const_str_as_bytes` has been stabilized in https://github.com/rust-lang/rust/pull/63770.