### PR TITLE
Use a bootstrap guard for modules with new target features

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -675,19 +675,27 @@ pub use self::avx512cd::*;
 mod avx512ifma;
 pub use self::avx512ifma::*;
 
+#[cfg(not(bootstrap))]
 mod avx512bitalg;
+#[cfg(not(bootstrap))]
 pub use self::avx512bitalg::*;
 
+#[cfg(not(bootstrap))]
 mod avx512gfni;
+#[cfg(not(bootstrap))]
 pub use self::avx512gfni::*;
 
 mod avx512vpopcntdq;
 pub use self::avx512vpopcntdq::*;
 
+#[cfg(not(bootstrap))]
 mod avx512vaes;
+#[cfg(not(bootstrap))]
 pub use self::avx512vaes::*;
 
+#[cfg(not(bootstrap))]
 mod avx512vpclmulqdq;
+#[cfg(not(bootstrap))]
 pub use self::avx512vpclmulqdq::*;
 
 mod bt;


### PR DESCRIPTION
The recently added modules use target features that are not yet
available in rustc compiler used for bootstrapping.

Guard them with `#[cfg(not(bootstrap))]`.