### PR TITLE
Fix non-fp64 libcore builds

### DIFF
--- a/crates/core_arch/src/mips/mod.rs
+++ b/crates/core_arch/src/mips/mod.rs
@@ -1,7 +1,12 @@
 //! MIPS
 
-mod msa;
-pub use self::msa::*;
+// Building this module (even if unused) for non-fp64 targets such as the Sony
+// PSP fails with an LLVM error. There doesn't seem to be a good way to detect
+// fp64 support as it is sometimes implied by the target cpu, so
+// `#[cfg(target_feature = "fp64")]` will unfortunately not work. This is a
+// fairly conservative workaround that only disables MSA intrinsics for the PSP.
+#[cfg(not(target_os = "psp"))] mod msa;
+#[cfg(not(target_os = "psp"))] pub use self::msa::*;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/mips/mod.rs
+++ b/crates/core_arch/src/mips/mod.rs
@@ -1,13 +1,10 @@
 //! MIPS
 
-// Building this module (even if unused) for non-fp64 targets such as the Sony
-// PSP fails with an LLVM error. There doesn't seem to be a good way to detect
-// fp64 support as it is sometimes implied by the target cpu, so
-// `#[cfg(target_feature = "fp64")]` will unfortunately not work. This is a
-// fairly conservative workaround that only disables MSA intrinsics for the PSP.
-#[cfg(not(target_os = "psp"))]
+// Building this module (even if unused) for non-fp64 targets fails with an LLVM
+// error.
+#[cfg(target_feature = "fp64")]
 mod msa;
-#[cfg(not(target_os = "psp"))]
+#[cfg(target_feature = "fp64")]
 pub use self::msa::*;
 
 #[cfg(test)]

--- a/crates/core_arch/src/mips/mod.rs
+++ b/crates/core_arch/src/mips/mod.rs
@@ -5,8 +5,10 @@
 // fp64 support as it is sometimes implied by the target cpu, so
 // `#[cfg(target_feature = "fp64")]` will unfortunately not work. This is a
 // fairly conservative workaround that only disables MSA intrinsics for the PSP.
-#[cfg(not(target_os = "psp"))] mod msa;
-#[cfg(not(target_os = "psp"))] pub use self::msa::*;
+#[cfg(not(target_os = "psp"))]
+mod msa;
+#[cfg(not(target_os = "psp"))]
+pub use self::msa::*;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;


### PR DESCRIPTION
Building the MIPS MSA module for non-`fp64` targets fails with an LLVM error. This PR blacklists PSP OS targets from MSA support in order to fix building libcore.