### PR TITLE
More trivial x86 intrinsics conversions to const generics

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -438,7 +438,7 @@ pub unsafe fn _mm256_floor_pd(a: __m256d) -> __m256d {
 }
 
 /// Rounds packed single-precision (32-bit) floating point elements in `a`
-/// according to the flag `b`. The value of `b` may be as follows:
+/// according to the flag `ROUNDING`. The value of `ROUNDING` may be as follows:
 ///
 /// - `0x00`: Round to the nearest whole number.
 /// - `0x01`: Round down, toward negative infinity.
@@ -452,16 +452,12 @@ pub unsafe fn _mm256_floor_pd(a: __m256d) -> __m256d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_round_ps)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vroundps, b = 0x00))]
-#[rustc_args_required_const(1)]
+#[cfg_attr(test, assert_instr(vroundps, ROUNDING = 0x00))]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_round_ps(a: __m256, b: i32) -> __m256 {
-    macro_rules! call {
-        ($imm8:expr) => {
-            roundps256(a, $imm8)
-        };
-    }
-    constify_imm8!(b, call)
+pub unsafe fn _mm256_round_ps<const ROUNDING: i32>(a: __m256) -> __m256 {
+    static_assert_imm4!(ROUNDING);
+    roundps256(a, ROUNDING)
 }
 
 /// Rounds packed single-precision (32-bit) floating point elements in `a`
@@ -3530,9 +3526,9 @@ mod tests {
     #[simd_test(enable = "avx")]
     unsafe fn test_mm256_round_ps() {
         let a = _mm256_setr_ps(1.55, 2.2, 3.99, -1.2, 1.55, 2.2, 3.99, -1.2);
-        let result_closest = _mm256_round_ps(a, 0b00000000);
-        let result_down = _mm256_round_ps(a, 0b00000001);
-        let result_up = _mm256_round_ps(a, 0b00000010);
+        let result_closest = _mm256_round_ps::<0b0000>(a);
+        let result_down = _mm256_round_ps::<0b0001>(a);
+        let result_up = _mm256_round_ps::<0b0010>(a);
         let expected_closest = _mm256_setr_ps(2., 2., 4., -1., 2., 2., 4., -1.);
         let expected_down = _mm256_setr_ps(1., 2., 3., -2., 1., 2., 3., -2.);
         let expected_up = _mm256_setr_ps(2., 3., 4., -1., 2., 3., 4., -1.);

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1385,16 +1385,12 @@ pub unsafe fn _mm_permute_pd(a: __m128d, imm8: i32) -> __m128d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_permute2f128_ps)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x5))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vperm2f128, IMM8 = 0x5))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2f128_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
-    macro_rules! call {
-        ($imm8:expr) => {
-            vperm2f128ps256(a, b, $imm8)
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm256_permute2f128_ps<const IMM8: i32>(a: __m256, b: __m256) -> __m256 {
+    static_assert_imm8!(IMM8);
+    vperm2f128ps256(a, b, IMM8 as i8)
 }
 
 /// Shuffles 256 bits (composed of 4 packed double-precision (64-bit)
@@ -3943,7 +3939,7 @@ mod tests {
     unsafe fn test_mm256_permute2f128_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 1., 2., 3., 4.);
         let b = _mm256_setr_ps(5., 6., 7., 8., 5., 6., 7., 8.);
-        let r = _mm256_permute2f128_ps(a, b, 0x13);
+        let r = _mm256_permute2f128_ps::<0x13>(a, b);
         let e = _mm256_setr_ps(5., 6., 7., 8., 1., 2., 3., 4.);
         assert_eq_m256(r, e);
     }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1399,16 +1399,12 @@ pub unsafe fn _mm256_permute2f128_ps<const IMM8: i32>(a: __m256, b: __m256) -> _
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_permute2f128_pd)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vperm2f128, IMM8 = 0x31))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2f128_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
-    macro_rules! call {
-        ($imm8:expr) => {
-            vperm2f128pd256(a, b, $imm8)
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm256_permute2f128_pd<const IMM8: i32>(a: __m256d, b: __m256d) -> __m256d {
+    static_assert_imm8!(IMM8);
+    vperm2f128pd256(a, b, IMM8 as i8)
 }
 
 /// Shuffles 128-bits (composed of integer data) selected by `imm8`
@@ -3948,7 +3944,7 @@ mod tests {
     unsafe fn test_mm256_permute2f128_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
-        let r = _mm256_permute2f128_pd(a, b, 0x31);
+        let r = _mm256_permute2f128_pd::<0x31>(a, b);
         let e = _mm256_setr_pd(3., 4., 7., 8.);
         assert_eq_m256d(r, e);
     }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -652,16 +652,12 @@ pub unsafe fn _mm256_blendv_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_dp_ps)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vdpps, imm8 = 0x0))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vdpps, IMM8 = 0x0))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_dp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
-    macro_rules! call {
-        ($imm8:expr) => {
-            vdpps(a, b, $imm8)
-        };
-    }
-    constify_imm8!(imm8, call)
+pub unsafe fn _mm256_dp_ps<const IMM8: i32>(a: __m256, b: __m256) -> __m256 {
+    static_assert_imm8!(IMM8);
+    vdpps(a, b, IMM8)
 }
 
 /// Horizontal addition of adjacent pairs in the two packed vectors
@@ -3638,7 +3634,7 @@ mod tests {
     unsafe fn test_mm256_dp_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
-        let r = _mm256_dp_ps(a, b, 0xFF);
+        let r = _mm256_dp_ps::<0xFF>(a, b);
         let e = _mm256_setr_ps(200., 200., 200., 200., 2387., 2387., 2387., 2387.);
         assert_eq_m256(r, e);
     }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1413,19 +1413,12 @@ pub unsafe fn _mm256_permute2f128_pd<const IMM8: i32>(a: __m256d, b: __m256d) ->
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_permute2f128_si256)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vperm2f128, IMM8 = 0x31))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2f128_si256(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
-    let a = a.as_i32x8();
-    let b = b.as_i32x8();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vperm2f128si256(a, b, $imm8)
-        };
-    }
-    let r = constify_imm8!(imm8, call);
-    transmute(r)
+pub unsafe fn _mm256_permute2f128_si256<const IMM8: i32>(a: __m256i, b: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(vperm2f128si256(a.as_i32x8(), b.as_i32x8(), IMM8 as i8))
 }
 
 /// Broadcasts a single-precision (32-bit) floating-point element from memory
@@ -3953,7 +3946,7 @@ mod tests {
     unsafe fn test_mm256_permute2f128_si256() {
         let a = _mm256_setr_epi32(1, 2, 3, 4, 1, 2, 3, 4);
         let b = _mm256_setr_epi32(5, 6, 7, 8, 5, 6, 7, 8);
-        let r = _mm256_permute2f128_si256(a, b, 0x20);
+        let r = _mm256_permute2f128_si256::<0x20>(a, b);
         let e = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         assert_eq_m256i(r, e);
     }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -391,7 +391,7 @@ pub unsafe fn _mm256_div_pd(a: __m256d, b: __m256d) -> __m256d {
 }
 
 /// Rounds packed double-precision (64-bit) floating point elements in `a`
-/// according to the flag `b`. The value of `b` may be as follows:
+/// according to the flag `ROUNDING`. The value of `ROUNDING` may be as follows:
 ///
 /// - `0x00`: Round to the nearest whole number.
 /// - `0x01`: Round down, toward negative infinity.
@@ -405,16 +405,12 @@ pub unsafe fn _mm256_div_pd(a: __m256d, b: __m256d) -> __m256d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_round_pd)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vroundpd, b = 0x3))]
-#[rustc_args_required_const(1)]
+#[cfg_attr(test, assert_instr(vroundpd, ROUNDING = 0x3))]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_round_pd(a: __m256d, b: i32) -> __m256d {
-    macro_rules! call {
-        ($imm8:expr) => {
-            roundpd256(a, $imm8)
-        };
-    }
-    constify_imm8!(b, call)
+pub unsafe fn _mm256_round_pd<const ROUNDING: i32>(a: __m256d) -> __m256d {
+    static_assert_imm4!(ROUNDING);
+    roundpd256(a, ROUNDING)
 }
 
 /// Rounds packed double-precision (64-bit) floating point elements in `a`
@@ -3504,9 +3500,9 @@ mod tests {
     #[simd_test(enable = "avx")]
     unsafe fn test_mm256_round_pd() {
         let a = _mm256_setr_pd(1.55, 2.2, 3.99, -1.2);
-        let result_closest = _mm256_round_pd(a, 0b00000000);
-        let result_down = _mm256_round_pd(a, 0b00000001);
-        let result_up = _mm256_round_pd(a, 0b00000010);
+        let result_closest = _mm256_round_pd::<0b0000>(a);
+        let result_down = _mm256_round_pd::<0b0001>(a);
+        let result_up = _mm256_round_pd::<0b0010>(a);
         let expected_closest = _mm256_setr_pd(2., 2., 4., -1.);
         let expected_down = _mm256_setr_pd(1., 2., 3., -2.);
         let expected_up = _mm256_setr_pd(2., 3., 4., -1.);

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1586,16 +1586,11 @@ pub unsafe fn _mm256_insert_epi16<const INDEX: i32>(a: __m256i, i: i16) -> __m25
 #[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
-#[rustc_args_required_const(2)]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_insert_epi32(a: __m256i, i: i32, index: i32) -> __m256i {
-    let a = a.as_i32x8();
-    macro_rules! call {
-        ($index:expr) => {
-            simd_insert(a, $index, i)
-        };
-    }
-    transmute(constify_imm3!(index, call))
+pub unsafe fn _mm256_insert_epi32<const INDEX: i32>(a: __m256i, i: i32) -> __m256i {
+    static_assert_imm3!(INDEX);
+    transmute(simd_insert(a.as_i32x8(), INDEX as u32, i))
 }
 
 /// Loads 256-bits (composed of 4 packed double-precision (64-bit)
@@ -4049,7 +4044,7 @@ mod tests {
     #[simd_test(enable = "avx")]
     unsafe fn test_mm256_insert_epi32() {
         let a = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
-        let r = _mm256_insert_epi32(a, 0, 7);
+        let r = _mm256_insert_epi32::<7>(a, 0);
         let e = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 0);
         assert_eq_m256i(r, e);
     }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1572,16 +1572,11 @@ pub unsafe fn _mm256_insert_epi8(a: __m256i, i: i8, index: i32) -> __m256i {
 #[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
-#[rustc_args_required_const(2)]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_insert_epi16(a: __m256i, i: i16, index: i32) -> __m256i {
-    let a = a.as_i16x16();
-    macro_rules! call {
-        ($index:expr) => {
-            simd_insert(a, $index, i)
-        };
-    }
-    transmute(constify_imm4!((index & 15), call))
+pub unsafe fn _mm256_insert_epi16<const INDEX: i32>(a: __m256i, i: i16) -> __m256i {
+    static_assert_imm4!(INDEX);
+    transmute(simd_insert(a.as_i16x16(), INDEX as u32, i))
 }
 
 /// Copies `a` to result, and inserts the 32-bit integer `i` into result
@@ -4042,7 +4037,7 @@ mod tests {
             0, 1, 2, 3, 4, 5, 6, 7,
             8, 9, 10, 11, 12, 13, 14, 15,
         );
-        let r = _mm256_insert_epi16(a, 0, 15);
+        let r = _mm256_insert_epi16::<15>(a, 0);
         #[rustfmt::skip]
         let e = _mm256_setr_epi16(
             0, 1, 2, 3, 4, 5, 6, 7,

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -4498,14 +4498,14 @@ mod tests {
 
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm_broadcastw_epi16() {
-        let a = _mm_insert_epi16(_mm_set1_epi16(0x2a), 0x22b, 0);
+        let a = _mm_insert_epi16::<0>(_mm_set1_epi16(0x2a), 0x22b);
         let res = _mm_broadcastw_epi16(a);
         assert_eq_m128i(res, _mm_set1_epi16(0x22b));
     }
 
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_broadcastw_epi16() {
-        let a = _mm_insert_epi16(_mm_set1_epi16(0x2a), 0x22b, 0);
+        let a = _mm_insert_epi16::<0>(_mm_set1_epi16(0x2a), 0x22b);
         let res = _mm256_broadcastw_epi16(a);
         assert_eq_m256i(res, _mm256_set1_epi16(0x22b));
     }
@@ -5196,7 +5196,7 @@ mod tests {
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_sll_epi16() {
         let a = _mm256_set1_epi16(0xFF);
-        let b = _mm_insert_epi16(_mm_set1_epi16(0), 4, 0);
+        let b = _mm_insert_epi16::<0>(_mm_set1_epi16(0), 4);
         let r = _mm256_sll_epi16(a, b);
         assert_eq_m256i(r, _mm256_set1_epi16(0xFF0));
     }
@@ -5357,7 +5357,7 @@ mod tests {
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_srl_epi16() {
         let a = _mm256_set1_epi16(0xFF);
-        let b = _mm_insert_epi16(_mm_set1_epi16(0), 4, 0);
+        let b = _mm_insert_epi16::<0>(_mm_set1_epi16(0), 4);
         let r = _mm256_srl_epi16(a, b);
         assert_eq_m256i(r, _mm256_set1_epi16(0xF));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3764,16 +3764,11 @@ pub unsafe fn _mm256_extract_epi8(a: __m256i, imm8: i32) -> i32 {
 #[inline]
 #[target_feature(enable = "avx2")]
 // This intrinsic has no corresponding instruction.
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_extract_epi16(a: __m256i, imm8: i32) -> i32 {
-    let a = a.as_u16x16();
-    macro_rules! call {
-        ($imm4:expr) => {
-            simd_extract::<_, u16>(a, $imm4) as i32
-        };
-    }
-    constify_imm4!((imm8 & 15), call)
+pub unsafe fn _mm256_extract_epi16<const IMM8: i32>(a: __m256i) -> i32 {
+    static_assert_imm4!(IMM8);
+    simd_extract::<_, u16>(a.as_u16x16(), IMM8 as u32) as i32
 }
 
 /// Extracts a 32-bit integer from `a`, selected with `imm8`.
@@ -6143,8 +6138,8 @@ mod tests {
             -1, 1, 2, 3, 4, 5, 6, 7,
             8, 9, 10, 11, 12, 13, 14, 15,
         );
-        let r1 = _mm256_extract_epi16(a, 0);
-        let r2 = _mm256_extract_epi16(a, 19);
+        let r1 = _mm256_extract_epi16::<0>(a);
+        let r2 = _mm256_extract_epi16::<3>(a);
         assert_eq!(r1, 0xFFFF);
         assert_eq!(r2, 3);
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2483,18 +2483,12 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_permute2x128_si256)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vperm2f128, imm8 = 9))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vperm2f128, IMM8 = 9))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2x128_si256(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
-    let a = a.as_i64x4();
-    let b = b.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vperm2i128(a, b, $imm8)
-        };
-    }
-    transmute(constify_imm8!(imm8, call))
+pub unsafe fn _mm256_permute2x128_si256<const IMM8: i32>(a: __m256i, b: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(vperm2i128(a.as_i64x4(), b.as_i64x4(), IMM8 as i8))
 }
 
 /// Shuffles 64-bit floating-point elements in `a` across lanes using the
@@ -5614,7 +5608,7 @@ mod tests {
     unsafe fn test_mm256_permute2x128_si256() {
         let a = _mm256_setr_epi64x(100, 200, 500, 600);
         let b = _mm256_setr_epi64x(300, 400, 700, 800);
-        let r = _mm256_permute2x128_si256(a, b, 0b00_01_00_11);
+        let r = _mm256_permute2x128_si256::<0b00_01_00_11>(a, b);
         let e = _mm256_setr_epi64x(700, 800, 500, 600);
         assert_eq_m256i(r, e);
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2246,19 +2246,12 @@ pub unsafe fn _mm256_movemask_epi8(a: __m256i) -> i32 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mpsadbw_epu8)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vmpsadbw, imm8 = 0))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vmpsadbw, IMM8 = 0))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mpsadbw_epu8(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
-    let a = a.as_u8x32();
-    let b = b.as_u8x32();
-    macro_rules! call {
-        ($imm8:expr) => {
-            mpsadbw(a, b, $imm8)
-        };
-    }
-    let r = constify_imm8!(imm8, call);
-    transmute(r)
+pub unsafe fn _mm256_mpsadbw_epu8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
+    transmute(mpsadbw(a.as_u8x32(), b.as_u8x32(), IMM8))
 }
 
 /// Multiplies the low 32-bit integers from each packed 64-bit element in
@@ -4997,7 +4990,7 @@ mod tests {
     unsafe fn test_mm256_mpsadbw_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
-        let r = _mm256_mpsadbw_epu8(a, b, 0);
+        let r = _mm256_mpsadbw_epu8::<0>(a, b);
         let e = _mm256_set1_epi16(8);
         assert_eq_m256i(r, e);
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -4552,7 +4552,7 @@ mod tests {
         let b = _mm256_setr_epi32(7, 6, 2, 4, 3, 2, 1, 0);
         let r = _mm256_cmpeq_epi32(a, b);
         let e = _mm256_set1_epi32(0);
-        let e = _mm256_insert_epi32(e, !0, 2);
+        let e = _mm256_insert_epi32::<2>(e, !0);
         assert_eq_m256i(r, e);
     }
 
@@ -4582,10 +4582,10 @@ mod tests {
 
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_cmpgt_epi32() {
-        let a = _mm256_insert_epi32(_mm256_set1_epi32(0), 5, 0);
+        let a = _mm256_insert_epi32::<0>(_mm256_set1_epi32(0), 5);
         let b = _mm256_set1_epi32(0);
         let r = _mm256_cmpgt_epi32(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi32(_mm256_set1_epi32(0), !0, 0));
+        assert_eq_m256i(r, _mm256_insert_epi32::<0>(_mm256_set1_epi32(0), !0));
     }
 
     #[simd_test(enable = "avx2")]

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3777,16 +3777,11 @@ pub unsafe fn _mm256_extract_epi16<const IMM8: i32>(a: __m256i) -> i32 {
 #[inline]
 #[target_feature(enable = "avx2")]
 // This intrinsic has no corresponding instruction.
-#[rustc_args_required_const(1)]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_extract_epi32(a: __m256i, imm8: i32) -> i32 {
-    let a = a.as_i32x8();
-    macro_rules! call {
-        ($imm3:expr) => {
-            simd_extract(a, $imm3)
-        };
-    }
-    constify_imm3!((imm8 & 7), call)
+pub unsafe fn _mm256_extract_epi32<const IMM8: i32>(a: __m256i) -> i32 {
+    static_assert_imm3!(IMM8);
+    simd_extract(a.as_i32x8(), IMM8 as u32)
 }
 
 /// Returns the first element of the input vector of `[4 x double]`.
@@ -6147,8 +6142,8 @@ mod tests {
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_extract_epi32() {
         let a = _mm256_setr_epi32(-1, 1, 2, 3, 4, 5, 6, 7);
-        let r1 = _mm256_extract_epi32(a, 0);
-        let r2 = _mm256_extract_epi32(a, 11);
+        let r1 = _mm256_extract_epi32::<0>(a);
+        let r2 = _mm256_extract_epi32::<3>(a);
         assert_eq!(r1, -1);
         assert_eq!(r2, 3);
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -4543,7 +4543,7 @@ mod tests {
             7, 6, 5, 4, 3, 2, 1, 0,
         );
         let r = _mm256_cmpeq_epi16(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 2));
+        assert_eq_m256i(r, _mm256_insert_epi16::<2>(_mm256_set1_epi16(0), !0));
     }
 
     #[simd_test(enable = "avx2")]
@@ -4574,10 +4574,10 @@ mod tests {
 
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_cmpgt_epi16() {
-        let a = _mm256_insert_epi16(_mm256_set1_epi16(0), 5, 0);
+        let a = _mm256_insert_epi16::<0>(_mm256_set1_epi16(0), 5);
         let b = _mm256_set1_epi16(0);
         let r = _mm256_cmpgt_epi16(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 0));
+        assert_eq_m256i(r, _mm256_insert_epi16::<0>(_mm256_set1_epi16(0), !0));
     }
 
     #[simd_test(enable = "avx2")]
@@ -4741,8 +4741,8 @@ mod tests {
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_hadds_epi16() {
         let a = _mm256_set1_epi16(2);
-        let a = _mm256_insert_epi16(a, 0x7fff, 0);
-        let a = _mm256_insert_epi16(a, 1, 1);
+        let a = _mm256_insert_epi16::<0>(a, 0x7fff);
+        let a = _mm256_insert_epi16::<1>(a, 1);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hadds_epi16(a, b);
         #[rustfmt::skip]
@@ -4774,11 +4774,11 @@ mod tests {
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_hsubs_epi16() {
         let a = _mm256_set1_epi16(2);
-        let a = _mm256_insert_epi16(a, 0x7fff, 0);
-        let a = _mm256_insert_epi16(a, -1, 1);
+        let a = _mm256_insert_epi16::<0>(a, 0x7fff);
+        let a = _mm256_insert_epi16::<1>(a, -1);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hsubs_epi16(a, b);
-        let e = _mm256_insert_epi16(_mm256_set1_epi16(0), 0x7FFF, 0);
+        let e = _mm256_insert_epi16::<0>(_mm256_set1_epi16(0), 0x7FFF);
         assert_eq_m256i(r, e);
     }
 

--- a/crates/core_arch/src/x86/macros.rs
+++ b/crates/core_arch/src/x86/macros.rs
@@ -40,6 +40,7 @@ macro_rules! constify_imm6 {
     };
 }
 
+#[allow(unused_macros)]
 macro_rules! constify_imm4 {
     ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1348,17 +1348,12 @@ pub unsafe fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_extract_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pextrw, imm8 = 9))]
-#[rustc_args_required_const(1)]
+#[cfg_attr(test, assert_instr(pextrw, IMM8 = 7))]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_extract_epi16(a: __m128i, imm8: i32) -> i32 {
-    let a = a.as_u16x8();
-    macro_rules! call {
-        ($imm3:expr) => {
-            simd_extract::<_, u16>(a, $imm3) as i32
-        };
-    }
-    constify_imm3!(imm8, call)
+pub unsafe fn _mm_extract_epi16<const IMM8: i32>(a: __m128i) -> i32 {
+    static_assert_imm3!(IMM8);
+    simd_extract::<_, u16>(a.as_u16x8(), IMM8 as u32) as i32
 }
 
 /// Returns a new vector where the `imm8` element of `a` is replaced with `i`.
@@ -3888,8 +3883,8 @@ mod tests {
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_extract_epi16() {
         let a = _mm_setr_epi16(-1, 1, 2, 3, 4, 5, 6, 7);
-        let r1 = _mm_extract_epi16(a, 0);
-        let r2 = _mm_extract_epi16(a, 11);
+        let r1 = _mm_extract_epi16::<0>(a);
+        let r2 = _mm_extract_epi16::<3>(a);
         assert_eq!(r1, 0xFFFF);
         assert_eq!(r2, 3);
     }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1361,17 +1361,12 @@ pub unsafe fn _mm_extract_epi16<const IMM8: i32>(a: __m128i) -> i32 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_insert_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(pinsrw, imm8 = 9))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(pinsrw, IMM8 = 7))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_insert_epi16(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    let a = a.as_i16x8();
-    macro_rules! call {
-        ($imm3:expr) => {
-            transmute(simd_insert(a, $imm3, i as i16))
-        };
-    }
-    constify_imm3!(imm8, call)
+pub unsafe fn _mm_insert_epi16<const IMM8: i32>(a: __m128i, i: i32) -> __m128i {
+    static_assert_imm3!(IMM8);
+    transmute(simd_insert(a.as_i16x8(), IMM8 as u32, i as i16))
 }
 
 /// Returns a mask of the most significant bit of each element in `a`.
@@ -3892,7 +3887,7 @@ mod tests {
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_insert_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
-        let r = _mm_insert_epi16(a, 9, 0);
+        let r = _mm_insert_epi16::<0>(a, 9);
         let e = _mm_setr_epi16(9, 1, 2, 3, 4, 5, 6, 7);
         assert_eq_m128i(r, e);
     }


### PR DESCRIPTION
This PR converts these trivial x86 intrinsics to const generics.

#### x86/sse2.rs:
- `_mm_extract_epi16`
- `_mm_insert_epi16`

#### x86/avx.rs:
- `_mm256_round_pd`
- `_mm256_round_ps`
- `_mm256_dp_ps`
- `_mm256_permute2f128_ps`
- `_mm256_permute2f128_pd`
- `_mm256_permute2f128_si256`
- `_mm256_insert_epi16`
- `_mm256_insert_epi32`

#### x86/avx2.rs:
- `_mm256_mpsadbw_epu8`
- `_mm256_permute2x128_si256`
- `_mm256_extract_epi16`
- `_mm256_extract_epi32`

I limited to these at first, as the other intrinsics I've done require different static assertions and `ValidateConstImm` changes that are being done in other open PRs (the MIPS ones). I wouldn't want to create conflicts and bitrot these other WIP PRs.
