### PR TITLE
Uncomment wasm32 bitmask instruction

### DIFF
--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -14,8 +14,7 @@ ENV PATH="$PATH:/root/.wasmer:/root/.wasmer/bin"
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
   --llvm \
   --enable-simd \
-  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
-  --"
+  --mapdir .::/checkout/target/wasm32-wasi/release/deps"
 
 #RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/wasmtime-v0.22.1-x86_64-linux.tar.xz | tar xJf -
 #ENV PATH=$PATH:/wasmtime-v0.22.1-x86_64-linux

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 RUN curl https://get.wasmer.io -sSfL | sh
 
+RUN source /root/.wasmer/wasmer.sh
+
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
   --llvm \
   --enable-simd \

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   clang
 
+ENV WASMER_DIR="/.wasmer"
+
 RUN curl https://get.wasmer.io -sSfL | sh
 
-ENV PATH="$PATH:/root/.wasmer:/root/.wasmer/bin"
+ENV PATH="$PATH:/.wasmer:/.wasmer/bin"
 
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
   --llvm \

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -7,10 +7,18 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   clang
 
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/wasmtime-v0.22.1-x86_64-linux.tar.xz | tar xJf -
-ENV PATH=$PATH:/wasmtime-v0.22.1-x86_64-linux
+RUN curl https://get.wasmer.io -sSfL | sh
 
-ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \
+ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
+  --llvm \
   --enable-simd \
   --mapdir .::/checkout/target/wasm32-wasi/release/deps \
   --"
+
+#RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/wasmtime-v0.22.1-x86_64-linux.tar.xz | tar xJf -
+#ENV PATH=$PATH:/wasmtime-v0.22.1-x86_64-linux
+
+#ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \
+#  --enable-simd \
+#  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
+#  --"

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -16,7 +16,8 @@ ENV PATH="$PATH:/.wasmer:/.wasmer/bin"
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
   --llvm \
   --enable-simd \
-  --mapdir .::/checkout/target/wasm32-wasi/release/deps"
+  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
+  --"
 
 #RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/wasmtime-v0.22.1-x86_64-linux.tar.xz | tar xJf -
 #ENV PATH=$PATH:/wasmtime-v0.22.1-x86_64-linux

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -7,22 +7,22 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   clang
 
-ENV WASMER_DIR="/.wasmer"
+#ENV WASMER_DIR="/.wasmer"
 
-RUN curl https://get.wasmer.io -sSfL | sh
+#RUN curl https://get.wasmer.io -sSfL | sh
 
-ENV PATH="$PATH:/.wasmer:/.wasmer/bin"
+#ENV PATH="$PATH:/.wasmer:/.wasmer/bin"
 
-ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
-  --llvm \
-  --enable-simd \
-  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
-  --"
-
-#RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/wasmtime-v0.22.1-x86_64-linux.tar.xz | tar xJf -
-#ENV PATH=$PATH:/wasmtime-v0.22.1-x86_64-linux
-
-#ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \
+#ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
+#  --llvm \
 #  --enable-simd \
 #  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
 #  --"
+
+RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz | tar xJf -
+ENV PATH=$PATH:/wasmtime-dev-x86_64-linux
+
+ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \
+  --enable-simd \
+  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
+  --"

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 RUN curl https://get.wasmer.io -sSfL | sh
 
-RUN source /root/.wasmer/wasmer.sh
+ENV PATH="$PATH:/root/.wasmer:/root/.wasmer/bin"
 
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmer run \
   --llvm \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -52,7 +52,7 @@ cargo_test() {
     # output.
     case ${TARGET} in
         wasm32*)
-            cmd="$cmd --nocapture"
+            cmd="$cmd -- --nocapture"
             ;;
     esac
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -52,7 +52,7 @@ cargo_test() {
     # output.
     case ${TARGET} in
         wasm32*)
-            cmd="$cmd -- --nocapture"
+            cmd="$cmd --nocapture"
             ;;
     esac
 

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -191,8 +191,8 @@ extern "C" {
     #[link_name = "llvm.wasm.widen.high.unsigned.v4i32.v8i16"]
     fn llvm_widen_high_i32x4_u(a: i16x8) -> i32x4;
 
-    #[link_name = "llvm.wasm.bitmask.v2i64"]
-    fn llvm_bitmask_i64x2(a: i64x2) -> i32;
+    //#[link_name = "llvm.wasm.bitmask.v2i64"]
+    //fn llvm_bitmask_i64x2(a: i64x2) -> i32;
 }
 
 /// Loads a `v128` vector from the given heap address.
@@ -2128,14 +2128,14 @@ pub unsafe fn i64x2_mul(a: v128, b: v128) -> v128 {
     transmute(simd_mul(a.as_i64x2(), b.as_i64x2()))
 }
 
-/// Extracts the high bit for each lane in `a` and produce a scalar mask with
+/*/// Extracts the high bit for each lane in `a` and produce a scalar mask with
 /// all bits concatenated.
 #[inline]
 #[cfg_attr(test, assert_instr(i64x2.bitmask))]
 #[target_feature(enable = "simd128")]
 pub unsafe fn i64x2_bitmask(a: v128) -> i32 {
     llvm_bitmask_i64x2(transmute(a))
-}
+}*/
 
 /// Calculates the absolute value of each lane of a 128-bit vector interpreted
 /// as four 32-bit floating point numbers.
@@ -2835,8 +2835,8 @@ pub mod tests {
             assert_eq!(r, 0b11001100);
             let r: i32 = i32x4_bitmask(vec_a);
             assert_eq!(r, 0b1010);
-            let r: i32 = i64x2_bitmask(vec_a);
-            assert_eq!(r, 0b11);
+            /*let r: i32 = i64x2_bitmask(vec_a);
+            assert_eq!(r, 0b11);*/
 
             let r: i32 = i8x16_bitmask(vec_b);
             assert_eq!(r, 0xFFFF);
@@ -2844,8 +2844,8 @@ pub mod tests {
             assert_eq!(r, 0xFF);
             let r: i32 = i32x4_bitmask(vec_b);
             assert_eq!(r, 0xF);
-            let r: i32 = i64x2_bitmask(vec_b);
-            assert_eq!(r, 0b11);
+            /*let r: i32 = i64x2_bitmask(vec_b);
+            assert_eq!(r, 0b11);*/
 
             let r: i32 = i8x16_bitmask(vec_c);
             assert_eq!(r, 0);
@@ -2853,8 +2853,8 @@ pub mod tests {
             assert_eq!(r, 0);
             let r: i32 = i32x4_bitmask(vec_c);
             assert_eq!(r, 0);
-            let r: i32 = i64x2_bitmask(vec_c);
-            assert_eq!(r, 0);
+            /*let r: i32 = i64x2_bitmask(vec_c);
+            assert_eq!(r, 0);*/
         }
     }
 

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -1452,14 +1452,14 @@ pub unsafe fn i8x16_all_true(a: v128) -> i32 {
     llvm_i8x16_all_true(a.as_i8x16())
 }
 
-// FIXME: not available in our LLVM yet
-// /// Extracts the high bit for each lane in `a` and produce a scalar mask with
-// /// all bits concatenated.
-// #[inline]
-// #[cfg_attr(test, assert_instr(i8x16.all_true))]
-// pub unsafe fn i8x16_bitmask(a: v128) -> i32 {
-//     llvm_bitmask_i8x16(transmute(a))
-// }
+/// Extracts the high bit for each lane in `a` and produce a scalar mask with
+/// all bits concatenated.
+#[inline]
+#[cfg_attr(test, assert_instr(i8x16.bitmask))]
+#[target_feature(enable = "simd128")]
+pub unsafe fn i8x16_bitmask(a: v128) -> i32 {
+    llvm_bitmask_i8x16(transmute(a))
+}
 
 /// Converts two input vectors into a smaller lane vector by narrowing each
 /// lane.
@@ -1662,14 +1662,14 @@ pub unsafe fn i16x8_all_true(a: v128) -> i32 {
     llvm_i16x8_all_true(a.as_i16x8())
 }
 
-// FIXME: not available in our LLVM yet
-// /// Extracts the high bit for each lane in `a` and produce a scalar mask with
-// /// all bits concatenated.
-// #[inline]
-// #[cfg_attr(test, assert_instr(i16x8.all_true))]
-// pub unsafe fn i16x8_bitmask(a: v128) -> i32 {
-//     llvm_bitmask_i16x8(transmute(a))
-// }
+/// Extracts the high bit for each lane in `a` and produce a scalar mask with
+/// all bits concatenated.
+#[inline]
+#[cfg_attr(test, assert_instr(i16x8.bitmask))]
+#[target_feature(enable = "simd128")]
+pub unsafe fn i16x8_bitmask(a: v128) -> i32 {
+    llvm_bitmask_i16x8(transmute(a))
+}
 
 /// Converts two input vectors into a smaller lane vector by narrowing each
 /// lane.
@@ -1913,14 +1913,14 @@ pub unsafe fn i32x4_all_true(a: v128) -> i32 {
     llvm_i32x4_all_true(a.as_i32x4())
 }
 
-// FIXME: not available in our LLVM yet
-// /// Extracts the high bit for each lane in `a` and produce a scalar mask with
-// /// all bits concatenated.
-// #[inline]
-// #[cfg_attr(test, assert_instr(i32x4.all_true))]
-// pub unsafe fn i32x4_bitmask(a: v128) -> i32 {
-//     llvm_bitmask_i32x4(transmute(a))
-// }
+/// Extracts the high bit for each lane in `a` and produce a scalar mask with
+/// all bits concatenated.
+#[inline]
+#[cfg_attr(test, assert_instr(i32x4.bitmask))]
+#[target_feature(enable = "simd128")]
+pub unsafe fn i32x4_bitmask(a: v128) -> i32 {
+    llvm_bitmask_i32x4(transmute(a))
+}
 
 /// Converts low half of the smaller lane vector to a larger lane
 /// vector, sign extended.

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -190,6 +190,9 @@ extern "C" {
     fn llvm_widen_low_i32x4_u(a: i16x8) -> i32x4;
     #[link_name = "llvm.wasm.widen.high.unsigned.v4i32.v8i16"]
     fn llvm_widen_high_i32x4_u(a: i16x8) -> i32x4;
+
+    #[link_name = "llvm.wasm.bitmask.v2i64"]
+    fn llvm_bitmask_i64x2(a: i64x2) -> i32;
 }
 
 /// Loads a `v128` vector from the given heap address.

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -1419,7 +1419,7 @@ pub unsafe fn v128_bitselect(v1: v128, v2: v128, c: v128) -> v128 {
 
 /// Lane-wise wrapping absolute value.
 #[inline]
-// #[cfg_attr(test, assert_instr(i8x16.abs))] // FIXME support not in our LLVM yet
+#[cfg_attr(test, assert_instr(i8x16.abs))]
 #[target_feature(enable = "simd128")]
 pub unsafe fn i8x16_abs(a: v128) -> v128 {
     let a = transmute::<_, i8x16>(a);
@@ -1629,7 +1629,7 @@ pub unsafe fn i8x16_avgr_u(a: v128, b: v128) -> v128 {
 
 /// Lane-wise wrapping absolute value.
 #[inline]
-// #[cfg_attr(test, assert_instr(i16x8.abs))] // FIXME support not in our LLVM yet
+#[cfg_attr(test, assert_instr(i16x8.abs))]
 #[target_feature(enable = "simd128")]
 pub unsafe fn i16x8_abs(a: v128) -> v128 {
     let a = transmute::<_, i16x8>(a);
@@ -1880,7 +1880,7 @@ pub unsafe fn i16x8_avgr_u(a: v128, b: v128) -> v128 {
 
 /// Lane-wise wrapping absolute value.
 #[inline]
-// #[cfg_attr(test, assert_instr(i32x4.abs))] // FIXME support not in our LLVM yet
+#[cfg_attr(test, assert_instr(i32x4.abs))]
 #[target_feature(enable = "simd128")]
 pub unsafe fn i32x4_abs(a: v128) -> v128 {
     let a = transmute::<_, i32x4>(a);
@@ -2122,7 +2122,7 @@ pub unsafe fn i64x2_sub(a: v128, b: v128) -> v128 {
 
 /// Multiplies two 128-bit vectors as if they were two packed two 64-bit integers.
 #[inline]
-// #[cfg_attr(test, assert_instr(i64x2.mul))] // FIXME: not present in our LLVM
+#[cfg_attr(test, assert_instr(i64x2.mul))]
 #[target_feature(enable = "simd128")]
 pub unsafe fn i64x2_mul(a: v128, b: v128) -> v128 {
     transmute(simd_mul(a.as_i64x2(), b.as_i64x2()))


### PR DESCRIPTION
#874 introduced some `iNNxMM_bitmask` instructions that were supposed to be supported in LLVM 11, but they were commented out. Since Rust is already on LLVM 11 (https://blog.rust-lang.org/2020/10/08/Rust-1.47.html), this PR uncomments those instructions so they can be used.