### PR TITLE
Fix unused import: `mem::transmute`

### DIFF
--- a/crates/core_arch/src/arm/neon.rs
+++ b/crates/core_arch/src/arm/neon.rs
@@ -1,6 +1,8 @@
 //! ARMv7 NEON intrinsics
 
-use crate::{core_arch::simd_llvm::*, mem::transmute};
+use crate::core_arch::simd_llvm::*;
+#[cfg(target_arch = "arm")]
+use crate::mem::transmute;
 #[cfg(test)]
 use stdarch_test::assert_instr;
 


### PR DESCRIPTION
When building on aarch64, the following warning occurs.

```
warning: unused import: `mem::transmute`
 --> crates/core_arch/src/arm/neon.rs:3:38
  |
3 | use crate::{core_arch::simd_llvm::*, mem::transmute};
  |                                      ^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```