### PR TITLE
Remove trailing semicolons from several macro definitions

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -120,7 +120,7 @@ pub unsafe fn _mm256_shuffle_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
         ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle4(a, b, [$a, $b, $c, $d]);
+            simd_shuffle4(a, b, [$a, $b, $c, $d])
         };
     }
     macro_rules! shuffle3 {
@@ -175,7 +175,7 @@ pub unsafe fn _mm256_shuffle_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {
@@ -532,7 +532,7 @@ pub unsafe fn _mm256_blend_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! blend4 {
         ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle4(a, b, [$a, $b, $c, $d]);
+            simd_shuffle4(a, b, [$a, $b, $c, $d])
         };
     }
     macro_rules! blend3 {
@@ -587,7 +587,7 @@ pub unsafe fn _mm256_blend_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! blend3 {
@@ -1324,7 +1324,7 @@ pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
         ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle4(a, _mm256_undefined_pd(), [$a, $b, $c, $d]);
+            simd_shuffle4(a, _mm256_undefined_pd(), [$a, $b, $c, $d])
         };
     }
     macro_rules! shuffle3 {
@@ -1370,7 +1370,7 @@ pub unsafe fn _mm_permute_pd(a: __m128d, imm8: i32) -> __m128d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle2 {
         ($a:expr, $b:expr) => {
-            simd_shuffle2(a, _mm_undefined_pd(), [$a, $b]);
+            simd_shuffle2(a, _mm_undefined_pd(), [$a, $b])
         };
     }
     macro_rules! shuffle1 {

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -372,7 +372,7 @@ pub unsafe fn _mm_blend_epi32(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let b = b.as_i32x4();
     macro_rules! blend2 {
         ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle4(a, b, [$a, $b, $c, $d]);
+            simd_shuffle4(a, b, [$a, $b, $c, $d])
         };
     }
     macro_rules! blend1 {
@@ -417,7 +417,7 @@ pub unsafe fn _mm256_blend_epi32(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! blend3 {
@@ -2443,7 +2443,7 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! permute4 {
         ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle4(a, zero, [$a, $b, $c, $d]);
+            simd_shuffle4(a, zero, [$a, $b, $c, $d])
         };
     }
     macro_rules! permute3 {
@@ -2746,7 +2746,7 @@ pub unsafe fn _mm256_shufflehi_epi16(a: __m256i, imm8: i32) -> __m256i {
                         simd_shuffle16(a, a, [
                             0, 1, 2, 3, 4+$x01, 4+$x23, 4+$x45, 4+$x67,
                             8, 9, 10, 11, 12+$x01, 12+$x23, 12+$x45, 12+$x67
-                        ]);
+                        ])
         };
     }
     macro_rules! shuffle_x67 {
@@ -2807,7 +2807,7 @@ pub unsafe fn _mm256_shufflelo_epi16(a: __m256i, imm8: i32) -> __m256i {
                         simd_shuffle16(a, a, [
                             0+$x01, 0+$x23, 0+$x45, 0+$x67, 4, 5, 6, 7,
                             8+$x01, 8+$x23, 8+$x45, 8+$x67, 12, 13, 14, 15,
-                        ]);
+                        ])
         };
     }
     macro_rules! shuffle_x67 {

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -11962,7 +11962,7 @@ pub unsafe fn _mm512_shuffle_epi32(a: __m512i, imm8: _MM_PERM_ENUM) -> __m512i {
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12045,7 +12045,7 @@ pub unsafe fn _mm512_mask_shuffle_epi32(
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12123,7 +12123,7 @@ pub unsafe fn _mm512_maskz_shuffle_epi32(k: __mmask16, a: __m512i, imm8: _MM_PER
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12201,7 +12201,7 @@ pub unsafe fn _mm512_shuffle_ps(a: __m512, b: __m512, imm8: i32) -> __m512 {
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12283,7 +12283,7 @@ pub unsafe fn _mm512_mask_shuffle_ps(
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12361,7 +12361,7 @@ pub unsafe fn _mm512_maskz_shuffle_ps(k: __mmask16, a: __m512, b: __m512, imm8: 
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12417,7 +12417,7 @@ pub unsafe fn _mm512_shuffle_pd(a: __m512d, b: __m512d, imm8: i32) -> __m512d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle8 {
         ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr, $g:expr, $h:expr) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle7 {
@@ -12500,7 +12500,7 @@ pub unsafe fn _mm512_mask_shuffle_pd(
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle8 {
         ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr, $g:expr, $h:expr) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle7 {
@@ -12579,7 +12579,7 @@ pub unsafe fn _mm512_maskz_shuffle_pd(k: __mmask8, a: __m512d, b: __m512d, imm8:
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle8 {
         ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr, $g:expr, $h:expr) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle7 {
@@ -12684,7 +12684,7 @@ pub unsafe fn _mm512_shuffle_i32x4(a: __m512i, b: __m512i, imm8: i32) -> __m512i
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12770,7 +12770,7 @@ pub unsafe fn _mm512_mask_shuffle_i32x4(
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12855,7 +12855,7 @@ pub unsafe fn _mm512_maskz_shuffle_i32x4(
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -12920,7 +12920,7 @@ pub unsafe fn _mm512_shuffle_i64x2(a: __m512i, b: __m512i, imm8: i32) -> __m512i
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {
@@ -12988,7 +12988,7 @@ pub unsafe fn _mm512_mask_shuffle_i64x2(
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {
@@ -13057,7 +13057,7 @@ pub unsafe fn _mm512_maskz_shuffle_i64x2(
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {
@@ -13136,7 +13136,7 @@ pub unsafe fn _mm512_shuffle_f32x4(a: __m512, b: __m512, imm8: i32) -> __m512 {
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -13218,7 +13218,7 @@ pub unsafe fn _mm512_mask_shuffle_f32x4(
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -13296,7 +13296,7 @@ pub unsafe fn _mm512_maskz_shuffle_f32x4(k: __mmask16, a: __m512, b: __m512, imm
                 [
                     $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
-            );
+            )
         };
     }
     macro_rules! shuffle3 {
@@ -13361,7 +13361,7 @@ pub unsafe fn _mm512_shuffle_f64x2(a: __m512d, b: __m512d, imm8: i32) -> __m512d
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {
@@ -13429,7 +13429,7 @@ pub unsafe fn _mm512_mask_shuffle_f64x2(
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {
@@ -13498,7 +13498,7 @@ pub unsafe fn _mm512_maskz_shuffle_f64x2(
             $g:expr,
             $h:expr
         ) => {
-            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
+            simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h])
         };
     }
     macro_rules! shuffle3 {


### PR DESCRIPTION
The x86 code contains several macros that following this pattern:

```rust
macro_rules! expr {
    () => { true; }
}

fn bar(_val: bool) {}

fn main() {
    bar(expr!());
}
```

Here, we have a macro `expr!` that expands to tokens sequence with
a trailing semicolon.

Currently, the trailing semicolon is ignored when the macro is invoked
in expression position, due to https://github.com/rust-lang/rust/issues/33953
If this behavior is changed, then a large number of macro invocations in
`stdarch` will stop compiling.

Regardless of whether nor not this change is made, removing the
semicolon more clearly expresses the intent of the code - these macros
are designed to expand to the result of a function call, not ignore its
results (as the `;` would suggest).