### PR TITLE
Remove unnecessary parens.

### DIFF
--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -35,20 +35,20 @@ pub const _MM_FROUND_NO_EXC: i32 = 0x08;
 pub const _MM_FROUND_NINT: i32 = 0x00;
 /// round down and do not suppress exceptions
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_FLOOR: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_NEG_INF);
+pub const _MM_FROUND_FLOOR: i32 = _MM_FROUND_RAISE_EXC | _MM_FROUND_TO_NEG_INF;
 /// round up and do not suppress exceptions
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_CEIL: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_POS_INF);
+pub const _MM_FROUND_CEIL: i32 = _MM_FROUND_RAISE_EXC | _MM_FROUND_TO_POS_INF;
 /// truncate and do not suppress exceptions
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_TRUNC: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_ZERO);
+pub const _MM_FROUND_TRUNC: i32 = _MM_FROUND_RAISE_EXC | _MM_FROUND_TO_ZERO;
 /// use MXCSR.RC and do not suppress exceptions; see
 /// `vendor::_MM_SET_ROUNDING_MODE`
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_RINT: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_CUR_DIRECTION);
+pub const _MM_FROUND_RINT: i32 = _MM_FROUND_RAISE_EXC | _MM_FROUND_CUR_DIRECTION;
 /// use MXCSR.RC and suppress exceptions; see `vendor::_MM_SET_ROUNDING_MODE`
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_NEARBYINT: i32 = (_MM_FROUND_NO_EXC | _MM_FROUND_CUR_DIRECTION);
+pub const _MM_FROUND_NEARBYINT: i32 = _MM_FROUND_NO_EXC | _MM_FROUND_CUR_DIRECTION;
 
 /// Blend packed 8-bit integers from `a` and `b` using `mask`
 ///


### PR DESCRIPTION
Remove unnecessary parens in `const` assigned value.

CC: [rust-lang/rust#67942](https://github.com/rust-lang/rust/issues/67942)