### PR TITLE
Remove requirement on neon feature for arm

### DIFF
--- a/crates/core_arch/src/arm/mod.rs
+++ b/crates/core_arch/src/arm/mod.rs
@@ -19,19 +19,9 @@ mod v7;
 #[cfg(any(target_arch = "aarch64", target_feature = "v7"))]
 pub use self::v7::*;
 
-// NEON is supported on AArch64, and on ARM when built with the v7 and neon
-// features. Building ARM without neon produces incorrect codegen.
-#[cfg(any(
-    target_arch = "aarch64",
-    all(target_feature = "v7", target_feature = "neon"),
-    dox
-))]
+#[cfg(any(target_arch = "aarch64", target_feature = "v7", dox))]
 mod neon;
-#[cfg(any(
-    target_arch = "aarch64",
-    all(target_feature = "v7", target_feature = "neon"),
-    dox
-))]
+#[cfg(any(target_arch = "aarch64", target_feature = "v7", dox))]
 pub use self::neon::*;
 
 #[cfg(any(target_arch = "aarch64", target_feature = "v7"))]


### PR DESCRIPTION
As I noted in #889, the `neon` target feature shouldn't be required to use NEON on ARM (it should be possible to detect it at runtime).