### PR TITLE
replace some unions by transmute and make the rest repr(C)

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -39,7 +39,7 @@
     allow_internal_unstable,
     decl_macro
 )]
-#![cfg_attr(test, feature(test, abi_vectorcall, untagged_unions))]
+#![cfg_attr(test, feature(test, abi_vectorcall))]
 #![cfg_attr(all(test, target_arch = "wasm32"), feature(wasm_simd))]
 #![deny(clippy::missing_inline_in_public_items)]
 #![allow(

--- a/crates/core_arch/src/x86/test.rs
+++ b/crates/core_arch/src/x86/test.rs
@@ -1,14 +1,11 @@
 //! Utilities used in testing the x86 intrinsics
 
 use crate::core_arch::x86::*;
+use std::mem::transmute;
 
 #[target_feature(enable = "sse2")]
 pub unsafe fn assert_eq_m128i(a: __m128i, b: __m128i) {
-    union A {
-        a: __m128i,
-        b: [u64; 2],
-    }
-    assert_eq!(A { a }.b, A { a: b }.b)
+    assert_eq!(transmute::<_, [u64; 2]>(a), transmute::<_, [u64; 2]>(b))
 }
 
 #[target_feature(enable = "sse2")]
@@ -20,11 +17,7 @@ pub unsafe fn assert_eq_m128d(a: __m128d, b: __m128d) {
 
 #[target_feature(enable = "sse2")]
 pub unsafe fn get_m128d(a: __m128d, idx: usize) -> f64 {
-    union A {
-        a: __m128d,
-        b: [f64; 2],
-    };
-    A { a }.b[idx]
+    transmute::<_, [f64; 2]>(a)[idx]
 }
 
 #[target_feature(enable = "sse")]
@@ -37,11 +30,7 @@ pub unsafe fn assert_eq_m128(a: __m128, b: __m128) {
 
 #[target_feature(enable = "sse")]
 pub unsafe fn get_m128(a: __m128, idx: usize) -> f32 {
-    union A {
-        a: __m128,
-        b: [f32; 4],
-    };
-    A { a }.b[idx]
+    transmute::<_, [f32; 4]>(a)[idx]
 }
 
 // not actually an intrinsic but useful in various tests as we proted from
@@ -53,11 +42,7 @@ pub unsafe fn _mm_setr_epi64x(a: i64, b: i64) -> __m128i {
 
 #[target_feature(enable = "avx")]
 pub unsafe fn assert_eq_m256i(a: __m256i, b: __m256i) {
-    union A {
-        a: __m256i,
-        b: [u64; 4],
-    }
-    assert_eq!(A { a }.b, A { a: b }.b)
+    assert_eq!(transmute::<_, [u64; 4]>(a), transmute::<_, [u64; 4]>(b))
 }
 
 #[target_feature(enable = "avx")]
@@ -70,11 +55,7 @@ pub unsafe fn assert_eq_m256d(a: __m256d, b: __m256d) {
 
 #[target_feature(enable = "avx")]
 pub unsafe fn get_m256d(a: __m256d, idx: usize) -> f64 {
-    union A {
-        a: __m256d,
-        b: [f64; 4],
-    };
-    A { a }.b[idx]
+    transmute::<_, [f64; 4]>(a)[idx]
 }
 
 #[target_feature(enable = "avx")]
@@ -87,11 +68,7 @@ pub unsafe fn assert_eq_m256(a: __m256, b: __m256) {
 
 #[target_feature(enable = "avx")]
 pub unsafe fn get_m256(a: __m256, idx: usize) -> f32 {
-    union A {
-        a: __m256,
-        b: [f32; 8],
-    };
-    A { a }.b[idx]
+    transmute::<_, [f32; 8]>(a)[idx]
 }
 
 // These intrinsics doesn't exist on x86 b/c it requires a 64-bit register,
@@ -101,6 +78,7 @@ mod x86_polyfill {
     use crate::core_arch::x86::*;
 
     pub unsafe fn _mm_insert_epi64(a: __m128i, val: i64, idx: i32) -> __m128i {
+        #[repr(C)]
         union A {
             a: __m128i,
             b: [i64; 2],
@@ -112,6 +90,7 @@ mod x86_polyfill {
 
     #[target_feature(enable = "avx2")]
     pub unsafe fn _mm256_insert_epi64(a: __m256i, val: i64, idx: i32) -> __m256i {
+        #[repr(C)]
         union A {
             a: __m256i,
             b: [i64; 4],
@@ -128,11 +107,7 @@ mod x86_polyfill {
 pub use self::x86_polyfill::*;
 
 pub unsafe fn assert_eq_m512i(a: __m512i, b: __m512i) {
-    union A {
-        a: __m512i,
-        b: [i32; 16],
-    }
-    assert_eq!(A { a }.b, A { a: b }.b)
+    assert_eq!(transmute::<_, [i32; 16]>(a), transmute::<_, [i32; 16]>(b))
 }
 
 pub unsafe fn assert_eq_m512(a: __m512, b: __m512) {


### PR DESCRIPTION
Turns out the `untagged_unions` feature already was not needed.

Fixes https://github.com/rust-lang/stdarch/issues/924