### PR TITLE
Use uppercase for const generic parameters

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -53,8 +53,7 @@
     clippy::shadow_reuse,
     clippy::cognitive_complexity,
     clippy::similar_names,
-    clippy::many_single_char_names,
-    non_upper_case_globals
+    clippy::many_single_char_names
 )]
 #![cfg_attr(test, allow(unused_imports))]
 #![no_std]

--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -2,10 +2,10 @@
 
 // Helper struct used to trigger const eval errors when the const generic immediate value `imm` is
 // out of `bits`-bit range.
-pub(crate) struct ValidateConstImm<const imm: i32, const bits: i32>;
-impl<const imm: i32, const bits: i32> ValidateConstImm<imm, bits> {
+pub(crate) struct ValidateConstImm<const IMM: i32, const BITS: i32>;
+impl<const IMM: i32, const BITS: i32> ValidateConstImm<IMM, BITS> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((imm >= 0 && imm < (1 << bits)) as usize);
+        let _ = 1 / ((IMM >= 0 && IMM < (1 << BITS)) as usize);
     };
 }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2923,46 +2923,46 @@ pub unsafe fn _mm256_sll_epi64(a: __m256i, count: __m128i) -> __m256i {
     transmute(psllq(a.as_i64x4(), count.as_i64x2()))
 }
 
-/// Shifts packed 16-bit integers in `a` left by `imm8` while
+/// Shifts packed 16-bit integers in `a` left by `IMM8` while
 /// shifting in zeros, return the results;
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_slli_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsllw, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsllw, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_slli_epi16<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(pslliw(a.as_i16x16(), imm8))
+pub unsafe fn _mm256_slli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(pslliw(a.as_i16x16(), IMM8))
 }
 
-/// Shifts packed 32-bit integers in `a` left by `imm8` while
+/// Shifts packed 32-bit integers in `a` left by `IMM8` while
 /// shifting in zeros, return the results;
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_slli_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpslld, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpslld, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_slli_epi32<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(psllid(a.as_i32x8(), imm8))
+pub unsafe fn _mm256_slli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(psllid(a.as_i32x8(), IMM8))
 }
 
-/// Shifts packed 64-bit integers in `a` left by `imm8` while
+/// Shifts packed 64-bit integers in `a` left by `IMM8` while
 /// shifting in zeros, return the results;
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_slli_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsllq, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsllq, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_slli_epi64<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(pslliq(a.as_i64x4(), imm8))
+pub unsafe fn _mm256_slli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(pslliq(a.as_i64x4(), IMM8))
 }
 
 /// Shifts 128-bit lanes in `a` left by `imm8` bytes while shifting in zeros.
@@ -3077,32 +3077,32 @@ pub unsafe fn _mm256_sra_epi32(a: __m256i, count: __m128i) -> __m256i {
     transmute(psrad(a.as_i32x8(), count.as_i32x4()))
 }
 
-/// Shifts packed 16-bit integers in `a` right by `imm8` while
+/// Shifts packed 16-bit integers in `a` right by `IMM8` while
 /// shifting in sign bits.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_srai_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsraw, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsraw, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_srai_epi16<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(psraiw(a.as_i16x16(), imm8))
+pub unsafe fn _mm256_srai_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(psraiw(a.as_i16x16(), IMM8))
 }
 
-/// Shifts packed 32-bit integers in `a` right by `imm8` while
+/// Shifts packed 32-bit integers in `a` right by `IMM8` while
 /// shifting in sign bits.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_srai_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsrad, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsrad, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_srai_epi32<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(psraid(a.as_i32x8(), imm8))
+pub unsafe fn _mm256_srai_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(psraid(a.as_i32x8(), IMM8))
 }
 
 /// Shifts packed 32-bit integers in `a` right by the amount specified by the
@@ -3201,46 +3201,46 @@ pub unsafe fn _mm256_srl_epi64(a: __m256i, count: __m128i) -> __m256i {
     transmute(psrlq(a.as_i64x4(), count.as_i64x2()))
 }
 
-/// Shifts packed 16-bit integers in `a` right by `imm8` while shifting in
+/// Shifts packed 16-bit integers in `a` right by `IMM8` while shifting in
 /// zeros
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_srli_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsrlw, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsrlw, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_srli_epi16<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(psrliw(a.as_i16x16(), imm8))
+pub unsafe fn _mm256_srli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(psrliw(a.as_i16x16(), IMM8))
 }
 
-/// Shifts packed 32-bit integers in `a` right by `imm8` while shifting in
+/// Shifts packed 32-bit integers in `a` right by `IMM8` while shifting in
 /// zeros
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_srli_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsrld, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsrld, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_srli_epi32<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(psrlid(a.as_i32x8(), imm8))
+pub unsafe fn _mm256_srli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(psrlid(a.as_i32x8(), IMM8))
 }
 
-/// Shifts packed 64-bit integers in `a` right by `imm8` while shifting in
+/// Shifts packed 64-bit integers in `a` right by `IMM8` while shifting in
 /// zeros
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_srli_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpsrlq, imm8 = 7))]
+#[cfg_attr(test, assert_instr(vpsrlq, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_srli_epi64<const imm8: i32>(a: __m256i) -> __m256i {
-    static_assert_imm8!(imm8);
-    transmute(psrliq(a.as_i64x4(), imm8))
+pub unsafe fn _mm256_srli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(psrliq(a.as_i64x4(), IMM8))
 }
 
 /// Shifts packed 32-bit integers in `a` right by the amount specified by

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -992,7 +992,7 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 }
 
 /// Shuffles packed single-precision (32-bit) floating-point elements in `a` and
-/// `b` using `mask`.
+/// `b` using `MASK`.
 ///
 /// The lower half of result takes values from `a` and the higher half from
 /// `b`. Mask is split to 2 control bits each to index the element from inputs.
@@ -1006,19 +1006,19 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 /// does not cause a problem in C, however Rust's commitment to strong typing does not allow this.
 #[inline]
 #[target_feature(enable = "sse")]
-#[cfg_attr(test, assert_instr(shufps, mask = 3))]
+#[cfg_attr(test, assert_instr(shufps, MASK = 3))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_shuffle_ps<const mask: i32>(a: __m128, b: __m128) -> __m128 {
-    static_assert_imm8!(mask);
+pub unsafe fn _mm_shuffle_ps<const MASK: i32>(a: __m128, b: __m128) -> __m128 {
+    static_assert_imm8!(MASK);
     simd_shuffle4(
         a,
         b,
         [
-            mask as u32 & 0b11,
-            (mask as u32 >> 2) & 0b11,
-            ((mask as u32 >> 4) & 0b11) + 4,
-            ((mask as u32 >> 6) & 0b11) + 4,
+            MASK as u32 & 0b11,
+            (MASK as u32 >> 2) & 0b11,
+            ((MASK as u32 >> 4) & 0b11) + 4,
+            ((MASK as u32 >> 6) & 0b11) + 4,
         ],
     )
 }
@@ -1701,9 +1701,9 @@ pub const _MM_HINT_ET0: i32 = 7;
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub const _MM_HINT_ET1: i32 = 6;
 
-/// Fetch the cache line that contains address `p` using the given `strategy`.
+/// Fetch the cache line that contains address `p` using the given `STRATEGY`.
 ///
-/// The `strategy` must be one of:
+/// The `STRATEGY` must be one of:
 ///
 /// * [`_MM_HINT_T0`](constant._MM_HINT_T0.html): Fetch into all levels of the
 ///   cache hierarchy.
@@ -1745,16 +1745,16 @@ pub const _MM_HINT_ET1: i32 = 6;
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_prefetch)
 #[inline]
 #[target_feature(enable = "sse")]
-#[cfg_attr(test, assert_instr(prefetcht0, strategy = _MM_HINT_T0))]
-#[cfg_attr(test, assert_instr(prefetcht1, strategy = _MM_HINT_T1))]
-#[cfg_attr(test, assert_instr(prefetcht2, strategy = _MM_HINT_T2))]
-#[cfg_attr(test, assert_instr(prefetchnta, strategy = _MM_HINT_NTA))]
+#[cfg_attr(test, assert_instr(prefetcht0, STRATEGY = _MM_HINT_T0))]
+#[cfg_attr(test, assert_instr(prefetcht1, STRATEGY = _MM_HINT_T1))]
+#[cfg_attr(test, assert_instr(prefetcht2, STRATEGY = _MM_HINT_T2))]
+#[cfg_attr(test, assert_instr(prefetchnta, STRATEGY = _MM_HINT_NTA))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_prefetch<const strategy: i32>(p: *const i8) {
+pub unsafe fn _mm_prefetch<const STRATEGY: i32>(p: *const i8) {
     // We use the `llvm.prefetch` instrinsic with `cache type` = 1 (data cache).
-    // `locality` and `rw` are based on our `strategy`.
-    prefetch(p, (strategy >> 2) & 1, strategy & 3, 1);
+    // `locality` and `rw` are based on our `STRATEGY`.
+    prefetch(p, (STRATEGY >> 2) & 1, STRATEGY & 3, 1);
 }
 
 /// Returns vector of type __m128 with undefined elements.

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -406,24 +406,24 @@ pub unsafe fn _mm_subs_epu16(a: __m128i, b: __m128i) -> __m128i {
     transmute(simd_saturating_sub(a.as_u16x8(), b.as_u16x8()))
 }
 
-/// Shifts `a` left by `imm8` bytes while shifting in zeros.
+/// Shifts `a` left by `IMM8` bytes while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_slli_si128)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pslldq, imm8 = 1))]
+#[cfg_attr(test, assert_instr(pslldq, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_si128<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    _mm_slli_si128_impl::<imm8>(a)
+pub unsafe fn _mm_slli_si128<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    _mm_slli_si128_impl::<IMM8>(a)
 }
 
 /// Implementation detail: converts the immediate argument of the
 /// `_mm_slli_si128` intrinsic into a compile-time constant.
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn _mm_slli_si128_impl<const imm8: i32>(a: __m128i) -> __m128i {
+unsafe fn _mm_slli_si128_impl<const IMM8: i32>(a: __m128i) -> __m128i {
     const fn mask(shift: i32, i: u32) -> u32 {
         if (shift as u32) > 15 {
             i
@@ -436,63 +436,63 @@ unsafe fn _mm_slli_si128_impl<const imm8: i32>(a: __m128i) -> __m128i {
         zero,
         a.as_i8x16(),
         [
-            mask(imm8, 0),
-            mask(imm8, 1),
-            mask(imm8, 2),
-            mask(imm8, 3),
-            mask(imm8, 4),
-            mask(imm8, 5),
-            mask(imm8, 6),
-            mask(imm8, 7),
-            mask(imm8, 8),
-            mask(imm8, 9),
-            mask(imm8, 10),
-            mask(imm8, 11),
-            mask(imm8, 12),
-            mask(imm8, 13),
-            mask(imm8, 14),
-            mask(imm8, 15),
+            mask(IMM8, 0),
+            mask(IMM8, 1),
+            mask(IMM8, 2),
+            mask(IMM8, 3),
+            mask(IMM8, 4),
+            mask(IMM8, 5),
+            mask(IMM8, 6),
+            mask(IMM8, 7),
+            mask(IMM8, 8),
+            mask(IMM8, 9),
+            mask(IMM8, 10),
+            mask(IMM8, 11),
+            mask(IMM8, 12),
+            mask(IMM8, 13),
+            mask(IMM8, 14),
+            mask(IMM8, 15),
         ],
     ))
 }
 
-/// Shifts `a` left by `imm8` bytes while shifting in zeros.
+/// Shifts `a` left by `IMM8` bytes while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_bslli_si128)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pslldq, imm8 = 1))]
+#[cfg_attr(test, assert_instr(pslldq, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_bslli_si128<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    _mm_slli_si128_impl::<imm8>(a)
+pub unsafe fn _mm_bslli_si128<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    _mm_slli_si128_impl::<IMM8>(a)
 }
 
-/// Shifts `a` right by `imm8` bytes while shifting in zeros.
+/// Shifts `a` right by `IMM8` bytes while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_bsrli_si128)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psrldq, imm8 = 1))]
+#[cfg_attr(test, assert_instr(psrldq, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_bsrli_si128<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    _mm_srli_si128_impl::<imm8>(a)
+pub unsafe fn _mm_bsrli_si128<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    _mm_srli_si128_impl::<IMM8>(a)
 }
 
-/// Shifts packed 16-bit integers in `a` left by `imm8` while shifting in zeros.
+/// Shifts packed 16-bit integers in `a` left by `IMM8` while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_slli_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psllw, imm8 = 7))]
+#[cfg_attr(test, assert_instr(psllw, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_epi16<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(pslliw(a.as_i16x8(), imm8))
+pub unsafe fn _mm_slli_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(pslliw(a.as_i16x8(), IMM8))
 }
 
 /// Shifts packed 16-bit integers in `a` left by `count` while shifting in
@@ -507,17 +507,17 @@ pub unsafe fn _mm_sll_epi16(a: __m128i, count: __m128i) -> __m128i {
     transmute(psllw(a.as_i16x8(), count.as_i16x8()))
 }
 
-/// Shifts packed 32-bit integers in `a` left by `imm8` while shifting in zeros.
+/// Shifts packed 32-bit integers in `a` left by `IMM8` while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_slli_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pslld, imm8 = 7))]
+#[cfg_attr(test, assert_instr(pslld, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_epi32<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(psllid(a.as_i32x4(), imm8))
+pub unsafe fn _mm_slli_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(psllid(a.as_i32x4(), IMM8))
 }
 
 /// Shifts packed 32-bit integers in `a` left by `count` while shifting in
@@ -532,17 +532,17 @@ pub unsafe fn _mm_sll_epi32(a: __m128i, count: __m128i) -> __m128i {
     transmute(pslld(a.as_i32x4(), count.as_i32x4()))
 }
 
-/// Shifts packed 64-bit integers in `a` left by `imm8` while shifting in zeros.
+/// Shifts packed 64-bit integers in `a` left by `IMM8` while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_slli_epi64)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psllq, imm8 = 7))]
+#[cfg_attr(test, assert_instr(psllq, IMM8 = 7))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_slli_epi64<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(pslliq(a.as_i64x2(), imm8))
+pub unsafe fn _mm_slli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(pslliq(a.as_i64x2(), IMM8))
 }
 
 /// Shifts packed 64-bit integers in `a` left by `count` while shifting in
@@ -557,18 +557,18 @@ pub unsafe fn _mm_sll_epi64(a: __m128i, count: __m128i) -> __m128i {
     transmute(psllq(a.as_i64x2(), count.as_i64x2()))
 }
 
-/// Shifts packed 16-bit integers in `a` right by `imm8` while shifting in sign
+/// Shifts packed 16-bit integers in `a` right by `IMM8` while shifting in sign
 /// bits.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_srai_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psraw, imm8 = 1))]
+#[cfg_attr(test, assert_instr(psraw, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srai_epi16<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(psraiw(a.as_i16x8(), imm8))
+pub unsafe fn _mm_srai_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(psraiw(a.as_i16x8(), IMM8))
 }
 
 /// Shifts packed 16-bit integers in `a` right by `count` while shifting in sign
@@ -583,18 +583,18 @@ pub unsafe fn _mm_sra_epi16(a: __m128i, count: __m128i) -> __m128i {
     transmute(psraw(a.as_i16x8(), count.as_i16x8()))
 }
 
-/// Shifts packed 32-bit integers in `a` right by `imm8` while shifting in sign
+/// Shifts packed 32-bit integers in `a` right by `IMM8` while shifting in sign
 /// bits.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_srai_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psrad, imm8 = 1))]
+#[cfg_attr(test, assert_instr(psrad, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srai_epi32<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(psraid(a.as_i32x4(), imm8))
+pub unsafe fn _mm_srai_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(psraid(a.as_i32x4(), IMM8))
 }
 
 /// Shifts packed 32-bit integers in `a` right by `count` while shifting in sign
@@ -609,24 +609,24 @@ pub unsafe fn _mm_sra_epi32(a: __m128i, count: __m128i) -> __m128i {
     transmute(psrad(a.as_i32x4(), count.as_i32x4()))
 }
 
-/// Shifts `a` right by `imm8` bytes while shifting in zeros.
+/// Shifts `a` right by `IMM8` bytes while shifting in zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_srli_si128)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psrldq, imm8 = 1))]
+#[cfg_attr(test, assert_instr(psrldq, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_si128<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    _mm_srli_si128_impl::<imm8>(a)
+pub unsafe fn _mm_srli_si128<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    _mm_srli_si128_impl::<IMM8>(a)
 }
 
 /// Implementation detail: converts the immediate argument of the
 /// `_mm_srli_si128` intrinsic into a compile-time constant.
 #[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn _mm_srli_si128_impl<const imm8: i32>(a: __m128i) -> __m128i {
+unsafe fn _mm_srli_si128_impl<const IMM8: i32>(a: __m128i) -> __m128i {
     const fn mask(shift: i32, i: u32) -> u32 {
         if (shift as u32) > 15 {
             i + 16
@@ -639,39 +639,39 @@ unsafe fn _mm_srli_si128_impl<const imm8: i32>(a: __m128i) -> __m128i {
         a.as_i8x16(),
         zero,
         [
-            mask(imm8, 0),
-            mask(imm8, 1),
-            mask(imm8, 2),
-            mask(imm8, 3),
-            mask(imm8, 4),
-            mask(imm8, 5),
-            mask(imm8, 6),
-            mask(imm8, 7),
-            mask(imm8, 8),
-            mask(imm8, 9),
-            mask(imm8, 10),
-            mask(imm8, 11),
-            mask(imm8, 12),
-            mask(imm8, 13),
-            mask(imm8, 14),
-            mask(imm8, 15),
+            mask(IMM8, 0),
+            mask(IMM8, 1),
+            mask(IMM8, 2),
+            mask(IMM8, 3),
+            mask(IMM8, 4),
+            mask(IMM8, 5),
+            mask(IMM8, 6),
+            mask(IMM8, 7),
+            mask(IMM8, 8),
+            mask(IMM8, 9),
+            mask(IMM8, 10),
+            mask(IMM8, 11),
+            mask(IMM8, 12),
+            mask(IMM8, 13),
+            mask(IMM8, 14),
+            mask(IMM8, 15),
         ],
     );
     transmute(x)
 }
 
-/// Shifts packed 16-bit integers in `a` right by `imm8` while shifting in
+/// Shifts packed 16-bit integers in `a` right by `IMM8` while shifting in
 /// zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_srli_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psrlw, imm8 = 1))]
+#[cfg_attr(test, assert_instr(psrlw, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_epi16<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(psrliw(a.as_i16x8(), imm8))
+pub unsafe fn _mm_srli_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(psrliw(a.as_i16x8(), IMM8))
 }
 
 /// Shifts packed 16-bit integers in `a` right by `count` while shifting in
@@ -686,18 +686,18 @@ pub unsafe fn _mm_srl_epi16(a: __m128i, count: __m128i) -> __m128i {
     transmute(psrlw(a.as_i16x8(), count.as_i16x8()))
 }
 
-/// Shifts packed 32-bit integers in `a` right by `imm8` while shifting in
+/// Shifts packed 32-bit integers in `a` right by `IMM8` while shifting in
 /// zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_srli_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psrld, imm8 = 8))]
+#[cfg_attr(test, assert_instr(psrld, IMM8 = 8))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_epi32<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(psrlid(a.as_i32x4(), imm8))
+pub unsafe fn _mm_srli_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(psrlid(a.as_i32x4(), IMM8))
 }
 
 /// Shifts packed 32-bit integers in `a` right by `count` while shifting in
@@ -712,18 +712,18 @@ pub unsafe fn _mm_srl_epi32(a: __m128i, count: __m128i) -> __m128i {
     transmute(psrld(a.as_i32x4(), count.as_i32x4()))
 }
 
-/// Shifts packed 64-bit integers in `a` right by `imm8` while shifting in
+/// Shifts packed 64-bit integers in `a` right by `IMM8` while shifting in
 /// zeros.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_srli_epi64)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(psrlq, imm8 = 1))]
+#[cfg_attr(test, assert_instr(psrlq, IMM8 = 1))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_srli_epi64<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(psrliq(a.as_i64x2(), imm8))
+pub unsafe fn _mm_srli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(psrliq(a.as_i64x2(), IMM8))
 }
 
 /// Shifts packed 64-bit integers in `a` right by `count` while shifting in
@@ -1390,32 +1390,32 @@ pub unsafe fn _mm_movemask_epi8(a: __m128i) -> i32 {
     pmovmskb(a.as_i8x16())
 }
 
-/// Shuffles 32-bit integers in `a` using the control in `imm8`.
+/// Shuffles 32-bit integers in `a` using the control in `IMM8`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shuffle_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pshufd, imm8 = 9))]
+#[cfg_attr(test, assert_instr(pshufd, IMM8 = 9))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_shuffle_epi32<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
+pub unsafe fn _mm_shuffle_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x4();
     let x: i32x4 = simd_shuffle4(
         a,
         a,
         [
-            imm8 as u32 & 0b11,
-            (imm8 as u32 >> 2) & 0b11,
-            (imm8 as u32 >> 4) & 0b11,
-            (imm8 as u32 >> 6) & 0b11,
+            IMM8 as u32 & 0b11,
+            (IMM8 as u32 >> 2) & 0b11,
+            (IMM8 as u32 >> 4) & 0b11,
+            (IMM8 as u32 >> 6) & 0b11,
         ],
     );
     transmute(x)
 }
 
 /// Shuffles 16-bit integers in the high 64 bits of `a` using the control in
-/// `imm8`.
+/// `IMM8`.
 ///
 /// Put the results in the high 64 bits of the returned vector, with the low 64
 /// bits being copied from from `a`.
@@ -1423,11 +1423,11 @@ pub unsafe fn _mm_shuffle_epi32<const imm8: i32>(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shufflehi_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pshufhw, imm8 = 9))]
+#[cfg_attr(test, assert_instr(pshufhw, IMM8 = 9))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_shufflehi_epi16<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
+pub unsafe fn _mm_shufflehi_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i16x8();
     let x: i16x8 = simd_shuffle8(
         a,
@@ -1437,17 +1437,17 @@ pub unsafe fn _mm_shufflehi_epi16<const imm8: i32>(a: __m128i) -> __m128i {
             1,
             2,
             3,
-            (imm8 as u32 & 0b11) + 4,
-            ((imm8 as u32 >> 2) & 0b11) + 4,
-            ((imm8 as u32 >> 4) & 0b11) + 4,
-            ((imm8 as u32 >> 6) & 0b11) + 4,
+            (IMM8 as u32 & 0b11) + 4,
+            ((IMM8 as u32 >> 2) & 0b11) + 4,
+            ((IMM8 as u32 >> 4) & 0b11) + 4,
+            ((IMM8 as u32 >> 6) & 0b11) + 4,
         ],
     );
     transmute(x)
 }
 
 /// Shuffles 16-bit integers in the low 64 bits of `a` using the control in
-/// `imm8`.
+/// `IMM8`.
 ///
 /// Put the results in the low 64 bits of the returned vector, with the high 64
 /// bits being copied from from `a`.
@@ -1455,20 +1455,20 @@ pub unsafe fn _mm_shufflehi_epi16<const imm8: i32>(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shufflelo_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pshuflw, imm8 = 9))]
+#[cfg_attr(test, assert_instr(pshuflw, IMM8 = 9))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_shufflelo_epi16<const imm8: i32>(a: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
+pub unsafe fn _mm_shufflelo_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i16x8();
     let x: i16x8 = simd_shuffle8(
         a,
         a,
         [
-            imm8 as u32 & 0b11,
-            (imm8 as u32 >> 2) & 0b11,
-            (imm8 as u32 >> 4) & 0b11,
-            (imm8 as u32 >> 6) & 0b11,
+            IMM8 as u32 & 0b11,
+            (IMM8 as u32 >> 2) & 0b11,
+            (IMM8 as u32 >> 4) & 0b11,
+            (IMM8 as u32 >> 6) & 0b11,
             4,
             5,
             6,

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -65,7 +65,7 @@ pub unsafe fn _mm_blendv_epi8(a: __m128i, b: __m128i, mask: __m128i) -> __m128i 
     transmute(pblendvb(a.as_i8x16(), b.as_i8x16(), mask.as_i8x16()))
 }
 
-/// Blend packed 16-bit integers from `a` and `b` using the mask `imm8`.
+/// Blend packed 16-bit integers from `a` and `b` using the mask `IMM8`.
 ///
 /// The mask bits determine the selection. A clear bit selects the
 /// corresponding element of `a`, and a set bit the corresponding
@@ -76,13 +76,13 @@ pub unsafe fn _mm_blendv_epi8(a: __m128i, b: __m128i, mask: __m128i) -> __m128i 
 #[target_feature(enable = "sse4.1")]
 // Note: LLVM7 prefers the single-precision floating-point domain when possible
 // see https://bugs.llvm.org/show_bug.cgi?id=38195
-// #[cfg_attr(test, assert_instr(pblendw, imm8 = 0xF0))]
-#[cfg_attr(test, assert_instr(blendps, imm8 = 0xF0))]
+// #[cfg_attr(test, assert_instr(pblendw, IMM8 = 0xF0))]
+#[cfg_attr(test, assert_instr(blendps, IMM8 = 0xF0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_blend_epi16<const imm8: i32>(a: __m128i, b: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(pblendw(a.as_i16x8(), b.as_i16x8(), imm8 as u8))
+pub unsafe fn _mm_blend_epi16<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(pblendw(a.as_i16x8(), b.as_i16x8(), IMM8 as u8))
 }
 
 /// Blend packed double-precision (64-bit) floating-point elements from `a`
@@ -110,54 +110,54 @@ pub unsafe fn _mm_blendv_ps(a: __m128, b: __m128, mask: __m128) -> __m128 {
 }
 
 /// Blend packed double-precision (64-bit) floating-point elements from `a`
-/// and `b` using control mask `imm2`
+/// and `b` using control mask `IMM2`
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_blend_pd)
 #[inline]
 #[target_feature(enable = "sse4.1")]
 // Note: LLVM7 prefers the single-precision floating-point domain when possible
 // see https://bugs.llvm.org/show_bug.cgi?id=38195
-// #[cfg_attr(test, assert_instr(blendpd, imm2 = 0b10))]
-#[cfg_attr(test, assert_instr(blendps, imm2 = 0b10))]
+// #[cfg_attr(test, assert_instr(blendpd, IMM2 = 0b10))]
+#[cfg_attr(test, assert_instr(blendps, IMM2 = 0b10))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_blend_pd<const imm2: i32>(a: __m128d, b: __m128d) -> __m128d {
-    static_assert_imm2!(imm2);
-    blendpd(a, b, imm2 as u8)
+pub unsafe fn _mm_blend_pd<const IMM2: i32>(a: __m128d, b: __m128d) -> __m128d {
+    static_assert_imm2!(IMM2);
+    blendpd(a, b, IMM2 as u8)
 }
 
 /// Blend packed single-precision (32-bit) floating-point elements from `a`
-/// and `b` using mask `imm4`
+/// and `b` using mask `IMM4`
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_blend_ps)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(blendps, imm4 = 0b0101))]
+#[cfg_attr(test, assert_instr(blendps, IMM4 = 0b0101))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_blend_ps<const imm4: i32>(a: __m128, b: __m128) -> __m128 {
-    static_assert_imm4!(imm4);
-    blendps(a, b, imm4 as u8)
+pub unsafe fn _mm_blend_ps<const IMM4: i32>(a: __m128, b: __m128) -> __m128 {
+    static_assert_imm4!(IMM4);
+    blendps(a, b, IMM4 as u8)
 }
 
 /// Extracts a single-precision (32-bit) floating-point element from `a`,
-/// selected with `imm8`
+/// selected with `IMM8`
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_extract_ps)
 #[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(
     all(test, not(target_os = "windows")),
-    assert_instr(extractps, imm8 = 0)
+    assert_instr(extractps, IMM8 = 0)
 )]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_extract_ps<const imm8: i32>(a: __m128) -> i32 {
-    static_assert_imm2!(imm8);
-    transmute(simd_extract::<_, f32>(a, imm8 as u32))
+pub unsafe fn _mm_extract_ps<const IMM8: i32>(a: __m128) -> i32 {
+    static_assert_imm2!(IMM8);
+    transmute(simd_extract::<_, f32>(a, IMM8 as u32))
 }
 
-/// Extracts an 8-bit integer from `a`, selected with `imm8`. Returns a 32-bit
+/// Extracts an 8-bit integer from `a`, selected with `IMM8`. Returns a 32-bit
 /// integer containing the zero-extended integer data.
 ///
 /// See [LLVM commit D20468](https://reviews.llvm.org/D20468).
@@ -165,34 +165,34 @@ pub unsafe fn _mm_extract_ps<const imm8: i32>(a: __m128) -> i32 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_extract_epi8)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(pextrb, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pextrb, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_extract_epi8<const imm8: i32>(a: __m128i) -> i32 {
-    static_assert_imm4!(imm8);
-    simd_extract::<_, u8>(a.as_u8x16(), imm8 as u32) as i32
+pub unsafe fn _mm_extract_epi8<const IMM8: i32>(a: __m128i) -> i32 {
+    static_assert_imm4!(IMM8);
+    simd_extract::<_, u8>(a.as_u8x16(), IMM8 as u32) as i32
 }
 
-/// Extracts an 32-bit integer from `a` selected with `imm8`
+/// Extracts an 32-bit integer from `a` selected with `IMM8`
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_extract_epi32)
 #[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(
     all(test, not(target_os = "windows")),
-    assert_instr(extractps, imm8 = 1)
+    assert_instr(extractps, IMM8 = 1)
 )]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_extract_epi32<const imm8: i32>(a: __m128i) -> i32 {
-    static_assert_imm2!(imm8);
-    simd_extract::<_, i32>(a.as_i32x4(), imm8 as u32)
+pub unsafe fn _mm_extract_epi32<const IMM8: i32>(a: __m128i) -> i32 {
+    static_assert_imm2!(IMM8);
+    simd_extract::<_, i32>(a.as_i32x4(), IMM8 as u32)
 }
 
 /// Select a single value in `a` to store at some position in `b`,
-/// Then zero elements according to `imm8`.
+/// Then zero elements according to `IMM8`.
 ///
-/// `imm8` specifies which bits from operand `a` will be copied, which bits in
+/// `IMM8` specifies which bits from operand `a` will be copied, which bits in
 /// the result they will be copied to, and which bits in the result will be
 /// cleared. The following assignments are made:
 ///
@@ -215,40 +215,40 @@ pub unsafe fn _mm_extract_epi32<const imm8: i32>(a: __m128i) -> i32 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_insert_ps)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(insertps, imm8 = 0b1010))]
+#[cfg_attr(test, assert_instr(insertps, IMM8 = 0b1010))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_insert_ps<const imm8: i32>(a: __m128, b: __m128) -> __m128 {
-    static_assert_imm8!(imm8);
-    insertps(a, b, imm8 as u8)
+pub unsafe fn _mm_insert_ps<const IMM8: i32>(a: __m128, b: __m128) -> __m128 {
+    static_assert_imm8!(IMM8);
+    insertps(a, b, IMM8 as u8)
 }
 
 /// Returns a copy of `a` with the 8-bit integer from `i` inserted at a
-/// location specified by `imm8`.
+/// location specified by `IMM8`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_insert_epi8)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(pinsrb, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pinsrb, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_insert_epi8<const imm8: i32>(a: __m128i, i: i32) -> __m128i {
-    static_assert_imm4!(imm8);
-    transmute(simd_insert(a.as_i8x16(), imm8 as u32, i as i8))
+pub unsafe fn _mm_insert_epi8<const IMM8: i32>(a: __m128i, i: i32) -> __m128i {
+    static_assert_imm4!(IMM8);
+    transmute(simd_insert(a.as_i8x16(), IMM8 as u32, i as i8))
 }
 
 /// Returns a copy of `a` with the 32-bit integer from `i` inserted at a
-/// location specified by `imm8`.
+/// location specified by `IMM8`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_insert_epi32)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(pinsrd, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pinsrd, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_insert_epi32<const imm8: i32>(a: __m128i, i: i32) -> __m128i {
-    static_assert_imm2!(imm8);
-    transmute(simd_insert(a.as_i32x4(), imm8 as u32, i))
+pub unsafe fn _mm_insert_epi32<const IMM8: i32>(a: __m128i, i: i32) -> __m128i {
+    static_assert_imm2!(IMM8);
+    transmute(simd_insert(a.as_i32x4(), IMM8 as u32, i))
 }
 
 /// Compares packed 8-bit integers in `a` and `b` and returns packed maximum
@@ -532,7 +532,7 @@ pub unsafe fn _mm_cvtepu32_epi64(a: __m128i) -> __m128i {
 
 /// Returns the dot product of two __m128d vectors.
 ///
-/// `imm8[1:0]` is the broadcast mask, and `imm8[5:4]` is the condition mask.
+/// `IMM8[1:0]` is the broadcast mask, and `IMM8[5:4]` is the condition mask.
 /// If a condition mask bit is zero, the corresponding multiplication is
 /// replaced by a value of `0.0`. If a broadcast mask bit is one, the result of
 /// the dot product will be stored in the return value component. Otherwise if
@@ -541,17 +541,17 @@ pub unsafe fn _mm_cvtepu32_epi64(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_dp_pd)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(dppd, imm8 = 0))]
+#[cfg_attr(test, assert_instr(dppd, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_dp_pd<const imm8: i32>(a: __m128d, b: __m128d) -> __m128d {
-    static_assert_imm8!(imm8);
-    dppd(a, b, imm8 as u8)
+pub unsafe fn _mm_dp_pd<const IMM8: i32>(a: __m128d, b: __m128d) -> __m128d {
+    static_assert_imm8!(IMM8);
+    dppd(a, b, IMM8 as u8)
 }
 
 /// Returns the dot product of two __m128 vectors.
 ///
-/// `imm8[3:0]` is the broadcast mask, and `imm8[7:4]` is the condition mask.
+/// `IMM8[3:0]` is the broadcast mask, and `IMM8[7:4]` is the condition mask.
 /// If a condition mask bit is zero, the corresponding multiplication is
 /// replaced by a value of `0.0`. If a broadcast mask bit is one, the result of
 /// the dot product will be stored in the return value component. Otherwise if
@@ -560,12 +560,12 @@ pub unsafe fn _mm_dp_pd<const imm8: i32>(a: __m128d, b: __m128d) -> __m128d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_dp_ps)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(dpps, imm8 = 0))]
+#[cfg_attr(test, assert_instr(dpps, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_dp_ps<const imm8: i32>(a: __m128, b: __m128) -> __m128 {
-    static_assert_imm8!(imm8);
-    dpps(a, b, imm8 as u8)
+pub unsafe fn _mm_dp_ps<const IMM8: i32>(a: __m128, b: __m128) -> __m128 {
+    static_assert_imm8!(IMM8);
+    dpps(a, b, IMM8 as u8)
 }
 
 /// Round the packed double-precision (64-bit) floating-point elements in `a`
@@ -681,7 +681,7 @@ pub unsafe fn _mm_ceil_ss(a: __m128, b: __m128) -> __m128 {
 }
 
 /// Round the packed double-precision (64-bit) floating-point elements in `a`
-/// using the `rounding` parameter, and stores the results as packed
+/// using the `ROUNDING` parameter, and stores the results as packed
 /// double-precision floating-point elements.
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
@@ -713,16 +713,16 @@ pub unsafe fn _mm_ceil_ss(a: __m128, b: __m128) -> __m128 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_round_pd)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(roundpd, rounding = 0))]
+#[cfg_attr(test, assert_instr(roundpd, ROUNDING = 0))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_round_pd<const rounding: i32>(a: __m128d) -> __m128d {
-    static_assert_imm4!(rounding);
-    roundpd(a, rounding)
+pub unsafe fn _mm_round_pd<const ROUNDING: i32>(a: __m128d) -> __m128d {
+    static_assert_imm4!(ROUNDING);
+    roundpd(a, ROUNDING)
 }
 
 /// Round the packed single-precision (32-bit) floating-point elements in `a`
-/// using the `rounding` parameter, and stores the results as packed
+/// using the `ROUNDING` parameter, and stores the results as packed
 /// single-precision floating-point elements.
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
@@ -754,16 +754,16 @@ pub unsafe fn _mm_round_pd<const rounding: i32>(a: __m128d) -> __m128d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_round_ps)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(roundps, rounding = 0))]
+#[cfg_attr(test, assert_instr(roundps, ROUNDING = 0))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_round_ps<const rounding: i32>(a: __m128) -> __m128 {
-    static_assert_imm4!(rounding);
-    roundps(a, rounding)
+pub unsafe fn _mm_round_ps<const ROUNDING: i32>(a: __m128) -> __m128 {
+    static_assert_imm4!(ROUNDING);
+    roundps(a, ROUNDING)
 }
 
 /// Round the lower double-precision (64-bit) floating-point element in `b`
-/// using the `rounding` parameter, store the result as a double-precision
+/// using the `ROUNDING` parameter, store the result as a double-precision
 /// floating-point element in the lower element of the intrinsic result,
 /// and copies the upper element from `a` to the upper element of the intrinsic
 /// result.
@@ -797,16 +797,16 @@ pub unsafe fn _mm_round_ps<const rounding: i32>(a: __m128) -> __m128 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_round_sd)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(roundsd, rounding = 0))]
+#[cfg_attr(test, assert_instr(roundsd, ROUNDING = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_round_sd<const rounding: i32>(a: __m128d, b: __m128d) -> __m128d {
-    static_assert_imm4!(rounding);
-    roundsd(a, b, rounding)
+pub unsafe fn _mm_round_sd<const ROUNDING: i32>(a: __m128d, b: __m128d) -> __m128d {
+    static_assert_imm4!(ROUNDING);
+    roundsd(a, b, ROUNDING)
 }
 
 /// Round the lower single-precision (32-bit) floating-point element in `b`
-/// using the `rounding` parameter, store the result as a single-precision
+/// using the `ROUNDING` parameter, store the result as a single-precision
 /// floating-point element in the lower element of the intrinsic result,
 /// and copies the upper 3 packed elements from `a` to the upper elements
 /// of the instrinsic result.
@@ -840,12 +840,12 @@ pub unsafe fn _mm_round_sd<const rounding: i32>(a: __m128d, b: __m128d) -> __m12
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_round_ss)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(roundss, rounding = 0))]
+#[cfg_attr(test, assert_instr(roundss, ROUNDING = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_round_ss<const rounding: i32>(a: __m128, b: __m128) -> __m128 {
-    static_assert_imm4!(rounding);
-    roundss(a, b, rounding)
+pub unsafe fn _mm_round_ss<const ROUNDING: i32>(a: __m128, b: __m128) -> __m128 {
+    static_assert_imm4!(ROUNDING);
+    roundss(a, b, ROUNDING)
 }
 
 /// Finds the minimum unsigned 16-bit element in the 128-bit __m128i vector,
@@ -913,8 +913,8 @@ pub unsafe fn _mm_mullo_epi32(a: __m128i, b: __m128i) -> __m128i {
 /// The following algorithm is performed:
 ///
 /// ```ignore
-/// i = imm8[2] * 4
-/// j = imm8[1:0] * 4
+/// i = IMM8[2] * 4
+/// j = IMM8[1:0] * 4
 /// for k := 0 to 7
 ///     d0 = abs(a[i + k + 0] - b[j + 0])
 ///     d1 = abs(a[i + k + 1] - b[j + 1])
@@ -927,7 +927,7 @@ pub unsafe fn _mm_mullo_epi32(a: __m128i, b: __m128i) -> __m128i {
 ///
 /// * `a` - A 128-bit vector of type `__m128i`.
 /// * `b` - A 128-bit vector of type `__m128i`.
-/// * `imm8` - An 8-bit immediate operand specifying how the absolute
+/// * `IMM8` - An 8-bit immediate operand specifying how the absolute
 ///   differences are to be calculated
 ///     * Bit `[2]` specify the offset for operand `a`
 ///     * Bits `[1:0]` specify the offset for operand `b`
@@ -940,12 +940,12 @@ pub unsafe fn _mm_mullo_epi32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mpsadbw_epu8)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(mpsadbw, imm8 = 0))]
+#[cfg_attr(test, assert_instr(mpsadbw, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_mpsadbw_epu8<const imm8: i32>(a: __m128i, b: __m128i) -> __m128i {
-    static_assert_imm3!(imm8);
-    transmute(mpsadbw(a.as_u8x16(), b.as_u8x16(), imm8 as u8))
+pub unsafe fn _mm_mpsadbw_epu8<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i {
+    static_assert_imm3!(IMM8);
+    transmute(mpsadbw(a.as_u8x16(), b.as_u8x16(), IMM8 as u8))
 }
 
 /// Tests whether the specified bits in a 128-bit integer vector are all

--- a/crates/core_arch/src/x86/sse42.rs
+++ b/crates/core_arch/src/x86/sse42.rs
@@ -65,27 +65,27 @@ pub const _SIDD_BIT_MASK: i32 = 0b0000_0000;
 pub const _SIDD_UNIT_MASK: i32 = 0b0100_0000;
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8`, and return the generated mask.
+/// control in `IMM8`, and return the generated mask.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistrm)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistrm, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistrm, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistrm<const imm8: i32>(a: __m128i, b: __m128i) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(pcmpistrm128(a.as_i8x16(), b.as_i8x16(), imm8 as i8))
+pub unsafe fn _mm_cmpistrm<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(pcmpistrm128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8))
 }
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8` and return the generated index. Similar to
+/// control in `IMM8` and return the generated index. Similar to
 /// [`_mm_cmpestri`] with the exception that [`_mm_cmpestri`] requires the
 /// lengths of `a` and `b` to be explicitly specified.
 ///
 /// # Control modes
 ///
-/// The control specified by `imm8` may be one or more of the following.
+/// The control specified by `IMM8` may be one or more of the following.
 ///
 /// ## Data size and signedness
 ///
@@ -258,110 +258,110 @@ pub unsafe fn _mm_cmpistrm<const imm8: i32>(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistri)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistri, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistri<const imm8: i32>(a: __m128i, b: __m128i) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpistri128(a.as_i8x16(), b.as_i8x16(), imm8 as i8)
+pub unsafe fn _mm_cmpistri<const IMM8: i32>(a: __m128i, b: __m128i) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpistri128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8)
 }
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8`, and return `1` if any character in `b` was null.
+/// control in `IMM8`, and return `1` if any character in `b` was null.
 /// and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistrz)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistri, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistrz<const imm8: i32>(a: __m128i, b: __m128i) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpistriz128(a.as_i8x16(), b.as_i8x16(), imm8 as i8)
+pub unsafe fn _mm_cmpistrz<const IMM8: i32>(a: __m128i, b: __m128i) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpistriz128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8)
 }
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8`, and return `1` if the resulting mask was non-zero,
+/// control in `IMM8`, and return `1` if the resulting mask was non-zero,
 /// and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistrc)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistri, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistrc<const imm8: i32>(a: __m128i, b: __m128i) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpistric128(a.as_i8x16(), b.as_i8x16(), imm8 as i8)
+pub unsafe fn _mm_cmpistrc<const IMM8: i32>(a: __m128i, b: __m128i) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpistric128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8)
 }
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8`, and returns `1` if any character in `a` was null,
+/// control in `IMM8`, and returns `1` if any character in `a` was null,
 /// and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistrs)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistri, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistrs<const imm8: i32>(a: __m128i, b: __m128i) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpistris128(a.as_i8x16(), b.as_i8x16(), imm8 as i8)
+pub unsafe fn _mm_cmpistrs<const IMM8: i32>(a: __m128i, b: __m128i) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpistris128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8)
 }
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8`, and return bit `0` of the resulting bit mask.
+/// control in `IMM8`, and return bit `0` of the resulting bit mask.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistro)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistri, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistro<const imm8: i32>(a: __m128i, b: __m128i) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpistrio128(a.as_i8x16(), b.as_i8x16(), imm8 as i8)
+pub unsafe fn _mm_cmpistro<const IMM8: i32>(a: __m128i, b: __m128i) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpistrio128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8)
 }
 
 /// Compares packed strings with implicit lengths in `a` and `b` using the
-/// control in `imm8`, and return `1` if `b` did not contain a null
+/// control in `IMM8`, and return `1` if `b` did not contain a null
 /// character and the resulting mask was zero, and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpistra)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpistri, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpistra<const imm8: i32>(a: __m128i, b: __m128i) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpistria128(a.as_i8x16(), b.as_i8x16(), imm8 as i8)
+pub unsafe fn _mm_cmpistra<const IMM8: i32>(a: __m128i, b: __m128i) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpistria128(a.as_i8x16(), b.as_i8x16(), IMM8 as i8)
 }
 
 /// Compares packed strings in `a` and `b` with lengths `la` and `lb`
-/// using the control in `imm8`, and return the generated mask.
+/// using the control in `IMM8`, and return the generated mask.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestrm)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestrm, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestrm, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrm<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> __m128i {
-    static_assert_imm8!(imm8);
-    transmute(pcmpestrm128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8))
+pub unsafe fn _mm_cmpestrm<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> __m128i {
+    static_assert_imm8!(IMM8);
+    transmute(pcmpestrm128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8))
 }
 
 /// Compares packed strings `a` and `b` with lengths `la` and `lb` using the
-/// control in `imm8` and return the generated index. Similar to
+/// control in `IMM8` and return the generated index. Similar to
 /// [`_mm_cmpistri`] with the exception that [`_mm_cmpistri`] implicitly
 /// determines the length of `a` and `b`.
 ///
 /// # Control modes
 ///
-/// The control specified by `imm8` may be one or more of the following.
+/// The control specified by `IMM8` may be one or more of the following.
 ///
 /// ## Data size and signedness
 ///
@@ -435,88 +435,88 @@ pub unsafe fn _mm_cmpestrm<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb:
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestri)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestri, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestri<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpestri128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8)
+pub unsafe fn _mm_cmpestri<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpestri128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8)
 }
 
 /// Compares packed strings in `a` and `b` with lengths `la` and `lb`
-/// using the control in `imm8`, and return `1` if any character in
+/// using the control in `IMM8`, and return `1` if any character in
 /// `b` was null, and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestrz)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestri, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrz<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpestriz128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8)
+pub unsafe fn _mm_cmpestrz<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpestriz128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8)
 }
 
 /// Compares packed strings in `a` and `b` with lengths `la` and `lb`
-/// using the control in `imm8`, and return `1` if the resulting mask
+/// using the control in `IMM8`, and return `1` if the resulting mask
 /// was non-zero, and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestrc)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestri, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrc<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpestric128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8)
+pub unsafe fn _mm_cmpestrc<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpestric128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8)
 }
 
 /// Compares packed strings in `a` and `b` with lengths `la` and `lb`
-/// using the control in `imm8`, and return `1` if any character in
+/// using the control in `IMM8`, and return `1` if any character in
 /// a was null, and `0` otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestrs)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestri, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrs<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpestris128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8)
+pub unsafe fn _mm_cmpestrs<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpestris128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8)
 }
 
 /// Compares packed strings in `a` and `b` with lengths `la` and `lb`
-/// using the control in `imm8`, and return bit `0` of the resulting
+/// using the control in `IMM8`, and return bit `0` of the resulting
 /// bit mask.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestro)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestri, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestro<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpestrio128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8)
+pub unsafe fn _mm_cmpestro<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpestrio128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8)
 }
 
 /// Compares packed strings in `a` and `b` with lengths `la` and `lb`
-/// using the control in `imm8`, and return `1` if `b` did not
+/// using the control in `IMM8`, and return `1` if `b` did not
 /// contain a null character and the resulting mask was zero, and `0`
 /// otherwise.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmpestra)
 #[inline]
 #[target_feature(enable = "sse4.2")]
-#[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
+#[cfg_attr(test, assert_instr(pcmpestri, IMM8 = 0))]
 #[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestra<const imm8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
-    static_assert_imm8!(imm8);
-    pcmpestria128(a.as_i8x16(), la, b.as_i8x16(), lb, imm8 as i8)
+pub unsafe fn _mm_cmpestra<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb: i32) -> i32 {
+    static_assert_imm8!(IMM8);
+    pcmpestria128(a.as_i8x16(), la, b.as_i8x16(), lb, IMM8 as i8)
 }
 
 /// Starting with the initial value in `crc`, return the accumulated


### PR DESCRIPTION
Originally I wanted to allow lowercase parameter names so that I could do automated bulk conversion, but it turns out this is impractical. Using uppercase is also clearer since it gives a better indication that some parameters are constants.