### PR TITLE
Add const unstability attributes

### DIFF
--- a/crates/core_arch/src/simd_llvm.rs
+++ b/crates/core_arch/src/simd_llvm.rs
@@ -25,7 +25,7 @@ extern "platform-intrinsic" {
     pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
     #[rustc_args_required_const(2)]
     pub fn simd_shuffle128<T, U>(x: T, y: T, idx: [u32; 128]) -> U;
-    
+
     #[rustc_const_unstable(feature = "const_simd_insert", issue = "0")]
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
     #[rustc_const_unstable(feature = "const_simd_extract", issue = "0")]

--- a/crates/core_arch/src/simd_llvm.rs
+++ b/crates/core_arch/src/simd_llvm.rs
@@ -25,8 +25,10 @@ extern "platform-intrinsic" {
     pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
     #[rustc_args_required_const(2)]
     pub fn simd_shuffle128<T, U>(x: T, y: T, idx: [u32; 128]) -> U;
-
+    
+    #[rustc_const_unstable(feature = "const_simd_insert", issue = "0")]
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
+    #[rustc_const_unstable(feature = "const_simd_extract", issue = "0")]
     pub fn simd_extract<T, U>(x: T, idx: u32) -> U;
     //pub fn simd_select
     pub fn simd_bitmask<T, U>(x: T) -> U;


### PR DESCRIPTION
These are needed for rustc to be able to correctly handle stability of constness of intrinsics. Without either `rustc_const_unstable` or `rustc_const_stable` an intrinsic is not const evaluable at all.

related: https://github.com/rust-lang/rust/issues/61495