### PR TITLE
Stabilize WebAssembly atomic intrinsics

### DIFF
--- a/crates/core_arch/src/wasm32/atomic.rs
+++ b/crates/core_arch/src/wasm32/atomic.rs
@@ -51,6 +51,7 @@ extern "C" {
 /// [instr]: https://webassembly.github.io/threads/syntax/instructions.html#syntax-instr-atomic-memory
 #[inline]
 #[cfg_attr(test, assert_instr("i32.atomic.wait"))]
+#[stable(feature = "wasm_atomics", since = "1.50.0")]
 pub unsafe fn memory_atomic_wait32(ptr: *mut i32, expression: i32, timeout_ns: i64) -> i32 {
     llvm_atomic_wait_i32(ptr, expression, timeout_ns)
 }
@@ -86,6 +87,7 @@ pub unsafe fn memory_atomic_wait32(ptr: *mut i32, expression: i32, timeout_ns: i
 /// [instr]: https://webassembly.github.io/threads/syntax/instructions.html#syntax-instr-atomic-memory
 #[inline]
 #[cfg_attr(test, assert_instr("i64.atomic.wait"))]
+#[stable(feature = "wasm_atomics", since = "1.50.0")]
 pub unsafe fn memory_atomic_wait64(ptr: *mut i64, expression: i64, timeout_ns: i64) -> i32 {
     llvm_atomic_wait_i64(ptr, expression, timeout_ns)
 }
@@ -113,6 +115,7 @@ pub unsafe fn memory_atomic_wait64(ptr: *mut i64, expression: i64, timeout_ns: i
 /// [instr]: https://webassembly.github.io/threads/syntax/instructions.html#syntax-instr-atomic-memory
 #[inline]
 #[cfg_attr(test, assert_instr("atomic.wake"))]
+#[stable(feature = "wasm_atomics", since = "1.50.0")]
 pub unsafe fn memory_atomic_notify(ptr: *mut i32, waiters: u32) -> u32 {
     llvm_atomic_notify(ptr, waiters as i32) as u32
 }


### PR DESCRIPTION
This commit stabilizes the wasm atomic intrinsics now that the threads
proposal has advanced to Stage 4, and is shipping in browsers.
Unfortunately these intrinsics still aren't available through the
precompiled versions of the standard library because atomics are no

~~This commit also updates the availability and documentation of these
intrinsics to reflect how they're always available, but they probably
won't work as expected unless shared memory is used (which isn't enabled
by default). This reflects a change in the threads proposal from the
last year or so where the instructions validate without requiring a
shared memory.~~