### PR TITLE
Add vcvtq_u32_f32 and vcvtq_s32_f32

### DIFF
--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -285,6 +285,11 @@ extern "C" {
         b3: int8x16_t,
         c: uint8x16_t,
     ) -> int8x16_t;
+
+    #[link_name = "llvm.aarch64.neon.fcvtzu.v4i32.v4f32"]
+    fn vcvtq_u32_f32_(a: float32x4_t) -> uint32x4_t;
+    #[link_name = "llvm.aarch64.neon.fcvtzs.v4i32.v4f32"]
+    fn vcvtq_s32_f32_(a: float32x4_t) -> int32x4_t;
 }
 
 /// Absolute Value (wrapping).
@@ -1838,6 +1843,21 @@ pub unsafe fn vld1q_u32(addr: *const u32) -> uint32x4_t {
     ))
 }
 
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(fcvtzs))]
+pub unsafe fn vcvtq_s32_f32(a: float32x4_t) -> int32x4_t {
+    vcvtq_s32_f32_(a)
+}
+
+/// Floating-point Convert to Unsigned fixed-point, rounding toward Zero (vector)
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub unsafe fn vcvtq_u32_f32(a: float32x4_t) -> uint32x4_t {
+    vcvtq_u32_f32_(a)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::core_arch::aarch64::test_support::*;
@@ -1845,6 +1865,42 @@ mod tests {
     use crate::core_arch::{aarch64::neon::*, aarch64::*, simd::*};
     use std::mem::transmute;
     use stdarch_test::simd_test;
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vcvtq_s32_f32() {
+        let f = f32x4::new(-1., 2., 3., 4.);
+        let e = i32x4::new(-1, 2, 3, 4);
+        let r: i32x4 = transmute(vcvtq_s32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(10e37, 2., 3., 4.);
+        let e = i32x4::new(0x7fffffff, 2, 3, 4);
+        let r: i32x4 = transmute(vcvtq_s32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(-10e37, 2., 3., 4.);
+        let e = i32x4::new(-0x80000000, 2, 3, 4);
+        let r: i32x4 = transmute(vcvtq_s32_f32(transmute(f)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vcvtq_u32_f32() {
+        let f = f32x4::new(1., 2., 3., 4.);
+        let e = u32x4::new(1, 2, 3, 4);
+        let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(-1., 2., 3., 4.);
+        let e = u32x4::new(0, 2, 3, 4);
+        let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(10e37, 2., 3., 4.);
+        let e = u32x4::new(0xffffffff, 2, 3, 4);
+        let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
+        assert_eq!(r, e);
+    }
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vld1q_f32() {

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -1813,6 +1813,28 @@ pub unsafe fn vld1q_dup_f32(addr: *const f32) -> float32x4_t {
     transmute(f32x4::new(v, v, v, v))
 }
 
+/// Floating-point Convert to Signed fixed-point, rounding toward Zero (vector)
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vcvt.s32.f32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fcvtzs))]
+pub unsafe fn vcvtq_s32_f32(a: float32x4_t) -> int32x4_t {
+    use crate::core_arch::simd::{f32x4, i32x4};
+    transmute(simd_cast::<_, i32x4>(transmute::<_, f32x4>(a)))
+}
+
+/// Floating-point Convert to Unsigned fixed-point, rounding toward Zero (vector)
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vcvt.u32.f32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fcvtzu))]
+pub unsafe fn vcvtq_u32_f32(a: float32x4_t) -> uint32x4_t {
+    use crate::core_arch::simd::{f32x4, u32x4};
+    transmute(simd_cast::<_, u32x4>(transmute::<_, f32x4>(a)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1875,6 +1897,22 @@ mod tests {
         let e = f32x4::new(1., 1., 1., 1.);
         let f = [1., 2., 3., 4.];
         let r: f32x4 = transmute(vld1q_dup_f32(f.as_ptr()));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vcvtq_s32_f32() {
+        let e = i32x4::new(-1, 2, 3, 4);
+        let f = f32x4::new(-1., 2., 3., 4.);
+        let r: i32x4 = transmute(vcvtq_s32_f32(transmute(f)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vcvtq_u32_f32() {
+        let e = u32x4::new(1, 2, 3, 4);
+        let f = f32x4::new(1., 2., 3., 4.);
+        let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -1902,16 +1902,36 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vcvtq_s32_f32() {
-        let e = i32x4::new(-1, 2, 3, 4);
         let f = f32x4::new(-1., 2., 3., 4.);
+        let e = i32x4::new(-1, 2, 3, 4);
         let r: i32x4 = transmute(vcvtq_s32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(10e37, 2., 3., 4.);
+        let e = i32x4::new(0x7fffffff, 2, 3, 4);
+        let r: i32x4 = transmute(vcvtq_u32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(-10e37, 2., 3., 4.);
+        let e = i32x4::new(-0x80000000, 2, 3, 4);
+        let r: i32x4 = transmute(vcvtq_u32_f32(transmute(f)));
         assert_eq!(r, e);
     }
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vcvtq_u32_f32() {
-        let e = u32x4::new(1, 2, 3, 4);
         let f = f32x4::new(1., 2., 3., 4.);
+        let e = u32x4::new(1, 2, 3, 4);
+        let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(-1., 2., 3., 4.);
+        let e = u32x4::new(0, 2, 3, 4);
+        let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
+        assert_eq!(r, e);
+
+        let f = f32x4::new(10e37, 2., 3., 4.);
+        let e = u32x4::new(0xffffffff, 2, 3, 4);
         let r: u32x4 = transmute(vcvtq_u32_f32(transmute(f)));
         assert_eq!(r, e);
     }


### PR DESCRIPTION
These intrinsics are implemented differently for aarch64 and arm
in clang. i.e. aarch64 uses the llvm.aarch64.neon.fcvtzs.v4i32.v4f32
intrinsic. However, there didn't seem to be any advantage to using
that intrinsic instead of just sharing code.