### PR TITLE
Install Python3 to wasm32 CI since wabt removes Python2 support

### DIFF
--- a/ci/docker/wasm32-unknown-unknown/Dockerfile
+++ b/ci/docker/wasm32-unknown-unknown/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   libc6-dev \
   make \
   python \
+  python3 \
   xz-utils
 
 # Install `wasm2wat`


### PR DESCRIPTION
See https://github.com/WebAssembly/wabt/pull/1321