### PR TITLE
Fix x86 extract_epi{8,16} functions

### DIFF
--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3743,9 +3743,9 @@ pub unsafe fn _mm256_xor_si256(a: __m256i, b: __m256i) -> __m256i {
 // This intrinsic has no corresponding instruction.
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_extract_epi8(a: __m256i, imm8: i32) -> i8 {
+pub unsafe fn _mm256_extract_epi8(a: __m256i, imm8: i32) -> i32 {
     let imm8 = (imm8 & 31) as u32;
-    simd_extract(a.as_i8x32(), imm8)
+    simd_extract::<_, u8>(a.as_u8x32(), imm8) as i32
 }
 
 /// Extracts a 16-bit integer from `a`, selected with `imm8`. Returns a 32-bit
@@ -3759,9 +3759,9 @@ pub unsafe fn _mm256_extract_epi8(a: __m256i, imm8: i32) -> i8 {
 // This intrinsic has no corresponding instruction.
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_extract_epi16(a: __m256i, imm8: i32) -> i16 {
+pub unsafe fn _mm256_extract_epi16(a: __m256i, imm8: i32) -> i32 {
     let imm8 = (imm8 & 15) as u32;
-    simd_extract(a.as_i16x16(), imm8)
+    simd_extract::<_, u16>(a.as_u16x16(), imm8) as i32
 }
 
 /// Extracts a 32-bit integer from `a`, selected with `imm8`.
@@ -6115,7 +6115,7 @@ mod tests {
         );
         let r1 = _mm256_extract_epi8(a, 0);
         let r2 = _mm256_extract_epi8(a, 35);
-        assert_eq!(r1, -1);
+        assert_eq!(r1, 0xFF);
         assert_eq!(r2, 3);
     }
 
@@ -6128,7 +6128,7 @@ mod tests {
         );
         let r1 = _mm256_extract_epi16(a, 0);
         let r2 = _mm256_extract_epi16(a, 19);
-        assert_eq!(r1, -1);
+        assert_eq!(r1, 0xFFFF);
         assert_eq!(r2, 3);
     }
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1375,7 +1375,7 @@ pub unsafe fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_epi16(a: __m128i, imm8: i32) -> i32 {
-    simd_extract::<_, i16>(a.as_i16x8(), (imm8 & 7) as u32) as i32
+    simd_extract::<_, u16>(a.as_u16x8(), (imm8 & 7) as u32) as i32
 }
 
 /// Returns a new vector where the `imm8` element of `a` is replaced with `i`.
@@ -4132,7 +4132,7 @@ mod tests {
         let a = _mm_setr_epi16(-1, 1, 2, 3, 4, 5, 6, 7);
         let r1 = _mm_extract_epi16(a, 0);
         let r2 = _mm_extract_epi16(a, 11);
-        assert_eq!(r1, -1);
+        assert_eq!(r1, 0xFFFF);
         assert_eq!(r2, 3);
     }
 

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -95,7 +95,8 @@ struct Data {
 
 #[derive(Deserialize)]
 struct Intrinsic {
-    rettype: String,
+    #[serde(rename = "return")]
+    return_: Return,
     name: String,
     #[serde(rename = "CPUID", default)]
     cpuid: Vec<String>,
@@ -107,6 +108,12 @@ struct Intrinsic {
 
 #[derive(Deserialize)]
 struct Parameter {
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Deserialize)]
+struct Return {
     #[serde(rename = "type")]
     type_: String,
 }
@@ -503,12 +510,12 @@ fn matches(rust: &Function, intel: &Intrinsic) -> Result<(), String> {
 
     // Make sure we've got the right return type.
     if let Some(t) = rust.ret {
-        equate(t, &intel.rettype, rust.name, false)?;
-    } else if intel.rettype != "" && intel.rettype != "void" {
+        equate(t, &intel.return_.type_, rust.name, false)?;
+    } else if intel.return_.type_ != "" && intel.return_.type_ != "void" {
         bail!(
             "{} returns `{}` with intel, void in rust",
             rust.name,
-            intel.rettype
+            intel.return_.type_
         )
     }
 


### PR DESCRIPTION
* Update Intel intrinsics definitions with the latest version
  * Surprisingly, the only thing that changed in terms of function signatures is exactly the inconsistency I pointed out in #867.
* Update _mm256_extract_epi{8,16} to match latest definition
* Fix _mm_extract_epi16 sign extension

Fixes #867