### PR TITLE
Convert __mmask16 to use an unsigned type

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -344,7 +344,7 @@ types! {
 
 /// The `__mmask16` type used in AVX-512 intrinsics, a 16-bit integer
 #[allow(non_camel_case_types)]
-pub type __mmask16 = i16;
+pub type __mmask16 = u16;
 
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
To be consistent with Clang:

https://github.com/llvm/llvm-project/blob/1b02db52b79e01f038775f59193a49850a34184d/clang/lib/Headers/avx512fintrin.h#L37

and to simplify literals where you want to set the top bit to 1.