### PR TITLE
Static assertion failures with more informative diagnostics

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -4,6 +4,7 @@
 // out of `[MIN-MAX]` range.
 pub(crate) struct ValidateConstImm<const IMM: i32, const MIN: i32, const MAX: i32>;
 impl<const IMM: i32, const MIN: i32, const MAX: i32> ValidateConstImm<IMM, MIN, MAX> {
+    #[allow(const_err)]
     pub(crate) const VALID: () = {
         let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
     };
@@ -63,6 +64,7 @@ macro_rules! static_assert {
     ($imm:ident : $ty:ty where $e:expr) => {
         struct Validate<const $imm: $ty>();
         impl<const $imm: $ty> Validate<$imm> {
+            #[allow(const_err)]
             const VALID: () = {
                 let _ = 1 / ($e as usize);
             };


### PR DESCRIPTION
Allow const evaluation errors in validation constants to obtain slightly
more informative diagnostics. For example, before:

```
error: any use of this value will cause an error
 --> crates/core_arch/src/macros.rs:8:17
  |
7 | /     pub(crate) const VALID: () = {
8 | |         let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
  | |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to divide `1_usize` by zero
9 | |     };
  | |______-
  |
  = note: `#[deny(const_err)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
```

and after:

```
error: erroneous constant encountered
    --> crates/core_arch/src/macros.rs:58:17
     |
58   |         let _ = $crate::core_arch::macros::ValidateConstImm::<$imm, 0, { (1 << 8) - 1 }>::VALID;
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: crates/core_arch/src/x86/avx.rs:1094:5
     |
1094 |     static_assert_imm8!(IMM8);
     |     -------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error
```