### PR TITLE
Use primitive type associated constants

### DIFF
--- a/crates/core_arch/src/acle/dsp.rs
+++ b/crates/core_arch/src/acle/dsp.rs
@@ -240,7 +240,7 @@ mod tests {
         arm::*,
         simd::{i16x2, i8x4, u8x4},
     };
-    use std::{i32, mem::transmute};
+    use std::mem::transmute;
     use stdarch_test::simd_test;
 
     #[test]

--- a/crates/core_arch/src/acle/simd32.rs
+++ b/crates/core_arch/src/acle/simd32.rs
@@ -464,7 +464,7 @@ pub unsafe fn __usada8(a: int8x4_t, b: int8x4_t, c: u32) -> u32 {
 #[cfg(test)]
 mod tests {
     use crate::core_arch::simd::{i16x2, i8x4, u8x4};
-    use std::{i16, i8, mem::transmute};
+    use std::mem::transmute;
     use stdarch_test::simd_test;
 
     #[test]

--- a/crates/core_arch/src/arm/neon.rs
+++ b/crates/core_arch/src/arm/neon.rs
@@ -1141,7 +1141,7 @@ pub unsafe fn vtbx4_p8(a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t) -> poly8x8_t 
 #[cfg(test)]
 mod tests {
     use crate::core_arch::{arm::*, simd::*};
-    use std::{i16, i32, i8, mem::transmute, u16, u32, u8};
+    use std::mem::transmute;
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "neon")]

--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -9319,10 +9319,10 @@ mod tests {
     unsafe fn test_msa_adds_a_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            100, i8::max_value(), 100, i8::max_value(),
-            100, i8::max_value(), 100, i8::max_value(),
-            100, i8::max_value(), 100, i8::max_value(),
-            100, i8::max_value(), 100, i8::max_value()
+            100, i8::MAX, 100, i8::MAX,
+            100, i8::MAX, 100, i8::MAX,
+            100, i8::MAX, 100, i8::MAX,
+            100, i8::MAX, 100, i8::MAX
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -9349,15 +9349,15 @@ mod tests {
     unsafe fn test_msa_adds_a_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            100, i16::max_value(), 100, i16::max_value(), 
-            100, i16::max_value(), 100, i16::max_value()
+            100, i16::MAX, 100, i16::MAX, 
+            100, i16::MAX, 100, i16::MAX
         );
         #[rustfmt::skip]
         let b = i16x8::new(-4, -3, -2, -1, -4, -3, -2, -1);
         #[rustfmt::skip]
         let r = i16x8::new(
-            104, i16::max_value(), 102, i16::max_value(),
-            104, i16::max_value(), 102, i16::max_value()
+            104, i16::MAX, 102, i16::MAX,
+            104, i16::MAX, 102, i16::MAX
         );
 
         assert_eq!(
@@ -9369,11 +9369,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_adds_a_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, i32::max_value(), 100, i32::max_value());
+        let a = i32x4::new(100, i32::MAX, 100, i32::MAX);
         #[rustfmt::skip]
         let b = i32x4::new(-4, -3, -2, -1);
         #[rustfmt::skip]
-        let r = i32x4::new(104, i32::max_value(), 102, i32::max_value());
+        let r = i32x4::new(104, i32::MAX, 102, i32::MAX);
 
         assert_eq!(
             r,
@@ -9384,11 +9384,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_adds_a_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::max_value());
+        let a = i64x2::new(100, i64::MAX);
         #[rustfmt::skip]
         let b = i64x2::new(-4, -3);
         #[rustfmt::skip]
-        let r = i64x2::new(104, i64::max_value());
+        let r = i64x2::new(104, i64::MAX);
 
         assert_eq!(
             r,
@@ -9400,10 +9400,10 @@ mod tests {
     unsafe fn test_msa_adds_s_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            100, i8::min_value(), 100, i8::max_value(),
-            100, i8::min_value(), 100, i8::max_value(),
-            100, i8::min_value(), 100, i8::max_value(),
-            100, i8::min_value(), 100, i8::max_value()
+            100, i8::MIN, 100, i8::MAX,
+            100, i8::MIN, 100, i8::MAX,
+            100, i8::MIN, 100, i8::MAX,
+            100, i8::MIN, 100, i8::MAX
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -9414,10 +9414,10 @@ mod tests {
         );
         #[rustfmt::skip]
         let r = i8x16::new(
-            96, i8::min_value(), 98, i8::max_value(), 
-            96, i8::min_value(), 98, i8::max_value(), 
-            96, i8::min_value(), 98, i8::max_value(), 
-            96, i8::min_value(), 98, i8::max_value()
+            96, i8::MIN, 98, i8::MAX, 
+            96, i8::MIN, 98, i8::MAX, 
+            96, i8::MIN, 98, i8::MAX, 
+            96, i8::MIN, 98, i8::MAX
         );
 
         assert_eq!(
@@ -9430,15 +9430,15 @@ mod tests {
     unsafe fn test_msa_adds_s_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            100, i16::min_value(), 100, i16::max_value(), 
-            100, i16::min_value(), 100, i16::max_value()
+            100, i16::MIN, 100, i16::MAX, 
+            100, i16::MIN, 100, i16::MAX
         );
         #[rustfmt::skip]
         let b = i16x8::new(-4, -3, -2, 1, -4, -3, -2, 1);
         #[rustfmt::skip]
         let r = i16x8::new(
-            96, i16::min_value(), 98, i16::max_value(), 
-            96, i16::min_value(), 98, i16::max_value()
+            96, i16::MIN, 98, i16::MAX, 
+            96, i16::MIN, 98, i16::MAX
         );
 
         assert_eq!(
@@ -9450,11 +9450,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_adds_s_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, i32::max_value(), 100, i32::min_value());
+        let a = i32x4::new(100, i32::MAX, 100, i32::MIN);
         #[rustfmt::skip]
         let b = i32x4::new(-4, 3, -2, -1);
         #[rustfmt::skip]
-        let r = i32x4::new(96, i32::max_value(), 98, i32::min_value());
+        let r = i32x4::new(96, i32::MAX, 98, i32::MIN);
 
         assert_eq!(
             r,
@@ -9465,11 +9465,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_adds_s_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::min_value());
+        let a = i64x2::new(100, i64::MIN);
         #[rustfmt::skip]
         let b = i64x2::new(-4, -3);
         #[rustfmt::skip]
-        let r = i64x2::new(96, i64::min_value());
+        let r = i64x2::new(96, i64::MIN);
 
         assert_eq!(
             r,
@@ -9481,10 +9481,10 @@ mod tests {
     unsafe fn test_msa_adds_u_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value()
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX
         );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -9495,10 +9495,10 @@ mod tests {
         );
         #[rustfmt::skip]
         let r = u8x16::new(
-            104, u8::max_value(), 102, u8::max_value(), 
-            104, u8::max_value(), 102, u8::max_value(), 
-            104, u8::max_value(), 102, u8::max_value(), 
-            104, u8::max_value(), 102, u8::max_value()
+            104, u8::MAX, 102, u8::MAX, 
+            104, u8::MAX, 102, u8::MAX, 
+            104, u8::MAX, 102, u8::MAX, 
+            104, u8::MAX, 102, u8::MAX
         );
 
         assert_eq!(
@@ -9511,15 +9511,15 @@ mod tests {
     unsafe fn test_msa_adds_u_h() {
         #[rustfmt::skip]
         let a = u16x8::new(
-            100, u16::max_value(), 100, u16::max_value(), 
-            100, u16::max_value(), 100, u16::max_value()
+            100, u16::MAX, 100, u16::MAX, 
+            100, u16::MAX, 100, u16::MAX
         );
         #[rustfmt::skip]
         let b = u16x8::new(4, 3, 2, 1, 4, 3, 2, 1);
         #[rustfmt::skip]
         let r = u16x8::new(
-            104, u16::max_value(), 102, u16::max_value(), 
-            104, u16::max_value(), 102, u16::max_value()
+            104, u16::MAX, 102, u16::MAX, 
+            104, u16::MAX, 102, u16::MAX
         );
 
         assert_eq!(
@@ -9531,11 +9531,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_adds_u_w() {
         #[rustfmt::skip]
-        let a = u32x4::new(100, u32::max_value(), 100, u32::max_value());
+        let a = u32x4::new(100, u32::MAX, 100, u32::MAX);
         #[rustfmt::skip]
         let b = u32x4::new(4, 3, 2, 1);
         #[rustfmt::skip]
-        let r = u32x4::new(104, u32::max_value(), 102, u32::max_value());
+        let r = u32x4::new(104, u32::MAX, 102, u32::MAX);
 
         assert_eq!(
             r,
@@ -9546,11 +9546,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_adds_u_d() {
         #[rustfmt::skip]
-        let a = u64x2::new(100, u64::max_value());
+        let a = u64x2::new(100, u64::MAX);
         #[rustfmt::skip]
         let b = u64x2::new(4, 3);
         #[rustfmt::skip]
-        let r = u64x2::new(104, u64::max_value());
+        let r = u64x2::new(104, u64::MAX);
 
         assert_eq!(
             r,
@@ -9562,10 +9562,10 @@ mod tests {
     unsafe fn test_msa_addv_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            100, i8::min_value(), 100, i8::max_value(),
-            100, i8::min_value(), 100, i8::max_value(),
-            100, i8::min_value(), 100, i8::max_value(),
-            100, i8::min_value(), 100, i8::max_value()
+            100, i8::MIN, 100, i8::MAX,
+            100, i8::MIN, 100, i8::MAX,
+            100, i8::MIN, 100, i8::MAX,
+            100, i8::MIN, 100, i8::MAX
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -9592,8 +9592,8 @@ mod tests {
     unsafe fn test_msa_addv_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            100, i16::min_value(), 100, i16::max_value(), 
-            100, i16::min_value(), 100, i16::max_value()
+            100, i16::MIN, 100, i16::MAX, 
+            100, i16::MIN, 100, i16::MAX
         );
         #[rustfmt::skip]
         let b = i16x8::new(-4, -3, -2, 1, -4, -3, -2, 1);
@@ -9609,7 +9609,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_addv_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, i32::max_value(), 100, i32::min_value());
+        let a = i32x4::new(100, i32::MAX, 100, i32::MIN);
         #[rustfmt::skip]
         let b = i32x4::new(-4, 3, -2, -1);
         #[rustfmt::skip]
@@ -9624,7 +9624,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_addv_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::min_value());
+        let a = i64x2::new(100, i64::MIN);
         #[rustfmt::skip]
         let b = i64x2::new(-4, -3);
         #[rustfmt::skip]
@@ -9640,10 +9640,10 @@ mod tests {
     unsafe fn test_msa_addvi_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            100, i8::max_value(), 100, i8::max_value(),
-            100, i8::max_value(), 100, i8::max_value(),
-            100, i8::max_value(), 100, i8::max_value(),
-            100, i8::max_value(), 100, i8::max_value()
+            100, i8::MAX, 100, i8::MAX,
+            100, i8::MAX, 100, i8::MAX,
+            100, i8::MAX, 100, i8::MAX,
+            100, i8::MAX, 100, i8::MAX
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -9660,8 +9660,8 @@ mod tests {
     unsafe fn test_msa_addvi_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 3276, -100, -127, 
-            i16::max_value(), 3276, -100, -127
+            i16::MAX, 3276, -100, -127, 
+            i16::MAX, 3276, -100, -127
         );
         #[rustfmt::skip]
         let r = i16x8::new(
@@ -9675,7 +9675,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_addvi_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, i32::max_value(), 100, i32::min_value());
+        let a = i32x4::new(100, i32::MAX, 100, i32::MIN);
         #[rustfmt::skip]
         let r = i32x4::new(103, -2147483646, 103, -2147483645);
 
@@ -9685,7 +9685,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_addvi_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::min_value());
+        let a = i64x2::new(100, i64::MIN);
         #[rustfmt::skip]
         let r = i64x2::new(117, -9223372036854775791);
 
@@ -9696,10 +9696,10 @@ mod tests {
     unsafe fn test_msa_and_v() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value()
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX
     );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -9726,10 +9726,10 @@ mod tests {
     unsafe fn test_msa_andi_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value(),
-            100, u8::max_value(), 100, u8::max_value()
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX,
+            100, u8::MAX, 100, u8::MAX
         );
         #[rustfmt::skip]
         let r = u8x16::new(
@@ -10437,10 +10437,10 @@ mod tests {
     unsafe fn test_msa_binsli_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1
         );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -10721,10 +10721,10 @@ mod tests {
     unsafe fn test_msa_bmnz_v() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1
         );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -10762,17 +10762,17 @@ mod tests {
     unsafe fn test_msa_bmnzi_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1
         );
         #[rustfmt::skip]
         let b = u8x16::new(
-            1, u8::max_value(), 155, 55,
-            1, u8::max_value(), 155, 55,
-            1, u8::max_value(), 155, 55,
-            1, u8::max_value(), 155, 55
+            1, u8::MAX, 155, 55,
+            1, u8::MAX, 155, 55,
+            1, u8::MAX, 155, 55,
+            1, u8::MAX, 155, 55
         );
         #[rustfmt::skip]
         let r = u8x16::new(
@@ -10792,10 +10792,10 @@ mod tests {
     unsafe fn test_msa_bmz_v() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1
         );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -10833,10 +10833,10 @@ mod tests {
     unsafe fn test_msa_bmzi_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1,
-            u8::max_value(), 155, 55, 1
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1,
+            u8::MAX, 155, 55, 1
         );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -10938,10 +10938,10 @@ mod tests {
     unsafe fn test_msa_bnegi_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            50, 100, 127, u8::max_value(),
-            50, 100, 127, u8::max_value(),
-            50, 100, 127, u8::max_value(),
-            50, 100, 127, u8::max_value()
+            50, 100, 127, u8::MAX,
+            50, 100, 127, u8::MAX,
+            50, 100, 127, u8::MAX,
+            50, 100, 127, u8::MAX
         );
         #[rustfmt::skip]
         let r = u8x16::new(
@@ -11518,17 +11518,17 @@ mod tests {
     unsafe fn test_msa_cle_u_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 127, 55, 2,
-            u8::max_value(), 127, 55, 2,
-            u8::max_value(), 127, 55, 2,
-            u8::max_value(), 127, 55, 2
+            u8::MAX, 127, 55, 2,
+            u8::MAX, 127, 55, 2,
+            u8::MAX, 127, 55, 2,
+            u8::MAX, 127, 55, 2
         );
         #[rustfmt::skip]
         let b = u8x16::new(
-            u8::max_value(), 126, 55, 1,
-            u8::max_value(), 126, 55, 1,
-            u8::max_value(), 126, 55, 1,
-            u8::max_value(), 126, 55, 1
+            u8::MAX, 126, 55, 1,
+            u8::MAX, 126, 55, 1,
+            u8::MAX, 126, 55, 1,
+            u8::MAX, 126, 55, 1
         );
         #[rustfmt::skip]
         let r = i8x16::new(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0);
@@ -11543,13 +11543,13 @@ mod tests {
     unsafe fn test_msa_cle_u_h() {
         #[rustfmt::skip]
         let a = u16x8::new(
-            u16::max_value(), 155, 55, 2, 
-            u16::max_value(), 155, 55, 2
+            u16::MAX, 155, 55, 2, 
+            u16::MAX, 155, 55, 2
         );
         #[rustfmt::skip]
         let b = u16x8::new(
-            u16::max_value(), 155, 56, 1, 
-            u16::max_value(), 155, 56, 1
+            u16::MAX, 155, 56, 1, 
+            u16::MAX, 155, 56, 1
         );
         #[rustfmt::skip]
         let r = i16x8::new(-1, -1, -1, 0, -1, -1, -1, 0);
@@ -11563,9 +11563,9 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_cle_u_w() {
         #[rustfmt::skip]
-        let a = u32x4::new(u32::max_value(), 155, 55, 2);
+        let a = u32x4::new(u32::MAX, 155, 55, 2);
         #[rustfmt::skip]
-        let b = u32x4::new(u32::max_value(), 156, 55, 1);
+        let b = u32x4::new(u32::MAX, 156, 55, 1);
         #[rustfmt::skip]
         let r = i32x4::new(-1, -1, -1, 0);
 
@@ -11578,9 +11578,9 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_cle_u_d() {
         #[rustfmt::skip]
-        let a = u64x2::new(u64::max_value(), 155);
+        let a = u64x2::new(u64::MAX, 155);
         #[rustfmt::skip]
-        let b = u64x2::new(u64::max_value(), 156);
+        let b = u64x2::new(u64::MAX, 156);
         #[rustfmt::skip]
         let r = i64x2::new(-1, -1);
 
@@ -12041,7 +12041,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_copy_u_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(3, i64::max_value());
+        let a = i64x2::new(3, i64::MAX);
         #[rustfmt::skip]
         let r = 9223372036854775807 as u64;
 
@@ -14701,7 +14701,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_insert_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(3, i64::max_value());
+        let a = i64x2::new(3, i64::MAX);
         #[rustfmt::skip]
         let r = i64x2::new(3, 100);
 
@@ -14712,10 +14712,10 @@ mod tests {
     unsafe fn test_msa_insve_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            -100, i8::max_value(), 4, i8::max_value(),
-            -100, i8::max_value(), 4, i8::max_value(),
-            -100, i8::max_value(), 4, i8::max_value(),
-            -100, i8::max_value(), 4, i8::max_value()
+            -100, i8::MAX, 4, i8::MAX,
+            -100, i8::MAX, 4, i8::MAX,
+            -100, i8::MAX, 4, i8::MAX,
+            -100, i8::MAX, 4, i8::MAX
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -14742,8 +14742,8 @@ mod tests {
     unsafe fn test_msa_insve_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 3276, 100, 11,
-            i16::max_value(), 3276, 100, 11
+            i16::MAX, 3276, 100, 11,
+            i16::MAX, 3276, 100, 11
         );
         #[rustfmt::skip]
         let b = i16x8::new(
@@ -14780,7 +14780,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_insve_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(3, i64::max_value());
+        let a = i64x2::new(3, i64::MAX);
         #[rustfmt::skip]
         let b = i64x2::new(1, 2);
         #[rustfmt::skip]
@@ -14895,7 +14895,7 @@ mod tests {
     unsafe fn test_msa_madd_q_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 1024, i16::min_value(), -1024,
+            i16::MAX, 1024, i16::MIN, -1024,
             1, 2, 3, 4
         );
         #[rustfmt::skip]
@@ -14905,7 +14905,7 @@ mod tests {
         );
         #[rustfmt::skip]
         let c = i16x8::new(
-            i16::max_value(), i16::max_value(), 1, -1,
+            i16::MAX, i16::MAX, 1, -1,
             33, 66, 99, 132
         );
         #[rustfmt::skip]
@@ -14924,7 +14924,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_madd_q_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::max_value(), i32::min_value(), 1, 2);
+        let a = i32x4::new(i32::MAX, i32::MIN, 1, 2);
         #[rustfmt::skip]
         let b = i32x4::new(102401, 102401, 102401, 102401);
         #[rustfmt::skip]
@@ -14975,7 +14975,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_maddr_q_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::max_value(), i32::min_value(), 1, 2);
+        let a = i32x4::new(i32::MAX, i32::MIN, 1, 2);
         #[rustfmt::skip]
         let b = i32x4::new(102401, 102401, 102401, 102401);
         #[rustfmt::skip]
@@ -16007,7 +16007,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_msubr_q_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::max_value(), -2147483647, 1, 2);
+        let a = i32x4::new(i32::MAX, -2147483647, 1, 2);
         #[rustfmt::skip]
         let b = i32x4::new(10240, 10240, 10240, 10240);
         #[rustfmt::skip]
@@ -16154,8 +16154,8 @@ mod tests {
     unsafe fn test_msa_mul_q_w() {
         #[rustfmt::skip]
         let a = i32x4::new(
-            i32::max_value(), i32::max_value(),
-            i32::min_value(), i32::min_value()
+            i32::MAX, i32::MAX,
+            i32::MIN, i32::MIN
         );
         #[rustfmt::skip]
         let b = i32x4::new(30, 60, 30, 60);
@@ -16193,8 +16193,8 @@ mod tests {
     unsafe fn test_msa_mulr_q_w() {
         #[rustfmt::skip]
         let a = i32x4::new(
-            i32::max_value(), i32::max_value(),
-            i32::min_value(), i32::min_value()
+            i32::MAX, i32::MAX,
+            i32::MIN, i32::MIN
         );
         #[rustfmt::skip]
         let b = i32x4::new(30, 60, 30, 60);
@@ -16325,8 +16325,8 @@ mod tests {
     unsafe fn test_msa_nloc_w() {
         #[rustfmt::skip]
         let a = i32x4::new(
-            i32::min_value(), -1073741824,
-            1073741824, i32::max_value()
+            i32::MIN, -1073741824,
+            1073741824, i32::MAX
         );
         #[rustfmt::skip]
         let r = i32x4::new(1, 2, 0, 0);
@@ -16337,7 +16337,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_nloc_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::min_value(), i64::max_value());
+        let a = i64x2::new(i64::MIN, i64::MAX);
         #[rustfmt::skip]
         let r = i64x2::new(1, 0);
 
@@ -16684,8 +16684,8 @@ mod tests {
     unsafe fn test_msa_pcnt_w() {
         #[rustfmt::skip]
         let a = i32x4::new(
-            i32::min_value(), -1073741824,
-            1073741824, i32::max_value()
+            i32::MIN, -1073741824,
+            1073741824, i32::MAX
         );
         #[rustfmt::skip]
         let r = i32x4::new(1, 2, 1, 31);
@@ -16707,10 +16707,10 @@ mod tests {
     unsafe fn test_msa_sat_s_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            i8::max_value(), 105, 30, 1,
-            i8::max_value(), 105, 30, 1,
-            i8::max_value(), 105, 30, 1,
-            i8::max_value(), 105, 30, 1
+            i8::MAX, 105, 30, 1,
+            i8::MAX, 105, 30, 1,
+            i8::MAX, 105, 30, 1,
+            i8::MAX, 105, 30, 1
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -16727,8 +16727,8 @@ mod tests {
     unsafe fn test_msa_sat_s_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 1155, 155, 1,
-            i16::max_value(), 1155, 155, 1
+            i16::MAX, 1155, 155, 1,
+            i16::MAX, 1155, 155, 1
         );
         #[rustfmt::skip]
         let r = i16x8::new(127, 127, 127, 1, 127, 127, 127, 1);
@@ -16739,7 +16739,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_sat_s_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::max_value(), 111111155, i32::max_value(), 1);
+        let a = i32x4::new(i32::MAX, 111111155, i32::MAX, 1);
         #[rustfmt::skip]
         let r = i32x4::new(131071, 131071, 131071, 1);
 
@@ -16749,7 +16749,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_sat_s_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::max_value(), 1);
+        let a = i64x2::new(i64::MAX, 1);
         #[rustfmt::skip]
         let r = i64x2::new(137438953471, 1);
 
@@ -16760,10 +16760,10 @@ mod tests {
     unsafe fn test_msa_sat_u_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 105, 30, 1,
-            u8::max_value(), 105, 30, 1,
-            u8::max_value(), 105, 30, 1,
-            u8::max_value(), 105, 30, 1
+            u8::MAX, 105, 30, 1,
+            u8::MAX, 105, 30, 1,
+            u8::MAX, 105, 30, 1,
+            u8::MAX, 105, 30, 1
         );
         #[rustfmt::skip]
         let r = u8x16::new(
@@ -16780,8 +16780,8 @@ mod tests {
     unsafe fn test_msa_sat_u_h() {
         #[rustfmt::skip]
         let a = u16x8::new(
-            u16::max_value(), 1155, 155, 1,
-            u16::max_value(), 1155, 155, 1
+            u16::MAX, 1155, 155, 1,
+            u16::MAX, 1155, 155, 1
         );
         #[rustfmt::skip]
         let r = u16x8::new(255, 255, 155, 1, 255, 255, 155, 1);
@@ -16792,7 +16792,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_sat_u_w() {
         #[rustfmt::skip]
-        let a = u32x4::new(u32::max_value(), 111111155, u32::max_value(), 1);
+        let a = u32x4::new(u32::MAX, 111111155, u32::MAX, 1);
         #[rustfmt::skip]
         let r = u32x4::new(262143, 262143, 262143, 1);
 
@@ -16802,7 +16802,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_sat_u_d() {
         #[rustfmt::skip]
-        let a = u64x2::new(u64::max_value(), 1);
+        let a = u64x2::new(u64::MAX, 1);
         #[rustfmt::skip]
         let r = u64x2::new(274877906943, 1);
 
@@ -17293,7 +17293,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_sra_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::min_value(), -1073741824, 1, 2);
+        let a = i32x4::new(i32::MIN, -1073741824, 1, 2);
         #[rustfmt::skip]
         let b = i32x4::new(16, 15, 16, 15);
         #[rustfmt::skip]
@@ -17308,7 +17308,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_sra_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::min_value(), i64::max_value());
+        let a = i64x2::new(i64::MIN, i64::MAX);
         #[rustfmt::skip]
         let b = i64x2::new(32, 31);
         #[rustfmt::skip]
@@ -17324,10 +17324,10 @@ mod tests {
     unsafe fn test_msa_srai_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            i8::max_value(), 125, 55, 1,
-            i8::max_value(), 125, 55, 1,
-            i8::max_value(), 125, 55, 1,
-            i8::max_value(), 125, 55, 1
+            i8::MAX, 125, 55, 1,
+            i8::MAX, 125, 55, 1,
+            i8::MAX, 125, 55, 1,
+            i8::MAX, 125, 55, 1
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -17344,8 +17344,8 @@ mod tests {
     unsafe fn test_msa_srai_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 125, 55, 1, 
-            i16::max_value(), 125, 55, 1
+            i16::MAX, 125, 55, 1, 
+            i16::MAX, 125, 55, 1
         );
         #[rustfmt::skip]
         let r = i16x8::new(8191, 31, 13, 0, 8191, 31, 13, 0);
@@ -17356,7 +17356,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srai_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::max_value(), 125, 55, 1);
+        let a = i32x4::new(i32::MAX, 125, 55, 1);
         let r = i32x4::new(536870911, 31, 13, 0);
 
         assert_eq!(r, mem::transmute(__msa_srai_w(mem::transmute(a), 2)));
@@ -17365,7 +17365,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srai_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::max_value(), 55);
+        let a = i64x2::new(i64::MAX, 55);
         #[rustfmt::skip]
         let r = i64x2::new(2305843009213693951, 13);
 
@@ -17406,7 +17406,7 @@ mod tests {
     unsafe fn test_msa_srar_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::min_value(), -16384, -8192, -4096,
+            i16::MIN, -16384, -8192, -4096,
             150, 50, 25, 15
         );
         #[rustfmt::skip]
@@ -17429,7 +17429,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srar_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::min_value(), -1073741824, 100, 50);
+        let a = i32x4::new(i32::MIN, -1073741824, 100, 50);
         #[rustfmt::skip]
         let b = i32x4::new(16, 15, 1, 2);
         #[rustfmt::skip]
@@ -17444,7 +17444,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srar_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::min_value(), i64::max_value());
+        let a = i64x2::new(i64::MIN, i64::MAX);
         #[rustfmt::skip]
         let b = i64x2::new(32, 31);
         #[rustfmt::skip]
@@ -17460,10 +17460,10 @@ mod tests {
     unsafe fn test_msa_srari_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            125, i8::max_value(), 55, 1,
-            125, i8::max_value(), 55, 1,
-            125, i8::max_value(), 55, 1,
-            125, i8::max_value(), 55, 1
+            125, i8::MAX, 55, 1,
+            125, i8::MAX, 55, 1,
+            125, i8::MAX, 55, 1,
+            125, i8::MAX, 55, 1
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -17560,7 +17560,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srl_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::min_value(), -1073741824, 1, 2);
+        let a = i32x4::new(i32::MIN, -1073741824, 1, 2);
         #[rustfmt::skip]
         let b = i32x4::new(16, 15, 16, 15);
         #[rustfmt::skip]
@@ -17575,7 +17575,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srl_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::min_value(), i64::max_value());
+        let a = i64x2::new(i64::MIN, i64::MAX);
         #[rustfmt::skip]
         let b = i64x2::new(32, 31);
         #[rustfmt::skip]
@@ -17611,8 +17611,8 @@ mod tests {
     unsafe fn test_msa_srli_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 3276, 100, 127,
-            i16::max_value(), 3276, 100, 127
+            i16::MAX, 3276, 100, 127,
+            i16::MAX, 3276, 100, 127
         );
         #[rustfmt::skip]
         let r = i16x8::new(
@@ -17626,7 +17626,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srli_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, i32::max_value(), 100, i32::max_value());
+        let a = i32x4::new(100, i32::MAX, 100, i32::MAX);
         #[rustfmt::skip]
         let r = i32x4::new(25, 536870911, 25, 536870911);
 
@@ -17636,7 +17636,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srli_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::max_value());
+        let a = i64x2::new(100, i64::MAX);
         #[rustfmt::skip]
         let r = i64x2::new(50, 4611686018427387903);
 
@@ -17697,7 +17697,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srlr_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::min_value(), -1073741824, 1, 2);
+        let a = i32x4::new(i32::MIN, -1073741824, 1, 2);
         #[rustfmt::skip]
         let b = i32x4::new(16, 15, 16, 15);
         let r = i32x4::new(32768, 98304, 0, 0);
@@ -17711,7 +17711,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srlr_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::min_value(), i64::max_value());
+        let a = i64x2::new(i64::MIN, i64::MAX);
         #[rustfmt::skip]
         let b = i64x2::new(32, 31);
         #[rustfmt::skip]
@@ -17727,10 +17727,10 @@ mod tests {
     unsafe fn test_msa_srlri_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            25, 50, 100, i8::max_value(),
-            25, 50, 100, i8::max_value(),
-            25, 50, 100, i8::max_value(),
-            25, 50, 100, i8::max_value()
+            25, 50, 100, i8::MAX,
+            25, 50, 100, i8::MAX,
+            25, 50, 100, i8::MAX,
+            25, 50, 100, i8::MAX
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -17747,8 +17747,8 @@ mod tests {
     unsafe fn test_msa_srlri_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 3276, 100, 127,
-            i16::max_value(), 3276, 100, 127
+            i16::MAX, 3276, 100, 127,
+            i16::MAX, 3276, 100, 127
         );
         let r = i16x8::new(8192, 819, 25, 32, 8192, 819, 25, 32);
 
@@ -17758,7 +17758,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srlri_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, 150, 200, i32::max_value());
+        let a = i32x4::new(100, 150, 200, i32::MAX);
         #[rustfmt::skip]
         let r = i32x4::new(25, 38, 50, 536870912);
 
@@ -17768,7 +17768,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_srlri_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::max_value());
+        let a = i64x2::new(100, i64::MAX);
         #[rustfmt::skip]
         let r = i64x2::new(50, 4611686018427387904);
 
@@ -17839,10 +17839,10 @@ mod tests {
     unsafe fn test_msa_subs_s_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            i8::min_value(), -2, -3, -4,
-            i8::min_value(), -2, -3, -4,
-            i8::min_value(), -2, -3, -4,
-            i8::min_value(), -2, -3, -4
+            i8::MIN, -2, -3, -4,
+            i8::MIN, -2, -3, -4,
+            i8::MIN, -2, -3, -4,
+            i8::MIN, -2, -3, -4
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -17853,10 +17853,10 @@ mod tests {
         );
         #[rustfmt::skip]
         let r = i8x16::new(
-            i8::min_value(), 5, -11, 5,
-            i8::min_value(), 5, -11, 5,
-            i8::min_value(), 5, -11, 5,
-            i8::min_value(), 5, -11, 5
+            i8::MIN, 5, -11, 5,
+            i8::MIN, 5, -11, 5,
+            i8::MIN, 5, -11, 5,
+            i8::MIN, 5, -11, 5
         );
 
         assert_eq!(
@@ -17869,15 +17869,15 @@ mod tests {
     unsafe fn test_msa_subs_s_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::min_value(), -2, -3, -4,
-            i16::min_value(), -2, -3, -4
+            i16::MIN, -2, -3, -4,
+            i16::MIN, -2, -3, -4
         );
         #[rustfmt::skip]
         let b = i16x8::new(6, -7, 8, -9, 6, -7, 8, -9);
         #[rustfmt::skip]
         let r = i16x8::new(
-            i16::min_value(), 5, -11, 5,
-            i16::min_value(), 5, -11, 5
+            i16::MIN, 5, -11, 5,
+            i16::MIN, 5, -11, 5
         );
 
         assert_eq!(
@@ -17889,11 +17889,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subs_s_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::min_value(), -2, -3, -4);
+        let a = i32x4::new(i32::MIN, -2, -3, -4);
         #[rustfmt::skip]
         let b = i32x4::new(6, -7, 8, -9);
         #[rustfmt::skip]
-        let r = i32x4::new(i32::min_value(), 5, -11, 5);
+        let r = i32x4::new(i32::MIN, 5, -11, 5);
 
         assert_eq!(
             r,
@@ -17904,11 +17904,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subs_s_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::min_value(), -2);
+        let a = i64x2::new(i64::MIN, -2);
         #[rustfmt::skip]
         let b = i64x2::new(6, -7);
         #[rustfmt::skip]
-        let r = i64x2::new(i64::min_value(), 5);
+        let r = i64x2::new(i64::MIN, 5);
 
         assert_eq!(
             r,
@@ -17920,10 +17920,10 @@ mod tests {
     unsafe fn test_msa_subs_u_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4
         );
         #[rustfmt::skip]
         let b = u8x16::new(
@@ -17950,8 +17950,8 @@ mod tests {
     unsafe fn test_msa_subs_u_h() {
         #[rustfmt::skip]
         let a = u16x8::new(
-            u16::max_value(), 2, 3, 4, 
-            u16::max_value(), 2, 3, 4
+            u16::MAX, 2, 3, 4, 
+            u16::MAX, 2, 3, 4
         );
         #[rustfmt::skip]
         let b = u16x8::new(6, 7, 8, 9, 6, 7, 8, 9);
@@ -17967,7 +17967,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subs_u_w() {
         #[rustfmt::skip]
-        let a = u32x4::new(u32::max_value(), 2, 3, 4);
+        let a = u32x4::new(u32::MAX, 2, 3, 4);
         #[rustfmt::skip]
         let b = u32x4::new(6, 7, 8, 9);
         #[rustfmt::skip]
@@ -17982,7 +17982,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subs_u_d() {
         #[rustfmt::skip]
-        let a = u64x2::new(u64::max_value(), 2);
+        let a = u64x2::new(u64::MAX, 2);
         #[rustfmt::skip]
         let b = u64x2::new(6, 7);
         #[rustfmt::skip]
@@ -17998,10 +17998,10 @@ mod tests {
     unsafe fn test_msa_subsus_u_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -18028,8 +18028,8 @@ mod tests {
     unsafe fn test_msa_subsus_u_h() {
         #[rustfmt::skip]
         let a = u16x8::new(
-            u16::max_value(), 2, 3, 4,
-            u16::max_value(), 2, 3, 4
+            u16::MAX, 2, 3, 4,
+            u16::MAX, 2, 3, 4
         );
         #[rustfmt::skip]
         let b = i16x8::new(-6, -7, -8, -9, -6, -7, -8, -9);
@@ -18045,7 +18045,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subsus_u_w() {
         #[rustfmt::skip]
-        let a = u32x4::new(u32::max_value(), 2, 3, 4);
+        let a = u32x4::new(u32::MAX, 2, 3, 4);
         #[rustfmt::skip]
         let b = i32x4::new(-6, -7, -8, -9);
         #[rustfmt::skip]
@@ -18060,7 +18060,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subsus_u_d() {
         #[rustfmt::skip]
-        let a = u64x2::new(u64::max_value(), 2);
+        let a = u64x2::new(u64::MAX, 2);
         #[rustfmt::skip]
         let b = i64x2::new(-6, -7);
         #[rustfmt::skip]
@@ -18076,17 +18076,17 @@ mod tests {
     unsafe fn test_msa_subsuu_s_b() {
         #[rustfmt::skip]
         let a = u8x16::new(
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4,
-            u8::max_value(), 2, 3, 4
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4,
+            u8::MAX, 2, 3, 4
         );
         #[rustfmt::skip]
         let b = u8x16::new(
-            6, 7, 8, u8::max_value(),
-            6, 7, 8, u8::max_value(),
-            6, 7, 8, u8::max_value(),
-            6, 7, 8, u8::max_value()
+            6, 7, 8, u8::MAX,
+            6, 7, 8, u8::MAX,
+            6, 7, 8, u8::MAX,
+            6, 7, 8, u8::MAX
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -18106,8 +18106,8 @@ mod tests {
     unsafe fn test_msa_subsuu_s_h() {
         #[rustfmt::skip]
         let a = u16x8::new(
-            u16::max_value(), 2, 3, 
-            4, u16::max_value(), 2, 3, 4
+            u16::MAX, 2, 3, 
+            4, u16::MAX, 2, 3, 4
         );
         #[rustfmt::skip]
         let b = u16x8::new(6, 7, 8, 65535, 6, 7, 8, 65535);
@@ -18123,7 +18123,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subsuu_s_w() {
         #[rustfmt::skip]
-        let a = u32x4::new(u32::max_value(), 2, 3, 4);
+        let a = u32x4::new(u32::MAX, 2, 3, 4);
         #[rustfmt::skip]
         let b = u32x4::new(6, 7, 8, 4294967295);
         #[rustfmt::skip]
@@ -18138,11 +18138,11 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subsuu_s_d() {
         #[rustfmt::skip]
-        let a = u64x2::new(u64::max_value(), 2);
+        let a = u64x2::new(u64::MAX, 2);
         #[rustfmt::skip]
         let b = u64x2::new(6, 7);
         #[rustfmt::skip]
-        let r = i64x2::new(i64::max_value(), -5);
+        let r = i64x2::new(i64::MAX, -5);
 
         assert_eq!(
             r,
@@ -18154,10 +18154,10 @@ mod tests {
     unsafe fn test_msa_subv_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            i8::min_value(), -2, -3, -4,
-            i8::min_value(), -2, -3, -4,
-            i8::min_value(), -2, -3, -4,
-            i8::min_value(), -2, -3, -4
+            i8::MIN, -2, -3, -4,
+            i8::MIN, -2, -3, -4,
+            i8::MIN, -2, -3, -4,
+            i8::MIN, -2, -3, -4
         );
         #[rustfmt::skip]
         let b = i8x16::new(
@@ -18184,8 +18184,8 @@ mod tests {
     unsafe fn test_msa_subv_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::min_value(), -2, -3, -4,
-            i16::min_value(), -2, -3, -4
+            i16::MIN, -2, -3, -4,
+            i16::MIN, -2, -3, -4
         );
         #[rustfmt::skip]
         let b = i16x8::new(6, -7, 8, -9, 6, -7, 8, -9);
@@ -18201,7 +18201,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subv_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(i32::min_value(), -2, -3, -4);
+        let a = i32x4::new(i32::MIN, -2, -3, -4);
         #[rustfmt::skip]
         let b = i32x4::new(6, -7, 8, -9);
         #[rustfmt::skip]
@@ -18216,7 +18216,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subv_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(i64::max_value(), -2);
+        let a = i64x2::new(i64::MAX, -2);
         #[rustfmt::skip]
         let b = i64x2::new(6, -7);
         #[rustfmt::skip]
@@ -18232,10 +18232,10 @@ mod tests {
     unsafe fn test_msa_subvi_b() {
         #[rustfmt::skip]
         let a = i8x16::new(
-            100, i8::max_value(), 50, i8::min_value(),
-            100, i8::max_value(), 50, i8::min_value(),
-            100, i8::max_value(), 50, i8::min_value(),
-            100, i8::max_value(), 50, i8::min_value()
+            100, i8::MAX, 50, i8::MIN,
+            100, i8::MAX, 50, i8::MIN,
+            100, i8::MAX, 50, i8::MIN,
+            100, i8::MAX, 50, i8::MIN
         );
         #[rustfmt::skip]
         let r = i8x16::new(
@@ -18252,8 +18252,8 @@ mod tests {
     unsafe fn test_msa_subvi_h() {
         #[rustfmt::skip]
         let a = i16x8::new(
-            i16::max_value(), 3276, -100, i16::min_value(),
-            i16::max_value(), 3276, -100, i16::min_value()
+            i16::MAX, 3276, -100, i16::MIN,
+            i16::MAX, 3276, -100, i16::MIN
         );
         #[rustfmt::skip]
         let r = i16x8::new(
@@ -18267,7 +18267,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subvi_w() {
         #[rustfmt::skip]
-        let a = i32x4::new(100, 150, 200, i32::max_value());
+        let a = i32x4::new(100, 150, 200, i32::MAX);
         #[rustfmt::skip]
         let r = i32x4::new(95, 145, 195, 2147483642);
 
@@ -18277,7 +18277,7 @@ mod tests {
     #[simd_test(enable = "msa")]
     unsafe fn test_msa_subvi_d() {
         #[rustfmt::skip]
-        let a = i64x2::new(100, i64::max_value());
+        let a = i64x2::new(100, i64::MAX);
         #[rustfmt::skip]
         let r = i64x2::new(95, 9223372036854775802);
 

--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -2045,32 +2045,32 @@ mod tests {
     }
 
     test_vec_avg! { test_vec_avg_i32x4, i32x4,
-    [i32::min_value(), i32::max_value(), 1, -1],
+    [i32::MIN, i32::MAX, 1, -1],
     [-1, 1, 1, -1],
     [-1073741824, 1073741824, 1, -1] }
 
     test_vec_avg! { test_vec_avg_u32x4, u32x4,
-    [u32::max_value(), 0, 1, 2],
+    [u32::MAX, 0, 1, 2],
     [2, 1, 0, 0],
     [2147483649, 1, 1, 1] }
 
     test_vec_avg! { test_vec_avg_i16x8, i16x8,
-    [i16::min_value(), i16::max_value(), 1, -1, 0, 0, 0, 0],
+    [i16::MIN, i16::MAX, 1, -1, 0, 0, 0, 0],
     [-1, 1, 1, -1, 0, 0, 0, 0],
     [-16384, 16384, 1, -1, 0, 0, 0, 0] }
 
     test_vec_avg! { test_vec_avg_u16x8, u16x8,
-    [u16::max_value(), 0, 1, 2, 0, 0, 0, 0],
+    [u16::MAX, 0, 1, 2, 0, 0, 0, 0],
     [2, 1, 0, 0, 0, 0, 0, 0],
     [32769, 1, 1, 1, 0, 0, 0, 0] }
 
     test_vec_avg! { test_vec_avg_i8x16, i8x16,
-    [i8::min_value(), i8::max_value(), 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [i8::MIN, i8::MAX, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [-1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [-64, 64, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
 
     test_vec_avg! { test_vec_avg_u8x16, u8x16,
-    [u8::max_value(), 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [u8::MAX, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [129, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
 
@@ -2081,36 +2081,36 @@ mod tests {
     }
 
     test_vec_adds! { test_vec_adds_i32x4, i32x4,
-    [i32::min_value(), i32::max_value(), 1, -1],
+    [i32::MIN, i32::MAX, 1, -1],
     [-1, 1, 1, -1],
-    [i32::min_value(), i32::max_value(), 2, -2] }
+    [i32::MIN, i32::MAX, 2, -2] }
 
     test_vec_adds! { test_vec_adds_u32x4, u32x4,
-    [u32::max_value(), 0, 1, 2],
+    [u32::MAX, 0, 1, 2],
     [2, 1, 0, 0],
-    [u32::max_value(), 1, 1, 2] }
+    [u32::MAX, 1, 1, 2] }
 
     test_vec_adds! { test_vec_adds_i16x8, i16x8,
-    [i16::min_value(), i16::max_value(), 1, -1, 0, 0, 0, 0],
+    [i16::MIN, i16::MAX, 1, -1, 0, 0, 0, 0],
     [-1, 1, 1, -1, 0, 0, 0, 0],
-    [i16::min_value(), i16::max_value(), 2, -2, 0, 0, 0, 0] }
+    [i16::MIN, i16::MAX, 2, -2, 0, 0, 0, 0] }
 
     test_vec_adds! { test_vec_adds_u16x8, u16x8,
-    [u16::max_value(), 0, 1, 2, 0, 0, 0, 0],
+    [u16::MAX, 0, 1, 2, 0, 0, 0, 0],
     [2, 1, 0, 0, 0, 0, 0, 0],
-    [u16::max_value(), 1, 1, 2, 0, 0, 0, 0] }
+    [u16::MAX, 1, 1, 2, 0, 0, 0, 0] }
 
     test_vec_adds! { test_vec_adds_i8x16, i8x16,
-    [i8::min_value(), i8::max_value(), 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [i8::MIN, i8::MAX, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [-1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    [i8::min_value(), i8::max_value(), 2, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+    [i8::MIN, i8::MAX, 2, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
 
     test_vec_adds! { test_vec_adds_u8x16, u8x16,
-    [u8::max_value(), 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [u8::MAX, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    [u8::max_value(), 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+    [u8::MAX, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
 
-    test_vec_2! { test_vec_addc, vec_addc, u32x4, [u32::max_value(), 0, 0, 0], [1, 1, 1, 1], [1, 0, 0, 0] }
+    test_vec_2! { test_vec_addc, vec_addc, u32x4, [u32::MAX, 0, 0, 0], [1, 1, 1, 1], [1, 0, 0, 0] }
 
     macro_rules! test_vec_abs {
         { $name: ident, $ty: ident, $a: expr, $d: expr } => {
@@ -2482,9 +2482,9 @@ mod tests {
         ));
         let b: vector_signed_short = transmute(i16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
         let c: vector_signed_short =
-            transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, i16::max_value() - 1));
+            transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, i16::MAX - 1));
 
-        let d = i16x8::new(0, 3, 6, 9, 12, 15, 18, i16::max_value());
+        let d = i16x8::new(0, 3, 6, 9, 12, 15, 18, i16::MAX);
 
         assert_eq!(d, transmute(vec_mradds(a, b, c)));
     }

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -1862,23 +1862,23 @@ pub mod tests {
 
         test_i32x4_add => {
             [0i32, 0, 0, 0] (+ | i32x4_add) [1, 2, 3, 4],
-            [1i32, 1283, i32::max_value(), i32::min_value()]
+            [1i32, 1283, i32::MAX, i32::MIN]
                 (+ | i32x4_add)
-            [i32::max_value(); 4],
+            [i32::MAX; 4],
         }
 
         test_i32x4_sub => {
             [0i32, 0, 0, 0] (- | i32x4_sub) [1, 2, 3, 4],
-            [1i32, 1283, i32::max_value(), i32::min_value()]
+            [1i32, 1283, i32::MAX, i32::MIN]
                 (- | i32x4_sub)
-            [i32::max_value(); 4],
+            [i32::MAX; 4],
         }
 
         test_i32x4_mul => {
             [0i32, 0, 0, 0] (* | i32x4_mul) [1, 2, 3, 4],
-            [1i32, 1283, i32::max_value(), i32::min_value()]
+            [1i32, 1283, i32::MAX, i32::MIN]
                 (* | i32x4_mul)
-            [i32::max_value(); 4],
+            [i32::MAX; 4],
         }
 
         // TODO: test_i64x2_add
@@ -1904,7 +1904,7 @@ pub mod tests {
 
         test_i32x4_neg => {
             (- | i32x4_neg) [1i32, 2, 3, 4],
-            (- | i32x4_neg) [i32::min_value(), i32::max_value(), 0, 4],
+            (- | i32x4_neg) [i32::MIN, i32::MAX, 0, 4],
         }
 
         // TODO: test_i64x2_neg
@@ -2042,10 +2042,10 @@ pub mod tests {
     //
     //
     // test_bops!(i8x16[i8; 16] | shl[i8x16_shl_test]:
-    //            ([0, -1, 2, 3, 4, 5, 6, i8::max_value(), 1, 1, 1, 1, 1, 1, 1, 1], 1) =>
+    //            ([0, -1, 2, 3, 4, 5, 6, i8::MAX, 1, 1, 1, 1, 1, 1, 1, 1], 1) =>
     //            [0, -2, 4, 6, 8, 10, 12, -2, 2, 2, 2, 2, 2, 2, 2, 2]);
     // test_bops!(i16x8[i16; 8] | shl[i16x8_shl_test]:
-    //            ([0, -1, 2, 3, 4, 5, 6, i16::max_value()], 1) =>
+    //            ([0, -1, 2, 3, 4, 5, 6, i16::MAX], 1) =>
     //            [0, -2, 4, 6, 8, 10, 12, -2]);
     // test_bops!(i32x4[i32; 4] | shl[i32x4_shl_test]:
     //            ([0, -1, 2, 3], 1) => [0, -2, 4, 6]);
@@ -2053,32 +2053,32 @@ pub mod tests {
     //            ([0, -1], 1) => [0, -2]);
     //
     // test_bops!(i8x16[i8; 16] | shr_s[i8x16_shr_s_test]:
-    //            ([0, -1, 2, 3, 4, 5, 6, i8::max_value(), 1, 1, 1, 1, 1, 1, 1, 1], 1) =>
+    //            ([0, -1, 2, 3, 4, 5, 6, i8::MAX, 1, 1, 1, 1, 1, 1, 1, 1], 1) =>
     //            [0, -1, 1, 1, 2, 2, 3, 63, 0, 0, 0, 0, 0, 0, 0, 0]);
     // test_bops!(i16x8[i16; 8] | shr_s[i16x8_shr_s_test]:
-    //            ([0, -1, 2, 3, 4, 5, 6, i16::max_value()], 1) =>
-    //            [0, -1, 1, 1, 2, 2, 3, i16::max_value() / 2]);
+    //            ([0, -1, 2, 3, 4, 5, 6, i16::MAX], 1) =>
+    //            [0, -1, 1, 1, 2, 2, 3, i16::MAX / 2]);
     // test_bops!(i32x4[i32; 4] | shr_s[i32x4_shr_s_test]:
     //            ([0, -1, 2, 3], 1) => [0, -1, 1, 1]);
     // test_bops!(i64x2[i64; 2] | shr_s[i64x2_shr_s_test]:
     //            ([0, -1], 1) => [0, -1]);
     //
     // test_bops!(i8x16[i8; 16] | shr_u[i8x16_uhr_u_test]:
-    //            ([0, -1, 2, 3, 4, 5, 6, i8::max_value(), 1, 1, 1, 1, 1, 1, 1, 1], 1) =>
-    //            [0, i8::max_value(), 1, 1, 2, 2, 3, 63, 0, 0, 0, 0, 0, 0, 0, 0]);
+    //            ([0, -1, 2, 3, 4, 5, 6, i8::MAX, 1, 1, 1, 1, 1, 1, 1, 1], 1) =>
+    //            [0, i8::MAX, 1, 1, 2, 2, 3, 63, 0, 0, 0, 0, 0, 0, 0, 0]);
     // test_bops!(i16x8[i16; 8] | shr_u[i16x8_uhr_u_test]:
-    //            ([0, -1, 2, 3, 4, 5, 6, i16::max_value()], 1) =>
-    //            [0, i16::max_value(), 1, 1, 2, 2, 3, i16::max_value() / 2]);
+    //            ([0, -1, 2, 3, 4, 5, 6, i16::MAX], 1) =>
+    //            [0, i16::MAX, 1, 1, 2, 2, 3, i16::MAX / 2]);
     // test_bops!(i32x4[i32; 4] | shr_u[i32x4_uhr_u_test]:
-    //            ([0, -1, 2, 3], 1) => [0, i32::max_value(), 1, 1]);
+    //            ([0, -1, 2, 3], 1) => [0, i32::MAX, 1, 1]);
     // test_bops!(i64x2[i64; 2] | shr_u[i64x2_uhr_u_test]:
-    //            ([0, -1], 1) => [0, i64::max_value()]);
+    //            ([0, -1], 1) => [0, i64::MAX]);
     //
     // #[wasm_bindgen_test]
     // fn v128_bitwise_logical_ops() {
     //     unsafe {
-    //         let a: [u32; 4] = [u32::max_value(), 0, u32::max_value(), 0];
-    //         let b: [u32; 4] = [u32::max_value(); 4];
+    //         let a: [u32; 4] = [u32::MAX, 0, u32::MAX, 0];
+    //         let b: [u32; 4] = [u32::MAX; 4];
     //         let c: [u32; 4] = [0; 4];
     //
     //         let vec_a: v128 = transmute(a);
@@ -2312,8 +2312,8 @@ pub mod tests {
     //     f32x4_convert_u_i32x4
     //         | convert_u_i32x4
     //         | f32x4
-    //         | [u32::max_value(), 2, 3, 4],
-    //     [u32::max_value() as f32, 2., 3., 4.]
+    //         | [u32::MAX, 2, 3, 4],
+    //     [u32::MAX as f32, 2., 3., 4.]
     // );
     // test_conv!(
     //     f64x2_convert_s_i64x2 | convert_s_i64x2 | f64x2 | [1_i64, 2],
@@ -2323,12 +2323,12 @@ pub mod tests {
     //     f64x2_convert_u_i64x2
     //         | convert_u_i64x2
     //         | f64x2
-    //         | [u64::max_value(), 2],
+    //         | [u64::MAX, 2],
     //     [18446744073709552000.0, 2.]
     // );
     //
     // // FIXME: this fails, and produces -2147483648 instead of saturating at
-    // // i32::max_value() test_conv!(i32x4_trunc_s_f32x4_sat | trunc_s_f32x4_sat
-    // // | i32x4 | [1_f32, 2., (i32::max_value() as f32 + 1.), 4.],
-    // // [1_i32, 2, i32::max_value(), 4]); FIXME: add other saturating tests
+    // // i32::MAX test_conv!(i32x4_trunc_s_f32x4_sat | trunc_s_f32x4_sat
+    // // | i32x4 | [1_f32, 2., (i32::MAX as f32 + 1.), 4.],
+    // // [1_i32, 2, i32::MAX, 4]); FIXME: add other saturating tests
 }

--- a/crates/core_arch/src/x86/adx.rs
+++ b/crates/core_arch/src/x86/adx.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn test_addcarry_u32() {
         unsafe {
-            let a = u32::max_value();
+            let a = u32::MAX;
             let mut out = 0;
 
             let r = _addcarry_u32(0, a, 1, &mut out);
@@ -86,7 +86,7 @@ mod tests {
 
     #[simd_test(enable = "adx")]
     unsafe fn test_addcarryx_u32() {
-        let a = u32::max_value();
+        let a = u32::MAX;
         let mut out = 0;
 
         let r = _addcarryx_u32(0, a, 1, &mut out);
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn test_subborrow_u32() {
         unsafe {
-            let a = u32::max_value();
+            let a = u32::MAX;
             let mut out = 0;
 
             let r = _subborrow_u32(0, 0, 1, &mut out);

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -4046,14 +4046,14 @@ mod tests {
     unsafe fn test_mm256_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi32(
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
         );
         let r = _mm256_abs_epi32(a);
         #[rustfmt::skip]
         let e = _mm256_setr_epi32(
-            0, 1, 1, std::i32::MAX,
-            std::i32::MAX.wrapping_add(1), 100, 100, 32,
+            0, 1, 1, i32::MAX,
+            i32::MAX.wrapping_add(1), 100, 100, 32,
         );
         assert_eq_m256i(r, e);
     }
@@ -4063,13 +4063,13 @@ mod tests {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0,  1, -1, 2, -2, 3, -3, 4,
-            -4, 5, -5, std::i16::MAX, std::i16::MIN, 100, -100, -32,
+            -4, 5, -5, i16::MAX, i16::MIN, 100, -100, -32,
         );
         let r = _mm256_abs_epi16(a);
         #[rustfmt::skip]
         let e = _mm256_setr_epi16(
             0, 1, 1, 2, 2, 3, 3, 4,
-            4, 5, 5, std::i16::MAX, std::i16::MAX.wrapping_add(1), 100, 100, 32,
+            4, 5, 5, i16::MAX, i16::MAX.wrapping_add(1), 100, 100, 32,
         );
         assert_eq_m256i(r, e);
     }
@@ -4079,17 +4079,17 @@ mod tests {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 1, -1, 2, -2, 3, -3, 4,
-            -4, 5, -5, std::i8::MAX, std::i8::MIN, 100, -100, -32,
+            -4, 5, -5, i8::MAX, i8::MIN, 100, -100, -32,
             0, 1, -1, 2, -2, 3, -3, 4,
-            -4, 5, -5, std::i8::MAX, std::i8::MIN, 100, -100, -32,
+            -4, 5, -5, i8::MAX, i8::MIN, 100, -100, -32,
         );
         let r = _mm256_abs_epi8(a);
         #[rustfmt::skip]
         let e = _mm256_setr_epi8(
             0, 1, 1, 2, 2, 3, 3, 4,
-            4, 5, 5, std::i8::MAX, std::i8::MAX.wrapping_add(1), 100, 100, 32,
+            4, 5, 5, i8::MAX, i8::MAX.wrapping_add(1), 100, 100, 32,
             0, 1, 1, 2, 2, 3, 3, 4,
-            4, 5, 5, std::i8::MAX, std::i8::MAX.wrapping_add(1), 100, 100, 32,
+            4, 5, 5, i8::MAX, i8::MAX.wrapping_add(1), 100, 100, 32,
         );
         assert_eq_m256i(r, e);
     }

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -105,26 +105,26 @@ mod tests {
     unsafe fn test_mm512_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
         );
         let r = _mm512_abs_epi32(a);
         let e = _mm512_setr_epi32(
             0,
             1,
             1,
-            std::i32::MAX,
-            std::i32::MAX.wrapping_add(1),
+            i32::MAX,
+            i32::MAX.wrapping_add(1),
             100,
             100,
             32,
             0,
             1,
             1,
-            std::i32::MAX,
-            std::i32::MAX.wrapping_add(1),
+            i32::MAX,
+            i32::MAX.wrapping_add(1),
             100,
             100,
             32,
@@ -136,10 +136,10 @@ mod tests {
     unsafe fn test_mm512_mask_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
         );
         let r = _mm512_mask_abs_epi32(a, 0, a);
         assert_eq_m512i(r, a);
@@ -148,16 +148,16 @@ mod tests {
             0,
             1,
             1,
-            std::i32::MAX,
-            std::i32::MAX.wrapping_add(1),
+            i32::MAX,
+            i32::MAX.wrapping_add(1),
             100,
             100,
             32,
             0,
             1,
             -1,
-            std::i32::MAX,
-            std::i32::MIN,
+            i32::MAX,
+            i32::MIN,
             100,
             -100,
             -32,
@@ -169,10 +169,10 @@ mod tests {
     unsafe fn test_mm512_maskz_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
-            0, 1, -1, std::i32::MAX,
-            std::i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
+            0, 1, -1, i32::MAX,
+            i32::MIN, 100, -100, -32,
         );
         let r = _mm512_maskz_abs_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -181,8 +181,8 @@ mod tests {
             0,
             1,
             1,
-            std::i32::MAX,
-            std::i32::MAX.wrapping_add(1),
+            i32::MAX,
+            i32::MAX.wrapping_add(1),
             100,
             100,
             32,

--- a/crates/core_arch/src/x86/mmx.rs
+++ b/crates/core_arch/src/x86/mmx.rs
@@ -552,8 +552,8 @@ mod tests {
     #[simd_test(enable = "mmx")]
     unsafe fn test_mm_add_pi16() {
         let a = _mm_setr_pi16(-1, -1, 1, 1);
-        let b = _mm_setr_pi16(i16::min_value() + 1, 30001, -30001, i16::max_value() - 1);
-        let e = _mm_setr_pi16(i16::min_value(), 30000, -30000, i16::max_value());
+        let b = _mm_setr_pi16(i16::MIN + 1, 30001, -30001, i16::MAX - 1);
+        let e = _mm_setr_pi16(i16::MIN, 30000, -30000, i16::MAX);
         assert_eq_m64(e, _mm_add_pi16(a, b));
         assert_eq_m64(e, _m_paddw(a, b));
     }
@@ -561,8 +561,8 @@ mod tests {
     #[simd_test(enable = "mmx")]
     unsafe fn test_mm_add_pi32() {
         let a = _mm_setr_pi32(1, -1);
-        let b = _mm_setr_pi32(i32::max_value() - 1, i32::min_value() + 1);
-        let e = _mm_setr_pi32(i32::max_value(), i32::min_value());
+        let b = _mm_setr_pi32(i32::MAX - 1, i32::MIN + 1);
+        let e = _mm_setr_pi32(i32::MAX, i32::MIN);
         assert_eq_m64(e, _mm_add_pi32(a, b));
         assert_eq_m64(e, _m_paddd(a, b));
     }
@@ -571,7 +571,7 @@ mod tests {
     unsafe fn test_mm_adds_pi8() {
         let a = _mm_setr_pi8(-100, -1, 1, 100, -1, 0, 1, 0);
         let b = _mm_setr_pi8(-100, 1, -1, 100, 0, -1, 0, 1);
-        let e = _mm_setr_pi8(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
+        let e = _mm_setr_pi8(i8::MIN, 0, 0, i8::MAX, -1, -1, 1, 1);
         assert_eq_m64(e, _mm_adds_pi8(a, b));
         assert_eq_m64(e, _m_paddsb(a, b));
     }
@@ -580,7 +580,7 @@ mod tests {
     unsafe fn test_mm_adds_pi16() {
         let a = _mm_setr_pi16(-32000, 32000, 4, 0);
         let b = _mm_setr_pi16(-32000, 32000, -5, 1);
-        let e = _mm_setr_pi16(i16::min_value(), i16::max_value(), -1, 1);
+        let e = _mm_setr_pi16(i16::MIN, i16::MAX, -1, 1);
         assert_eq_m64(e, _mm_adds_pi16(a, b));
         assert_eq_m64(e, _m_paddsw(a, b));
     }
@@ -589,7 +589,7 @@ mod tests {
     unsafe fn test_mm_adds_pu8() {
         let a = _mm_setr_pi8(0, 1, 2, 3, 4, 5, 6, 200u8 as i8);
         let b = _mm_setr_pi8(0, 10, 20, 30, 40, 50, 60, 200u8 as i8);
-        let e = _mm_setr_pi8(0, 11, 22, 33, 44, 55, 66, u8::max_value() as i8);
+        let e = _mm_setr_pi8(0, 11, 22, 33, 44, 55, 66, u8::MAX as i8);
         assert_eq_m64(e, _mm_adds_pu8(a, b));
         assert_eq_m64(e, _m_paddusb(a, b));
     }
@@ -598,7 +598,7 @@ mod tests {
     unsafe fn test_mm_adds_pu16() {
         let a = _mm_setr_pi16(0, 1, 2, 60000u16 as i16);
         let b = _mm_setr_pi16(0, 10, 20, 60000u16 as i16);
-        let e = _mm_setr_pi16(0, 11, 22, u16::max_value() as i16);
+        let e = _mm_setr_pi16(0, 11, 22, u16::MAX as i16);
         assert_eq_m64(e, _mm_adds_pu16(a, b));
         assert_eq_m64(e, _m_paddusw(a, b));
     }
@@ -633,11 +633,11 @@ mod tests {
     #[simd_test(enable = "mmx")]
     unsafe fn test_mm_subs_pi8() {
         let a = _mm_setr_pi8(-100, 100, 0, 0, 0, 0, -5, 5);
-        let b = _mm_setr_pi8(100, -100, i8::min_value(), 127, -1, 1, 3, -3);
+        let b = _mm_setr_pi8(100, -100, i8::MIN, 127, -1, 1, 3, -3);
         let e = _mm_setr_pi8(
-            i8::min_value(),
-            i8::max_value(),
-            i8::max_value(),
+            i8::MIN,
+            i8::MAX,
+            i8::MAX,
             -127,
             1,
             -1,
@@ -652,7 +652,7 @@ mod tests {
     unsafe fn test_mm_subs_pi16() {
         let a = _mm_setr_pi16(-20000, 20000, 0, 0);
         let b = _mm_setr_pi16(20000, -20000, -1, 1);
-        let e = _mm_setr_pi16(i16::min_value(), i16::max_value(), 1, -1);
+        let e = _mm_setr_pi16(i16::MIN, i16::MAX, 1, -1);
         assert_eq_m64(e, _mm_subs_pi16(a, b));
         assert_eq_m64(e, _m_psubsw(a, b));
     }

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -3414,7 +3414,7 @@ mod tests {
     #[simd_test(enable = "sse")]
     unsafe fn test_mm_cvtss_si32() {
         let inputs = &[42.0f32, -3.1, 4.0e10, 4.0e-20, NAN, 2147483500.1];
-        let result = &[42i32, -3, i32::min_value(), 0, i32::min_value(), 2147483520];
+        let result = &[42i32, -3, i32::MIN, 0, i32::MIN, 2147483520];
         for i in 0..inputs.len() {
             let x = _mm_setr_ps(inputs[i], 1.0, 3.0, 4.0);
             let e = result[i];
@@ -3436,9 +3436,9 @@ mod tests {
             (-34.5, -34),
             (10.999, 10),
             (-5.99, -5),
-            (4.0e10, i32::min_value()),
+            (4.0e10, i32::MIN),
             (4.0e-10, 0),
-            (NAN, i32::min_value()),
+            (NAN, i32::MIN),
             (2147483500.1, 2147483520),
         ];
         for i in 0..inputs.len() {

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -5229,7 +5229,6 @@ mod tests {
 
     #[simd_test(enable = "sse2,mmx")]
     unsafe fn test_mm_cvttpd_pi32() {
-        use std::{f64, i32};
 
         let a = _mm_setr_pd(5., 0.);
         let r = _mm_cvttpd_pi32(a);

--- a/crates/core_arch/src/x86_64/adx.rs
+++ b/crates/core_arch/src/x86_64/adx.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn test_addcarry_u64() {
         unsafe {
-            let a = u64::max_value();
+            let a = u64::MAX;
             let mut out = 0;
 
             let r = _addcarry_u64(0, a, 1, &mut out);
@@ -86,7 +86,7 @@ mod tests {
 
     #[simd_test(enable = "adx")]
     unsafe fn test_addcarryx_u64() {
-        let a = u64::max_value();
+        let a = u64::MAX;
         let mut out = 0;
 
         let r = _addcarry_u64(0, a, 1, &mut out);
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_subborrow_u64() {
         unsafe {
-            let a = u64::max_value();
+            let a = u64::MAX;
             let mut out = 0;
 
             let r = _subborrow_u64(0, 0, 1, &mut out);

--- a/crates/core_arch/src/x86_64/sse.rs
+++ b/crates/core_arch/src/x86_64/sse.rs
@@ -71,7 +71,6 @@ pub unsafe fn _mm_cvtsi64_ss(a: __m128, b: i64) -> __m128 {
 #[cfg(test)]
 mod tests {
     use crate::core_arch::arch::x86_64::*;
-    use std::{f32::NAN, i64::MIN};
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse")]
@@ -83,7 +82,7 @@ mod tests {
             (-34.5, -34),
             (4.0e10, 40_000_000_000),
             (4.0e-10, 0),
-            (NAN, MIN),
+            (f32::NAN, i64::MIN),
             (2147483500.1, 2147483520),
             (9.223371e18, 9223370937343148032),
         ];
@@ -110,10 +109,10 @@ mod tests {
             (-5.99, -5),
             (4.0e10, 40_000_000_000),
             (4.0e-10, 0),
-            (NAN, MIN),
+            (f32::NAN, i64::MIN),
             (2147483500.1, 2147483520),
             (9.223371e18, 9223370937343148032),
-            (9.223372e18, MIN),
+            (9.223372e18, i64::MIN),
         ];
         for i in 0..inputs.len() {
             let (xi, e) = inputs[i];

--- a/crates/core_arch/src/x86_64/sse2.rs
+++ b/crates/core_arch/src/x86_64/sse2.rs
@@ -148,7 +148,7 @@ pub unsafe fn _mm_cvtsi64x_sd(a: __m128d, b: i64) -> __m128d {
 #[cfg(test)]
 mod tests {
     use crate::core_arch::arch::x86_64::*;
-    use std::{boxed, f64, i64};
+    use std::boxed;
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse2")]

--- a/crates/std_detect/src/detect/cache.rs
+++ b/crates/std_detect/src/detect/cache.rs
@@ -98,12 +98,12 @@ impl Cache {
     /// Creates an uninitialized cache.
     #[allow(clippy::declare_interior_mutable_const)]
     const fn uninitialized() -> Self {
-        Cache(AtomicUsize::new(usize::max_value()))
+        Cache(AtomicUsize::new(usize::MAX))
     }
     /// Is the cache uninitialized?
     #[inline]
     pub(crate) fn is_uninitialized(&self) -> bool {
-        self.0.load(Ordering::SeqCst) == usize::max_value()
+        self.0.load(Ordering::SeqCst) == usize::MAX
     }
 
     /// Is the `bit` in the cache set?

--- a/examples/wasm.rs
+++ b/examples/wasm.rs
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn page_alloc() -> *mut u8 {
     let ret = memory_grow(0, 1);
 
     // if we failed to allocate a page then return null
-    if ret == usize::max_value() {
+    if ret == usize::MAX {
         return ptr::null_mut();
     }
 


### PR DESCRIPTION
Using the primitive type associated constants throughout stdarch

* Stop importing `std::<int/float type>` since those constants are now available on the primitive types directly.
* Search and replace all instances of `min_value()` with `MIN` and `max_value()` with `MAX`.
* Remove `std::` from all `std::<int/float type>::MIN/MAX` usage.

If reviewing seems too daunting or the usage of `min_value` and `max_value` does not seem that bad, I can remove that specific commit since it's most of the lines. The other two commits should at least stop using the std modules, which is a good step in the right direction and would entail far fewer changes.

r? @dtolnay 