### PR TITLE
Replace module MIN/MAX and min/max_value() with assoc consts

### DIFF
--- a/crates/core_arch/src/wasm32/memory.rs
+++ b/crates/core_arch/src/wasm32/memory.rs
@@ -41,7 +41,7 @@ pub fn memory_size(mem: u32) -> usize {
 /// by the specified `delta` of pages. The current WebAssembly page size is
 /// 65536 bytes (64 KB). If memory is successfully grown then the previous size
 /// of memory, in pages, is returned. If memory cannot be grown then
-/// `usize::max_value()` is returned.
+/// `usize::MAX` is returned.
 ///
 /// The argument `mem` is the numerical index of which memory to return the
 /// size of. Note that currently the WebAssembly specification only supports one

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -1059,7 +1059,7 @@ pub fn i8x16_add(a: v128, b: v128) -> v128 {
 }
 
 /// Adds two 128-bit vectors as if they were two packed sixteen 8-bit signed
-/// integers, saturating on overflow to `i8::max_value()`.
+/// integers, saturating on overflow to `i8::MAX`.
 #[inline]
 #[cfg_attr(test, assert_instr(i8x16.add_saturate_s))]
 pub fn i8x16_add_saturate_s(a: v128, b: v128) -> v128 {
@@ -1067,7 +1067,7 @@ pub fn i8x16_add_saturate_s(a: v128, b: v128) -> v128 {
 }
 
 /// Adds two 128-bit vectors as if they were two packed sixteen 8-bit unsigned
-/// integers, saturating on overflow to `u8::max_value()`.
+/// integers, saturating on overflow to `u8::MAX`.
 #[inline]
 #[cfg_attr(test, assert_instr(i8x16.add_saturate_u))]
 pub fn i8x16_add_saturate_u(a: v128, b: v128) -> v128 {
@@ -1082,7 +1082,7 @@ pub fn i8x16_sub(a: v128, b: v128) -> v128 {
 }
 
 /// Subtracts two 128-bit vectors as if they were two packed sixteen 8-bit
-/// signed integers, saturating on overflow to `i8::min_value()`.
+/// signed integers, saturating on overflow to `i8::MIN`.
 #[inline]
 #[cfg_attr(test, assert_instr(i8x16.sub_saturate_s))]
 pub fn i8x16_sub_saturate_s(a: v128, b: v128) -> v128 {
@@ -1169,7 +1169,7 @@ pub fn i16x8_add(a: v128, b: v128) -> v128 {
 }
 
 /// Adds two 128-bit vectors as if they were two packed eight 16-bit signed
-/// integers, saturating on overflow to `i16::max_value()`.
+/// integers, saturating on overflow to `i16::MAX`.
 #[inline]
 #[cfg_attr(test, assert_instr(i16x8.add_saturate_s))]
 pub fn i16x8_add_saturate_s(a: v128, b: v128) -> v128 {
@@ -1177,7 +1177,7 @@ pub fn i16x8_add_saturate_s(a: v128, b: v128) -> v128 {
 }
 
 /// Adds two 128-bit vectors as if they were two packed eight 16-bit unsigned
-/// integers, saturating on overflow to `u16::max_value()`.
+/// integers, saturating on overflow to `u16::MAX`.
 #[inline]
 #[cfg_attr(test, assert_instr(i16x8.add_saturate_u))]
 pub fn i16x8_add_saturate_u(a: v128, b: v128) -> v128 {
@@ -1192,7 +1192,7 @@ pub fn i16x8_sub(a: v128, b: v128) -> v128 {
 }
 
 /// Subtracts two 128-bit vectors as if they were two packed eight 16-bit
-/// signed integers, saturating on overflow to `i16::min_value()`.
+/// signed integers, saturating on overflow to `i16::MIN`.
 #[inline]
 #[cfg_attr(test, assert_instr(i16x8.sub_saturate_s))]
 pub fn i16x8_sub_saturate_s(a: v128, b: v128) -> v128 {

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -790,7 +790,7 @@ pub unsafe fn _mm_ucomineq_ss(a: __m128, b: __m128) -> i32 {
 ///
 /// The result is rounded according to the current rounding mode. If the result
 /// cannot be represented as a 32 bit integer the result will be `0x8000_0000`
-/// (`std::i32::MIN`) or an invalid operation floating point exception if
+/// (`i32::MIN`) or an invalid operation floating point exception if
 /// unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTSS2SI` instruction (with 32 bit output).
@@ -821,7 +821,7 @@ pub unsafe fn _mm_cvt_ss2si(a: __m128) -> i32 {
 ///
 /// The result is rounded always using truncation (round towards zero). If the
 /// result cannot be represented as a 32 bit integer the result will be
-/// `0x8000_0000` (`std::i32::MIN`) or an invalid operation floating point
+/// `0x8000_0000` (`i32::MIN`) or an invalid operation floating point
 /// exception if unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTTSS2SI` instruction (with 32 bit output).

--- a/crates/core_arch/src/x86_64/sse.rs
+++ b/crates/core_arch/src/x86_64/sse.rs
@@ -19,7 +19,7 @@ extern "C" {
 ///
 /// The result is rounded according to the current rounding mode. If the result
 /// cannot be represented as a 64 bit integer the result will be
-/// `0x8000_0000_0000_0000` (`std::i64::MIN`) or trigger an invalid operation
+/// `0x8000_0000_0000_0000` (`i64::MIN`) or trigger an invalid operation
 /// floating point exception if unmasked (see
 /// [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
@@ -39,7 +39,7 @@ pub unsafe fn _mm_cvtss_si64(a: __m128) -> i64 {
 ///
 /// The result is rounded always using truncation (round towards zero). If the
 /// result cannot be represented as a 64 bit integer the result will be
-/// `0x8000_0000_0000_0000` (`std::i64::MIN`) or an invalid operation floating
+/// `0x8000_0000_0000_0000` (`i64::MIN`) or an invalid operation floating
 /// point exception if unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTTSS2SI` instruction (with 64 bit output).

--- a/crates/std_detect/src/detect/cache.rs
+++ b/crates/std_detect/src/detect/cache.rs
@@ -80,7 +80,7 @@ impl Initializer {
 // Note: on x64, we only use the first slot
 static CACHE: [Cache; 2] = [Cache::uninitialized(), Cache::uninitialized()];
 
-/// Feature cache with capacity for `usize::max_value() - 1` features.
+/// Feature cache with capacity for `usize::MAX - 1` features.
 ///
 /// Note: the last feature bit is used to represent an
 /// uninitialized cache.


### PR DESCRIPTION
Since it's recommended use use the integer associated constants for new code from Rust 1.43 the docs better mention them instead of the older slightly less recommended versions.

EDIT: Corresponding PR doing the same thing in most of the `rust` repo comes soon. But I thought submodules get their own PRs(?). Please enlighten me to what the procedure is.