### PR TITLE
ci: switch mirrors to use our CDN

### DIFF
--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir /toolchain
 
 # Note that this originally came from:
 # https://downloads.openwrt.org/snapshots/trunk/malta/generic/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2
-RUN curl -L https://s3-us-west-1.amazonaws.com/rust-lang-ci2/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
+RUN curl -L https://ci-mirrors.rust-lang.org/libc/OpenWrt-Toolchain-malta-le_gcc-5.3.0_musl-1.1.15.Linux-x86_64.tar.bz2 | \
       tar xjf - -C /toolchain --strip-components=2
 
 ENV PATH=$PATH:/rust/bin:/toolchain/bin \


### PR DESCRIPTION
We recently added a CDN in front of our CI mirrors as it's faster and
cheaper for us. This switches libc's CI to use it instead of accessing
the underlying bucket directly.

r? @gnzlbg 