### PR TITLE
Don't use `&&` on GitHub Actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
-      run: rustup update nightly --no-self-update && rustup default nightly
+      run: |
+        rustup update nightly --no-self-update
+        rustup default nightly
       if: matrix.os != 'macos-latest'
     - name: Install Rust (macos)
       run: |


### PR DESCRIPTION
According to [the document](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idsteps), default shell of Windows is PowerShell. But `&&` isn't supported on PowerShell yet.

So we should use multi line run syntax instead.