### PR TITLE
Manually preserve rbx across cpuid instruction

### DIFF
--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -65,6 +65,8 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     #[cfg(target_arch = "x86_64")]
     {
         // x86-64 uses %rbx as the base register, so preserve it.
+        // This works around a bug in LLVM with ASAN enabled:
+        // https://bugs.llvm.org/show_bug.cgi?id=17907
         llvm_asm!(r#"
                   mov %rbx, %rsi
                   cpuid

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -65,10 +65,14 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     #[cfg(target_arch = "x86_64")]
     {
         // x86-64 uses %rbx as the base register, so preserve it.
-        llvm_asm!("cpuid"
-                  : "={eax}"(eax), "={ebx}"(ebx), "={ecx}"(ecx), "={edx}"(edx)
+        llvm_asm!(r#"
+                  mov %rbx, %rsi
+                  cpuid
+                  xchg %rbx, %rsi
+                  "#
+                  : "={eax}"(eax), "={esi}"(ebx), "={ecx}"(ecx), "={edx}"(edx)
                   : "{eax}"(leaf), "{ecx}"(sub_leaf)
-                  : "rbx" :);
+                  : :);
     }
     CpuidResult { eax, ebx, ecx, edx }
 }


### PR DESCRIPTION
This fixes an issue observed when using __cpuid and __cpuid_count with
Address Sanitizer enabled: the generated code uses the rbx register to
access ASAN tracking information without reloading it after cpuid,
resulting in a segfault since the rbx register is overwritten by cpuid
(https://crbug.com/1072045).

This seems like a compiler backend bug, and indeed there is a
long-standing LLVM bug report about a very similar issue:
https://bugs.llvm.org/show_bug.cgi?id=17907

To work around this issue, we can manually preserve the rbx register
contents in the inline assembly.  This is the approach taken by LLVM's
own host cpuid detection code (lib/Host/Support.cpp).  The original rbx
value is stashed in rsi, which is then swapped with rbx to restore the
original value as well as keep the output ebx value from the CPUID
instruction to be used as an output of the inline assembly.

The rbx clobber is also removed; this seems ineffective, and it
conflicts with the ebx output of the inline assembly (ebx is a
subregister of rbx): "Note that clobbering named registers that are also
present in output constraints is not legal."
(https://llvm.org/docs/LangRef.html#clobber-constraints)