### PR TITLE
Add `#[rustc_args_required_const]` to `simd_shuffle`

### DIFF
--- a/crates/core_arch/src/simd_llvm.rs
+++ b/crates/core_arch/src/simd_llvm.rs
@@ -10,12 +10,19 @@ extern "platform-intrinsic" {
     pub fn simd_gt<T, U>(x: T, y: T) -> U;
     pub fn simd_ge<T, U>(x: T, y: T) -> U;
 
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle32<T, U>(x: T, y: T, idx: [u32; 32]) -> U;
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle128<T, U>(x: T, y: T, idx: [u32; 128]) -> U;
 
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;


### PR DESCRIPTION
Currently, these have to be special-cased in the promotion logic in `rustc`, as they predate the existence of the attribute. Add the attribute now so we can clean up the special-case later in the compiler.

I'm not sure if there are additional considerations here. Perhaps someone could fill me in if so?