### PR TITLE
Add 'volatile' to cpuid inline asm

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(unused_features)]
 #![allow(incomplete_features)]
 #![feature(
+    asm,
     const_fn,
     const_fn_union,
     const_fn_transmute,

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -55,26 +55,33 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     let ebx;
     let ecx;
     let edx;
+
     #[cfg(target_arch = "x86")]
     {
-        llvm_asm!("cpuid"
-                  : "={eax}"(eax), "={ebx}"(ebx), "={ecx}"(ecx), "={edx}"(edx)
-                  : "{eax}"(leaf), "{ecx}"(sub_leaf)
-                  : : "volatile");
+        asm!(
+            "cpuid",
+            inlateout("eax") leaf => eax,
+            lateout("ebx") ebx,
+            inlateout("ecx") sub_leaf => ecx,
+            lateout("edx") edx,
+            options(nostack, nomem, preserves_flags),
+        );
     }
     #[cfg(target_arch = "x86_64")]
     {
-        // x86-64 uses %rbx as the base register, so preserve it.
+        // x86-64 uses `rbx` as the base register, so preserve it.
         // This works around a bug in LLVM with ASAN enabled:
         // https://bugs.llvm.org/show_bug.cgi?id=17907
-        llvm_asm!(r#"
-                  mov %rbx, %rsi
-                  cpuid
-                  xchg %rbx, %rsi
-                  "#
-                  : "={eax}"(eax), "={esi}"(ebx), "={ecx}"(ecx), "={edx}"(edx)
-                  : "{eax}"(leaf), "{ecx}"(sub_leaf)
-                  : : "volatile");
+        asm!(
+            "mov rsi, rbx",
+            "cpuid",
+            "xchg rsi, rbx",
+            inlateout("eax") leaf => eax,
+            lateout("esi") ebx,
+            inlateout("ecx") sub_leaf => ecx,
+            lateout("edx") edx,
+            options(nostack, nomem, preserves_flags),
+        );
     }
     CpuidResult { eax, ebx, ecx, edx }
 }

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -64,7 +64,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             lateout("ebx") ebx,
             inlateout("ecx") sub_leaf => ecx,
             lateout("edx") edx,
-            options(nostack, nomem, preserves_flags),
+            options(nostack, preserves_flags),
         );
     }
     #[cfg(target_arch = "x86_64")]
@@ -80,7 +80,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             lateout("esi") ebx,
             inlateout("ecx") sub_leaf => ecx,
             lateout("edx") edx,
-            options(nostack, nomem, preserves_flags),
+            options(nostack, preserves_flags),
         );
     }
     CpuidResult { eax, ebx, ecx, edx }

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -60,7 +60,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
         llvm_asm!("cpuid"
                   : "={eax}"(eax), "={ebx}"(ebx), "={ecx}"(ecx), "={edx}"(edx)
                   : "{eax}"(leaf), "{ecx}"(sub_leaf)
-                  : :);
+                  : : "volatile");
     }
     #[cfg(target_arch = "x86_64")]
     {
@@ -74,7 +74,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
                   "#
                   : "={eax}"(eax), "={esi}"(ebx), "={ecx}"(ecx), "={edx}"(edx)
                   : "{eax}"(leaf), "{ecx}"(sub_leaf)
-                  : :);
+                  : : "volatile");
     }
     CpuidResult { eax, ebx, ecx, edx }
 }


### PR DESCRIPTION
`cpuid` is a serializing instruction, and is the only serializing instruction available as an intrinsic AFAIK. Various points of intels documentation suggests to use it as a way to fence other instructions — The typical case is in conjunction with rdtsc/rdtscp for measurement (though on sse2 processors you can also use `mfence`/`lfence` for this purpose), although this is not the only use case.

Without the "volatile" clobber, this intrinsic can't easily be used this way, since you have to fake the use of the result or LLVM will entirely remove it. This fails to reflect the behavior documentated for instruction, so it seems like a clear-cut bug worth fixing to me.

See these for further info if desired:

- https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-system-programming-manual-325384.pdf (in particular sections on serializing instructions)
- https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/ia-32-ia-64-benchmark-code-execution-paper.pdf (which is dated and fails to mention lfence/mfence, but still applies for code in a "no sse2" fallback case)

TLDR: CPUID has side effects in the x86 memory model (including out of order execution) and this patch makes sure the intrinsic works for that.