### PR TITLE
Use black_box instead of llvm_asm

### DIFF
--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -143,10 +143,6 @@ pub fn assert_instr(
         fn #assert_name() {
             #to_test
 
-            // Make sure that the shim is not removed by leaking it to unknown
-            // code:
-            unsafe { llvm_asm!("" : : "r"(#shim_name as usize) : "memory" : "volatile") };
-
             ::stdarch_test::assert(#shim_name as usize,
                                    stringify!(#shim_name),
                                    #instr);

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -3,6 +3,7 @@
 //! This basically just disassembles the current executable and then parses the
 //! output once globally and then provides the `assert` function which makes
 //! assertions about the disassembly of a function.
+#![feature(test)] // For black_box
 #![allow(clippy::missing_docs_in_private_items, clippy::print_stdout)]
 
 extern crate assert_instr_macro;
@@ -16,7 +17,7 @@ extern crate cfg_if;
 
 pub use assert_instr_macro::*;
 pub use simd_test_macro::*;
-use std::{cmp, collections::HashSet, env, hash, str, sync::atomic::AtomicPtr};
+use std::{cmp, collections::HashSet, env, hash, hint::black_box, str, sync::atomic::AtomicPtr};
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
@@ -63,7 +64,10 @@ impl hash::Hash for Function {
 ///
 /// This asserts that the function at `fnptr` contains the instruction
 /// `expected` provided.
-pub fn assert(_fnptr: usize, fnname: &str, expected: &str) {
+pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
+    // Make sure that the shim is not removed
+    black_box(shim_addr);
+
     //eprintln!("shim name: {}", fnname);
     let function = &DISASSEMBLY
         .get(&Function::new(fnname))


### PR DESCRIPTION
The [`black_box` implementation](https://github.com/rust-lang/rust/blob/56293097f7f877f1350a6cd00f79d03132f16515/library/core/src/hint.rs#L126) is the same as what we have in this crate.

This PR unblocks #904, see https://github.com/rust-lang/stdarch/issues/904#issuecomment-721433828

Signed-off-by: Joe Richey <joerichey@google.com>