### PR TITLE
Make function signatures consistent

### DIFF
--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -161,13 +161,13 @@ extern "C" {
     fn msa_aver_s_w(a: v4i32, b: v4i32) -> v4i32;
     #[link_name = "llvm.mips.aver.s.d"]
     fn msa_aver_s_d(a: v2i64, b: v2i64) -> v2i64;
-    #[link_name = "llvm.mips.aver.s.b"]
+    #[link_name = "llvm.mips.aver.u.b"]
     fn msa_aver_u_b(a: v16u8, b: v16u8) -> v16u8;
-    #[link_name = "llvm.mips.aver.s.h"]
+    #[link_name = "llvm.mips.aver.u.h"]
     fn msa_aver_u_h(a: v8u16, b: v8u16) -> v8u16;
-    #[link_name = "llvm.mips.aver.s.w"]
+    #[link_name = "llvm.mips.aver.u.w"]
     fn msa_aver_u_w(a: v4u32, b: v4u32) -> v4u32;
-    #[link_name = "llvm.mips.aver.s.d"]
+    #[link_name = "llvm.mips.aver.u.d"]
     fn msa_aver_u_d(a: v2u64, b: v2u64) -> v2u64;
     #[link_name = "llvm.mips.bclr.b"]
     fn msa_bclr_b(a: v16u8, b: v16u8) -> v16u8;
@@ -415,7 +415,7 @@ extern "C" {
     fn msa_dpadd_s_w(a: v4i32, b: v8i16, c: v8i16) -> v4i32;
     #[link_name = "llvm.mips.dpadd.s.d"]
     fn msa_dpadd_s_d(a: v2i64, b: v4i32, c: v4i32) -> v2i64;
-    #[link_name = "llvm.mips.dpadd.s.h"]
+    #[link_name = "llvm.mips.dpadd.u.h"]
     fn msa_dpadd_u_h(a: v8u16, b: v16u8, c: v16u8) -> v8u16;
     #[link_name = "llvm.mips.dpadd.u.w"]
     fn msa_dpadd_u_w(a: v4u32, b: v8u16, c: v8u16) -> v4u32;

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -3187,17 +3187,17 @@ extern "C" {
     #[link_name = "llvm.x86.avx.hsub.ps.256"]
     fn vhsubps(a: __m256, b: __m256) -> __m256;
     #[link_name = "llvm.x86.sse2.cmp.pd"]
-    fn vcmppd(a: __m128d, b: __m128d, imm8: u8) -> __m128d;
+    fn vcmppd(a: __m128d, b: __m128d, imm8: i8) -> __m128d;
     #[link_name = "llvm.x86.avx.cmp.pd.256"]
     fn vcmppd256(a: __m256d, b: __m256d, imm8: u8) -> __m256d;
     #[link_name = "llvm.x86.sse.cmp.ps"]
-    fn vcmpps(a: __m128, b: __m128, imm8: u8) -> __m128;
+    fn vcmpps(a: __m128, b: __m128, imm8: i8) -> __m128;
     #[link_name = "llvm.x86.avx.cmp.ps.256"]
     fn vcmpps256(a: __m256, b: __m256, imm8: u8) -> __m256;
     #[link_name = "llvm.x86.sse2.cmp.sd"]
-    fn vcmpsd(a: __m128d, b: __m128d, imm8: u8) -> __m128d;
+    fn vcmpsd(a: __m128d, b: __m128d, imm8: i8) -> __m128d;
     #[link_name = "llvm.x86.sse.cmp.ss"]
-    fn vcmpss(a: __m128, b: __m128, imm8: u8) -> __m128;
+    fn vcmpss(a: __m128, b: __m128, imm8: i8) -> __m128;
     #[link_name = "llvm.x86.avx.cvtdq2.ps.256"]
     fn vcvtdq2ps(a: i32x8) -> __m256;
     #[link_name = "llvm.x86.avx.cvt.pd2.ps.256"]


### PR DESCRIPTION
On newer nightlies, the fact that these function signatures conflicted caused warnings that failed CI. I chose to convert unsigned to signed to be consistent with the LLVM signature.

Example failure: https://github.com/rust-lang/stdarch/runs/835662285