### PR TITLE
Add CRC32 detection to arm32

### DIFF
--- a/crates/std_detect/src/detect/arch/arm.rs
+++ b/crates/std_detect/src/detect/arch/arm.rs
@@ -14,4 +14,6 @@ features! {
     /// ARM Advanced SIMD (NEON) - Aarch32
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] pmull: "pmull";
     /// Polynomial Multiply
+    @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] crc: "crc";
+    /// CRC32 (Cyclic Redundancy Check)
 }

--- a/crates/std_detect/src/detect/os/linux/arm.rs
+++ b/crates/std_detect/src/detect/os/linux/arm.rs
@@ -15,10 +15,11 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
     // The values are part of the platform-specific [asm/hwcap.h][hwcap]
     //
-    // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/arm64/include/uapi/asm/hwcap.h
+    // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/arm/include/uapi/asm/hwcap.h
     if let Ok(auxv) = auxvec::auxv() {
         enable_feature(&mut value, Feature::neon, bit::test(auxv.hwcap, 12));
         enable_feature(&mut value, Feature::pmull, bit::test(auxv.hwcap2, 1));
+        enable_feature(&mut value, Feature::crc, bit::test(auxv.hwcap2, 4));
         return value;
     }
 
@@ -29,6 +30,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
             c.field("Features").has("neon") && !has_broken_neon(&c),
         );
         enable_feature(&mut value, Feature::pmull, c.field("Features").has("pmull"));
+        enable_feature(&mut value, Feature::crc, c.field("Features").has("crc32"));
         return value;
     }
     value

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -24,6 +24,7 @@ fn all() {
 fn arm_linux() {
     println!("neon: {}", is_arm_feature_detected!("neon"));
     println!("pmull: {}", is_arm_feature_detected!("pmull"));
+    println!("crc: {}", is_arm_feature_detected!("crc"));
 }
 
 #[test]


### PR DESCRIPTION
Cortex-A53 etc has 32-bit mode, and it can use crc32 instruction sets even if 32-bit (A32 mode) and CPU is supported. So we should add crc32 detection for arm32.