### PR TITLE
fix _mm_loadu_si64

### DIFF
--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1243,7 +1243,6 @@ pub unsafe fn _mm_loadr_ps(p: *const f32) -> __m128 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_loadu_si64)
 #[inline]
 #[target_feature(enable = "sse")]
-#[cfg_attr(all(test, not(target_arch = "x86")), assert_instr(movq))]
 #[stable(feature = "simd_x86_mm_loadu_si64", since = "1.46.0")]
 pub unsafe fn _mm_loadu_si64(mem_addr: *const u8) -> __m128i {
     transmute(i64x2(ptr::read_unaligned(mem_addr as *const i64), 0))

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1246,7 +1246,7 @@ pub unsafe fn _mm_loadr_ps(p: *const f32) -> __m128 {
 #[cfg_attr(all(test, not(target_arch = "x86")), assert_instr(movq))]
 #[stable(feature = "simd_x86_mm_loadu_si64", since = "1.46.0")]
 pub unsafe fn _mm_loadu_si64(mem_addr: *const u8) -> __m128i {
-    transmute(i64x2(0, ptr::read_unaligned(mem_addr as *const i64)))
+    transmute(i64x2(ptr::read_unaligned(mem_addr as *const i64), 0))
 }
 
 /// Stores the lowest 32 bit float of `a` into memory.
@@ -3083,7 +3083,7 @@ mod tests {
     unsafe fn test_mm_loadu_si64() {
         let a = _mm_setr_epi64x(5, 6);
         let r = _mm_loadu_si64(&a as *const _ as *const _);
-        assert_eq_m128i(r, _mm_set_epi64x(5, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(5, 0));
     }
 
     #[simd_test(enable = "sse")]


### PR DESCRIPTION
The value should be loaded into the lowest 64 bits, not the highest.