### PR TITLE
Use llvm_asm! instead of asm!

### DIFF
--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -139,7 +139,7 @@ pub fn assert_instr(
 
             // Make sure that the shim is not removed by leaking it to unknown
             // code:
-            unsafe { asm!("" : : "r"(#shim_name as usize) : "memory" : "volatile") };
+            unsafe { llvm_asm!("" : : "r"(#shim_name as usize) : "memory" : "volatile") };
 
             ::stdarch_test::assert(#shim_name as usize,
                                    stringify!(#shim_name),

--- a/crates/core_arch/src/acle/barrier/cp15.rs
+++ b/crates/core_arch/src/acle/barrier/cp15.rs
@@ -8,20 +8,20 @@ pub struct SY;
 impl super::super::sealed::Dmb for SY {
     #[inline(always)]
     unsafe fn __dmb(&self) {
-        asm!("mcr p15, 0, r0, c7, c10, 5" : : : "memory" : "volatile")
+        llvm_asm!("mcr p15, 0, r0, c7, c10, 5" : : : "memory" : "volatile")
     }
 }
 
 impl super::super::sealed::Dsb for SY {
     #[inline(always)]
     unsafe fn __dsb(&self) {
-        asm!("mcr p15, 0, r0, c7, c10, 4" : : : "memory" : "volatile")
+        llvm_asm!("mcr p15, 0, r0, c7, c10, 4" : : : "memory" : "volatile")
     }
 }
 
 impl super::super::sealed::Isb for SY {
     #[inline(always)]
     unsafe fn __isb(&self) {
-        asm!("mcr p15, 0, r0, c7, c5, 4" : : : "memory" : "volatile")
+        llvm_asm!("mcr p15, 0, r0, c7, c5, 4" : : : "memory" : "volatile")
     }
 }

--- a/crates/core_arch/src/acle/hints.rs
+++ b/crates/core_arch/src/acle/hints.rs
@@ -85,7 +85,7 @@ pub unsafe fn __yield() {
 pub unsafe fn __dbg(imm4: u32) {
     macro_rules! call {
         ($imm4:expr) => {
-            asm!(concat!("DBG ", stringify!($imm4)) : : : : "volatile")
+            llvm_asm!(concat!("DBG ", stringify!($imm4)) : : : : "volatile")
         }
     }
 
@@ -117,7 +117,7 @@ pub unsafe fn __dbg(imm4: u32) {
 /// will increase execution time.
 #[inline(always)]
 pub unsafe fn __nop() {
-    asm!("NOP" : : : : "volatile")
+    llvm_asm!("NOP" : : : : "volatile")
 }
 
 extern "C" {

--- a/crates/core_arch/src/acle/registers/mod.rs
+++ b/crates/core_arch/src/acle/registers/mod.rs
@@ -4,7 +4,7 @@ macro_rules! rsr {
         impl super::super::sealed::Rsr for $R {
             unsafe fn __rsr(&self) -> u32 {
                 let r: u32;
-                asm!(concat!("mrs $0,", stringify!($R)) : "=r"(r) : : : "volatile");
+                llvm_asm!(concat!("mrs $0,", stringify!($R)) : "=r"(r) : : : "volatile");
                 r
             }
         }
@@ -17,7 +17,7 @@ macro_rules! rsrp {
         impl super::super::sealed::Rsrp for $R {
             unsafe fn __rsrp(&self) -> *const u8 {
                 let r: *const u8;
-                asm!(concat!("mrs $0,", stringify!($R)) : "=r"(r) : : : "volatile");
+                llvm_asm!(concat!("mrs $0,", stringify!($R)) : "=r"(r) : : : "volatile");
                 r
             }
         }
@@ -29,7 +29,7 @@ macro_rules! wsr {
     ($R:ident) => {
         impl super::super::sealed::Wsr for $R {
             unsafe fn __wsr(&self, value: u32) {
-                asm!(concat!("msr ", stringify!($R), ",$0") : : "r"(value) : : "volatile");
+                llvm_asm!(concat!("msr ", stringify!($R), ",$0") : : "r"(value) : : "volatile");
             }
         }
     };
@@ -40,7 +40,7 @@ macro_rules! wsrp {
     ($R:ident) => {
         impl super::super::sealed::Wsrp for $R {
             unsafe fn __wsrp(&self, value: *const u8) {
-                asm!(concat!("msr ", stringify!($R), ",$0") : : "r"(value) : : "volatile");
+                llvm_asm!(concat!("msr ", stringify!($R), ",$0") : : "r"(value) : : "volatile");
             }
         }
     };

--- a/crates/core_arch/src/arm/armclang.rs
+++ b/crates/core_arch/src/arm/armclang.rs
@@ -51,14 +51,14 @@ pub unsafe fn __breakpoint(val: i32) {
     #[cfg(target_arch = "arm")]
     macro_rules! call {
         ($imm8:expr) => {
-            asm!(concat!("BKPT ", stringify!($imm8)) : : : : "volatile")
+            llvm_asm!(concat!("BKPT ", stringify!($imm8)) : : : : "volatile")
         }
     }
 
     #[cfg(target_arch = "aarch64")]
     macro_rules! call {
         ($imm8:expr) => {
-            asm!(concat!("BRK ", stringify!($imm8)) : : : : "volatile")
+            llvm_asm!(concat!("BRK ", stringify!($imm8)) : : : : "volatile")
         }
     }
 

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -9,7 +9,7 @@
     platform_intrinsics,
     repr_simd,
     simd_ffi,
-    asm,
+    llvm_asm,
     proc_macro_hygiene,
     stmt_expr_attributes,
     core_intrinsics,

--- a/crates/core_arch/src/x86/bt.rs
+++ b/crates/core_arch/src/x86/bt.rs
@@ -7,10 +7,10 @@ use stdarch_test::assert_instr;
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittest(p: *const i32, b: i32) -> u8 {
     let r: u8;
-    asm!("btl $2, $1\n\tsetc ${0:b}"
-         : "=r"(r)
-         : "*m"(p), "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btl $2, $1\n\tsetc ${0:b}"
+              : "=r"(r)
+              : "*m"(p), "r"(b)
+              : "cc", "memory");
     r
 }
 
@@ -20,10 +20,10 @@ pub unsafe fn _bittest(p: *const i32, b: i32) -> u8 {
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittestandset(p: *mut i32, b: i32) -> u8 {
     let r: u8;
-    asm!("btsl $2, $1\n\tsetc ${0:b}"
-         : "=r"(r), "+*m"(p)
-         : "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btsl $2, $1\n\tsetc ${0:b}"
+              : "=r"(r), "+*m"(p)
+              : "r"(b)
+              : "cc", "memory");
     r
 }
 
@@ -33,10 +33,10 @@ pub unsafe fn _bittestandset(p: *mut i32, b: i32) -> u8 {
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittestandreset(p: *mut i32, b: i32) -> u8 {
     let r: u8;
-    asm!("btrl $2, $1\n\tsetc ${0:b}"
-         : "=r"(r), "+*m"(p)
-         : "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btrl $2, $1\n\tsetc ${0:b}"
+              : "=r"(r), "+*m"(p)
+              : "r"(b)
+              : "cc", "memory");
     r
 }
 
@@ -46,10 +46,10 @@ pub unsafe fn _bittestandreset(p: *mut i32, b: i32) -> u8 {
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittestandcomplement(p: *mut i32, b: i32) -> u8 {
     let r: u8;
-    asm!("btcl $2, $1\n\tsetc ${0:b}"
-         : "=r"(r), "+*m"(p)
-         : "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btcl $2, $1\n\tsetc ${0:b}"
+              : "=r"(r), "+*m"(p)
+              : "r"(b)
+              : "cc", "memory");
     r
 }
 

--- a/crates/core_arch/src/x86/eflags.rs
+++ b/crates/core_arch/src/x86/eflags.rs
@@ -13,7 +13,7 @@
 #[doc(hidden)]
 pub unsafe fn __readeflags() -> u32 {
     let eflags: u32;
-    asm!("pushfd; popl $0" : "=r"(eflags) : : : "volatile");
+    llvm_asm!("pushfd; popl $0" : "=r"(eflags) : : : "volatile");
     eflags
 }
 
@@ -30,7 +30,7 @@ pub unsafe fn __readeflags() -> u32 {
 #[doc(hidden)]
 pub unsafe fn __readeflags() -> u64 {
     let eflags: u64;
-    asm!("pushfq; popq $0" : "=r"(eflags) : : : "volatile");
+    llvm_asm!("pushfq; popq $0" : "=r"(eflags) : : : "volatile");
     eflags
 }
 
@@ -46,7 +46,7 @@ pub unsafe fn __readeflags() -> u64 {
 )]
 #[doc(hidden)]
 pub unsafe fn __writeeflags(eflags: u32) {
-    asm!("pushl $0; popfd" : : "r"(eflags) : "cc", "flags" : "volatile");
+    llvm_asm!("pushl $0; popfd" : : "r"(eflags) : "cc", "flags" : "volatile");
 }
 
 /// Write EFLAGS.
@@ -61,7 +61,7 @@ pub unsafe fn __writeeflags(eflags: u32) {
 )]
 #[doc(hidden)]
 pub unsafe fn __writeeflags(eflags: u64) {
-    asm!("pushq $0; popfq" : : "r"(eflags) : "cc", "flags" : "volatile");
+    llvm_asm!("pushq $0; popfq" : : "r"(eflags) : "cc", "flags" : "volatile");
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/xsave.rs
+++ b/crates/core_arch/src/x86/xsave.rs
@@ -87,7 +87,7 @@ pub unsafe fn _xsetbv(a: u32, val: u64) {
 pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
     let eax: u32;
     let edx: u32;
-    asm!("xgetbv" : "={eax}"(eax), "={edx}"(edx) : "{ecx}"(xcr_no));
+    llvm_asm!("xgetbv" : "={eax}"(eax), "={edx}"(edx) : "{ecx}"(xcr_no));
     ((edx as u64) << 32) | (eax as u64)
 }
 

--- a/crates/core_arch/src/x86_64/bt.rs
+++ b/crates/core_arch/src/x86_64/bt.rs
@@ -7,10 +7,10 @@ use stdarch_test::assert_instr;
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittest64(p: *const i64, b: i64) -> u8 {
     let r: u8;
-    asm!("btq $2, $1\n\tsetc ${0:b}"
-         : "=r"(r)
-         : "*m"(p), "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btq $2, $1\n\tsetc ${0:b}"
+              : "=r"(r)
+              : "*m"(p), "r"(b)
+              : "cc", "memory");
     r
 }
 
@@ -20,10 +20,10 @@ pub unsafe fn _bittest64(p: *const i64, b: i64) -> u8 {
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittestandset64(p: *mut i64, b: i64) -> u8 {
     let r: u8;
-    asm!("btsq $2, $1\n\tsetc ${0:b}"
-         : "=r"(r), "+*m"(p)
-         : "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btsq $2, $1\n\tsetc ${0:b}"
+              : "=r"(r), "+*m"(p)
+              : "r"(b)
+              : "cc", "memory");
     r
 }
 
@@ -33,10 +33,10 @@ pub unsafe fn _bittestandset64(p: *mut i64, b: i64) -> u8 {
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittestandreset64(p: *mut i64, b: i64) -> u8 {
     let r: u8;
-    asm!("btrq $2, $1\n\tsetc ${0:b}"
-         : "=r"(r), "+*m"(p)
-         : "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btrq $2, $1\n\tsetc ${0:b}"
+              : "=r"(r), "+*m"(p)
+              : "r"(b)
+              : "cc", "memory");
     r
 }
 
@@ -46,10 +46,10 @@ pub unsafe fn _bittestandreset64(p: *mut i64, b: i64) -> u8 {
 #[unstable(feature = "simd_x86_bittest", issue = "59414")]
 pub unsafe fn _bittestandcomplement64(p: *mut i64, b: i64) -> u8 {
     let r: u8;
-    asm!("btcq $2, $1\n\tsetc ${0:b}"
-         : "=r"(r), "+*m"(p)
-         : "r"(b)
-         : "cc", "memory");
+    llvm_asm!("btcq $2, $1\n\tsetc ${0:b}"
+              : "=r"(r), "+*m"(p)
+              : "r"(b)
+              : "cc", "memory");
     r
 }
 

--- a/crates/std_detect/src/detect/os/aarch64.rs
+++ b/crates/std_detect/src/detect/os/aarch64.rs
@@ -34,7 +34,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
         // ID_AA64ISAR0_EL1 - Instruction Set Attribute Register 0
         let aa64isar0: u64;
         unsafe {
-            asm!("mrs $0, ID_AA64ISAR0_EL1" : "=r"(aa64isar0));
+            llvm_asm!("mrs $0, ID_AA64ISAR0_EL1" : "=r"(aa64isar0));
         }
 
         let aes = bits_shift(aa64isar0, 7, 4) >= 1;
@@ -50,7 +50,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
         // ID_AA64PFR0_EL1 - Processor Feature Register 0
         let aa64pfr0: u64;
         unsafe {
-            asm!("mrs $0, ID_AA64PFR0_EL1" : "=r"(aa64pfr0));
+            llvm_asm!("mrs $0, ID_AA64PFR0_EL1" : "=r"(aa64pfr0));
         }
 
         let fp = bits_shift(aa64pfr0, 19, 16) < 0xF;
@@ -73,7 +73,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
         // ID_AA64ISAR1_EL1 - Instruction Set Attribute Register 1
         let aa64isar1: u64;
         unsafe {
-            asm!("mrs $0, ID_AA64ISAR1_EL1" : "=r"(aa64isar1));
+            llvm_asm!("mrs $0, ID_AA64ISAR1_EL1" : "=r"(aa64isar1));
         }
 
         enable_feature(Feature::rcpc, bits_shift(aa64isar1, 23, 20) >= 1);

--- a/crates/std_detect/src/lib.rs
+++ b/crates/std_detect/src/lib.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::shadow_reuse)]
 #![deny(clippy::missing_inline_in_public_items)]
 #![cfg_attr(target_os = "linux", feature(linkage))]
-#![cfg_attr(all(target_os = "freebsd", target_arch = "aarch64"), feature(asm))]
+#![cfg_attr(all(target_os = "freebsd", target_arch = "aarch64"), feature(llvm_asm))]
 #![cfg_attr(test, allow(unused_imports))]
 #![no_std]
 


### PR DESCRIPTION
`asm!` will be deprecated soon in preparation for the new `asm!` macro, so switch to using `llvm_asm!` instead.

cc https://github.com/rust-lang/rfcs/pull/2843