### PR TITLE
Implement prefetch hints for aarch64

### DIFF
--- a/crates/core_arch/src/aarch64/mod.rs
+++ b/crates/core_arch/src/aarch64/mod.rs
@@ -21,6 +21,9 @@ pub use self::tme::*;
 mod crc;
 pub use self::crc::*;
 
+mod prefetch;
+pub use self::prefetch::*;
+
 pub use super::acle::*;
 
 #[cfg(test)]

--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -1,0 +1,70 @@
+#[cfg(test)]
+use stdarch_test::assert_instr;
+
+extern {
+    #[link_name = "llvm.prefetch"]
+    fn prefetch(p: *const i8, rw: i32, loc: i32, ty: i32);
+}
+
+/// See [`prefetch`](fn._prefetch.html).
+pub const _PREFETCH_READ: i32 = 0;
+
+/// See [`prefetch`](fn._prefetch.html).
+pub const _PREFETCH_WRITE: i32 = 1;
+
+/// See [`prefetch`](fn._prefetch.html).
+pub const _PREFETCH_LOCALITY0: i32 = 0;
+
+/// See [`prefetch`](fn._prefetch.html).
+pub const _PREFETCH_LOCALITY1: i32 = 1;
+
+/// See [`prefetch`](fn._prefetch.html).
+pub const _PREFETCH_LOCALITY2: i32 = 2;
+
+/// See [`prefetch`](fn._prefetch.html).
+pub const _PREFETCH_LOCALITY3: i32 = 3;
+
+/// Fetch the cache line that contains address `p` using the given `rw` and `locality`.
+///
+/// The `rw` must be one of:
+///
+/// * [`_PREFETCH_READ`](constant._PREFETCH_READ.html): the prefetch is preparing
+///   for a read.
+///
+/// * [`_PREFETCH_WRITE`](constant._PREFETCH_WRITE.html): the prefetch is preparing
+///   for a write.
+///
+/// The `locality` must be one of:
+///
+/// * [`_PREFETCH_LOCALITY0`](constant._PREFETCH_LOCALITY0.html): Streaming or
+///   non-temporal prefetch, for data that is used only once.
+///
+/// * [`_PREFETCH_LOCALITY1`](constant._PREFETCH_LOCALITY1.html): Fetch into level 3 cache.
+///
+/// * [`_PREFETCH_LOCALITY2`](constant._PREFETCH_LOCALITY2.html): Fetch into level 2 cache.
+///
+/// * [`_PREFETCH_LOCALITY3`](constant._PREFETCH_LOCALITY3.html): Fetch into level 1 cache.
+///
+/// The prefetch memory instructions signal to the memory system that memory accesses
+/// from a specified address are likely to occur in the near future. The memory system
+/// can respond by taking actions that are expected to speed up the memory access when
+/// they do occur, such as preloading the specified address into one or more caches.
+/// Because these signals are only hints, it is valid for a particular CPU to treat
+/// any or all prefetch instructions as a NOP.
+///
+///
+/// [Arm's documentation](https://developer.arm.com/documentation/den0024/a/the-a64-instruction-set/memory-access-instructions/prefetching-memory?lang=en)
+#[inline(always)]
+#[cfg_attr(test, assert_instr("prfm pldl1strm", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY0))]
+#[cfg_attr(test, assert_instr("prfm pldl3keep", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY1))]
+#[cfg_attr(test, assert_instr("prfm pldl2keep", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY2))]
+#[cfg_attr(test, assert_instr("prfm pldl1keep", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY3))]
+#[cfg_attr(test, assert_instr("prfm pstl1strm", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY0))]
+#[cfg_attr(test, assert_instr("prfm pstl3keep", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY1))]
+#[cfg_attr(test, assert_instr("prfm pstl2keep", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY2))]
+#[cfg_attr(test, assert_instr("prfm pstl1keep", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY3))]
+pub unsafe fn _prefetch(p: *const i8, rw: i32, locality: i32) {
+    // We use the `llvm.prefetch` instrinsic with `cache type` = 1 (data cache).
+    // `rw` and `strategy` are based on the function parameters.
+    prefetch(p, rw, locality, 1);
+}

--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -78,7 +78,9 @@ pub unsafe fn _prefetch(p: *const i8, rw: i32, locality: i32) {
                 (1, 1) => prefetch(p, 1, 1, 1),
                 (1, 2) => prefetch(p, 1, 2, 1),
                 (1, 3) => prefetch(p, 1, 3, 1),
-                (_, _) => panic!("Illegal (rw, locality) pair in prefetch, value ({}, {}).", $rdwr, $local),
+                (_, _) => panic!(
+                    "Illegal (rw, locality) pair in prefetch, value ({}, {}).",
+                    $rdwr, $local),
             }
         };
     }

--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -80,7 +80,8 @@ pub unsafe fn _prefetch(p: *const i8, rw: i32, locality: i32) {
                 (1, 3) => prefetch(p, 1, 3, 1),
                 (_, _) => panic!(
                     "Illegal (rw, locality) pair in prefetch, value ({}, {}).",
-                    $rdwr, $local),
+                    $rdwr, $local
+                ),
             }
         };
     }

--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-extern {
+extern "C" {
     #[link_name = "llvm.prefetch"]
     fn prefetch(p: *const i8, rw: i32, loc: i32, ty: i32);
 }

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(
     const_fn,
     const_fn_union,
+    const_fn_transmute,
     const_generics,
     custom_inner_attributes,
     link_llvm_intrinsics,

--- a/crates/stdarch-verify/tests/arm.rs
+++ b/crates/stdarch-verify/tests/arm.rs
@@ -330,6 +330,7 @@ fn verify_all_signatures() {
                 "_rbit_u64",
                 "_cls_u32",
                 "_cls_u64",
+                "_prefetch",
             ];
             if !skip.contains(&rust.name) {
                 println!(
@@ -350,7 +351,7 @@ fn verify_all_signatures() {
         // Skip some intrinsics that aren't NEON and are located in different
         // places than the whitelists below.
         match rust.name {
-            "brk" | "__breakpoint" | "udf" => continue,
+            "brk" | "__breakpoint" | "udf" | "_prefetch" => continue,
             _ => {}
         }
         let arm = match map.get(rust.name) {


### PR DESCRIPTION
Co-authored-by: Wang Maozhang <wangmaozhang@huawei.com>

This implements prefetch hints for aarch64 via LLVMs `prefetch` instrinsic.

We wintness ~20% performance gain in seal_pre_commit_phase1 of Filecoin with 32GB data input.

Verified with `cargo +nightly test` and `cargo +nightly test --release`.
There are four failures (as shown below), but these are not cause by this PR.
These tests failed both with and without this PR.
```
---- core_arch::aarch64::tme::assert___tcommit_tcommit stdout ----
disassembly for stdarch_test_shim___tcommit_tcommit:
         0: adrp x8, 16f000 <_GLOBAL_OFFSET_TABLE_+0x280>
         1: ldr x8, [x8, #3792]
         2: adrp x9, f1000 <anon.1626de38755f4729e9f2a08512645c0a.14.llvm.15569108828795629504+0x10b87>
         3: add x9, x9, #0xd29
         4: str x9, [x8]
         5: msr s0_3_c3_c0_3, xzr
         6: ret
thread 'core_arch::aarch64::tme::assert___tcommit_tcommit' panicked at 'failed to find instruction `tcommit` in the disassembly', crates/stdarch-test/src/lib.rs:144:9


failures:
    core_arch::aarch64::tme::assert___tcancel_tcancel
    core_arch::aarch64::tme::assert___tcommit_tcommit
    core_arch::aarch64::tme::assert___tstart_tstart
    core_arch::aarch64::tme::assert___ttest_ttest
```

Thanks.