### PR TITLE
Convert _mm_slli_epi{16,32,64} & _mm_srli_epi{16,32,64} to const generics

### DIFF
--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -5201,7 +5201,7 @@ pub unsafe fn _mm256_maskz_slli_epi16(k: __mmask16, a: __m256i, imm8: u32) -> __
 pub unsafe fn _mm_mask_slli_epi16(src: __m128i, k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_slli_epi16(a, $imm8)
+            _mm_slli_epi16::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);
@@ -5218,7 +5218,7 @@ pub unsafe fn _mm_mask_slli_epi16(src: __m128i, k: __mmask8, a: __m128i, imm8: u
 pub unsafe fn _mm_maskz_slli_epi16(k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_slli_epi16(a, $imm8)
+            _mm_slli_epi16::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -5530,7 +5530,7 @@ pub unsafe fn _mm256_maskz_srli_epi16(k: __mmask16, a: __m256i, imm8: i32) -> __
 pub unsafe fn _mm_mask_srli_epi16(src: __m128i, k: __mmask8, a: __m128i, imm8: i32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_srli_epi16(a, $imm8)
+            _mm_srli_epi16::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);
@@ -5547,7 +5547,7 @@ pub unsafe fn _mm_mask_srli_epi16(src: __m128i, k: __mmask8, a: __m128i, imm8: i
 pub unsafe fn _mm_maskz_srli_epi16(k: __mmask8, a: __m128i, imm8: i32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_srli_epi16(a, $imm8)
+            _mm_srli_epi16::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -18434,7 +18434,7 @@ pub unsafe fn _mm256_maskz_slli_epi64(k: __mmask8, a: __m256i, imm8: u32) -> __m
 pub unsafe fn _mm_mask_slli_epi64(src: __m128i, k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_slli_epi64(a, $imm8)
+            _mm_slli_epi64::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);
@@ -18451,7 +18451,7 @@ pub unsafe fn _mm_mask_slli_epi64(src: __m128i, k: __mmask8, a: __m128i, imm8: u
 pub unsafe fn _mm_maskz_slli_epi64(k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_slli_epi64(a, $imm8)
+            _mm_slli_epi64::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -18309,7 +18309,7 @@ pub unsafe fn _mm256_maskz_srli_epi32(k: __mmask8, a: __m256i, imm8: u32) -> __m
 pub unsafe fn _mm_mask_srli_epi32(src: __m128i, k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_srli_epi32(a, $imm8)
+            _mm_srli_epi32::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);
@@ -18326,7 +18326,7 @@ pub unsafe fn _mm_mask_srli_epi32(src: __m128i, k: __mmask8, a: __m128i, imm8: u
 pub unsafe fn _mm_maskz_srli_epi32(k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_srli_epi32(a, $imm8)
+            _mm_srli_epi32::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -18184,7 +18184,7 @@ pub unsafe fn _mm256_maskz_slli_epi32(k: __mmask8, a: __m256i, imm8: u32) -> __m
 pub unsafe fn _mm_mask_slli_epi32(src: __m128i, k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_slli_epi32(a, $imm8)
+            _mm_slli_epi32::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);
@@ -18201,7 +18201,7 @@ pub unsafe fn _mm_mask_slli_epi32(src: __m128i, k: __mmask8, a: __m128i, imm8: u
 pub unsafe fn _mm_maskz_slli_epi32(k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_slli_epi32(a, $imm8)
+            _mm_slli_epi32::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -18559,7 +18559,7 @@ pub unsafe fn _mm256_maskz_srli_epi64(k: __mmask8, a: __m256i, imm8: u32) -> __m
 pub unsafe fn _mm_mask_srli_epi64(src: __m128i, k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_srli_epi64(a, $imm8)
+            _mm_srli_epi64::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);
@@ -18576,7 +18576,7 @@ pub unsafe fn _mm_mask_srli_epi64(src: __m128i, k: __mmask8, a: __m128i, imm8: u
 pub unsafe fn _mm_maskz_srli_epi64(k: __mmask8, a: __m128i, imm8: u32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
-            _mm_srli_epi64(a, $imm8)
+            _mm_srli_epi64::<$imm8>(a)
         };
     }
     let shf = constify_imm8_sae!(imm8, call);

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -503,16 +503,10 @@ pub unsafe fn _mm_bsrli_si128(a: __m128i, imm8: i32) -> __m128i {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psllw, imm8 = 7))]
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_epi16(a: __m128i, imm8: i32) -> __m128i {
-    let a = a.as_i16x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            transmute(pslliw(a, $imm8))
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm_slli_epi16<const imm8: i32>(a: __m128i) -> __m128i {
+    transmute(pslliw(a.as_i16x8(), imm8))
 }
 
 /// Shifts packed 16-bit integers in `a` left by `count` while shifting in
@@ -3427,7 +3421,7 @@ mod tests {
         let a = _mm_setr_epi16(
             0xFFFF as u16 as i16, 0x0FFF, 0x00FF, 0x000F, 0, 0, 0, 0,
         );
-        let r = _mm_slli_epi16(a, 4);
+        let r = _mm_slli_epi16::<4>(a);
 
         #[rustfmt::skip]
         let e = _mm_setr_epi16(

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -763,9 +763,9 @@ pub unsafe fn _mm_srl_epi32(a: __m128i, count: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrlq, imm8 = 1))]
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_epi64(a: __m128i, imm8: i32) -> __m128i {
+pub unsafe fn _mm_srli_epi64<const imm8: i32>(a: __m128i) -> __m128i {
     transmute(psrliq(a.as_i64x2(), imm8))
 }
 
@@ -3584,7 +3584,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_srli_epi64() {
-        let r = _mm_srli_epi64(_mm_set1_epi64x(0xFFFFFFFF), 4);
+        let r = _mm_srli_epi64::<4>(_mm_set1_epi64x(0xFFFFFFFF));
         assert_eq_m128i(r, _mm_set1_epi64x(0xFFFFFFF));
     }
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -527,16 +527,10 @@ pub unsafe fn _mm_sll_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pslld, imm8 = 7))]
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_epi32(a: __m128i, imm8: i32) -> __m128i {
-    let a = a.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            transmute(psllid(a, $imm8))
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm_slli_epi32<const imm8: i32>(a: __m128i) -> __m128i {
+    transmute(psllid(a.as_i32x4(), imm8))
 }
 
 /// Shifts packed 32-bit integers in `a` left by `count` while shifting in
@@ -3442,7 +3436,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_slli_epi32() {
-        let r = _mm_slli_epi32(_mm_set1_epi32(0xFFFF), 4);
+        let r = _mm_slli_epi32::<4>(_mm_set1_epi32(0xFFFF));
         assert_eq_m128i(r, _mm_set1_epi32(0xFFFF0));
     }
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -713,16 +713,10 @@ unsafe fn _mm_srli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrlw, imm8 = 1))]
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_epi16(a: __m128i, imm8: i32) -> __m128i {
-    let a = a.as_i16x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            transmute(psrliw(a, $imm8))
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm_srli_epi16<const imm8: i32>(a: __m128i) -> __m128i {
+    transmute(psrliw(a.as_i16x8(), imm8))
 }
 
 /// Shifts packed 16-bit integers in `a` right by `count` while shifting in
@@ -3563,7 +3557,7 @@ mod tests {
         let a = _mm_setr_epi16(
             0xFFFF as u16 as i16, 0x0FFF, 0x00FF, 0x000F, 0, 0, 0, 0,
         );
-        let r = _mm_srli_epi16(a, 4);
+        let r = _mm_srli_epi16::<4>(a);
         #[rustfmt::skip]
         let e = _mm_setr_epi16(
             0xFFF as u16 as i16, 0xFF as u16 as i16, 0xF, 0, 0, 0, 0, 0,

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -738,16 +738,10 @@ pub unsafe fn _mm_srl_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrld, imm8 = 8))]
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_epi32(a: __m128i, imm8: i32) -> __m128i {
-    let a = a.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            transmute(psrlid(a, $imm8))
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm_srli_epi32<const imm8: i32>(a: __m128i) -> __m128i {
+    transmute(psrlid(a.as_i32x4(), imm8))
 }
 
 /// Shifts packed 32-bit integers in `a` right by `count` while shifting in
@@ -3576,7 +3570,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_srli_epi32() {
-        let r = _mm_srli_epi32(_mm_set1_epi32(0xFFFF), 4);
+        let r = _mm_srli_epi32::<4>(_mm_set1_epi32(0xFFFF));
         assert_eq_m128i(r, _mm_set1_epi32(0xFFF));
     }
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -506,6 +506,7 @@ pub unsafe fn _mm_bsrli_si128(a: __m128i, imm8: i32) -> __m128i {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_slli_epi16<const imm8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(imm8);
     transmute(pslliw(a.as_i16x8(), imm8))
 }
 
@@ -530,6 +531,7 @@ pub unsafe fn _mm_sll_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_slli_epi32<const imm8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(imm8);
     transmute(psllid(a.as_i32x4(), imm8))
 }
 
@@ -554,6 +556,7 @@ pub unsafe fn _mm_sll_epi32(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_slli_epi64<const imm8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(imm8);
     transmute(pslliq(a.as_i64x2(), imm8))
 }
 
@@ -698,6 +701,7 @@ unsafe fn _mm_srli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srli_epi16<const imm8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(imm8);
     transmute(psrliw(a.as_i16x8(), imm8))
 }
 
@@ -723,6 +727,7 @@ pub unsafe fn _mm_srl_epi16(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srli_epi32<const imm8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(imm8);
     transmute(psrlid(a.as_i32x4(), imm8))
 }
 
@@ -748,6 +753,7 @@ pub unsafe fn _mm_srl_epi32(a: __m128i, count: __m128i) -> __m128i {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srli_epi64<const imm8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(imm8);
     transmute(psrliq(a.as_i64x2(), imm8))
 }
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -551,16 +551,10 @@ pub unsafe fn _mm_sll_epi32(a: __m128i, count: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psllq, imm8 = 7))]
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_epi64(a: __m128i, imm8: i32) -> __m128i {
-    let a = a.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            transmute(pslliq(a, $imm8))
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm_slli_epi64<const imm8: i32>(a: __m128i) -> __m128i {
+    transmute(pslliq(a.as_i64x2(), imm8))
 }
 
 /// Shifts packed 64-bit integers in `a` left by `count` while shifting in
@@ -3450,7 +3444,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_slli_epi64() {
-        let r = _mm_slli_epi64(_mm_set1_epi64x(0xFFFFFFFF), 4);
+        let r = _mm_slli_epi64::<4>(_mm_set1_epi64x(0xFFFFFFFF));
         assert_eq_m128i(r, _mm_set1_epi64x(0xFFFFFFFF0));
     }
 


### PR DESCRIPTION
* `_mm_slli_epi64`
* `_mm_slli_epi32`
* `_mm_slli_epi16`
* `_mm_srli_epi64`
* `_mm_srli_epi32`
* `_mm_srli_epi16`
