### PR TITLE
Remove `cfg(not(doc))` from doctests

### DIFF
--- a/crates/core_arch/src/core_arch_docs.md
+++ b/crates/core_arch/src/core_arch_docs.md
@@ -210,12 +210,6 @@ using LLVM's auto-vectorization to produce optimized vectorized code for
 AVX2 and also for the default platform.
 
 ```rust
-# #![cfg_attr(not(doc),feature(stdsimd))]
-# #[allow(unused_imports)]
-# #[cfg(not(doc))]
-# #[macro_use(is_x86_feature_detected)]
-# extern crate std_detect;
-
 fn main() {
     let mut dst = [0];
     add_quickly(&[1], &[2], &mut dst);


### PR DESCRIPTION
This was changed from `cfg(dox)` to `cfg(doc)` in
https://github.com/rust-lang/stdarch/pull/920. `cfg(doc)` is incorrect here; rustdoc sets `cfg(doctest)`, not `cfg(doc)` in doc-tests.

However, this piece of code isn't needed anyway: this code will only
ever be run as a doc-test, so it will never be compiled in.

Part of https://github.com/rust-lang/rust/pull/77347.

r? @Amanieu 