### PR TITLE
Replace rustfmt::skip custom inner attribute with rustfmt.toml

### DIFF
--- a/crates/core_arch/rustfmt.toml
+++ b/crates/core_arch/rustfmt.toml
@@ -1,0 +1,3 @@
+ignore = [
+    "src/simd.rs",
+]

--- a/crates/core_arch/src/simd.rs
+++ b/crates/core_arch/src/simd.rs
@@ -1,6 +1,5 @@
 //! Internal `#[repr(simd)]` types
 
-#![rustfmt::skip]
 #![allow(non_camel_case_types)]
 
 macro_rules! simd_ty {


### PR DESCRIPTION
Fixes errors like https://travis-ci.com/rust-lang-nursery/packed_simd/jobs/248339096#L367