### PR TITLE
remove redundant feature declaration const_fn_transmute in lib.rs

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -37,8 +37,7 @@
     f16c_target_feature,
     external_doc,
     allow_internal_unstable,
-    decl_macro,
-    const_fn_transmute
+    decl_macro
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, untagged_unions))]
 #![cfg_attr(all(test, target_arch = "wasm32"), feature(wasm_simd))]


### PR DESCRIPTION
This remove redundant feature declaration const_fn_transmute in lib.rs.
Seems caused by PR 917 and PR 918 megerd recently.
Feature `const_fn_transmute` are declared twice on line 9 and line 41 in `lib.rs`.

Thanks.