### PR TITLE
Remove cfg(not(bootstrap))

### DIFF
--- a/crates/core_arch/src/aarch64/mod.rs
+++ b/crates/core_arch/src/aarch64/mod.rs
@@ -15,9 +15,7 @@ pub use self::neon::*;
 mod crypto;
 pub use self::crypto::*;
 
-#[cfg(not(bootstrap))]
 mod tme;
-#[cfg(not(bootstrap))]
 pub use self::tme::*;
 
 mod crc;


### PR DESCRIPTION
This won't be needed once we bootstrap from beta 1.47.