### PR TITLE
Switch from `doc(include)` to `doc = include_str!`

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(include = "core_arch_docs.md")]
+#![doc = include_str!("core_arch_docs.md")]
 #![allow(improper_ctypes_definitions)]
 #![allow(dead_code)]
 #![allow(unused_features)]
@@ -36,7 +36,8 @@
     f16c_target_feature,
     external_doc,
     allow_internal_unstable,
-    decl_macro
+    decl_macro,
+    extended_key_value_attributes
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall))]
 #![cfg_attr(all(test, target_arch = "wasm32"), feature(wasm_simd))]

--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -9,7 +9,7 @@ mod acle;
 
 mod simd;
 
-#[doc(include = "core_arch_docs.md")]
+#[doc = include_str!("core_arch_docs.md")]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
     /// Platform-specific intrinsics for the `x86` platform.


### PR DESCRIPTION
I plan to deprecate `doc(include)` in the near future, and rust-lang/rust denies warnings in CI.

cc https://github.com/rust-lang/rust/issues/78835#issuecomment-742531894, https://github.com/rust-lang/rust/issues/44732#issuecomment-742754659