### PR TITLE
Disable bootstrap for stage0

### DIFF
--- a/crates/core_arch/src/aarch64/mod.rs
+++ b/crates/core_arch/src/aarch64/mod.rs
@@ -15,7 +15,9 @@ pub use self::neon::*;
 mod crypto;
 pub use self::crypto::*;
 
+#[cfg(not(bootstrap))]
 mod tme;
+#[cfg(not(bootstrap))]
 pub use self::tme::*;
 
 mod crc;


### PR DESCRIPTION
Amanieu mentioned that stage0 build should exclude TME for Aarch64 in here: https://github.com/rust-lang/rust/pull/72749#issuecomment-636148778

r? @Amanieu 