### PR TITLE
Use static assertions to bound-check const generics

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -1,6 +1,19 @@
 //! Utility macros.
 
 #[allow(unused)]
+macro_rules! static_assert {
+    ($imm:ident : $ty:ty where $e:expr) => {
+        struct Validate<const $imm: $ty>();
+        impl<const $imm: $ty> Validate<$imm> {
+            const VALID: () = {
+                let _ = 1 / ($e as usize);
+            };
+        }
+        let _ = Validate::<$imm>::VALID;
+    };
+}
+
+#[allow(unused)]
 macro_rules! constify_imm8 {
     ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1010,7 +1010,7 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_shuffle_ps<const mask: i32>(a: __m128, b: __m128) -> __m128 {
-    assert!(mask >= 0 && mask <= 255);
+    static_assert!(mask: i32 where mask >= 0 && mask <= 255);
     simd_shuffle4(
         a,
         b,


### PR DESCRIPTION
This builds on top of #1018 and prevents invalid constants from reaching LLVM and triggering assertions. 

Thanks @lcnr and @RalfJung for helping me find a construct that works with const generics!