### PR TITLE
Updated CONTRIBUTING.MD for new package name and environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ $ cargo +nightly test --release -p core_arch
 
 If these don't work out of the box, try running
 them with the environment variables `TARGET=<your-target-triple>`
-and `RUSTFLAGS=-C -target-feature=+<target-feature>` or `RUSTFLAGS=-C -target-cpu=native`
+and `RUSTCFLAGS="-C -target-feature=+<target-feature>"` or `RUSTCFLAGS="-C -target-cpu=native"`
 if you're targeting a host CPU feature. An example for these may look like `TARGET=x86_64-unknown-linux-gnu`
-and `RUSTFLAGS=-C -target-features=+avx2`, if you're unsure of your target triple, simply run `rustup show`
+and `RUSTCFLAGS="-C -target-features=+avx2"`, if you're unsure of your target triple, simply run `rustup show`
 to find out which you have installed for nightly.
 Also remember that this repository requires the nightly channel of Rust!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,18 @@ $ cargo +nightly test
 To run codegen tests, run in release mode:
 
 ```
-$ cargo +nightly test --release -p coresimd
+$ cargo +nightly test --release -p core_arch
 ```
 
-Remember that this repository requires the nightly channel of Rust! If any of
-the above steps don't work, [please let us know][new]!
+If these don't work out of the box, try running
+them with the environment variables `TARGET=<your-target-triple>`
+and `RUSTFLAGS=-C -target-feature=+<target-feature>` or `RUSTFLAGS=-C -target-cpu=native`
+if you're targeting a host CPU feature. An example for these may look like `TARGET=x86_64-unknown-linux-gnu`
+and `RUSTFLAGS=-C -target-features=+avx2`, if you're unsure of your target triple, simply run `rustup show`
+to find out which you have installed for nightly.
+Also remember that this repository requires the nightly channel of Rust!
+
+If any of the above steps don't work, [please let us know][new]!
 
 Next up you can [find an issue][issues] to help out on, we've selected a few
 with the [`help wanted`][help] and [`impl-period`][impl] tags which could

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,13 @@ to improve the documentation of `stdarch`!
 It is generally recommended that you use `ci/run.sh` to run the tests.
 However this might not work for you, e.g. if you are on Windows.
 
-In that case you can fall back to running `cargo +nightly test` and `cargo +nightly test --release -p core_arch`.
+In that case you can fall back to running `cargo +nightly test` and `cargo +nightly test --release -p core_arch` for testing the code generation.
 Note that these require the nightly toolchain to be installed and for `rustc` to know about your target triple and its CPU.
 In particular you need to set the `TARGET` environment variable as you would for `ci/run.sh`.
 In addition you need to set `RUSTCFLAGS` (need the `C`) to indicate target features, e.g. `RUSTCFLAGS="-C -target-features=+avx2"`.
 You can also set `-C -target-cpu=native` if you're "just" developing against your current CPU.
 
-Be warned that when you use these alternative instructions, things may go less smoothly than they would with `ci/run.sh`, e.g. instruction generation tests may fail because the disassembler named them differently, e.g. it may generate `vaesenc` instead of `aesenc` instructions despite them behaving the same.
+Be warned that when you use these alternative instructions, [things may go less smoothly than they would with `ci/run.sh`][ci-run-good], e.g. instruction generation tests may fail because the disassembler named them differently, e.g. it may generate `vaesenc` instead of `aesenc` instructions despite them behaving the same.
 Also these instructions execute less tests than would normally be done, so don't be surprised that when you eventually pull-request some errors may show up for tests not covered here.
 
 
@@ -90,3 +90,4 @@ Also these instructions execute less tests than would normally be done, so don't
 [vendor]: https://github.com/rust-lang/stdarch/issues/40
 [Documentation as tests]: https://doc.rust-lang.org/book/first-edition/documentation.html#documentation-as-tests
 [Rust Book]: https://doc.rust-lang.org/book/first-edition
+[ci-run-good]: https://github.com/rust-lang/stdarch/issues/931#issuecomment-711412126

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,22 +6,12 @@ probably want to check out the repository and make sure that tests pass for you:
 ```
 $ git clone https://github.com/rust-lang/stdarch
 $ cd stdarch
-$ cargo +nightly test
+$ TARGET="<your-target-arch>" ci/run.sh
 ```
 
-To run codegen tests, run in release mode:
-
-```
-$ cargo +nightly test --release -p core_arch
-```
-
-If these don't work out of the box, try running
-them with the environment variables `TARGET=<your-target-triple>`
-and `RUSTCFLAGS="-C -target-feature=+<target-feature>"` or `RUSTCFLAGS="-C -target-cpu=native"`
-if you're targeting a host CPU feature. An example for these may look like `TARGET=x86_64-unknown-linux-gnu`
-and `RUSTCFLAGS="-C -target-features=+avx2"`, if you're unsure of your target triple, simply run `rustup show`
-to find out which you have installed for nightly.
+Where `<your-target-arch>` is the target triple as used by `rustup`, e.g. `x86_x64-unknown-linux-gnu` (without any preceding `nightly-` or similar).
 Also remember that this repository requires the nightly channel of Rust!
+The above tests do in fact require nightly rust to be the default on your system, to set that use `rustup default nightly` (and `rustup default stable` to revert).
 
 If any of the above steps don't work, [please let us know][new]!
 
@@ -77,6 +67,21 @@ If some of the above syntax does not look familiar, the [Documentation as tests]
 of the [Rust Book] describes the `rustdoc` syntax quite well. As always, feel free
 to [join us on gitter][gitter] and ask us if you hit any snags, and thank you for helping
 to improve the documentation of `stdarch`!
+
+# Alternative Testing Instructions
+
+It is generally recommended that you use `ci/run.sh` to run the tests.
+However this might not work for you, e.g. if you are on Windows.
+
+In that case you can fall back to running `cargo +nightly test` and `cargo +nightly test --release -p core_arch`.
+Note that these require the nightly toolchain to be installed and for `rustc` to know about your target triple and its CPU.
+In particular you need to set the `TARGET` environment variable as you would for `ci/run.sh`.
+In addition you need to set `RUSTCFLAGS` (need the `C`) to indicate target features, e.g. `RUSTCFLAGS="-C -target-features=+avx2"`.
+You can also set `-C -target-cpu=native` if you're "just" developing against your current CPU.
+
+Be warned that when you use these alternative instructions, things may go less smoothly than they would with `ci/run.sh`, e.g. instruction generation tests may fail because the disassembler named them differently, e.g. it may generate `vaesenc` instead of `aesenc` instructions despite them behaving the same.
+Also these instructions execute less tests than would normally be done, so don't be surprised that when you eventually pull-request some errors may show up for tests not covered here.
+
 
 [new]: https://github.com/rust-lang/stdarch/issues/new
 [issues]: https://github.com/rust-lang/stdarch/issues


### PR DESCRIPTION
When I tried to execute the instructions in CONTRIBUTING.MD I noticed that they actually don't work out of the box.

First, apparently the `coresimd` package had been renamed at some point but the contributing.md was not updated, I fixed that.

Additionally apparently since this documentation was written there was an update on how tests are invoked now requiring specific environment variables. I have added text to explain which those are and what they need to say to make `cargo` and `rustc` happy.