### PR TITLE
Initial conversion to const generics

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -53,7 +53,8 @@
     clippy::shadow_reuse,
     clippy::cognitive_complexity,
     clippy::similar_names,
-    clippy::many_single_char_names
+    clippy::many_single_char_names,
+    non_upper_case_globals
 )]
 #![cfg_attr(test, allow(unused_imports))]
 #![no_std]

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -22694,7 +22694,7 @@ pub unsafe fn _mm_mask_shuffle_ps(
 ) -> __m128 {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_shuffle_ps(a, b, $imm8)
+            _mm_shuffle_ps::<$imm8>(a, b)
         };
     }
     let r = constify_imm8_sae!(imm8, call);
@@ -22711,7 +22711,7 @@ pub unsafe fn _mm_mask_shuffle_ps(
 pub unsafe fn _mm_maskz_shuffle_ps(k: __mmask8, a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_shuffle_ps(a, b, $imm8)
+            _mm_shuffle_ps::<$imm8>(a, b)
         };
     }
     let r = constify_imm8_sae!(imm8, call);


### PR DESCRIPTION
This PR builds on top https://github.com/rust-lang/rust/pull/82447 to start transition intrinsics to use const generics. This is the first step towards solving #248.

- Updated the testing infrastructure to support const generics.
- Updated the intrinsic verification to support const generics.
- Ported `_mm_shuffle_ps` and `_mm_prefetch` to use const generics.