### PR TITLE
Unbreak non-x86 build on FreeBSD

### DIFF
--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -100,7 +100,7 @@ cfg_if! {
     } else if #[cfg(all(target_os = "linux", feature = "use_std"))] {
         #[path = "os/linux/mod.rs"]
         mod os;
-    } else if #[cfg(target_os = "freebsd")] {
+    } else if #[cfg(all(target_os = "freebsd", feature = "use_std"))] {
         #[cfg(target_arch = "aarch64")]
         #[path = "os/aarch64.rs"]
         mod aarch64;


### PR DESCRIPTION
```
error[E0432]: unresolved import `self::arm::check_for`
  --> src/libstd/../stdarch/crates/std_detect/src/detect/os/freebsd/mod.rs:11:17
   |
11 |         pub use self::arm::check_for;
   |                 ^^^^^^^^^^^^^^^^^^^^ no `check_for` in `std_detect::detect::os::arm`

error[E0425]: cannot find value `detect_features` in module `self::os`
   --> src/libstd/../stdarch/crates/std_detect/src/detect/mod.rs:121:37
    |
121 |     cache::test(x as u32, self::os::detect_features)
    |                                     ^^^^^^^^^^^^^^^ not found in `self::os`
    |
help: possible candidate is found in another module, you can import it into scope
    |
20  | use crate::std_detect::detect::os::arm::detect_features;
```
Regressed by: https://github.com/rust-lang/stdarch/commit/9fad9649a117ecbf1a84be3953183bba36f62f23
Found during Rust 1.43.0 package update: https://reviews.freebsd.org/D24521
Submitted by: @MikaelUrankar 