### PR TITLE
Constify all x86 rustc_args_required_const intrinsics

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1579,7 +1579,13 @@ pub unsafe fn _mm256_insertf128_si256(a: __m256i, b: __m128i, imm8: i32) -> __m2
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insert_epi8(a: __m256i, i: i8, index: i32) -> __m256i {
-    transmute(simd_insert(a.as_i8x32(), (index as u32) & 31, i))
+    let a = a.as_i8x32();
+    macro_rules! call {
+        ($index:expr) => {
+            simd_insert(a, $index, i)
+        };
+    }
+    transmute(constify_imm5!(index, call))
 }
 
 /// Copies `a` to result, and inserts the 16-bit integer `i` into result
@@ -1592,7 +1598,13 @@ pub unsafe fn _mm256_insert_epi8(a: __m256i, i: i8, index: i32) -> __m256i {
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insert_epi16(a: __m256i, i: i16, index: i32) -> __m256i {
-    transmute(simd_insert(a.as_i16x16(), (index as u32) & 15, i))
+    let a = a.as_i16x16();
+    macro_rules! call {
+        ($index:expr) => {
+            simd_insert(a, $index, i)
+        };
+    }
+    transmute(constify_imm4!((index & 15), call))
 }
 
 /// Copies `a` to result, and inserts the 32-bit integer `i` into result
@@ -1605,7 +1617,13 @@ pub unsafe fn _mm256_insert_epi16(a: __m256i, i: i16, index: i32) -> __m256i {
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insert_epi32(a: __m256i, i: i32, index: i32) -> __m256i {
-    transmute(simd_insert(a.as_i32x8(), (index as u32) & 7, i))
+    let a = a.as_i32x8();
+    macro_rules! call {
+        ($index:expr) => {
+            simd_insert(a, $index, i)
+        };
+    }
+    transmute(constify_imm8!((index & 7), call))
 }
 
 /// Loads 256-bits (composed of 4 packed double-precision (64-bit)

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3744,8 +3744,13 @@ pub unsafe fn _mm256_xor_si256(a: __m256i, b: __m256i) -> __m256i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extract_epi8(a: __m256i, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 31) as u32;
-    simd_extract::<_, u8>(a.as_u8x32(), imm8) as i32
+    let a = a.as_u8x32();
+    macro_rules! call {
+        ($imm5:expr) => {
+            simd_extract::<_, u8>(a, $imm5) as i32
+        };
+    }
+    constify_imm5!(imm8, call)
 }
 
 /// Extracts a 16-bit integer from `a`, selected with `imm8`. Returns a 32-bit
@@ -3760,8 +3765,13 @@ pub unsafe fn _mm256_extract_epi8(a: __m256i, imm8: i32) -> i32 {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extract_epi16(a: __m256i, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 15) as u32;
-    simd_extract::<_, u16>(a.as_u16x16(), imm8) as i32
+    let a = a.as_u16x16();
+    macro_rules! call {
+        ($imm4:expr) => {
+            simd_extract::<_, u16>(a, $imm4) as i32
+        };
+    }
+    constify_imm4!((imm8 & 15), call)
 }
 
 /// Extracts a 32-bit integer from `a`, selected with `imm8`.
@@ -3773,8 +3783,13 @@ pub unsafe fn _mm256_extract_epi16(a: __m256i, imm8: i32) -> i32 {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extract_epi32(a: __m256i, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 7) as u32;
-    simd_extract(a.as_i32x8(), imm8)
+    let a = a.as_i32x8();
+    macro_rules! call {
+        ($imm3:expr) => {
+            simd_extract(a, $imm3)
+        };
+    }
+    constify_imm3!((imm8 & 7), call)
 }
 
 /// Returns the first element of the input vector of `[4 x double]`.

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -506,7 +506,13 @@ pub unsafe fn _mm_bsrli_si128(a: __m128i, imm8: i32) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_slli_epi16(a: __m128i, imm8: i32) -> __m128i {
-    transmute(pslliw(a.as_i16x8(), imm8))
+    let a = a.as_i16x8();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(pslliw(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 16-bit integers in `a` left by `count` while shifting in
@@ -530,7 +536,13 @@ pub unsafe fn _mm_sll_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_slli_epi32(a: __m128i, imm8: i32) -> __m128i {
-    transmute(psllid(a.as_i32x4(), imm8))
+    let a = a.as_i32x4();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(psllid(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 32-bit integers in `a` left by `count` while shifting in
@@ -554,7 +566,13 @@ pub unsafe fn _mm_sll_epi32(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_slli_epi64(a: __m128i, imm8: i32) -> __m128i {
-    transmute(pslliq(a.as_i64x2(), imm8))
+    let a = a.as_i64x2();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(pslliq(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 64-bit integers in `a` left by `count` while shifting in
@@ -579,7 +597,13 @@ pub unsafe fn _mm_sll_epi64(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srai_epi16(a: __m128i, imm8: i32) -> __m128i {
-    transmute(psraiw(a.as_i16x8(), imm8))
+    let a = a.as_i16x8();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(psraiw(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 16-bit integers in `a` right by `count` while shifting in sign
@@ -604,7 +628,13 @@ pub unsafe fn _mm_sra_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srai_epi32(a: __m128i, imm8: i32) -> __m128i {
-    transmute(psraid(a.as_i32x4(), imm8))
+    let a = a.as_i32x4();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(psraid(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 32-bit integers in `a` right by `count` while shifting in sign
@@ -696,7 +726,13 @@ unsafe fn _mm_srli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srli_epi16(a: __m128i, imm8: i32) -> __m128i {
-    transmute(psrliw(a.as_i16x8(), imm8))
+    let a = a.as_i16x8();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(psrliw(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 16-bit integers in `a` right by `count` while shifting in
@@ -721,7 +757,13 @@ pub unsafe fn _mm_srl_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srli_epi32(a: __m128i, imm8: i32) -> __m128i {
-    transmute(psrlid(a.as_i32x4(), imm8))
+    let a = a.as_i32x4();
+    macro_rules! call {
+        ($imm8:expr) => {
+            transmute(psrlid(a, $imm8))
+        };
+    }
+    constify_imm8!(imm8, call)
 }
 
 /// Shifts packed 32-bit integers in `a` right by `count` while shifting in
@@ -1375,7 +1417,13 @@ pub unsafe fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_epi16(a: __m128i, imm8: i32) -> i32 {
-    simd_extract::<_, u16>(a.as_u16x8(), (imm8 & 7) as u32) as i32
+    let a = a.as_u16x8();
+    macro_rules! call {
+        ($imm3:expr) => {
+            simd_extract::<_, u16>(a, $imm3) as i32
+        };
+    }
+    constify_imm3!(imm8, call)
 }
 
 /// Returns a new vector where the `imm8` element of `a` is replaced with `i`.
@@ -1387,7 +1435,13 @@ pub unsafe fn _mm_extract_epi16(a: __m128i, imm8: i32) -> i32 {
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_insert_epi16(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    transmute(simd_insert(a.as_i16x8(), (imm8 & 7) as u32, i as i16))
+    let a = a.as_i16x8();
+    macro_rules! call {
+        ($imm3:expr) => {
+            transmute(simd_insert(a, $imm3, i as i16))
+        };
+    }
+    constify_imm3!(imm8, call)
 }
 
 /// Returns a mask of the most significant bit of each element in `a`.

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -167,7 +167,12 @@ pub unsafe fn _mm_blend_ps(a: __m128, b: __m128, imm4: i32) -> __m128 {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_ps(a: __m128, imm8: i32) -> i32 {
-    transmute(simd_extract::<_, f32>(a, imm8 as u32 & 0b11))
+    macro_rules! call {
+        ($imm2:expr) => {
+            transmute(simd_extract::<_, f32>(a, $imm2))
+        };
+    }
+    constify_imm2!(imm8, call)
 }
 
 /// Extracts an 8-bit integer from `a`, selected with `imm8`. Returns a 32-bit
@@ -182,8 +187,13 @@ pub unsafe fn _mm_extract_ps(a: __m128, imm8: i32) -> i32 {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_epi8(a: __m128i, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 15) as u32;
-    simd_extract::<_, u8>(a.as_u8x16(), imm8) as i32
+    let a = a.as_u8x16();
+    macro_rules! call {
+        ($imm4:expr) => {
+            simd_extract::<_, u8>(a, $imm4) as i32
+        };
+    }
+    constify_imm4!(imm8, call)
 }
 
 /// Extracts an 32-bit integer from `a` selected with `imm8`
@@ -198,8 +208,13 @@ pub unsafe fn _mm_extract_epi8(a: __m128i, imm8: i32) -> i32 {
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_epi32(a: __m128i, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 3) as u32;
-    simd_extract::<_, i32>(a.as_i32x4(), imm8)
+    let a = a.as_i32x4();
+    macro_rules! call {
+        ($imm2:expr) => {
+            simd_extract::<_, i32>(a, $imm2)
+        };
+    }
+    constify_imm2!(imm8, call)
 }
 
 /// Select a single value in `a` to store at some position in `b`,
@@ -250,7 +265,13 @@ pub unsafe fn _mm_insert_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_insert_epi8(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    transmute(simd_insert(a.as_i8x16(), (imm8 & 0b1111) as u32, i as i8))
+    let a = a.as_i8x16();
+    macro_rules! call {
+        ($imm4:expr) => {
+            transmute(simd_insert(a, $imm4, i as i8))
+        };
+    }
+    constify_imm4!(imm8, call)
 }
 
 /// Returns a copy of `a` with the 32-bit integer from `i` inserted at a
@@ -263,7 +284,13 @@ pub unsafe fn _mm_insert_epi8(a: __m128i, i: i32, imm8: i32) -> __m128i {
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_insert_epi32(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    transmute(simd_insert(a.as_i32x4(), (imm8 & 0b11) as u32, i))
+    let a = a.as_i32x4();
+    macro_rules! call {
+        ($imm2:expr) => {
+            transmute(simd_insert(a, $imm2, i))
+        };
+    }
+    constify_imm2!(imm8, call)
 }
 
 /// Compares packed 8-bit integers in `a` and `b` and returns packed maximum

--- a/crates/core_arch/src/x86_64/avx.rs
+++ b/crates/core_arch/src/x86_64/avx.rs
@@ -28,7 +28,13 @@ use crate::{
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insert_epi64(a: __m256i, i: i64, index: i32) -> __m256i {
-    transmute(simd_insert(a.as_i64x4(), (index as u32) & 3, i))
+    let a = a.as_i64x4();
+    match index & 3 {
+        0 => transmute(simd_insert(a, 0, i)),
+        1 => transmute(simd_insert(a, 1, i)),
+        2 => transmute(simd_insert(a, 2, i)),
+        _ => transmute(simd_insert(a, 3, i)),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86_64/avx2.rs
+++ b/crates/core_arch/src/x86_64/avx2.rs
@@ -29,8 +29,13 @@ use crate::core_arch::{simd_llvm::*, x86::*};
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extract_epi64(a: __m256i, imm8: i32) -> i64 {
-    let imm8 = (imm8 & 3) as u32;
-    simd_extract(a.as_i64x4(), imm8)
+    let a = a.as_i64x4();
+    match imm8 & 3 {
+        0 => simd_extract(a, 0),
+        1 => simd_extract(a, 1),
+        2 => simd_extract(a, 2),
+        _ => simd_extract(a, 3),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86_64/sse41.rs
+++ b/crates/core_arch/src/x86_64/sse41.rs
@@ -17,8 +17,11 @@ use stdarch_test::assert_instr;
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_epi64(a: __m128i, imm8: i32) -> i64 {
-    let imm8 = (imm8 & 1) as u32;
-    simd_extract(a.as_i64x2(), imm8)
+    let a = a.as_i64x2();
+    match imm8 & 1 {
+        0 => simd_extract(a, 0),
+        _ => simd_extract(a, 1),
+    }
 }
 
 /// Returns a copy of `a` with the 64-bit integer from `i` inserted at a
@@ -31,7 +34,11 @@ pub unsafe fn _mm_extract_epi64(a: __m128i, imm8: i32) -> i64 {
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_insert_epi64(a: __m128i, i: i64, imm8: i32) -> __m128i {
-    transmute(simd_insert(a.as_i64x2(), (imm8 & 1) as u32, i))
+    let a = a.as_i64x2();
+    match imm8 & 1 {
+        0 => transmute(simd_insert(a, 0, i)),
+        _ => transmute(simd_insert(a, 1, i)),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes https://github.com/bjorn3/rustc_codegen_cranelift/issues/669

I am not quite sure about how some intrinsics should handle `imm8` values > 255. Where there was no masking before, I have used saturating through `constify_imm8`.