### PR TITLE
Clarify documentation about wasm32 target_feature gates

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -57,6 +57,13 @@ pub mod arch {
 
     /// Platform-specific intrinsics for the `wasm32` platform.
     ///
+
+    /// # Availability
+    ///
+    /// Note that intrinsics gated by `target_feature = "atomics"` or `target_feature = "simd128"`
+    /// are only available **when the standard library itself is compiled with the the respective
+    /// target feature**. This version of the standard library is not obtainable via `rustup`,
+    /// but rather will require the standard library to be compiled from source.
     /// See the [module documentation](../index.html) for more details.
     #[cfg(any(target_arch = "wasm32", dox))]
     #[doc(cfg(target_arch = "wasm32"))]


### PR DESCRIPTION
Most wasm32 SIMD intrinsics are available behind a feature gate only after recompiling libcore with relevant `target_feature`. This is documented for [atomic_notify](https://doc.rust-lang.org/core/arch/wasm32/fn.atomic_notify.html), for example but is not documented for any of the `simd128`-gated intrinsics. Unlike the atomics, it would probably not make sense to add this comment above each function so here is my attempt at putting it somewhere visible globally to make sure it is clear that recompilation of libcore is needed. 