### PR TITLE
Convert shuffle_ps and shuffle_pd to const generics

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -45,6 +45,13 @@ macro_rules! static_assert_imm8 {
 }
 
 #[allow(unused)]
+macro_rules! static_assert_rounding {
+    ($imm:ident) => {
+        let _ = $imm == 4 || $imm == 8 || $imm == 9 || $imm == 10 || $imm == 11;
+    };
+}
+
+#[allow(unused)]
 macro_rules! static_assert {
     ($imm:ident : $ty:ty where $e:expr) => {
         struct Validate<const $imm: $ty>();

--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -45,13 +45,6 @@ macro_rules! static_assert_imm8 {
 }
 
 #[allow(unused)]
-macro_rules! static_assert_rounding {
-    ($imm:ident) => {
-        let _ = $imm == 4 || $imm == 8 || $imm == 9 || $imm == 10 || $imm == 11;
-    };
-}
-
-#[allow(unused)]
 macro_rules! static_assert {
     ($imm:ident : $ty:ty where $e:expr) => {
         struct Validate<const $imm: $ty>();

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -6863,17 +6863,13 @@ pub unsafe fn _mm_maskz_getmant_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_add_round_ps&expand=145)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddps, rounding = 8))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm512_add_round_ps(a: __m512, b: __m512, rounding: i32) -> __m512 {
+#[cfg_attr(test, assert_instr(vaddps, IMM4 = 8))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm512_add_round_ps<const IMM4: i32>(a: __m512, b: __m512) -> __m512 {
+    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    macro_rules! call {
-        ($imm4:expr) => {
-            vaddps(a, b, $imm4)
-        };
-    }
-    let r = constify_imm4_round!(rounding, call);
+    let r = vaddps(a, b, IMM4);
     transmute(r)
 }
 
@@ -6889,24 +6885,19 @@ pub unsafe fn _mm512_add_round_ps(a: __m512, b: __m512, rounding: i32) -> __m512
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_add_round_ps&expand=146)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddps, rounding = 8))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_mask_add_round_ps(
+#[cfg_attr(test, assert_instr(vaddps, IMM4 = 8))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_mask_add_round_ps<const IMM4: i32>(
     src: __m512,
     k: __mmask16,
     a: __m512,
     b: __m512,
-    rounding: i32,
 ) -> __m512 {
+    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    macro_rules! call {
-        ($imm4:expr) => {
-            vaddps(a, b, $imm4)
-        };
-    }
-    let addround = constify_imm4_round!(rounding, call);
-    transmute(simd_select_bitmask(k, addround, src.as_f32x16()))
+    let r = vaddps(a, b, IMM4);
+    transmute(simd_select_bitmask(k, r, src.as_f32x16()))
 }
 
 /// Add packed single-precision (32-bit) floating-point elements in a and b, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).\
@@ -6921,24 +6912,19 @@ pub unsafe fn _mm512_mask_add_round_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_add_round_ps&expand=147)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddps, rounding = 8))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_maskz_add_round_ps(
+#[cfg_attr(test, assert_instr(vaddps, IMM4 = 8))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_maskz_add_round_ps<const IMM4: i32>(
     k: __mmask16,
     a: __m512,
     b: __m512,
-    rounding: i32,
 ) -> __m512 {
+    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    macro_rules! call {
-        ($imm4:expr) => {
-            vaddps(a, b, $imm4)
-        };
-    }
-    let addround = constify_imm4_round!(rounding, call);
+    let r = vaddps(a, b, IMM4);
     let zero = _mm512_setzero_ps().as_f32x16();
-    transmute(simd_select_bitmask(k, addround, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Add packed double-precision (64-bit) floating-point elements in a and b, and store the results in dst.\
@@ -6953,17 +6939,13 @@ pub unsafe fn _mm512_maskz_add_round_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_add_round_pd&expand=142)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddpd, rounding = 8))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm512_add_round_pd(a: __m512d, b: __m512d, rounding: i32) -> __m512d {
+#[cfg_attr(test, assert_instr(vaddpd, IMM4 = 8))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm512_add_round_pd<const IMM4: i32>(a: __m512d, b: __m512d) -> __m512d {
+    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    macro_rules! call {
-        ($imm4:expr) => {
-            vaddpd(a, b, $imm4)
-        };
-    }
-    let r = constify_imm4_round!(rounding, call);
+    let r = vaddpd(a, b, IMM4);
     transmute(r)
 }
 
@@ -6979,24 +6961,18 @@ pub unsafe fn _mm512_add_round_pd(a: __m512d, b: __m512d, rounding: i32) -> __m5
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_add_round_pd&expand=143)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddpd, rounding = 8))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_mask_add_round_pd(
+#[cfg_attr(test, assert_instr(vaddpd, IMM4 = 8))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_mask_add_round_pd<const IMM4: i32>(
     src: __m512d,
     k: __mmask8,
     a: __m512d,
     b: __m512d,
-    rounding: i32,
 ) -> __m512d {
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    macro_rules! call {
-        ($imm4:expr) => {
-            vaddpd(a, b, $imm4)
-        };
-    }
-    let addround = constify_imm4_round!(rounding, call);
-    transmute(simd_select_bitmask(k, addround, src.as_f64x8()))
+    let r = vaddpd(a, b, IMM4);
+    transmute(simd_select_bitmask(k, r, src.as_f64x8()))
 }
 
 /// Add packed double-precision (64-bit) floating-point elements in a and b, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).\
@@ -7011,24 +6987,18 @@ pub unsafe fn _mm512_mask_add_round_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_add_round_pd&expand=144)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddpd, rounding = 8))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_maskz_add_round_pd(
+#[cfg_attr(test, assert_instr(vaddpd, IMM4 = 8))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_maskz_add_round_pd<const IMM4: i32>(
     k: __mmask8,
     a: __m512d,
     b: __m512d,
-    rounding: i32,
 ) -> __m512d {
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    macro_rules! call {
-        ($imm4:expr) => {
-            vaddpd(a, b, $imm4)
-        };
-    }
-    let addround = constify_imm4_round!(rounding, call);
+    let r = vaddpd(a, b, IMM4);
     let zero = _mm512_setzero_pd().as_f64x8();
-    transmute(simd_select_bitmask(k, addround, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Subtract packed single-precision (32-bit) floating-point elements in b from packed single-precision (32-bit) floating-point elements in a, and store the results in dst.\
@@ -42336,7 +42306,7 @@ mod tests {
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
         let b = _mm512_set1_ps(-1.);
-        let r = _mm512_add_round_ps(a, b, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        let r = _mm512_add_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
         #[rustfmt::skip]
         let e = _mm512_setr_ps(
             -1., 0.5, 1., 2.5,
@@ -42345,7 +42315,7 @@ mod tests {
             11., 12.5, 13., -0.99999994,
         );
         assert_eq_m512(r, e);
-        let r = _mm512_add_round_ps(a, b, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+        let r = _mm512_add_round_ps::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
         let e = _mm512_setr_ps(
             -1., 0.5, 1., 2.5, 3., 4.5, 5., 6.5, 7., 8.5, 9., 10.5, 11., 12.5, 13., -0.9999999,
         );
@@ -42358,14 +42328,13 @@ mod tests {
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
         let b = _mm512_set1_ps(-1.);
-        let r = _mm512_mask_add_round_ps(a, 0, a, b, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        let r = _mm512_mask_add_round_ps::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, 0, a, b);
         assert_eq_m512(r, a);
-        let r = _mm512_mask_add_round_ps(
+        let r = _mm512_mask_add_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             a,
             0b11111111_00000000,
             a,
             b,
-            _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC,
         );
         #[rustfmt::skip]
         let e = _mm512_setr_ps(
@@ -42383,13 +42352,12 @@ mod tests {
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
         let b = _mm512_set1_ps(-1.);
-        let r = _mm512_maskz_add_round_ps(0, a, b, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        let r = _mm512_maskz_add_round_ps::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
         assert_eq_m512(r, _mm512_setzero_ps());
-        let r = _mm512_maskz_add_round_ps(
+        let r = _mm512_maskz_add_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b11111111_00000000,
             a,
             b,
-            _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC,
         );
         #[rustfmt::skip]
         let e = _mm512_setr_ps(

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -5065,17 +5065,12 @@ pub unsafe fn _mm_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m128) -
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_roundscale_pd&expand=4775)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(1)]
-pub unsafe fn _mm512_roundscale_pd(a: __m512d, imm8: i32) -> __m512d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(1)]
+pub unsafe fn _mm512_roundscale_pd<const IMM8: i32>(a: __m512d) -> __m512d {
     let a = a.as_f64x8();
     let zero = _mm512_setzero_pd().as_f64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd(a, $imm8, zero, 0b11111111, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd(a, IMM8, zero, 0b11111111, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5090,22 +5085,16 @@ pub unsafe fn _mm512_roundscale_pd(a: __m512d, imm8: i32) -> __m512d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_roundscale_pd&expand=4773)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_mask_roundscale_pd(
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_mask_roundscale_pd<const IMM8: i32>(
     src: __m512d,
     k: __mmask8,
     a: __m512d,
-    imm8: i32,
 ) -> __m512d {
     let a = a.as_f64x8();
     let src = src.as_f64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd(a, $imm8, src, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd(a, IMM8, src, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5120,17 +5109,12 @@ pub unsafe fn _mm512_mask_roundscale_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_roundscale_pd&expand=4774)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm512_maskz_roundscale_pd(k: __mmask8, a: __m512d, imm8: i32) -> __m512d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm512_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m512d) -> __m512d {
     let a = a.as_f64x8();
     let zero = _mm512_setzero_pd().as_f64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd(a, $imm8, zero, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd(a, IMM8, zero, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5145,17 +5129,12 @@ pub unsafe fn _mm512_maskz_roundscale_pd(k: __mmask8, a: __m512d, imm8: i32) -> 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_roundscale_pd&expand=4772)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(1)]
-pub unsafe fn _mm256_roundscale_pd(a: __m256d, imm8: i32) -> __m256d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(1)]
+pub unsafe fn _mm256_roundscale_pd<const IMM8: i32>(a: __m256d) -> __m256d {
     let a = a.as_f64x4();
     let zero = _mm256_setzero_pd().as_f64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd256(a, $imm8, zero, 0b00001111)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd256(a, IMM8, zero, 0b00001111);
     transmute(r)
 }
 
@@ -5170,22 +5149,16 @@ pub unsafe fn _mm256_roundscale_pd(a: __m256d, imm8: i32) -> __m256d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_roundscale_pd&expand=4770)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm256_mask_roundscale_pd(
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm256_mask_roundscale_pd<const IMM8: i32>(
     src: __m256d,
     k: __mmask8,
     a: __m256d,
-    imm8: i32,
 ) -> __m256d {
     let a = a.as_f64x4();
     let src = src.as_f64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd256(a, $imm8, src, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd256(a, IMM8, src, k);
     transmute(r)
 }
 
@@ -5200,17 +5173,12 @@ pub unsafe fn _mm256_mask_roundscale_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_roundscale_pd&expand=4771)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm256_maskz_roundscale_pd(k: __mmask8, a: __m256d, imm8: i32) -> __m256d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm256_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m256d) -> __m256d {
     let a = a.as_f64x4();
     let zero = _mm256_setzero_pd().as_f64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd256(a, $imm8, zero, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd256(a, IMM8, zero, k);
     transmute(r)
 }
 
@@ -5225,17 +5193,12 @@ pub unsafe fn _mm256_maskz_roundscale_pd(k: __mmask8, a: __m256d, imm8: i32) -> 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_roundscale_pd&expand=4769)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(1)]
-pub unsafe fn _mm_roundscale_pd(a: __m128d, imm8: i32) -> __m128d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(1)]
+pub unsafe fn _mm_roundscale_pd<const IMM8: i32>(a: __m128d) -> __m128d {
     let a = a.as_f64x2();
     let zero = _mm_setzero_pd().as_f64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd128(a, $imm8, zero, 0b00000011)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd128(a, IMM8, zero, 0b00000011);
     transmute(r)
 }
 
@@ -5250,17 +5213,16 @@ pub unsafe fn _mm_roundscale_pd(a: __m128d, imm8: i32) -> __m128d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_roundscale_pd&expand=4767)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm_mask_roundscale_pd(src: __m128d, k: __mmask8, a: __m128d, imm8: i32) -> __m128d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm_mask_roundscale_pd<const IMM8: i32>(
+    src: __m128d,
+    k: __mmask8,
+    a: __m128d,
+) -> __m128d {
     let a = a.as_f64x2();
     let src = src.as_f64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd128(a, $imm8, src, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd128(a, IMM8, src, k);
     transmute(r)
 }
 
@@ -5275,17 +5237,12 @@ pub unsafe fn _mm_mask_roundscale_pd(src: __m128d, k: __mmask8, a: __m128d, imm8
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_roundscale_pd&expand=4768)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscalepd, imm8 = 0))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm_maskz_roundscale_pd(k: __mmask8, a: __m128d, imm8: i32) -> __m128d {
+#[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m128d) -> __m128d {
     let a = a.as_f64x2();
     let zero = _mm_setzero_pd().as_f64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscalepd128(a, $imm8, zero, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscalepd128(a, IMM8, zero, k);
     transmute(r)
 }
 

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -4872,23 +4872,13 @@ pub unsafe fn _mm_maskz_getexp_pd(k: __mmask8, a: __m128d) -> __m128d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_roundscale_ps&expand=4784)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(1)]
-pub unsafe fn _mm512_roundscale_ps(a: __m512, imm8: i32) -> __m512 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(1)]
+pub unsafe fn _mm512_roundscale_ps<const IMM8: i32>(a: __m512) -> __m512 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x16();
     let zero = _mm512_setzero_ps().as_f32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps(
-                a,
-                $imm8,
-                zero,
-                0b11111111_11111111,
-                _MM_FROUND_CUR_DIRECTION,
-            )
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps(a, IMM8, zero, 0b11111111_11111111, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -4903,17 +4893,16 @@ pub unsafe fn _mm512_roundscale_ps(a: __m512, imm8: i32) -> __m512 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_roundscale_ps&expand=4782)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_mask_roundscale_ps(src: __m512, k: __mmask16, a: __m512, imm8: i32) -> __m512 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_mask_roundscale_ps<const IMM8: i32>(
+    src: __m512,
+    k: __mmask16,
+    a: __m512,
+) -> __m512 {
     let a = a.as_f32x16();
     let src = src.as_f32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps(a, $imm8, src, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps(a, IMM8, src, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -4928,17 +4917,12 @@ pub unsafe fn _mm512_mask_roundscale_ps(src: __m512, k: __mmask16, a: __m512, im
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_roundscale_ps&expand=4783)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm512_maskz_roundscale_ps(k: __mmask16, a: __m512, imm8: i32) -> __m512 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm512_maskz_roundscale_ps<const IMM8: i32>(k: __mmask16, a: __m512) -> __m512 {
     let a = a.as_f32x16();
     let zero = _mm512_setzero_ps().as_f32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps(a, $imm8, zero, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps(a, IMM8, zero, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -4953,17 +4937,12 @@ pub unsafe fn _mm512_maskz_roundscale_ps(k: __mmask16, a: __m512, imm8: i32) -> 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_roundscale_ps&expand=4781)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 250))]
-#[rustc_args_required_const(1)]
-pub unsafe fn _mm256_roundscale_ps(a: __m256, imm8: i32) -> __m256 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 250))]
+#[rustc_legacy_const_generics(1)]
+pub unsafe fn _mm256_roundscale_ps<const IMM8: i32>(a: __m256) -> __m256 {
     let a = a.as_f32x8();
     let zero = _mm256_setzero_ps().as_f32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps256(a, $imm8, zero, 0b11111111)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps256(a, IMM8, zero, 0b11111111);
     transmute(r)
 }
 
@@ -4978,17 +4957,16 @@ pub unsafe fn _mm256_roundscale_ps(a: __m256, imm8: i32) -> __m256 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_roundscale_ps&expand=4779)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm256_mask_roundscale_ps(src: __m256, k: __mmask8, a: __m256, imm8: i32) -> __m256 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm256_mask_roundscale_ps<const IMM8: i32>(
+    src: __m256,
+    k: __mmask8,
+    a: __m256,
+) -> __m256 {
     let a = a.as_f32x8();
     let src = src.as_f32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps256(a, $imm8, src, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps256(a, IMM8, src, k);
     transmute(r)
 }
 
@@ -5003,17 +4981,12 @@ pub unsafe fn _mm256_mask_roundscale_ps(src: __m256, k: __mmask8, a: __m256, imm
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_roundscale_ps&expand=4780)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm256_maskz_roundscale_ps(k: __mmask8, a: __m256, imm8: i32) -> __m256 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm256_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m256) -> __m256 {
     let a = a.as_f32x8();
     let zero = _mm256_setzero_ps().as_f32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps256(a, $imm8, zero, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps256(a, IMM8, zero, k);
     transmute(r)
 }
 
@@ -5028,17 +5001,12 @@ pub unsafe fn _mm256_maskz_roundscale_ps(k: __mmask8, a: __m256, imm8: i32) -> _
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_roundscale_ps&expand=4778)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 250))]
-#[rustc_args_required_const(1)]
-pub unsafe fn _mm_roundscale_ps(a: __m128, imm8: i32) -> __m128 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 250))]
+#[rustc_legacy_const_generics(1)]
+pub unsafe fn _mm_roundscale_ps<const IMM8: i32>(a: __m128) -> __m128 {
     let a = a.as_f32x4();
     let zero = _mm_setzero_ps().as_f32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps128(a, $imm8, zero, 0b00001111)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps128(a, IMM8, zero, 0b00001111);
     transmute(r)
 }
 
@@ -5053,17 +5021,16 @@ pub unsafe fn _mm_roundscale_ps(a: __m128, imm8: i32) -> __m128 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_roundscale_ps&expand=4776)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm_mask_roundscale_ps(src: __m128, k: __mmask8, a: __m128, imm8: i32) -> __m128 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm_mask_roundscale_ps<const IMM8: i32>(
+    src: __m128,
+    k: __mmask8,
+    a: __m128,
+) -> __m128 {
     let a = a.as_f32x4();
     let src = src.as_f32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps128(a, $imm8, src, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps128(a, IMM8, src, k);
     transmute(r)
 }
 
@@ -5078,17 +5045,12 @@ pub unsafe fn _mm_mask_roundscale_ps(src: __m128, k: __mmask8, a: __m128, imm8: 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_roundscale_ps&expand=4777)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vrndscaleps, imm8 = 0))]
-#[rustc_args_required_const(2)]
-pub unsafe fn _mm_maskz_roundscale_ps(k: __mmask8, a: __m128, imm8: i32) -> __m128 {
+#[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
+pub unsafe fn _mm_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m128) -> __m128 {
     let a = a.as_f32x4();
     let zero = _mm_setzero_ps().as_f32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vrndscaleps128(a, $imm8, zero, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vrndscaleps128(a, IMM8, zero, k);
     transmute(r)
 }
 
@@ -42060,7 +42022,7 @@ mod tests {
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_roundscale_ps() {
         let a = _mm512_set1_ps(1.1);
-        let r = _mm512_roundscale_ps(a, 0);
+        let r = _mm512_roundscale_ps::<0b00_00_00_00>(a);
         let e = _mm512_set1_ps(1.0);
         assert_eq_m512(r, e);
     }
@@ -42068,10 +42030,10 @@ mod tests {
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_mask_roundscale_ps() {
         let a = _mm512_set1_ps(1.1);
-        let r = _mm512_mask_roundscale_ps(a, 0, a, 0);
+        let r = _mm512_mask_roundscale_ps::<0b00_00_00_00>(a, 0, a);
         let e = _mm512_set1_ps(1.1);
         assert_eq_m512(r, e);
-        let r = _mm512_mask_roundscale_ps(a, 0b11111111_11111111, a, 0);
+        let r = _mm512_mask_roundscale_ps::<0b00_00_00_00>(a, 0b11111111_11111111, a);
         let e = _mm512_set1_ps(1.0);
         assert_eq_m512(r, e);
     }
@@ -42079,9 +42041,9 @@ mod tests {
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_maskz_roundscale_ps() {
         let a = _mm512_set1_ps(1.1);
-        let r = _mm512_maskz_roundscale_ps(0, a, 0);
+        let r = _mm512_maskz_roundscale_ps::<0b00_00_00_00>(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
-        let r = _mm512_maskz_roundscale_ps(0b11111111_11111111, a, 0);
+        let r = _mm512_maskz_roundscale_ps::<0b00_00_00_00>(0b11111111_11111111, a);
         let e = _mm512_set1_ps(1.0);
         assert_eq_m512(r, e);
     }
@@ -42089,7 +42051,7 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_roundscale_ps() {
         let a = _mm256_set1_ps(1.1);
-        let r = _mm256_roundscale_ps(a, 0);
+        let r = _mm256_roundscale_ps::<0b00_00_00_00>(a);
         let e = _mm256_set1_ps(1.0);
         assert_eq_m256(r, e);
     }
@@ -42097,10 +42059,10 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_mask_roundscale_ps() {
         let a = _mm256_set1_ps(1.1);
-        let r = _mm256_mask_roundscale_ps(a, 0, a, 0);
+        let r = _mm256_mask_roundscale_ps::<0b00_00_00_00>(a, 0, a);
         let e = _mm256_set1_ps(1.1);
         assert_eq_m256(r, e);
-        let r = _mm256_mask_roundscale_ps(a, 0b11111111, a, 0);
+        let r = _mm256_mask_roundscale_ps::<0b00_00_00_00>(a, 0b11111111, a);
         let e = _mm256_set1_ps(1.0);
         assert_eq_m256(r, e);
     }
@@ -42108,9 +42070,9 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_maskz_roundscale_ps() {
         let a = _mm256_set1_ps(1.1);
-        let r = _mm256_maskz_roundscale_ps(0, a, 0);
+        let r = _mm256_maskz_roundscale_ps::<0b00_00_00_00>(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
-        let r = _mm256_maskz_roundscale_ps(0b11111111, a, 0);
+        let r = _mm256_maskz_roundscale_ps::<0b00_00_00_00>(0b11111111, a);
         let e = _mm256_set1_ps(1.0);
         assert_eq_m256(r, e);
     }
@@ -42118,7 +42080,7 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_roundscale_ps() {
         let a = _mm_set1_ps(1.1);
-        let r = _mm_roundscale_ps(a, 0);
+        let r = _mm_roundscale_ps::<0b00_00_00_00>(a);
         let e = _mm_set1_ps(1.0);
         assert_eq_m128(r, e);
     }
@@ -42126,10 +42088,10 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_mask_roundscale_ps() {
         let a = _mm_set1_ps(1.1);
-        let r = _mm_mask_roundscale_ps(a, 0, a, 0);
+        let r = _mm_mask_roundscale_ps::<0b00_00_00_00>(a, 0, a);
         let e = _mm_set1_ps(1.1);
         assert_eq_m128(r, e);
-        let r = _mm_mask_roundscale_ps(a, 0b00001111, a, 0);
+        let r = _mm_mask_roundscale_ps::<0b00_00_00_00>(a, 0b00001111, a);
         let e = _mm_set1_ps(1.0);
         assert_eq_m128(r, e);
     }
@@ -42137,9 +42099,9 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_maskz_roundscale_ps() {
         let a = _mm_set1_ps(1.1);
-        let r = _mm_maskz_roundscale_ps(0, a, 0);
+        let r = _mm_maskz_roundscale_ps::<0b00_00_00_00>(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
-        let r = _mm_maskz_roundscale_ps(0b00001111, a, 0);
+        let r = _mm_maskz_roundscale_ps::<0b00_00_00_00>(0b00001111, a);
         let e = _mm_set1_ps(1.0);
         assert_eq_m128(r, e);
     }

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -4900,6 +4900,7 @@ pub unsafe fn _mm512_mask_roundscale_ps<const IMM8: i32>(
     k: __mmask16,
     a: __m512,
 ) -> __m512 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x16();
     let src = src.as_f32x16();
     let r = vrndscaleps(a, IMM8, src, k, _MM_FROUND_CUR_DIRECTION);
@@ -4920,6 +4921,7 @@ pub unsafe fn _mm512_mask_roundscale_ps<const IMM8: i32>(
 #[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_roundscale_ps<const IMM8: i32>(k: __mmask16, a: __m512) -> __m512 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x16();
     let zero = _mm512_setzero_ps().as_f32x16();
     let r = vrndscaleps(a, IMM8, zero, k, _MM_FROUND_CUR_DIRECTION);
@@ -4940,6 +4942,7 @@ pub unsafe fn _mm512_maskz_roundscale_ps<const IMM8: i32>(k: __mmask16, a: __m51
 #[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 250))]
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_roundscale_ps<const IMM8: i32>(a: __m256) -> __m256 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x8();
     let zero = _mm256_setzero_ps().as_f32x8();
     let r = vrndscaleps256(a, IMM8, zero, 0b11111111);
@@ -4964,6 +4967,7 @@ pub unsafe fn _mm256_mask_roundscale_ps<const IMM8: i32>(
     k: __mmask8,
     a: __m256,
 ) -> __m256 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x8();
     let src = src.as_f32x8();
     let r = vrndscaleps256(a, IMM8, src, k);
@@ -4984,6 +4988,7 @@ pub unsafe fn _mm256_mask_roundscale_ps<const IMM8: i32>(
 #[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m256) -> __m256 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x8();
     let zero = _mm256_setzero_ps().as_f32x8();
     let r = vrndscaleps256(a, IMM8, zero, k);
@@ -5004,6 +5009,7 @@ pub unsafe fn _mm256_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m256
 #[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 250))]
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm_roundscale_ps<const IMM8: i32>(a: __m128) -> __m128 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x4();
     let zero = _mm_setzero_ps().as_f32x4();
     let r = vrndscaleps128(a, IMM8, zero, 0b00001111);
@@ -5028,6 +5034,7 @@ pub unsafe fn _mm_mask_roundscale_ps<const IMM8: i32>(
     k: __mmask8,
     a: __m128,
 ) -> __m128 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x4();
     let src = src.as_f32x4();
     let r = vrndscaleps128(a, IMM8, src, k);
@@ -5048,6 +5055,7 @@ pub unsafe fn _mm_mask_roundscale_ps<const IMM8: i32>(
 #[cfg_attr(test, assert_instr(vrndscaleps, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m128) -> __m128 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x4();
     let zero = _mm_setzero_ps().as_f32x4();
     let r = vrndscaleps128(a, IMM8, zero, k);
@@ -5068,6 +5076,7 @@ pub unsafe fn _mm_maskz_roundscale_ps<const IMM8: i32>(k: __mmask8, a: __m128) -
 #[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_roundscale_pd<const IMM8: i32>(a: __m512d) -> __m512d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x8();
     let zero = _mm512_setzero_pd().as_f64x8();
     let r = vrndscalepd(a, IMM8, zero, 0b11111111, _MM_FROUND_CUR_DIRECTION);
@@ -5092,6 +5101,7 @@ pub unsafe fn _mm512_mask_roundscale_pd<const IMM8: i32>(
     k: __mmask8,
     a: __m512d,
 ) -> __m512d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x8();
     let src = src.as_f64x8();
     let r = vrndscalepd(a, IMM8, src, k, _MM_FROUND_CUR_DIRECTION);
@@ -5112,6 +5122,7 @@ pub unsafe fn _mm512_mask_roundscale_pd<const IMM8: i32>(
 #[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m512d) -> __m512d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x8();
     let zero = _mm512_setzero_pd().as_f64x8();
     let r = vrndscalepd(a, IMM8, zero, k, _MM_FROUND_CUR_DIRECTION);
@@ -5132,6 +5143,7 @@ pub unsafe fn _mm512_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m512
 #[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_roundscale_pd<const IMM8: i32>(a: __m256d) -> __m256d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x4();
     let zero = _mm256_setzero_pd().as_f64x4();
     let r = vrndscalepd256(a, IMM8, zero, 0b00001111);
@@ -5156,6 +5168,7 @@ pub unsafe fn _mm256_mask_roundscale_pd<const IMM8: i32>(
     k: __mmask8,
     a: __m256d,
 ) -> __m256d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x4();
     let src = src.as_f64x4();
     let r = vrndscalepd256(a, IMM8, src, k);
@@ -5176,6 +5189,7 @@ pub unsafe fn _mm256_mask_roundscale_pd<const IMM8: i32>(
 #[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m256d) -> __m256d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x4();
     let zero = _mm256_setzero_pd().as_f64x4();
     let r = vrndscalepd256(a, IMM8, zero, k);
@@ -5196,6 +5210,7 @@ pub unsafe fn _mm256_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m256
 #[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm_roundscale_pd<const IMM8: i32>(a: __m128d) -> __m128d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x2();
     let zero = _mm_setzero_pd().as_f64x2();
     let r = vrndscalepd128(a, IMM8, zero, 0b00000011);
@@ -5220,6 +5235,7 @@ pub unsafe fn _mm_mask_roundscale_pd<const IMM8: i32>(
     k: __mmask8,
     a: __m128d,
 ) -> __m128d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x2();
     let src = src.as_f64x2();
     let r = vrndscalepd128(a, IMM8, src, k);
@@ -5240,6 +5256,7 @@ pub unsafe fn _mm_mask_roundscale_pd<const IMM8: i32>(
 #[cfg_attr(test, assert_instr(vrndscalepd, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_roundscale_pd<const IMM8: i32>(k: __mmask8, a: __m128d) -> __m128d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x2();
     let zero = _mm_setzero_pd().as_f64x2();
     let r = vrndscalepd128(a, IMM8, zero, k);
@@ -5507,25 +5524,14 @@ pub unsafe fn _mm_maskz_scalef_pd(k: __mmask8, a: __m128d, b: __m128d) -> __m128
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_fixupimm_ps&expand=2499)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_fixupimm_ps(a: __m512, b: __m512, c: __m512i, imm8: i32) -> __m512 {
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_fixupimm_ps<const IMM8: i32>(a: __m512, b: __m512, c: __m512i) -> __m512 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
     let c = c.as_i32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmps(
-                a,
-                b,
-                c,
-                $imm8,
-                0b11111111_11111111,
-                _MM_FROUND_CUR_DIRECTION,
-            )
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmps(a, b, c, IMM8, 0b11111111_11111111, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5534,24 +5540,19 @@ pub unsafe fn _mm512_fixupimm_ps(a: __m512, b: __m512, c: __m512i, imm8: i32) ->
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_fixupimm_ps&expand=2500)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_mask_fixupimm_ps(
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_mask_fixupimm_ps<const IMM8: i32>(
     a: __m512,
     k: __mmask16,
     b: __m512,
     c: __m512i,
-    imm8: i32,
 ) -> __m512 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
     let c = c.as_i32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmps(a, b, c, $imm8, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmps(a, b, c, IMM8, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5560,24 +5561,19 @@ pub unsafe fn _mm512_mask_fixupimm_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_fixupimm_ps&expand=2501)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_maskz_fixupimm_ps(
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_maskz_fixupimm_ps<const IMM8: i32>(
     k: __mmask16,
     a: __m512,
     b: __m512,
     c: __m512i,
-    imm8: i32,
 ) -> __m512 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
     let c = c.as_i32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpsz(a, b, c, $imm8, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpsz(a, b, c, IMM8, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5586,18 +5582,14 @@ pub unsafe fn _mm512_maskz_fixupimm_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_fixupimm_ps&expand=2496)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm256_fixupimm_ps(a: __m256, b: __m256, c: __m256i, imm8: i32) -> __m256 {
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm256_fixupimm_ps<const IMM8: i32>(a: __m256, b: __m256, c: __m256i) -> __m256 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x8();
     let b = b.as_f32x8();
     let c = c.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmps256(a, b, c, $imm8, 0b11111111)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmps256(a, b, c, IMM8, 0b11111111);
     transmute(r)
 }
 
@@ -5606,24 +5598,19 @@ pub unsafe fn _mm256_fixupimm_ps(a: __m256, b: __m256, c: __m256i, imm8: i32) ->
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_fixupimm_ps&expand=2497)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_mask_fixupimm_ps(
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_mask_fixupimm_ps<const IMM8: i32>(
     a: __m256,
     k: __mmask8,
     b: __m256,
     c: __m256i,
-    imm8: i32,
 ) -> __m256 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x8();
     let b = b.as_f32x8();
     let c = c.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmps256(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmps256(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5632,24 +5619,19 @@ pub unsafe fn _mm256_mask_fixupimm_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_fixupimm_ps&expand=2498)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_maskz_fixupimm_ps(
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_maskz_fixupimm_ps<const IMM8: i32>(
     k: __mmask8,
     a: __m256,
     b: __m256,
     c: __m256i,
-    imm8: i32,
 ) -> __m256 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x8();
     let b = b.as_f32x8();
     let c = c.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpsz256(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpsz256(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5658,18 +5640,14 @@ pub unsafe fn _mm256_maskz_fixupimm_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_fixupimm_ps&expand=2493)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm_fixupimm_ps(a: __m128, b: __m128, c: __m128i, imm8: i32) -> __m128 {
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm_fixupimm_ps<const IMM8: i32>(a: __m128, b: __m128, c: __m128i) -> __m128 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x4();
     let b = b.as_f32x4();
     let c = c.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmps128(a, b, c, $imm8, 0b00001111)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmps128(a, b, c, IMM8, 0b00001111);
     transmute(r)
 }
 
@@ -5678,24 +5656,19 @@ pub unsafe fn _mm_fixupimm_ps(a: __m128, b: __m128, c: __m128i, imm8: i32) -> __
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_fixupimm_ps&expand=2494)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_mask_fixupimm_ps(
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_mask_fixupimm_ps<const IMM8: i32>(
     a: __m128,
     k: __mmask8,
     b: __m128,
     c: __m128i,
-    imm8: i32,
 ) -> __m128 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x4();
     let b = b.as_f32x4();
     let c = c.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmps128(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmps128(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5704,24 +5677,19 @@ pub unsafe fn _mm_mask_fixupimm_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_fixupimm_ps&expand=2495)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmps, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_maskz_fixupimm_ps(
+#[cfg_attr(test, assert_instr(vfixupimmps, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_maskz_fixupimm_ps<const IMM8: i32>(
     k: __mmask8,
     a: __m128,
     b: __m128,
     c: __m128i,
-    imm8: i32,
 ) -> __m128 {
+    static_assert_imm8!(IMM8);
     let a = a.as_f32x4();
     let b = b.as_f32x4();
     let c = c.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpsz128(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpsz128(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5730,18 +5698,14 @@ pub unsafe fn _mm_maskz_fixupimm_ps(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_fixupimm_pd&expand=2490)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_fixupimm_pd(a: __m512d, b: __m512d, c: __m512i, imm8: i32) -> __m512d {
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_fixupimm_pd<const IMM8: i32>(a: __m512d, b: __m512d, c: __m512i) -> __m512d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
     let c = c.as_i64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpd(a, b, c, $imm8, 0b11111111, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpd(a, b, c, IMM8, 0b11111111, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5750,24 +5714,19 @@ pub unsafe fn _mm512_fixupimm_pd(a: __m512d, b: __m512d, c: __m512i, imm8: i32) 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_fixupimm_pd&expand=2491)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_mask_fixupimm_pd(
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_mask_fixupimm_pd<const IMM8: i32>(
     a: __m512d,
     k: __mmask8,
     b: __m512d,
     c: __m512i,
-    imm8: i32,
 ) -> __m512d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
     let c = c.as_i64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpd(a, b, c, $imm8, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpd(a, b, c, IMM8, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5776,24 +5735,19 @@ pub unsafe fn _mm512_mask_fixupimm_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_fixupimm_pd&expand=2492)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_maskz_fixupimm_pd(
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_maskz_fixupimm_pd<const IMM8: i32>(
     k: __mmask8,
     a: __m512d,
     b: __m512d,
     c: __m512i,
-    imm8: i32,
 ) -> __m512d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
     let c = c.as_i64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpdz(a, b, c, $imm8, k, _MM_FROUND_CUR_DIRECTION)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpdz(a, b, c, IMM8, k, _MM_FROUND_CUR_DIRECTION);
     transmute(r)
 }
 
@@ -5802,18 +5756,14 @@ pub unsafe fn _mm512_maskz_fixupimm_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_fixupimm_pd&expand=2487)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm256_fixupimm_pd(a: __m256d, b: __m256d, c: __m256i, imm8: i32) -> __m256d {
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm256_fixupimm_pd<const IMM8: i32>(a: __m256d, b: __m256d, c: __m256i) -> __m256d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x4();
     let b = b.as_f64x4();
     let c = c.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpd256(a, b, c, $imm8, 0b00001111)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpd256(a, b, c, IMM8, 0b00001111);
     transmute(r)
 }
 
@@ -5822,24 +5772,19 @@ pub unsafe fn _mm256_fixupimm_pd(a: __m256d, b: __m256d, c: __m256i, imm8: i32) 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_fixupimm_pd&expand=2488)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_mask_fixupimm_pd(
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_mask_fixupimm_pd<const IMM8: i32>(
     a: __m256d,
     k: __mmask8,
     b: __m256d,
     c: __m256i,
-    imm8: i32,
 ) -> __m256d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x4();
     let b = b.as_f64x4();
     let c = c.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpd256(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpd256(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5848,24 +5793,19 @@ pub unsafe fn _mm256_mask_fixupimm_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_fixupimm_pd&expand=2489)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_maskz_fixupimm_pd(
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_maskz_fixupimm_pd<const IMM8: i32>(
     k: __mmask8,
     a: __m256d,
     b: __m256d,
     c: __m256i,
-    imm8: i32,
 ) -> __m256d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x4();
     let b = b.as_f64x4();
     let c = c.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpdz256(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpdz256(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5874,18 +5814,14 @@ pub unsafe fn _mm256_maskz_fixupimm_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_fixupimm_pd&expand=2484)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm_fixupimm_pd(a: __m128d, b: __m128d, c: __m128i, imm8: i32) -> __m128d {
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm_fixupimm_pd<const IMM8: i32>(a: __m128d, b: __m128d, c: __m128i) -> __m128d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x2();
     let b = b.as_f64x2();
     let c = c.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpd128(a, b, c, $imm8, 0b00000011)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpd128(a, b, c, IMM8, 0b00000011);
     transmute(r)
 }
 
@@ -5894,24 +5830,19 @@ pub unsafe fn _mm_fixupimm_pd(a: __m128d, b: __m128d, c: __m128i, imm8: i32) -> 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_fixupimm_pd&expand=2485)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_mask_fixupimm_pd(
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_mask_fixupimm_pd<const IMM8: i32>(
     a: __m128d,
     k: __mmask8,
     b: __m128d,
     c: __m128i,
-    imm8: i32,
 ) -> __m128d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x2();
     let b = b.as_f64x2();
     let c = c.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpd128(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpd128(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -5920,24 +5851,19 @@ pub unsafe fn _mm_mask_fixupimm_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_fixupimm_pd&expand=2486)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vfixupimmpd, imm8 = 0))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_maskz_fixupimm_pd(
+#[cfg_attr(test, assert_instr(vfixupimmpd, IMM8 = 0))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_maskz_fixupimm_pd<const IMM8: i32>(
     k: __mmask8,
     a: __m128d,
     b: __m128d,
     c: __m128i,
-    imm8: i32,
 ) -> __m128d {
+    static_assert_imm8!(IMM8);
     let a = a.as_f64x2();
     let b = b.as_f64x2();
     let c = c.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vfixupimmpdz128(a, b, c, $imm8, k)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vfixupimmpdz128(a, b, c, IMM8, k);
     transmute(r)
 }
 
@@ -42165,7 +42091,8 @@ mod tests {
         let a = _mm512_set1_ps(f32::NAN);
         let b = _mm512_set1_ps(f32::MAX);
         let c = _mm512_set1_epi32(i32::MAX);
-        let r = _mm512_fixupimm_ps(a, b, c, 5);
+        //let r = _mm512_fixupimm_ps(a, b, c, 5);
+        let r = _mm512_fixupimm_ps::<5>(a, b, c);
         let e = _mm512_set1_ps(0.0);
         assert_eq_m512(r, e);
     }
@@ -42181,7 +42108,7 @@ mod tests {
         );
         let b = _mm512_set1_ps(f32::MAX);
         let c = _mm512_set1_epi32(i32::MAX);
-        let r = _mm512_mask_fixupimm_ps(a, 0b11111111_00000000, b, c, 5);
+        let r = _mm512_mask_fixupimm_ps::<5>(a, 0b11111111_00000000, b, c);
         let e = _mm512_set_ps(
             0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1., 1., 1.,
         );
@@ -42199,7 +42126,7 @@ mod tests {
         );
         let b = _mm512_set1_ps(f32::MAX);
         let c = _mm512_set1_epi32(i32::MAX);
-        let r = _mm512_maskz_fixupimm_ps(0b11111111_00000000, a, b, c, 5);
+        let r = _mm512_maskz_fixupimm_ps::<5>(0b11111111_00000000, a, b, c);
         let e = _mm512_set_ps(
             0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
         );
@@ -42211,7 +42138,7 @@ mod tests {
         let a = _mm256_set1_ps(f32::NAN);
         let b = _mm256_set1_ps(f32::MAX);
         let c = _mm256_set1_epi32(i32::MAX);
-        let r = _mm256_fixupimm_ps(a, b, c, 5);
+        let r = _mm256_fixupimm_ps::<5>(a, b, c);
         let e = _mm256_set1_ps(0.0);
         assert_eq_m256(r, e);
     }
@@ -42221,7 +42148,7 @@ mod tests {
         let a = _mm256_set1_ps(f32::NAN);
         let b = _mm256_set1_ps(f32::MAX);
         let c = _mm256_set1_epi32(i32::MAX);
-        let r = _mm256_mask_fixupimm_ps(a, 0b11111111, b, c, 5);
+        let r = _mm256_mask_fixupimm_ps::<5>(a, 0b11111111, b, c);
         let e = _mm256_set1_ps(0.0);
         assert_eq_m256(r, e);
     }
@@ -42231,7 +42158,7 @@ mod tests {
         let a = _mm256_set1_ps(f32::NAN);
         let b = _mm256_set1_ps(f32::MAX);
         let c = _mm256_set1_epi32(i32::MAX);
-        let r = _mm256_maskz_fixupimm_ps(0b11111111, a, b, c, 5);
+        let r = _mm256_maskz_fixupimm_ps::<5>(0b11111111, a, b, c);
         let e = _mm256_set1_ps(0.0);
         assert_eq_m256(r, e);
     }
@@ -42241,7 +42168,7 @@ mod tests {
         let a = _mm_set1_ps(f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
-        let r = _mm_fixupimm_ps(a, b, c, 5);
+        let r = _mm_fixupimm_ps::<5>(a, b, c);
         let e = _mm_set1_ps(0.0);
         assert_eq_m128(r, e);
     }
@@ -42251,7 +42178,7 @@ mod tests {
         let a = _mm_set1_ps(f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
-        let r = _mm_mask_fixupimm_ps(a, 0b00001111, b, c, 5);
+        let r = _mm_mask_fixupimm_ps::<5>(a, 0b00001111, b, c);
         let e = _mm_set1_ps(0.0);
         assert_eq_m128(r, e);
     }
@@ -42261,7 +42188,7 @@ mod tests {
         let a = _mm_set1_ps(f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
-        let r = _mm_maskz_fixupimm_ps(0b00001111, a, b, c, 5);
+        let r = _mm_maskz_fixupimm_ps::<5>(0b00001111, a, b, c);
         let e = _mm_set1_ps(0.0);
         assert_eq_m128(r, e);
     }

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -6863,13 +6863,13 @@ pub unsafe fn _mm_maskz_getmant_pd(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_add_round_ps&expand=145)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddps, IMM4 = 8))]
+#[cfg_attr(test, assert_instr(vaddps, ROUNDING = 8))]
 #[rustc_legacy_const_generics(2)]
-pub unsafe fn _mm512_add_round_ps<const IMM4: i32>(a: __m512, b: __m512) -> __m512 {
-    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
+pub unsafe fn _mm512_add_round_ps<const ROUNDING: i32>(a: __m512, b: __m512) -> __m512 {
+    static_assert_rounding!(ROUNDING);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    let r = vaddps(a, b, IMM4);
+    let r = vaddps(a, b, ROUNDING);
     transmute(r)
 }
 
@@ -6885,18 +6885,18 @@ pub unsafe fn _mm512_add_round_ps<const IMM4: i32>(a: __m512, b: __m512) -> __m5
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_add_round_ps&expand=146)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddps, IMM4 = 8))]
+#[cfg_attr(test, assert_instr(vaddps, ROUNDING = 8))]
 #[rustc_legacy_const_generics(4)]
-pub unsafe fn _mm512_mask_add_round_ps<const IMM4: i32>(
+pub unsafe fn _mm512_mask_add_round_ps<const ROUNDING: i32>(
     src: __m512,
     k: __mmask16,
     a: __m512,
     b: __m512,
 ) -> __m512 {
-    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
+    static_assert_rounding!(ROUNDING);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    let r = vaddps(a, b, IMM4);
+    let r = vaddps(a, b, ROUNDING);
     transmute(simd_select_bitmask(k, r, src.as_f32x16()))
 }
 
@@ -6912,17 +6912,17 @@ pub unsafe fn _mm512_mask_add_round_ps<const IMM4: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_add_round_ps&expand=147)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddps, IMM4 = 8))]
+#[cfg_attr(test, assert_instr(vaddps, ROUNDING = 8))]
 #[rustc_legacy_const_generics(3)]
-pub unsafe fn _mm512_maskz_add_round_ps<const IMM4: i32>(
+pub unsafe fn _mm512_maskz_add_round_ps<const ROUNDING: i32>(
     k: __mmask16,
     a: __m512,
     b: __m512,
 ) -> __m512 {
-    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
+    static_assert_rounding!(ROUNDING);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    let r = vaddps(a, b, IMM4);
+    let r = vaddps(a, b, ROUNDING);
     let zero = _mm512_setzero_ps().as_f32x16();
     transmute(simd_select_bitmask(k, r, zero))
 }
@@ -6939,13 +6939,13 @@ pub unsafe fn _mm512_maskz_add_round_ps<const IMM4: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_add_round_pd&expand=142)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddpd, IMM4 = 8))]
+#[cfg_attr(test, assert_instr(vaddpd, ROUNDING = 8))]
 #[rustc_legacy_const_generics(2)]
-pub unsafe fn _mm512_add_round_pd<const IMM4: i32>(a: __m512d, b: __m512d) -> __m512d {
-    static_assert!(IMM4: i32 where IMM4 == 4 || IMM4 == 8 || IMM4 == 9 || IMM4 == 10 || IMM4 == 11);
+pub unsafe fn _mm512_add_round_pd<const ROUNDING: i32>(a: __m512d, b: __m512d) -> __m512d {
+    static_assert_rounding!(ROUNDING);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    let r = vaddpd(a, b, IMM4);
+    let r = vaddpd(a, b, ROUNDING);
     transmute(r)
 }
 
@@ -6961,17 +6961,18 @@ pub unsafe fn _mm512_add_round_pd<const IMM4: i32>(a: __m512d, b: __m512d) -> __
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_add_round_pd&expand=143)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddpd, IMM4 = 8))]
+#[cfg_attr(test, assert_instr(vaddpd, ROUNDING = 8))]
 #[rustc_legacy_const_generics(4)]
-pub unsafe fn _mm512_mask_add_round_pd<const IMM4: i32>(
+pub unsafe fn _mm512_mask_add_round_pd<const ROUNDING: i32>(
     src: __m512d,
     k: __mmask8,
     a: __m512d,
     b: __m512d,
 ) -> __m512d {
+    static_assert_rounding!(ROUNDING);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    let r = vaddpd(a, b, IMM4);
+    let r = vaddpd(a, b, ROUNDING);
     transmute(simd_select_bitmask(k, r, src.as_f64x8()))
 }
 
@@ -6987,16 +6988,17 @@ pub unsafe fn _mm512_mask_add_round_pd<const IMM4: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_add_round_pd&expand=144)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vaddpd, IMM4 = 8))]
+#[cfg_attr(test, assert_instr(vaddpd, ROUNDING = 8))]
 #[rustc_legacy_const_generics(3)]
-pub unsafe fn _mm512_maskz_add_round_pd<const IMM4: i32>(
+pub unsafe fn _mm512_maskz_add_round_pd<const ROUNDING: i32>(
     k: __mmask8,
     a: __m512d,
     b: __m512d,
 ) -> __m512d {
+    static_assert_rounding!(ROUNDING);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    let r = vaddpd(a, b, IMM4);
+    let r = vaddpd(a, b, ROUNDING);
     let zero = _mm512_setzero_pd().as_f64x8();
     transmute(simd_select_bitmask(k, r, zero))
 }

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -5872,18 +5872,18 @@ pub unsafe fn _mm_maskz_fixupimm_pd<const IMM8: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_ternarylogic_epi32&expand=5867)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_ternarylogic_epi32(a: __m512i, b: __m512i, c: __m512i, imm8: i32) -> __m512i {
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_ternarylogic_epi32<const IMM8: i32>(
+    a: __m512i,
+    b: __m512i,
+    c: __m512i,
+) -> __m512i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x16();
     let b = b.as_i32x16();
     let c = c.as_i32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd(a, b, c, $imm8)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vpternlogd(a, b, c, IMM8);
     transmute(r)
 }
 
@@ -5892,25 +5892,20 @@ pub unsafe fn _mm512_ternarylogic_epi32(a: __m512i, b: __m512i, c: __m512i, imm8
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_ternarylogic_epi32&expand=5865)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_mask_ternarylogic_epi32(
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_mask_ternarylogic_epi32<const IMM8: i32>(
     src: __m512i,
     k: __mmask16,
     a: __m512i,
     b: __m512i,
-    imm8: i32,
 ) -> __m512i {
+    static_assert_imm8!(IMM8);
     let src = src.as_i32x16();
     let a = a.as_i32x16();
     let b = b.as_i32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd(src, a, b, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
-    transmute(simd_select_bitmask(k, ternarylogic, src))
+    let r = vpternlogd(src, a, b, IMM8);
+    transmute(simd_select_bitmask(k, r, src))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 32-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst using zeromask k at 32-bit granularity (32-bit elements are zeroed out when the corresponding mask bit is not set).
@@ -5918,26 +5913,21 @@ pub unsafe fn _mm512_mask_ternarylogic_epi32(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_ternarylogic_epi32&expand=5866)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_maskz_ternarylogic_epi32(
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_maskz_ternarylogic_epi32<const IMM8: i32>(
     k: __mmask16,
     a: __m512i,
     b: __m512i,
     c: __m512i,
-    imm8: i32,
 ) -> __m512i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x16();
     let b = b.as_i32x16();
     let c = c.as_i32x16();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd(a, b, c, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
+    let r = vpternlogd(a, b, c, IMM8);
     let zero = _mm512_setzero_si512().as_i32x16();
-    transmute(simd_select_bitmask(k, ternarylogic, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 32-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst.
@@ -5945,18 +5935,18 @@ pub unsafe fn _mm512_maskz_ternarylogic_epi32(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_ternarylogic_epi32&expand=5864)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm256_ternarylogic_epi32(a: __m256i, b: __m256i, c: __m256i, imm8: i32) -> __m256i {
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm256_ternarylogic_epi32<const IMM8: i32>(
+    a: __m256i,
+    b: __m256i,
+    c: __m256i,
+) -> __m256i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x8();
     let b = b.as_i32x8();
     let c = c.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd256(a, b, c, $imm8)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vpternlogd256(a, b, c, IMM8);
     transmute(r)
 }
 
@@ -5965,25 +5955,20 @@ pub unsafe fn _mm256_ternarylogic_epi32(a: __m256i, b: __m256i, c: __m256i, imm8
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_ternarylogic_epi32&expand=5862)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_mask_ternarylogic_epi32(
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_mask_ternarylogic_epi32<const IMM8: i32>(
     src: __m256i,
     k: __mmask8,
     a: __m256i,
     b: __m256i,
-    imm8: i32,
 ) -> __m256i {
+    static_assert_imm8!(IMM8);
     let src = src.as_i32x8();
     let a = a.as_i32x8();
     let b = b.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd256(src, a, b, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
-    transmute(simd_select_bitmask(k, ternarylogic, src))
+    let r = vpternlogd256(src, a, b, IMM8);
+    transmute(simd_select_bitmask(k, r, src))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 32-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst using zeromask k at 32-bit granularity (32-bit elements are zeroed out when the corresponding mask bit is not set).
@@ -5991,26 +5976,21 @@ pub unsafe fn _mm256_mask_ternarylogic_epi32(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_ternarylogic_epi32&expand=5863)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_maskz_ternarylogic_epi32(
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_maskz_ternarylogic_epi32<const IMM8: i32>(
     k: __mmask8,
     a: __m256i,
     b: __m256i,
     c: __m256i,
-    imm8: i32,
 ) -> __m256i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x8();
     let b = b.as_i32x8();
     let c = c.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd256(a, b, c, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
+    let r = vpternlogd256(a, b, c, IMM8);
     let zero = _mm256_setzero_si256().as_i32x8();
-    transmute(simd_select_bitmask(k, ternarylogic, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 32-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst.
@@ -6018,18 +5998,18 @@ pub unsafe fn _mm256_maskz_ternarylogic_epi32(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_ternarylogic_epi32&expand=5861)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm_ternarylogic_epi32(a: __m128i, b: __m128i, c: __m128i, imm8: i32) -> __m128i {
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm_ternarylogic_epi32<const IMM8: i32>(
+    a: __m128i,
+    b: __m128i,
+    c: __m128i,
+) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x4();
     let b = b.as_i32x4();
     let c = c.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd128(a, b, c, $imm8)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vpternlogd128(a, b, c, IMM8);
     transmute(r)
 }
 
@@ -6038,25 +6018,20 @@ pub unsafe fn _mm_ternarylogic_epi32(a: __m128i, b: __m128i, c: __m128i, imm8: i
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_ternarylogic_epi32&expand=5859)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_mask_ternarylogic_epi32(
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_mask_ternarylogic_epi32<const IMM8: i32>(
     src: __m128i,
     k: __mmask8,
     a: __m128i,
     b: __m128i,
-    imm8: i32,
 ) -> __m128i {
+    static_assert_imm8!(IMM8);
     let src = src.as_i32x4();
     let a = a.as_i32x4();
     let b = b.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd128(src, a, b, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
-    transmute(simd_select_bitmask(k, ternarylogic, src))
+    let r = vpternlogd128(src, a, b, IMM8);
+    transmute(simd_select_bitmask(k, r, src))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 32-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst using zeromask k at 32-bit granularity (32-bit elements are zeroed out when the corresponding mask bit is not set).
@@ -6064,26 +6039,21 @@ pub unsafe fn _mm_mask_ternarylogic_epi32(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_ternarylogic_epi32&expand=5860)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogd, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_maskz_ternarylogic_epi32(
+#[cfg_attr(test, assert_instr(vpternlogd, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_maskz_ternarylogic_epi32<const IMM8: i32>(
     k: __mmask8,
     a: __m128i,
     b: __m128i,
     c: __m128i,
-    imm8: i32,
 ) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i32x4();
     let b = b.as_i32x4();
     let c = c.as_i32x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogd128(a, b, c, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
+    let r = vpternlogd128(a, b, c, IMM8);
     let zero = _mm_setzero_si128().as_i32x4();
-    transmute(simd_select_bitmask(k, ternarylogic, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 64-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst.
@@ -6091,18 +6061,18 @@ pub unsafe fn _mm_maskz_ternarylogic_epi32(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_ternarylogic_epi64&expand=5876)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm512_ternarylogic_epi64(a: __m512i, b: __m512i, c: __m512i, imm8: i32) -> __m512i {
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm512_ternarylogic_epi64<const IMM8: i32>(
+    a: __m512i,
+    b: __m512i,
+    c: __m512i,
+) -> __m512i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i64x8();
     let b = b.as_i64x8();
     let c = c.as_i64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq(a, b, c, $imm8)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vpternlogq(a, b, c, IMM8);
     transmute(r)
 }
 
@@ -6111,25 +6081,20 @@ pub unsafe fn _mm512_ternarylogic_epi64(a: __m512i, b: __m512i, c: __m512i, imm8
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_ternarylogic_epi64&expand=5874)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_mask_ternarylogic_epi64(
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_mask_ternarylogic_epi64<const IMM8: i32>(
     src: __m512i,
     k: __mmask8,
     a: __m512i,
     b: __m512i,
-    imm8: i32,
 ) -> __m512i {
+    static_assert_imm8!(IMM8);
     let src = src.as_i64x8();
     let a = a.as_i64x8();
     let b = b.as_i64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq(src, a, b, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
-    transmute(simd_select_bitmask(k, ternarylogic, src))
+    let r = vpternlogq(src, a, b, IMM8);
+    transmute(simd_select_bitmask(k, r, src))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 64-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst using zeromask k at 64-bit granularity (64-bit elements are zeroed out when the corresponding mask bit is not set).
@@ -6137,26 +6102,21 @@ pub unsafe fn _mm512_mask_ternarylogic_epi64(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_ternarylogic_epi64&expand=5875)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm512_maskz_ternarylogic_epi64(
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm512_maskz_ternarylogic_epi64<const IMM8: i32>(
     k: __mmask8,
     a: __m512i,
     b: __m512i,
     c: __m512i,
-    imm8: i32,
 ) -> __m512i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i64x8();
     let b = b.as_i64x8();
     let c = c.as_i64x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq(a, b, c, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
+    let r = vpternlogq(a, b, c, IMM8);
     let zero = _mm512_setzero_si512().as_i64x8();
-    transmute(simd_select_bitmask(k, ternarylogic, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 64-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst.
@@ -6164,18 +6124,18 @@ pub unsafe fn _mm512_maskz_ternarylogic_epi64(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_ternarylogic_epi64&expand=5873)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm256_ternarylogic_epi64(a: __m256i, b: __m256i, c: __m256i, imm8: i32) -> __m256i {
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm256_ternarylogic_epi64<const IMM8: i32>(
+    a: __m256i,
+    b: __m256i,
+    c: __m256i,
+) -> __m256i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i64x4();
     let b = b.as_i64x4();
     let c = c.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq256(a, b, c, $imm8)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vpternlogq256(a, b, c, IMM8);
     transmute(r)
 }
 
@@ -6184,25 +6144,20 @@ pub unsafe fn _mm256_ternarylogic_epi64(a: __m256i, b: __m256i, c: __m256i, imm8
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_ternarylogic_epi64&expand=5871)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_mask_ternarylogic_epi64(
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_mask_ternarylogic_epi64<const IMM8: i32>(
     src: __m256i,
     k: __mmask8,
     a: __m256i,
     b: __m256i,
-    imm8: i32,
 ) -> __m256i {
+    static_assert_imm8!(IMM8);
     let src = src.as_i64x4();
     let a = a.as_i64x4();
     let b = b.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq256(src, a, b, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
-    transmute(simd_select_bitmask(k, ternarylogic, src))
+    let r = vpternlogq256(src, a, b, IMM8);
+    transmute(simd_select_bitmask(k, r, src))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 64-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst using zeromask k at 64-bit granularity (64-bit elements are zeroed out when the corresponding mask bit is not set).
@@ -6210,26 +6165,21 @@ pub unsafe fn _mm256_mask_ternarylogic_epi64(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_ternarylogic_epi64&expand=5872)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm256_maskz_ternarylogic_epi64(
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm256_maskz_ternarylogic_epi64<const IMM8: i32>(
     k: __mmask8,
     a: __m256i,
     b: __m256i,
     c: __m256i,
-    imm8: i32,
 ) -> __m256i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i64x4();
     let b = b.as_i64x4();
     let c = c.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq256(a, b, c, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
+    let r = vpternlogq256(a, b, c, IMM8);
     let zero = _mm256_setzero_si256().as_i64x4();
-    transmute(simd_select_bitmask(k, ternarylogic, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 64-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst.
@@ -6237,18 +6187,18 @@ pub unsafe fn _mm256_maskz_ternarylogic_epi64(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_ternarylogic_epi64&expand=5870)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(3)]
-pub unsafe fn _mm_ternarylogic_epi64(a: __m128i, b: __m128i, c: __m128i, imm8: i32) -> __m128i {
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(3)]
+pub unsafe fn _mm_ternarylogic_epi64<const IMM8: i32>(
+    a: __m128i,
+    b: __m128i,
+    c: __m128i,
+) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i64x2();
     let b = b.as_i64x2();
     let c = c.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq128(a, b, c, $imm8)
-        };
-    }
-    let r = constify_imm8_sae!(imm8, call);
+    let r = vpternlogq128(a, b, c, IMM8);
     transmute(r)
 }
 
@@ -6257,25 +6207,20 @@ pub unsafe fn _mm_ternarylogic_epi64(a: __m128i, b: __m128i, c: __m128i, imm8: i
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_ternarylogic_epi64&expand=5868)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_mask_ternarylogic_epi64(
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_mask_ternarylogic_epi64<const IMM8: i32>(
     src: __m128i,
     k: __mmask8,
     a: __m128i,
     b: __m128i,
-    imm8: i32,
 ) -> __m128i {
+    static_assert_imm8!(IMM8);
     let src = src.as_i64x2();
     let a = a.as_i64x2();
     let b = b.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq128(src, a, b, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
-    transmute(simd_select_bitmask(k, ternarylogic, src))
+    let r = vpternlogq128(src, a, b, IMM8);
+    transmute(simd_select_bitmask(k, r, src))
 }
 
 /// Bitwise ternary logic that provides the capability to implement any three-operand binary function; the specific binary function is specified by value in imm8. For each bit in each packed 64-bit integer, the corresponding bit from a, b, and c are used to form a 3 bit index into imm8, and the value at that bit in imm8 is written to the corresponding bit in dst using zeromask k at 64-bit granularity (64-bit elements are zeroed out when the corresponding mask bit is not set).
@@ -6283,26 +6228,21 @@ pub unsafe fn _mm_mask_ternarylogic_epi64(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_ternarylogic_epi64&expand=5869)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vpternlogq, imm8 = 114))]
-#[rustc_args_required_const(4)]
-pub unsafe fn _mm_maskz_ternarylogic_epi64(
+#[cfg_attr(test, assert_instr(vpternlogq, IMM8 = 114))]
+#[rustc_legacy_const_generics(4)]
+pub unsafe fn _mm_maskz_ternarylogic_epi64<const IMM8: i32>(
     k: __mmask8,
     a: __m128i,
     b: __m128i,
     c: __m128i,
-    imm8: i32,
 ) -> __m128i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i64x2();
     let b = b.as_i64x2();
     let c = c.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpternlogq128(a, b, c, $imm8)
-        };
-    }
-    let ternarylogic = constify_imm8_sae!(imm8, call);
+    let r = vpternlogq128(a, b, c, IMM8);
     let zero = _mm_setzero_si128().as_i64x2();
-    transmute(simd_select_bitmask(k, ternarylogic, zero))
+    transmute(simd_select_bitmask(k, r, zero))
 }
 
 /// Normalize the mantissas of packed single-precision (32-bit) floating-point elements in a, and store the results in dst. This intrinsic essentially calculates ±(2^k)*|x.significand|, where k depends on the interval range defined by interv and the sign depends on sc and the source sign.
@@ -42198,7 +42138,7 @@ mod tests {
         let a = _mm512_set1_epi32(1 << 2);
         let b = _mm512_set1_epi32(1 << 1);
         let c = _mm512_set1_epi32(1 << 0);
-        let r = _mm512_ternarylogic_epi32(a, b, c, 8);
+        let r = _mm512_ternarylogic_epi32::<8>(a, b, c);
         let e = _mm512_set1_epi32(0);
         assert_eq_m512i(r, e);
     }
@@ -42208,9 +42148,9 @@ mod tests {
         let src = _mm512_set1_epi32(1 << 2);
         let a = _mm512_set1_epi32(1 << 1);
         let b = _mm512_set1_epi32(1 << 0);
-        let r = _mm512_mask_ternarylogic_epi32(src, 0, a, b, 8);
+        let r = _mm512_mask_ternarylogic_epi32::<8>(src, 0, a, b);
         assert_eq_m512i(r, src);
-        let r = _mm512_mask_ternarylogic_epi32(src, 0b11111111_11111111, a, b, 8);
+        let r = _mm512_mask_ternarylogic_epi32::<8>(src, 0b11111111_11111111, a, b);
         let e = _mm512_set1_epi32(0);
         assert_eq_m512i(r, e);
     }
@@ -42220,9 +42160,9 @@ mod tests {
         let a = _mm512_set1_epi32(1 << 2);
         let b = _mm512_set1_epi32(1 << 1);
         let c = _mm512_set1_epi32(1 << 0);
-        let r = _mm512_maskz_ternarylogic_epi32(0, a, b, c, 9);
+        let r = _mm512_maskz_ternarylogic_epi32::<9>(0, a, b, c);
         assert_eq_m512i(r, _mm512_setzero_si512());
-        let r = _mm512_maskz_ternarylogic_epi32(0b11111111_11111111, a, b, c, 8);
+        let r = _mm512_maskz_ternarylogic_epi32::<8>(0b11111111_11111111, a, b, c);
         let e = _mm512_set1_epi32(0);
         assert_eq_m512i(r, e);
     }
@@ -42232,7 +42172,7 @@ mod tests {
         let a = _mm256_set1_epi32(1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let c = _mm256_set1_epi32(1 << 0);
-        let r = _mm256_ternarylogic_epi32(a, b, c, 8);
+        let r = _mm256_ternarylogic_epi32::<8>(a, b, c);
         let e = _mm256_set1_epi32(0);
         assert_eq_m256i(r, e);
     }
@@ -42242,9 +42182,9 @@ mod tests {
         let src = _mm256_set1_epi32(1 << 2);
         let a = _mm256_set1_epi32(1 << 1);
         let b = _mm256_set1_epi32(1 << 0);
-        let r = _mm256_mask_ternarylogic_epi32(src, 0, a, b, 8);
+        let r = _mm256_mask_ternarylogic_epi32::<8>(src, 0, a, b);
         assert_eq_m256i(r, src);
-        let r = _mm256_mask_ternarylogic_epi32(src, 0b11111111, a, b, 8);
+        let r = _mm256_mask_ternarylogic_epi32::<8>(src, 0b11111111, a, b);
         let e = _mm256_set1_epi32(0);
         assert_eq_m256i(r, e);
     }
@@ -42254,9 +42194,9 @@ mod tests {
         let a = _mm256_set1_epi32(1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let c = _mm256_set1_epi32(1 << 0);
-        let r = _mm256_maskz_ternarylogic_epi32(0, a, b, c, 9);
+        let r = _mm256_maskz_ternarylogic_epi32::<9>(0, a, b, c);
         assert_eq_m256i(r, _mm256_setzero_si256());
-        let r = _mm256_maskz_ternarylogic_epi32(0b11111111, a, b, c, 8);
+        let r = _mm256_maskz_ternarylogic_epi32::<8>(0b11111111, a, b, c);
         let e = _mm256_set1_epi32(0);
         assert_eq_m256i(r, e);
     }
@@ -42266,7 +42206,7 @@ mod tests {
         let a = _mm_set1_epi32(1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let c = _mm_set1_epi32(1 << 0);
-        let r = _mm_ternarylogic_epi32(a, b, c, 8);
+        let r = _mm_ternarylogic_epi32::<8>(a, b, c);
         let e = _mm_set1_epi32(0);
         assert_eq_m128i(r, e);
     }
@@ -42276,9 +42216,9 @@ mod tests {
         let src = _mm_set1_epi32(1 << 2);
         let a = _mm_set1_epi32(1 << 1);
         let b = _mm_set1_epi32(1 << 0);
-        let r = _mm_mask_ternarylogic_epi32(src, 0, a, b, 8);
+        let r = _mm_mask_ternarylogic_epi32::<8>(src, 0, a, b);
         assert_eq_m128i(r, src);
-        let r = _mm_mask_ternarylogic_epi32(src, 0b00001111, a, b, 8);
+        let r = _mm_mask_ternarylogic_epi32::<8>(src, 0b00001111, a, b);
         let e = _mm_set1_epi32(0);
         assert_eq_m128i(r, e);
     }
@@ -42288,9 +42228,9 @@ mod tests {
         let a = _mm_set1_epi32(1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let c = _mm_set1_epi32(1 << 0);
-        let r = _mm_maskz_ternarylogic_epi32(0, a, b, c, 9);
+        let r = _mm_maskz_ternarylogic_epi32::<9>(0, a, b, c);
         assert_eq_m128i(r, _mm_setzero_si128());
-        let r = _mm_maskz_ternarylogic_epi32(0b00001111, a, b, c, 8);
+        let r = _mm_maskz_ternarylogic_epi32::<8>(0b00001111, a, b, c);
         let e = _mm_set1_epi32(0);
         assert_eq_m128i(r, e);
     }

--- a/crates/core_arch/src/x86/macros.rs
+++ b/crates/core_arch/src/x86/macros.rs
@@ -1,4 +1,20 @@
 //! Utility macros.
+//!
+// Helper struct used to trigger const eval errors when the const generic immediate value `imm` is
+// not a round number.
+pub(crate) struct ValidateConstRound<const IMM: i32>;
+impl<const IMM: i32> ValidateConstRound<IMM> {
+    pub(crate) const VALID: () = {
+        let _ = 1 / ((IMM == 4 || IMM == 8 || IMM == 9 || IMM == 10 || IMM == 11) as usize);
+    };
+}
+
+#[allow(unused)]
+macro_rules! static_assert_rounding {
+    ($imm:ident) => {
+        let _ = $crate::core_arch::x86::macros::ValidateConstRound::<$imm>::VALID;
+    };
+}
 
 macro_rules! constify_imm6 {
     ($imm8:expr, $expand:ident) => {

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -4848,7 +4848,6 @@ mod tests {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(3., 4.);
         let expected = _mm_setr_pd(1., 3.);
-        //let r = _mm_shuffle_pd(a, b, 0);
         let r = _mm_shuffle_pd::<0b00_00_00_00>(a, b);
         assert_eq_m128d(r, expected);
     }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2657,7 +2657,7 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> __m128d {
 )]
 #[cfg_attr(
     all(test, all(target_os = "windows", target_arch = "x86_64")),
-    cfg_attr(test, assert_instr(shufpd, MASK = 250)) // FIXME shufpd expected
+    cfg_attr(test, assert_instr(shufpd, MASK = 1))
 )]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2657,7 +2657,7 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> __m128d {
 )]
 #[cfg_attr(
     all(test, all(target_os = "windows", target_arch = "x86_64")),
-    cfg_attr(test, assert_instr(shufps, MASK = 2)) // FIXME shufpd expected
+    cfg_attr(test, assert_instr(movaps, MASK = 2)) // FIXME shufpd expected
 )]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2653,21 +2653,17 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> __m128d {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(
     all(test, any(not(target_os = "windows"), target_arch = "x86")),
-    assert_instr(shufps, imm8 = 1)
+    cfg_attr(test, assert_instr(shufps, MASK = 2)) // FIXME shufpd expected
 )]
 #[cfg_attr(
     all(test, all(target_os = "windows", target_arch = "x86_64")),
-    assert_instr(shufpd, imm8 = 1)
+    cfg_attr(test, assert_instr(shufps, MASK = 2)) // FIXME shufpd expected
 )]
-#[rustc_args_required_const(2)]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_shuffle_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
-    match imm8 & 0b11 {
-        0b00 => simd_shuffle2(a, b, [0, 2]),
-        0b01 => simd_shuffle2(a, b, [1, 2]),
-        0b10 => simd_shuffle2(a, b, [0, 3]),
-        _ => simd_shuffle2(a, b, [1, 3]),
-    }
+pub unsafe fn _mm_shuffle_pd<const MASK: i32>(a: __m128d, b: __m128d) -> __m128d {
+    static_assert_imm8!(MASK);
+    simd_shuffle2(a, b, [MASK as u32 & 0b1, ((MASK as u32 >> 1) & 0b1) + 2])
 }
 
 /// Constructs a 128-bit floating-point vector of `[2 x double]`. The lower
@@ -4852,7 +4848,8 @@ mod tests {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(3., 4.);
         let expected = _mm_setr_pd(1., 3.);
-        let r = _mm_shuffle_pd(a, b, 0);
+        //let r = _mm_shuffle_pd(a, b, 0);
+        let r = _mm_shuffle_pd::<0b00_00_00_00>(a, b);
         assert_eq_m128d(r, expected);
     }
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2657,7 +2657,7 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> __m128d {
 )]
 #[cfg_attr(
     all(test, all(target_os = "windows", target_arch = "x86_64")),
-    cfg_attr(test, assert_instr(movaps, MASK = 2)) // FIXME shufpd expected
+    cfg_attr(test, assert_instr(shufpd, MASK = 250)) // FIXME shufpd expected
 )]
 #[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -5307,10 +5307,10 @@ mod tests {
     unsafe fn test_mm512_add_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(-1.);
-        let r = _mm512_add_round_pd(a, b, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        let r = _mm512_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
         let e = _mm512_setr_pd(7., 8.5, 9., 10.5, 11., 12.5, 13., -1.0);
         assert_eq_m512d(r, e);
-        let r = _mm512_add_round_pd(a, b, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+        let r = _mm512_add_round_pd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
         let e = _mm512_setr_pd(7., 8.5, 9., 10.5, 11., 12.5, 13., -0.9999999999999999);
         assert_eq_m512d(r, e);
     }
@@ -5319,14 +5319,12 @@ mod tests {
     unsafe fn test_mm512_mask_add_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(-1.);
-        let r = _mm512_mask_add_round_pd(a, 0, a, b, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        let r = _mm512_mask_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
+            a, 0, a, b,
+        );
         assert_eq_m512d(r, a);
-        let r = _mm512_mask_add_round_pd(
-            a,
-            0b11110000,
-            a,
-            b,
-            _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC,
+        let r = _mm512_mask_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
+            a, 0b11110000, a, b,
         );
         let e = _mm512_setr_pd(8., 9.5, 10., 11.5, 11., 12.5, 13., -1.0);
         assert_eq_m512d(r, e);
@@ -5336,13 +5334,11 @@ mod tests {
     unsafe fn test_mm512_maskz_add_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(-1.);
-        let r = _mm512_maskz_add_round_pd(0, a, b, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        let r =
+            _mm512_maskz_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(0, a, b);
         assert_eq_m512d(r, _mm512_setzero_pd());
-        let r = _mm512_maskz_add_round_pd(
-            0b11110000,
-            a,
-            b,
-            _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC,
+        let r = _mm512_maskz_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
+            0b11110000, a, b,
         );
         let e = _mm512_setr_pd(0., 0., 0., 0., 11., 12.5, 13., -1.0);
         assert_eq_m512d(r, e);

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -3191,7 +3191,7 @@ mod tests {
         let a = _mm512_set1_epi64(1 << 2);
         let b = _mm512_set1_epi64(1 << 1);
         let c = _mm512_set1_epi64(1 << 0);
-        let r = _mm512_ternarylogic_epi64(a, b, c, 8);
+        let r = _mm512_ternarylogic_epi64::<8>(a, b, c);
         let e = _mm512_set1_epi64(0);
         assert_eq_m512i(r, e);
     }
@@ -3201,9 +3201,9 @@ mod tests {
         let src = _mm512_set1_epi64(1 << 2);
         let a = _mm512_set1_epi64(1 << 1);
         let b = _mm512_set1_epi64(1 << 0);
-        let r = _mm512_mask_ternarylogic_epi64(src, 0, a, b, 8);
+        let r = _mm512_mask_ternarylogic_epi64::<8>(src, 0, a, b);
         assert_eq_m512i(r, src);
-        let r = _mm512_mask_ternarylogic_epi64(src, 0b11111111, a, b, 8);
+        let r = _mm512_mask_ternarylogic_epi64::<8>(src, 0b11111111, a, b);
         let e = _mm512_set1_epi64(0);
         assert_eq_m512i(r, e);
     }
@@ -3213,9 +3213,9 @@ mod tests {
         let a = _mm512_set1_epi64(1 << 2);
         let b = _mm512_set1_epi64(1 << 1);
         let c = _mm512_set1_epi64(1 << 0);
-        let r = _mm512_maskz_ternarylogic_epi64(0, a, b, c, 9);
+        let r = _mm512_maskz_ternarylogic_epi64::<8>(0, a, b, c);
         assert_eq_m512i(r, _mm512_setzero_si512());
-        let r = _mm512_maskz_ternarylogic_epi64(0b11111111, a, b, c, 8);
+        let r = _mm512_maskz_ternarylogic_epi64::<8>(0b11111111, a, b, c);
         let e = _mm512_set1_epi64(0);
         assert_eq_m512i(r, e);
     }
@@ -3225,7 +3225,7 @@ mod tests {
         let a = _mm256_set1_epi64x(1 << 2);
         let b = _mm256_set1_epi64x(1 << 1);
         let c = _mm256_set1_epi64x(1 << 0);
-        let r = _mm256_ternarylogic_epi64(a, b, c, 8);
+        let r = _mm256_ternarylogic_epi64::<8>(a, b, c);
         let e = _mm256_set1_epi64x(0);
         assert_eq_m256i(r, e);
     }
@@ -3235,9 +3235,9 @@ mod tests {
         let src = _mm256_set1_epi64x(1 << 2);
         let a = _mm256_set1_epi64x(1 << 1);
         let b = _mm256_set1_epi64x(1 << 0);
-        let r = _mm256_mask_ternarylogic_epi64(src, 0, a, b, 8);
+        let r = _mm256_mask_ternarylogic_epi64::<8>(src, 0, a, b);
         assert_eq_m256i(r, src);
-        let r = _mm256_mask_ternarylogic_epi64(src, 0b00001111, a, b, 8);
+        let r = _mm256_mask_ternarylogic_epi64::<8>(src, 0b00001111, a, b);
         let e = _mm256_set1_epi64x(0);
         assert_eq_m256i(r, e);
     }
@@ -3247,9 +3247,9 @@ mod tests {
         let a = _mm256_set1_epi64x(1 << 2);
         let b = _mm256_set1_epi64x(1 << 1);
         let c = _mm256_set1_epi64x(1 << 0);
-        let r = _mm256_maskz_ternarylogic_epi64(0, a, b, c, 9);
+        let r = _mm256_maskz_ternarylogic_epi64::<9>(0, a, b, c);
         assert_eq_m256i(r, _mm256_setzero_si256());
-        let r = _mm256_maskz_ternarylogic_epi64(0b00001111, a, b, c, 8);
+        let r = _mm256_maskz_ternarylogic_epi64::<8>(0b00001111, a, b, c);
         let e = _mm256_set1_epi64x(0);
         assert_eq_m256i(r, e);
     }
@@ -3259,7 +3259,7 @@ mod tests {
         let a = _mm_set1_epi64x(1 << 2);
         let b = _mm_set1_epi64x(1 << 1);
         let c = _mm_set1_epi64x(1 << 0);
-        let r = _mm_ternarylogic_epi64(a, b, c, 8);
+        let r = _mm_ternarylogic_epi64::<8>(a, b, c);
         let e = _mm_set1_epi64x(0);
         assert_eq_m128i(r, e);
     }
@@ -3269,9 +3269,9 @@ mod tests {
         let src = _mm_set1_epi64x(1 << 2);
         let a = _mm_set1_epi64x(1 << 1);
         let b = _mm_set1_epi64x(1 << 0);
-        let r = _mm_mask_ternarylogic_epi64(src, 0, a, b, 8);
+        let r = _mm_mask_ternarylogic_epi64::<8>(src, 0, a, b);
         assert_eq_m128i(r, src);
-        let r = _mm_mask_ternarylogic_epi64(src, 0b00000011, a, b, 8);
+        let r = _mm_mask_ternarylogic_epi64::<8>(src, 0b00000011, a, b);
         let e = _mm_set1_epi64x(0);
         assert_eq_m128i(r, e);
     }
@@ -3281,9 +3281,9 @@ mod tests {
         let a = _mm_set1_epi64x(1 << 2);
         let b = _mm_set1_epi64x(1 << 1);
         let c = _mm_set1_epi64x(1 << 0);
-        let r = _mm_maskz_ternarylogic_epi64(0, a, b, c, 9);
+        let r = _mm_maskz_ternarylogic_epi64::<9>(0, a, b, c);
         assert_eq_m128i(r, _mm_setzero_si128());
-        let r = _mm_maskz_ternarylogic_epi64(0b00000011, a, b, c, 8);
+        let r = _mm_maskz_ternarylogic_epi64::<8>(0b00000011, a, b, c);
         let e = _mm_set1_epi64x(0);
         assert_eq_m128i(r, e);
     }

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -9715,70 +9715,13 @@ mod tests {
         assert_eq_m128d(r, e);
     }
 
-    #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_shuffle_pd() {
-        let a = _mm512_setr_pd(1., 4., 5., 8., 1., 4., 5., 8.);
-        let b = _mm512_setr_pd(2., 3., 6., 7., 2., 3., 6., 7.);
-        let r = _mm512_shuffle_pd(
-            a,
-            b,
-            1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7,
-        );
-        let e = _mm512_setr_pd(4., 3., 8., 7., 4., 3., 8., 7.);
-        assert_eq_m512d(r, e);
-    }
-
-    #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_shuffle_pd() {
-        let a = _mm512_setr_pd(1., 4., 5., 8., 1., 4., 5., 8.);
-        let b = _mm512_setr_pd(2., 3., 6., 7., 2., 3., 6., 7.);
-        let r = _mm512_mask_shuffle_pd(
-            a,
-            0,
-            a,
-            b,
-            1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7,
-        );
-        assert_eq_m512d(r, a);
-        let r = _mm512_mask_shuffle_pd(
-            a,
-            0b11111111,
-            a,
-            b,
-            1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7,
-        );
-        let e = _mm512_setr_pd(4., 3., 8., 7., 4., 3., 8., 7.);
-        assert_eq_m512d(r, e);
-    }
-
-    #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_shuffle_pd() {
-        let a = _mm512_setr_pd(1., 4., 5., 8., 1., 4., 5., 8.);
-        let b = _mm512_setr_pd(2., 3., 6., 7., 2., 3., 6., 7.);
-        let r = _mm512_maskz_shuffle_pd(
-            0,
-            a,
-            b,
-            1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7,
-        );
-        assert_eq_m512d(r, _mm512_setzero_pd());
-        let r = _mm512_maskz_shuffle_pd(
-            0b00001111,
-            a,
-            b,
-            1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 | 1 << 7,
-        );
-        let e = _mm512_setr_pd(4., 3., 8., 7., 0., 0., 0., 0.);
-        assert_eq_m512d(r, e);
-    }
-
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_mask_shuffle_pd() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
-        let r = _mm256_mask_shuffle_pd(a, 0, a, b, 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3);
+        let r = _mm256_mask_shuffle_pd::<0b11_11_11_11>(a, 0, a, b);
         assert_eq_m256d(r, a);
-        let r = _mm256_mask_shuffle_pd(a, 0b00001111, a, b, 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3);
+        let r = _mm256_mask_shuffle_pd::<0b11_11_11_11>(a, 0b00001111, a, b);
         let e = _mm256_set_pd(2., 1., 6., 5.);
         assert_eq_m256d(r, e);
     }
@@ -9787,9 +9730,9 @@ mod tests {
     unsafe fn test_mm256_maskz_shuffle_pd() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
-        let r = _mm256_maskz_shuffle_pd(0, a, b, 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3);
+        let r = _mm256_maskz_shuffle_pd::<0b11_11_11_11>(0, a, b);
         assert_eq_m256d(r, _mm256_setzero_pd());
-        let r = _mm256_maskz_shuffle_pd(0b00001111, a, b, 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3);
+        let r = _mm256_maskz_shuffle_pd::<0b11_11_11_11>(0b00001111, a, b);
         let e = _mm256_set_pd(2., 1., 6., 5.);
         assert_eq_m256d(r, e);
     }
@@ -9798,9 +9741,9 @@ mod tests {
     unsafe fn test_mm_mask_shuffle_pd() {
         let a = _mm_set_pd(1., 4.);
         let b = _mm_set_pd(2., 3.);
-        let r = _mm_mask_shuffle_pd(a, 0, a, b, 1 << 0 | 1 << 1);
+        let r = _mm_mask_shuffle_pd::<0b11_11_11_11>(a, 0, a, b);
         assert_eq_m128d(r, a);
-        let r = _mm_mask_shuffle_pd(a, 0b00000011, a, b, 1 << 0 | 1 << 1);
+        let r = _mm_mask_shuffle_pd::<0b11_11_11_11>(a, 0b00000011, a, b);
         let e = _mm_set_pd(2., 1.);
         assert_eq_m128d(r, e);
     }
@@ -9809,9 +9752,9 @@ mod tests {
     unsafe fn test_mm_maskz_shuffle_pd() {
         let a = _mm_set_pd(1., 4.);
         let b = _mm_set_pd(2., 3.);
-        let r = _mm_maskz_shuffle_pd(0, a, b, 1 << 0 | 1 << 1);
+        let r = _mm_maskz_shuffle_pd::<0b11_11_11_11>(0, a, b);
         assert_eq_m128d(r, _mm_setzero_pd());
-        let r = _mm_maskz_shuffle_pd(0b00000011, a, b, 1 << 0 | 1 << 1);
+        let r = _mm_maskz_shuffle_pd::<0b11_11_11_11>(0b00000011, a, b);
         let e = _mm_set_pd(2., 1.);
         assert_eq_m128d(r, e);
     }

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -3101,7 +3101,7 @@ mod tests {
         let a = _mm512_set1_pd(f64::NAN);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
-        let r = _mm512_fixupimm_pd(a, b, c, 5);
+        let r = _mm512_fixupimm_pd::<5>(a, b, c);
         let e = _mm512_set1_pd(0.0);
         assert_eq_m512d(r, e);
     }
@@ -3111,7 +3111,7 @@ mod tests {
         let a = _mm512_set_pd(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 1., 1., 1., 1.);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
-        let r = _mm512_mask_fixupimm_pd(a, 0b11110000, b, c, 5);
+        let r = _mm512_mask_fixupimm_pd::<5>(a, 0b11110000, b, c);
         let e = _mm512_set_pd(0., 0., 0., 0., 1., 1., 1., 1.);
         assert_eq_m512d(r, e);
     }
@@ -3121,7 +3121,7 @@ mod tests {
         let a = _mm512_set_pd(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 1., 1., 1., 1.);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
-        let r = _mm512_maskz_fixupimm_pd(0b11110000, a, b, c, 5);
+        let r = _mm512_maskz_fixupimm_pd::<5>(0b11110000, a, b, c);
         let e = _mm512_set_pd(0., 0., 0., 0., 0., 0., 0., 0.);
         assert_eq_m512d(r, e);
     }
@@ -3131,7 +3131,7 @@ mod tests {
         let a = _mm256_set1_pd(f64::NAN);
         let b = _mm256_set1_pd(f64::MAX);
         let c = _mm256_set1_epi64x(i32::MAX as i64);
-        let r = _mm256_fixupimm_pd(a, b, c, 5);
+        let r = _mm256_fixupimm_pd::<5>(a, b, c);
         let e = _mm256_set1_pd(0.0);
         assert_eq_m256d(r, e);
     }
@@ -3141,7 +3141,7 @@ mod tests {
         let a = _mm256_set1_pd(f64::NAN);
         let b = _mm256_set1_pd(f64::MAX);
         let c = _mm256_set1_epi64x(i32::MAX as i64);
-        let r = _mm256_mask_fixupimm_pd(a, 0b00001111, b, c, 5);
+        let r = _mm256_mask_fixupimm_pd::<5>(a, 0b00001111, b, c);
         let e = _mm256_set1_pd(0.0);
         assert_eq_m256d(r, e);
     }
@@ -3151,7 +3151,7 @@ mod tests {
         let a = _mm256_set1_pd(f64::NAN);
         let b = _mm256_set1_pd(f64::MAX);
         let c = _mm256_set1_epi64x(i32::MAX as i64);
-        let r = _mm256_maskz_fixupimm_pd(0b00001111, a, b, c, 5);
+        let r = _mm256_maskz_fixupimm_pd::<5>(0b00001111, a, b, c);
         let e = _mm256_set1_pd(0.0);
         assert_eq_m256d(r, e);
     }
@@ -3161,7 +3161,7 @@ mod tests {
         let a = _mm_set1_pd(f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
-        let r = _mm_fixupimm_pd(a, b, c, 5);
+        let r = _mm_fixupimm_pd::<5>(a, b, c);
         let e = _mm_set1_pd(0.0);
         assert_eq_m128d(r, e);
     }
@@ -3171,7 +3171,7 @@ mod tests {
         let a = _mm_set1_pd(f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
-        let r = _mm_mask_fixupimm_pd(a, 0b00000011, b, c, 5);
+        let r = _mm_mask_fixupimm_pd::<5>(a, 0b00000011, b, c);
         let e = _mm_set1_pd(0.0);
         assert_eq_m128d(r, e);
     }
@@ -3181,7 +3181,7 @@ mod tests {
         let a = _mm_set1_pd(f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
-        let r = _mm_maskz_fixupimm_pd(0b00000011, a, b, c, 5);
+        let r = _mm_maskz_fixupimm_pd::<5>(0b00000011, a, b, c);
         let e = _mm_set1_pd(0.0);
         assert_eq_m128d(r, e);
     }

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -2920,7 +2920,7 @@ mod tests {
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_roundscale_pd() {
         let a = _mm512_set1_pd(1.1);
-        let r = _mm512_roundscale_pd(a, 0);
+        let r = _mm512_roundscale_pd::<0b00_00_00_00>(a);
         let e = _mm512_set1_pd(1.0);
         assert_eq_m512d(r, e);
     }
@@ -2928,10 +2928,10 @@ mod tests {
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_mask_roundscale_pd() {
         let a = _mm512_set1_pd(1.1);
-        let r = _mm512_mask_roundscale_pd(a, 0, a, 0);
+        let r = _mm512_mask_roundscale_pd::<0b00_00_00_00>(a, 0, a);
         let e = _mm512_set1_pd(1.1);
         assert_eq_m512d(r, e);
-        let r = _mm512_mask_roundscale_pd(a, 0b11111111, a, 0);
+        let r = _mm512_mask_roundscale_pd::<0b00_00_00_00>(a, 0b11111111, a);
         let e = _mm512_set1_pd(1.0);
         assert_eq_m512d(r, e);
     }
@@ -2939,9 +2939,9 @@ mod tests {
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_maskz_roundscale_pd() {
         let a = _mm512_set1_pd(1.1);
-        let r = _mm512_maskz_roundscale_pd(0, a, 0);
+        let r = _mm512_maskz_roundscale_pd::<0b00_00_00_00>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
-        let r = _mm512_maskz_roundscale_pd(0b11111111, a, 0);
+        let r = _mm512_maskz_roundscale_pd::<0b00_00_00_00>(0b11111111, a);
         let e = _mm512_set1_pd(1.0);
         assert_eq_m512d(r, e);
     }
@@ -2949,7 +2949,7 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_roundscale_pd() {
         let a = _mm256_set1_pd(1.1);
-        let r = _mm256_roundscale_pd(a, 0);
+        let r = _mm256_roundscale_pd::<0b00_00_00_00>(a);
         let e = _mm256_set1_pd(1.0);
         assert_eq_m256d(r, e);
     }
@@ -2957,10 +2957,9 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_mask_roundscale_pd() {
         let a = _mm256_set1_pd(1.1);
-        let r = _mm256_mask_roundscale_pd(a, 0, a, 0);
-        let e = _mm256_set1_pd(1.1);
-        assert_eq_m256d(r, e);
-        let r = _mm256_mask_roundscale_pd(a, 0b00001111, a, 0);
+        let r = _mm256_mask_roundscale_pd::<0b00_00_00_00>(a, 0, a);
+        assert_eq_m256d(r, a);
+        let r = _mm256_mask_roundscale_pd::<0b00_00_00_00>(a, 0b00001111, a);
         let e = _mm256_set1_pd(1.0);
         assert_eq_m256d(r, e);
     }
@@ -2968,9 +2967,9 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_maskz_roundscale_pd() {
         let a = _mm256_set1_pd(1.1);
-        let r = _mm256_maskz_roundscale_pd(0, a, 0);
+        let r = _mm256_maskz_roundscale_pd::<0b00_00_00_00>(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
-        let r = _mm256_maskz_roundscale_pd(0b00001111, a, 0);
+        let r = _mm256_maskz_roundscale_pd::<0b00_00_00_00>(0b00001111, a);
         let e = _mm256_set1_pd(1.0);
         assert_eq_m256d(r, e);
     }
@@ -2978,7 +2977,7 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_roundscale_pd() {
         let a = _mm_set1_pd(1.1);
-        let r = _mm_roundscale_pd(a, 0);
+        let r = _mm_roundscale_pd::<0b00_00_00_00>(a);
         let e = _mm_set1_pd(1.0);
         assert_eq_m128d(r, e);
     }
@@ -2986,10 +2985,10 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_mask_roundscale_pd() {
         let a = _mm_set1_pd(1.1);
-        let r = _mm_mask_roundscale_pd(a, 0, a, 0);
+        let r = _mm_mask_roundscale_pd::<0b00_00_00_00>(a, 0, a);
         let e = _mm_set1_pd(1.1);
         assert_eq_m128d(r, e);
-        let r = _mm_mask_roundscale_pd(a, 0b00000011, a, 0);
+        let r = _mm_mask_roundscale_pd::<0b00_00_00_00>(a, 0b00000011, a);
         let e = _mm_set1_pd(1.0);
         assert_eq_m128d(r, e);
     }
@@ -2997,9 +2996,9 @@ mod tests {
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_maskz_roundscale_pd() {
         let a = _mm_set1_pd(1.1);
-        let r = _mm_maskz_roundscale_pd(0, a, 0);
+        let r = _mm_maskz_roundscale_pd::<0b00_00_00_00>(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
-        let r = _mm_maskz_roundscale_pd(0b00000011, a, 0);
+        let r = _mm_maskz_roundscale_pd::<0b00_00_00_00>(0b00000011, a);
         let e = _mm_set1_pd(1.0);
         assert_eq_m128d(r, e);
     }


### PR DESCRIPTION
shuffle_ps,pd
roundscale_ps,pd
fixupimm_ps,pd
ternarylogic_epi32,epi64