### PR TITLE
More AVX2 conversions to const generics

### DIFF
--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1550,20 +1550,16 @@ pub unsafe fn _mm256_mask_i64gather_epi32<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_i64gather_ps)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vgatherqps, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i64gather_ps(slice: *const f32, offsets: __m128i, scale: i32) -> __m128 {
+pub unsafe fn _mm_i64gather_ps<const SCALE: i32>(slice: *const f32, offsets: __m128i) -> __m128 {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm_setzero_ps();
     let neg_one = _mm_set1_ps(-1.0);
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherqps(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    pgatherqps(zero, slice, offsets, neg_one, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5797,7 +5793,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r = _mm_i64gather_ps(arr.as_ptr(), _mm_setr_epi64x(0, 16), 4);
+        let r = _mm_i64gather_ps::<4>(arr.as_ptr(), _mm_setr_epi64x(0, 16));
         assert_eq_m128(r, _mm_setr_ps(0.0, 16.0, 0.0, 0.0));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1203,24 +1203,19 @@ pub unsafe fn _mm_i32gather_ps<const SCALE: i32>(slice: *const f32, offsets: __m
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_i32gather_ps)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vgatherdps, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_mask_i32gather_ps(
+pub unsafe fn _mm_mask_i32gather_ps<const SCALE: i32>(
     src: __m128,
     slice: *const f32,
     offsets: __m128i,
     mask: __m128,
-    scale: i32,
 ) -> __m128 {
+    static_assert_imm8_scale!(SCALE);
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherdps(src, slice, offsets, mask, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    pgatherdps(src, slice, offsets, mask, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5627,12 +5622,11 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r = _mm_mask_i32gather_ps(
+        let r = _mm_mask_i32gather_ps::<4>(
             _mm_set1_ps(256.0),
             arr.as_ptr(),
             _mm_setr_epi32(0, 16, 64, 96),
             _mm_setr_ps(-1.0, -1.0, -1.0, 0.0),
-            4,
         );
         assert_eq_m128(r, _mm_setr_ps(0.0, 16.0, 64.0, 256.0));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1658,26 +1658,21 @@ pub unsafe fn _mm_i64gather_epi64<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_i64gather_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vpgatherqq, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_mask_i64gather_epi64(
+pub unsafe fn _mm_mask_i64gather_epi64<const SCALE: i32>(
     src: __m128i,
     slice: *const i64,
     offsets: __m128i,
     mask: __m128i,
-    scale: i32,
 ) -> __m128i {
+    static_assert_imm8_scale!(SCALE);
     let src = src.as_i64x2();
     let mask = mask.as_i64x2();
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherqq(src, slice, offsets, mask, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = pgatherqq(src, slice, offsets, mask, SCALE as i8);
     transmute(r)
 }
 
@@ -5849,12 +5844,11 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm_mask_i64gather_epi64(
+        let r = _mm_mask_i64gather_epi64::<8>(
             _mm_set1_epi64x(256),
             arr.as_ptr(),
             _mm_setr_epi64x(16, 16),
             _mm_setr_epi64x(-1, 0),
-            8,
         );
         assert_eq_m128i(r, _mm_setr_epi64x(16, 256));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1683,20 +1683,19 @@ pub unsafe fn _mm_mask_i64gather_epi64<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_i64gather_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vpgatherqq, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_epi64(slice: *const i64, offsets: __m256i, scale: i32) -> __m256i {
+pub unsafe fn _mm256_i64gather_epi64<const SCALE: i32>(
+    slice: *const i64,
+    offsets: __m256i,
+) -> __m256i {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm256_setzero_si256().as_i64x4();
     let neg_one = _mm256_set1_epi64x(-1).as_i64x4();
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherqq(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = vpgatherqq(zero, slice, offsets, neg_one, SCALE as i8);
     transmute(r)
 }
 
@@ -5860,7 +5859,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm256_i64gather_epi64(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 8);
+        let r = _mm256_i64gather_epi64::<8>(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48));
         assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 32, 48));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1612,24 +1612,19 @@ pub unsafe fn _mm256_i64gather_ps<const SCALE: i32>(slice: *const f32, offsets: 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_i64gather_ps)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vgatherqps, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mask_i64gather_ps(
+pub unsafe fn _mm256_mask_i64gather_ps<const SCALE: i32>(
     src: __m128,
     slice: *const f32,
     offsets: __m256i,
     mask: __m128,
-    scale: i32,
 ) -> __m128 {
+    static_assert_imm8_scale!(SCALE);
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherqps(src, slice, offsets, mask, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    vpgatherqps(src, slice, offsets, mask, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5828,12 +5823,11 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r = _mm256_mask_i64gather_ps(
+        let r = _mm256_mask_i64gather_ps::<4>(
             _mm_set1_ps(256.0),
             arr.as_ptr(),
             _mm256_setr_epi64x(0, 16, 64, 96),
             _mm_setr_ps(-1.0, -1.0, -1.0, 0.0),
-            4,
         );
         assert_eq_m128(r, _mm_setr_ps(0.0, 16.0, 64.0, 256.0));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1501,20 +1501,19 @@ pub unsafe fn _mm_mask_i64gather_epi32<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_i64gather_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vpgatherqd, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_epi32(slice: *const i32, offsets: __m256i, scale: i32) -> __m128i {
+pub unsafe fn _mm256_i64gather_epi32<const SCALE: i32>(
+    slice: *const i32,
+    offsets: __m256i,
+) -> __m128i {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm_setzero_si128().as_i32x4();
     let neg_one = _mm_set1_epi64x(-1).as_i32x4();
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherqd(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = vpgatherqd(zero, slice, offsets, neg_one, SCALE as i8);
     transmute(r)
 }
 
@@ -5774,7 +5773,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 4 is word-addressing
-        let r = _mm256_i64gather_epi32(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 4);
+        let r = _mm256_i64gather_epi32::<4>(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48));
         assert_eq_m128i(r, _mm_setr_epi32(0, 16, 32, 48));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1340,26 +1340,21 @@ pub unsafe fn _mm256_i32gather_epi64<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_i32gather_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vpgatherdq, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mask_i32gather_epi64(
+pub unsafe fn _mm256_mask_i32gather_epi64<const SCALE: i32>(
     src: __m256i,
     slice: *const i64,
     offsets: __m128i,
     mask: __m256i,
-    scale: i32,
 ) -> __m256i {
+    static_assert_imm8_scale!(SCALE);
     let src = src.as_i64x4();
     let mask = mask.as_i64x4();
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherdq(src, slice, offsets, mask, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = vpgatherdq(src, slice, offsets, mask, SCALE as i8);
     transmute(r)
 }
 
@@ -5695,12 +5690,11 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm256_mask_i32gather_epi64(
+        let r = _mm256_mask_i32gather_epi64::<8>(
             _mm256_set1_epi64x(256),
             arr.as_ptr(),
             _mm_setr_epi32(0, 16, 64, 96),
             _mm256_setr_epi64x(-1, -1, -1, 0),
-            8,
         );
         assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 64, 256));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1732,20 +1732,16 @@ pub unsafe fn _mm256_mask_i64gather_epi64<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_i64gather_pd)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vgatherqpd, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i64gather_pd(slice: *const f64, offsets: __m128i, scale: i32) -> __m128d {
+pub unsafe fn _mm_i64gather_pd<const SCALE: i32>(slice: *const f64, offsets: __m128i) -> __m128d {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm_setzero_pd();
     let neg_one = _mm_set1_pd(-1.0);
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherqpd(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    pgatherqpd(zero, slice, offsets, neg_one, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5883,7 +5879,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm_i64gather_pd(arr.as_ptr(), _mm_setr_epi64x(0, 16), 8);
+        let r = _mm_i64gather_pd::<8>(arr.as_ptr(), _mm_setr_epi64x(0, 16));
         assert_eq_m128d(r, _mm_setr_pd(0.0, 16.0));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1430,24 +1430,19 @@ pub unsafe fn _mm256_i32gather_pd<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_i32gather_pd)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vgatherdpd, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mask_i32gather_pd(
+pub unsafe fn _mm256_mask_i32gather_pd<const SCALE: i32>(
     src: __m256d,
     slice: *const f64,
     offsets: __m128i,
     mask: __m256d,
-    scale: i32,
 ) -> __m256d {
+    static_assert_imm8_scale!(SCALE);
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherdpd(src, slice, offsets, mask, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    vpgatherdpd(src, slice, offsets, mask, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5742,12 +5737,11 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm256_mask_i32gather_pd(
+        let r = _mm256_mask_i32gather_pd::<8>(
             _mm256_set1_pd(256.0),
             arr.as_ptr(),
             _mm_setr_epi32(0, 16, 64, 96),
             _mm256_setr_pd(-1.0, -1.0, -1.0, 0.0),
-            8,
         );
         assert_eq_m256d(r, _mm256_setr_pd(0.0, 16.0, 64.0, 256.0));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1365,20 +1365,16 @@ pub unsafe fn _mm256_mask_i32gather_epi64<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_i32gather_pd)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vgatherdpd, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_pd(slice: *const f64, offsets: __m128i, scale: i32) -> __m128d {
+pub unsafe fn _mm_i32gather_pd<const SCALE: i32>(slice: *const f64, offsets: __m128i) -> __m128d {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm_setzero_pd();
     let neg_one = _mm_set1_pd(-1.0);
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherdpd(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    pgatherdpd(zero, slice, offsets, neg_one, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5708,7 +5704,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm_i32gather_pd(arr.as_ptr(), _mm_setr_epi32(0, 16, 0, 0), 8);
+        let r = _mm_i32gather_pd::<8>(arr.as_ptr(), _mm_setr_epi32(0, 16, 0, 0));
         assert_eq_m128d(r, _mm_setr_pd(0.0, 16.0));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1267,20 +1267,19 @@ pub unsafe fn _mm256_mask_i32gather_ps<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_i32gather_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vpgatherdq, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_epi64(slice: *const i64, offsets: __m128i, scale: i32) -> __m128i {
+pub unsafe fn _mm_i32gather_epi64<const SCALE: i32>(
+    slice: *const i64,
+    offsets: __m128i,
+) -> __m128i {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm_setzero_si128().as_i64x2();
     let neg_one = _mm_set1_epi64x(-1).as_i64x2();
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherdq(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = pgatherdq(zero, slice, offsets, neg_one, SCALE as i8);
     transmute(r)
 }
 
@@ -5664,7 +5663,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm_i32gather_epi64(arr.as_ptr(), _mm_setr_epi32(0, 16, 0, 0), 8);
+        let r = _mm_i32gather_epi64::<8>(arr.as_ptr(), _mm_setr_epi32(0, 16, 0, 0));
         assert_eq_m128i(r, _mm_setr_epi64x(0, 16));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1385,24 +1385,19 @@ pub unsafe fn _mm_i32gather_pd<const SCALE: i32>(slice: *const f64, offsets: __m
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_i32gather_pd)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vgatherdpd, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_mask_i32gather_pd(
+pub unsafe fn _mm_mask_i32gather_pd<const SCALE: i32>(
     src: __m128d,
     slice: *const f64,
     offsets: __m128i,
     mask: __m128d,
-    scale: i32,
 ) -> __m128d {
+    static_assert_imm8_scale!(SCALE);
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherdpd(src, slice, offsets, mask, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    pgatherdpd(src, slice, offsets, mask, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5717,12 +5712,11 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm_mask_i32gather_pd(
+        let r = _mm_mask_i32gather_pd::<8>(
             _mm_set1_pd(256.0),
             arr.as_ptr(),
             _mm_setr_epi32(16, 16, 16, 16),
             _mm_setr_pd(-1.0, 0.0),
-            8,
         );
         assert_eq_m128d(r, _mm_setr_pd(16.0, 256.0));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1774,20 +1774,19 @@ pub unsafe fn _mm_mask_i64gather_pd<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_i64gather_pd)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vgatherqpd, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_pd(slice: *const f64, offsets: __m256i, scale: i32) -> __m256d {
+pub unsafe fn _mm256_i64gather_pd<const SCALE: i32>(
+    slice: *const f64,
+    offsets: __m256i,
+) -> __m256d {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm256_setzero_pd();
     let neg_one = _mm256_set1_pd(-1.0);
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherqpd(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    vpgatherqpd(zero, slice, offsets, neg_one, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5905,7 +5904,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm256_i64gather_pd(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 8);
+        let r = _mm256_i64gather_pd::<8>(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48));
         assert_eq_m256d(r, _mm256_setr_pd(0.0, 16.0, 32.0, 48.0));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1183,20 +1183,16 @@ pub unsafe fn _mm256_mask_i32gather_epi32<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_i32gather_ps)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vgatherdps, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_ps(slice: *const f32, offsets: __m128i, scale: i32) -> __m128 {
+pub unsafe fn _mm_i32gather_ps<const SCALE: i32>(slice: *const f32, offsets: __m128i) -> __m128 {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm_setzero_ps();
     let neg_one = _mm_set1_ps(-1.0);
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherdps(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    pgatherdps(zero, slice, offsets, neg_one, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5618,7 +5614,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r = _mm_i32gather_ps(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 4);
+        let r = _mm_i32gather_ps::<4>(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48));
         assert_eq_m128(r, _mm_setr_ps(0.0, 16.0, 32.0, 48.0));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1134,20 +1134,19 @@ pub unsafe fn _mm_mask_i32gather_epi32<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_i32gather_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vpgatherdd, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i32gather_epi32(slice: *const i32, offsets: __m256i, scale: i32) -> __m256i {
+pub unsafe fn _mm256_i32gather_epi32<const SCALE: i32>(
+    slice: *const i32,
+    offsets: __m256i,
+) -> __m256i {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm256_setzero_si256().as_i32x8();
     let neg_one = _mm256_set1_epi32(-1).as_i32x8();
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherdd(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = vpgatherdd(zero, slice, offsets, neg_one, SCALE as i8);
     transmute(r)
 }
 
@@ -5594,11 +5593,8 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 4 is word-addressing
-        let r = _mm256_i32gather_epi32(
-            arr.as_ptr(),
-            _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4),
-            4,
-        );
+        let r =
+            _mm256_i32gather_epi32::<4>(arr.as_ptr(), _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4));
         assert_eq_m256i(r, _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1245,24 +1245,19 @@ pub unsafe fn _mm256_i32gather_ps<const SCALE: i32>(slice: *const f32, offsets: 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_i32gather_ps)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vgatherdps, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mask_i32gather_ps(
+pub unsafe fn _mm256_mask_i32gather_ps<const SCALE: i32>(
     src: __m256,
     slice: *const f32,
     offsets: __m256i,
     mask: __m256,
-    scale: i32,
 ) -> __m256 {
+    static_assert_imm8_scale!(SCALE);
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherdps(src, slice, offsets, mask, $imm8)
-        };
-    }
-    constify_imm8_gather!(scale, call)
+    vpgatherdps(src, slice, offsets, mask, SCALE as i8)
 }
 
 /// Returns values from `slice` at offsets determined by `offsets * scale`,
@@ -5650,12 +5645,11 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r = _mm256_mask_i32gather_ps(
+        let r = _mm256_mask_i32gather_ps::<4>(
             _mm256_set1_ps(256.0),
             arr.as_ptr(),
             _mm256_setr_epi32(0, 16, 64, 96, 0, 0, 0, 0),
             _mm256_setr_ps(-1.0, -1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-            4,
         );
         assert_eq_m256(
             r,

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1316,20 +1316,19 @@ pub unsafe fn _mm_mask_i32gather_epi64<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_i32gather_epi64)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
-#[rustc_args_required_const(2)]
+#[cfg_attr(test, assert_instr(vpgatherdq, SCALE = 1))]
+#[rustc_legacy_const_generics(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i32gather_epi64(slice: *const i64, offsets: __m128i, scale: i32) -> __m256i {
+pub unsafe fn _mm256_i32gather_epi64<const SCALE: i32>(
+    slice: *const i64,
+    offsets: __m128i,
+) -> __m256i {
+    static_assert_imm8_scale!(SCALE);
     let zero = _mm256_setzero_si256().as_i64x4();
     let neg_one = _mm256_set1_epi64x(-1).as_i64x4();
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherdq(zero, slice, offsets, neg_one, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = vpgatherdq(zero, slice, offsets, neg_one, SCALE as i8);
     transmute(r)
 }
 
@@ -5685,7 +5684,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm256_i32gather_epi64(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 8);
+        let r = _mm256_i32gather_epi64::<8>(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48));
         assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 32, 48));
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2493,57 +2493,34 @@ pub unsafe fn _mm256_shuffle_epi32<const MASK: i32>(a: __m256i) -> __m256i {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_shufflehi_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpshufhw, imm8 = 9))]
-#[rustc_args_required_const(1)]
+#[cfg_attr(test, assert_instr(vpshufhw, IMM8 = 9))]
+#[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_shufflehi_epi16(a: __m256i, imm8: i32) -> __m256i {
-    let imm8 = (imm8 & 0xFF) as u8;
+pub unsafe fn _mm256_shufflehi_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
+    static_assert_imm8!(IMM8);
     let a = a.as_i16x16();
-    macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
-            #[rustfmt::skip]
-                        simd_shuffle16(a, a, [
-                            0, 1, 2, 3, 4+$x01, 4+$x23, 4+$x45, 4+$x67,
-                            8, 9, 10, 11, 12+$x01, 12+$x23, 12+$x45, 12+$x67
-                        ])
-        };
-    }
-    macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
-            match (imm8 >> 6) & 0b11 {
-                0b00 => shuffle_done!($x01, $x23, $x45, 0),
-                0b01 => shuffle_done!($x01, $x23, $x45, 1),
-                0b10 => shuffle_done!($x01, $x23, $x45, 2),
-                _ => shuffle_done!($x01, $x23, $x45, 3),
-            }
-        };
-    }
-    macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
-            match (imm8 >> 4) & 0b11 {
-                0b00 => shuffle_x67!($x01, $x23, 0),
-                0b01 => shuffle_x67!($x01, $x23, 1),
-                0b10 => shuffle_x67!($x01, $x23, 2),
-                _ => shuffle_x67!($x01, $x23, 3),
-            }
-        };
-    }
-    macro_rules! shuffle_x23 {
-        ($x01:expr) => {
-            match (imm8 >> 2) & 0b11 {
-                0b00 => shuffle_x45!($x01, 0),
-                0b01 => shuffle_x45!($x01, 1),
-                0b10 => shuffle_x45!($x01, 2),
-                _ => shuffle_x45!($x01, 3),
-            }
-        };
-    }
-    let r: i16x16 = match imm8 & 0b11 {
-        0b00 => shuffle_x23!(0),
-        0b01 => shuffle_x23!(1),
-        0b10 => shuffle_x23!(2),
-        _ => shuffle_x23!(3),
-    };
+    let r: i16x16 = simd_shuffle16(
+        a,
+        a,
+        [
+            0,
+            1,
+            2,
+            3,
+            4 + (IMM8 as u32 & 0b11),
+            4 + ((IMM8 as u32 >> 2) & 0b11),
+            4 + ((IMM8 as u32 >> 4) & 0b11),
+            4 + ((IMM8 as u32 >> 6) & 0b11),
+            8,
+            9,
+            10,
+            11,
+            12 + (IMM8 as u32 & 0b11),
+            12 + ((IMM8 as u32 >> 2) & 0b11),
+            12 + ((IMM8 as u32 >> 4) & 0b11),
+            12 + ((IMM8 as u32 >> 6) & 0b11),
+        ],
+    );
     transmute(r)
 }
 
@@ -4891,7 +4868,7 @@ mod tests {
             0, 1, 2, 3, 44, 22, 22, 11,
             4, 5, 6, 7, 88, 66, 66, 55,
         );
-        let r = _mm256_shufflehi_epi16(a, 0b00_01_01_11);
+        let r = _mm256_shufflehi_epi16::<0b00_01_01_11>(a);
         assert_eq_m256i(r, e);
     }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1525,26 +1525,21 @@ pub unsafe fn _mm256_i64gather_epi32<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_i64gather_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vpgatherqd, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mask_i64gather_epi32(
+pub unsafe fn _mm256_mask_i64gather_epi32<const SCALE: i32>(
     src: __m128i,
     slice: *const i32,
     offsets: __m256i,
     mask: __m128i,
-    scale: i32,
 ) -> __m128i {
+    static_assert_imm8_scale!(SCALE);
     let src = src.as_i32x4();
     let mask = mask.as_i32x4();
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            vpgatherqd(src, slice, offsets, mask, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = vpgatherqd(src, slice, offsets, mask, SCALE as i8);
     transmute(r)
 }
 
@@ -5784,12 +5779,11 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 4 is word-addressing
-        let r = _mm256_mask_i64gather_epi32(
+        let r = _mm256_mask_i64gather_epi32::<4>(
             _mm_set1_epi32(256),
             arr.as_ptr(),
             _mm256_setr_epi64x(0, 16, 64, 96),
             _mm_setr_epi32(-1, -1, -1, 0),
-            4,
         );
         assert_eq_m128i(r, _mm_setr_epi32(0, 16, 64, 256));
     }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -1109,26 +1109,21 @@ pub unsafe fn _mm_i32gather_epi32<const SCALE: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_i32gather_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
-#[rustc_args_required_const(4)]
+#[cfg_attr(test, assert_instr(vpgatherdd, SCALE = 1))]
+#[rustc_legacy_const_generics(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_mask_i32gather_epi32(
+pub unsafe fn _mm_mask_i32gather_epi32<const SCALE: i32>(
     src: __m128i,
     slice: *const i32,
     offsets: __m128i,
     mask: __m128i,
-    scale: i32,
 ) -> __m128i {
+    static_assert_imm8_scale!(SCALE);
     let src = src.as_i32x4();
     let mask = mask.as_i32x4();
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
-    macro_rules! call {
-        ($imm8:expr) => {
-            pgatherdd(src, slice, offsets, mask, $imm8)
-        };
-    }
-    let r = constify_imm8_gather!(scale, call);
+    let r = pgatherdd(src, slice, offsets, mask, SCALE as i8);
     transmute(r)
 }
 
@@ -5583,12 +5578,11 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 4 is word-addressing
-        let r = _mm_mask_i32gather_epi32(
+        let r = _mm_mask_i32gather_epi32::<4>(
             _mm_set1_epi32(256),
             arr.as_ptr(),
             _mm_setr_epi32(0, 16, 64, 96),
             _mm_setr_epi32(-1, -1, -1, 0),
-            4,
         );
         assert_eq_m128i(r, _mm_setr_epi32(0, 16, 64, 256));
     }

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -7384,7 +7384,7 @@ pub unsafe fn _mm256_mask_shufflehi_epi16<const IMM8: i32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_imm8!(IMM8);
-    let shuffle = _mm256_shufflehi_epi16(a, IMM8);
+    let shuffle = _mm256_shufflehi_epi16::<IMM8>(a);
     transmute(simd_select_bitmask(k, shuffle.as_i16x16(), src.as_i16x16()))
 }
 
@@ -7397,7 +7397,7 @@ pub unsafe fn _mm256_mask_shufflehi_epi16<const IMM8: i32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_shufflehi_epi16<const IMM8: i32>(k: __mmask16, a: __m256i) -> __m256i {
     static_assert_imm8!(IMM8);
-    let shuffle = _mm256_shufflehi_epi16(a, IMM8);
+    let shuffle = _mm256_shufflehi_epi16::<IMM8>(a);
     let zero = _mm256_setzero_si256().as_i16x16();
     transmute(simd_select_bitmask(k, shuffle.as_i16x16(), zero))
 }

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -7233,7 +7233,7 @@ pub unsafe fn _mm256_mask_shufflelo_epi16<const IMM8: i32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_imm8!(IMM8);
-    let shuffle = _mm256_shufflelo_epi16(a, IMM8);
+    let shuffle = _mm256_shufflelo_epi16::<IMM8>(a);
     transmute(simd_select_bitmask(k, shuffle.as_i16x16(), src.as_i16x16()))
 }
 
@@ -7246,7 +7246,7 @@ pub unsafe fn _mm256_mask_shufflelo_epi16<const IMM8: i32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_shufflelo_epi16<const IMM8: i32>(k: __mmask16, a: __m256i) -> __m256i {
     static_assert_imm8!(IMM8);
-    let shuffle = _mm256_shufflelo_epi16(a, IMM8);
+    let shuffle = _mm256_shufflelo_epi16::<IMM8>(a);
     let zero = _mm256_setzero_si256().as_i16x16();
     transmute(simd_select_bitmask(k, shuffle.as_i16x16(), zero))
 }

--- a/crates/core_arch/src/x86/avx512gfni.rs
+++ b/crates/core_arch/src/x86/avx512gfni.rs
@@ -1008,7 +1008,7 @@ mod tests {
             let expected_result = _mm256_gf2p8mul_epi8(left, right);
             let result_masked = _mm256_maskz_gf2p8mul_epi8(mask_bytes, left, right);
             let expected_masked =
-                _mm256_blend_epi32(_mm256_setzero_si256(), expected_result, MASK_WORDS);
+                _mm256_blend_epi32::<MASK_WORDS>(_mm256_setzero_si256(), expected_result);
             assert_eq_m256i(result_masked, expected_masked);
         }
     }
@@ -1026,7 +1026,7 @@ mod tests {
             const MASK_WORDS: i32 = 0b01_10_11_00;
             let expected_result = _mm256_gf2p8mul_epi8(left, right);
             let result_masked = _mm256_mask_gf2p8mul_epi8(left, mask_bytes, left, right);
-            let expected_masked = _mm256_blend_epi32(left, expected_result, MASK_WORDS);
+            let expected_masked = _mm256_blend_epi32::<MASK_WORDS>(left, expected_result);
             assert_eq_m256i(result_masked, expected_masked);
         }
     }
@@ -1207,7 +1207,7 @@ mod tests {
             let result_masked =
                 _mm256_maskz_gf2p8affine_epi64_epi8(mask_bytes, vector, matrix, CONSTANT_BYTE);
             let expected_masked =
-                _mm256_blend_epi32(_mm256_setzero_si256(), expected_result, MASK_WORDS);
+                _mm256_blend_epi32::<MASK_WORDS>(_mm256_setzero_si256(), expected_result);
             assert_eq_m256i(result_masked, expected_masked);
         }
     }
@@ -1228,7 +1228,7 @@ mod tests {
             let expected_result = _mm256_gf2p8affine_epi64_epi8(left, right, CONSTANT_BYTE);
             let result_masked =
                 _mm256_mask_gf2p8affine_epi64_epi8(left, mask_bytes, left, right, CONSTANT_BYTE);
-            let expected_masked = _mm256_blend_epi32(left, expected_result, MASK_WORDS);
+            let expected_masked = _mm256_blend_epi32::<MASK_WORDS>(left, expected_result);
             assert_eq_m256i(result_masked, expected_masked);
         }
     }
@@ -1456,7 +1456,7 @@ mod tests {
             let result_masked =
                 _mm256_maskz_gf2p8affineinv_epi64_epi8(mask_bytes, vector, matrix, CONSTANT_BYTE);
             let expected_masked =
-                _mm256_blend_epi32(_mm256_setzero_si256(), expected_result, MASK_WORDS);
+                _mm256_blend_epi32::<MASK_WORDS>(_mm256_setzero_si256(), expected_result);
             assert_eq_m256i(result_masked, expected_masked);
         }
     }
@@ -1477,7 +1477,7 @@ mod tests {
             let expected_result = _mm256_gf2p8affineinv_epi64_epi8(left, right, CONSTANT_BYTE);
             let result_masked =
                 _mm256_mask_gf2p8affineinv_epi64_epi8(left, mask_bytes, left, right, CONSTANT_BYTE);
-            let expected_masked = _mm256_blend_epi32(left, expected_result, MASK_WORDS);
+            let expected_masked = _mm256_blend_epi32::<MASK_WORDS>(left, expected_result);
             assert_eq_m256i(result_masked, expected_masked);
         }
     }

--- a/crates/core_arch/src/x86/avx512gfni.rs
+++ b/crates/core_arch/src/x86/avx512gfni.rs
@@ -1057,7 +1057,8 @@ mod tests {
             const MASK_WORDS: i32 = 0b01_10;
             let expected_result = _mm_gf2p8mul_epi8(left, right);
             let result_masked = _mm_maskz_gf2p8mul_epi8(mask_bytes, left, right);
-            let expected_masked = _mm_blend_epi32(_mm_setzero_si128(), expected_result, MASK_WORDS);
+            let expected_masked =
+                _mm_blend_epi32::<MASK_WORDS>(_mm_setzero_si128(), expected_result);
             assert_eq_m128i(result_masked, expected_masked);
         }
     }
@@ -1075,7 +1076,7 @@ mod tests {
             const MASK_WORDS: i32 = 0b01_10;
             let expected_result = _mm_gf2p8mul_epi8(left, right);
             let result_masked = _mm_mask_gf2p8mul_epi8(left, mask_bytes, left, right);
-            let expected_masked = _mm_blend_epi32(left, expected_result, MASK_WORDS);
+            let expected_masked = _mm_blend_epi32::<MASK_WORDS>(left, expected_result);
             assert_eq_m128i(result_masked, expected_masked);
         }
     }
@@ -1281,7 +1282,8 @@ mod tests {
             let expected_result = _mm_gf2p8affine_epi64_epi8(vector, matrix, CONSTANT_BYTE);
             let result_masked =
                 _mm_maskz_gf2p8affine_epi64_epi8(mask_bytes, vector, matrix, CONSTANT_BYTE);
-            let expected_masked = _mm_blend_epi32(_mm_setzero_si128(), expected_result, MASK_WORDS);
+            let expected_masked =
+                _mm_blend_epi32::<MASK_WORDS>(_mm_setzero_si128(), expected_result);
             assert_eq_m128i(result_masked, expected_masked);
         }
     }
@@ -1301,7 +1303,7 @@ mod tests {
             let expected_result = _mm_gf2p8affine_epi64_epi8(left, right, CONSTANT_BYTE);
             let result_masked =
                 _mm_mask_gf2p8affine_epi64_epi8(left, mask_bytes, left, right, CONSTANT_BYTE);
-            let expected_masked = _mm_blend_epi32(left, expected_result, MASK_WORDS);
+            let expected_masked = _mm_blend_epi32::<MASK_WORDS>(left, expected_result);
             assert_eq_m128i(result_masked, expected_masked);
         }
     }
@@ -1539,7 +1541,8 @@ mod tests {
             let expected_result = _mm_gf2p8affineinv_epi64_epi8(vector, matrix, CONSTANT_BYTE);
             let result_masked =
                 _mm_maskz_gf2p8affineinv_epi64_epi8(mask_bytes, vector, matrix, CONSTANT_BYTE);
-            let expected_masked = _mm_blend_epi32(_mm_setzero_si128(), expected_result, MASK_WORDS);
+            let expected_masked =
+                _mm_blend_epi32::<MASK_WORDS>(_mm_setzero_si128(), expected_result);
             assert_eq_m128i(result_masked, expected_masked);
         }
     }
@@ -1560,7 +1563,7 @@ mod tests {
             let expected_result = _mm_gf2p8affineinv_epi64_epi8(left, right, CONSTANT_BYTE);
             let result_masked =
                 _mm_mask_gf2p8affineinv_epi64_epi8(left, mask_bytes, left, right, CONSTANT_BYTE);
-            let expected_masked = _mm_blend_epi32(left, expected_result, MASK_WORDS);
+            let expected_masked = _mm_blend_epi32::<MASK_WORDS>(left, expected_result);
             assert_eq_m128i(result_masked, expected_masked);
         }
     }

--- a/crates/core_arch/src/x86/avx512vaes.rs
+++ b/crates/core_arch/src/x86/avx512vaes.rs
@@ -155,18 +155,18 @@ mod tests {
             0x978093862CDE7187,
         );
         let mut a_decomp = [_mm_setzero_si128(); 2];
-        a_decomp[0] = _mm256_extracti128_si256(a, 0);
-        a_decomp[1] = _mm256_extracti128_si256(a, 1);
+        a_decomp[0] = _mm256_extracti128_si256::<0>(a);
+        a_decomp[1] = _mm256_extracti128_si256::<1>(a);
         let mut k_decomp = [_mm_setzero_si128(); 2];
-        k_decomp[0] = _mm256_extracti128_si256(k, 0);
-        k_decomp[1] = _mm256_extracti128_si256(k, 1);
+        k_decomp[0] = _mm256_extracti128_si256::<0>(k);
+        k_decomp[1] = _mm256_extracti128_si256::<1>(k);
         let r = vectorized(a, k);
         let mut e_decomp = [_mm_setzero_si128(); 2];
         for i in 0..2 {
             e_decomp[i] = linear(a_decomp[i], k_decomp[i]);
         }
-        assert_eq_m128i(_mm256_extracti128_si256(r, 0), e_decomp[0]);
-        assert_eq_m128i(_mm256_extracti128_si256(r, 1), e_decomp[1]);
+        assert_eq_m128i(_mm256_extracti128_si256::<0>(r), e_decomp[0]);
+        assert_eq_m128i(_mm256_extracti128_si256::<1>(r), e_decomp[1]);
     }
 
     #[target_feature(enable = "sse2")]

--- a/crates/core_arch/src/x86/avx512vpclmulqdq.rs
+++ b/crates/core_arch/src/x86/avx512vpclmulqdq.rs
@@ -125,6 +125,10 @@ mod tests {
             assert_eq_m128i($op($vec_res, 1), $lin_res[1]);
             assert_eq_m128i($op($vec_res, 0), $lin_res[0]);
         };
+        (assert_eq_m128i($op:ident::<2>($vec_res:ident),$lin_res:ident[2]);) => {
+            assert_eq_m128i($op::<1>($vec_res), $lin_res[1]);
+            assert_eq_m128i($op::<0>($vec_res), $lin_res[0]);
+        };
     }
 
     // this function tests one of the possible 4 instances
@@ -209,7 +213,7 @@ mod tests {
         for i in 0..2 {
             e_decomp[i] = linear(a_decomp[i], b_decomp[i]);
         }
-        unroll! {assert_eq_m128i(_mm256_extracti128_si256(r,2),e_decomp[2]);}
+        unroll! {assert_eq_m128i(_mm256_extracti128_si256::<2>(r),e_decomp[2]);}
     }
 
     #[simd_test(enable = "avx512vpclmulqdq,avx512f")]

--- a/crates/core_arch/src/x86/macros.rs
+++ b/crates/core_arch/src/x86/macros.rs
@@ -49,6 +49,22 @@ macro_rules! static_assert_imm_u8 {
     };
 }
 
+// Helper struct used to trigger const eval errors when the const generic immediate value `SCALE` is
+// not valid for gather instructions: the only valid scale values are 1, 2, 4 and 8.
+pub(crate) struct ValidateConstGatherScale<const SCALE: i32>;
+impl<const SCALE: i32> ValidateConstGatherScale<SCALE> {
+    pub(crate) const VALID: () = {
+        let _ = 1 / ((SCALE == 1 || SCALE == 2 || SCALE == 4 || SCALE == 8) as usize);
+    };
+}
+
+#[allow(unused)]
+macro_rules! static_assert_imm8_scale {
+    ($imm:ident) => {
+        let _ = $crate::core_arch::x86::macros::ValidateConstGatherScale::<$imm>::VALID;
+    };
+}
+
 macro_rules! constify_imm3 {
     ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]


### PR DESCRIPTION
This PR updates the following "x86/avx2.rs" intrinsics to const generics:

- `_mm_i32gather_epi32`
- `_mm_mask_i32gather_epi32`
- `_mm256_i32gather_epi32`
- `_mm256_mask_i32gather_epi32`
- `_mm_i32gather_ps`
- `_mm_mask_i32gather_ps`
- `_mm256_i32gather_ps`
- `_mm256_mask_i32gather_ps`
- `_mm_i32gather_epi64`
- `_mm_mask_i32gather_epi64`
- `_mm256_i32gather_epi64`
- `_mm256_mask_i32gather_epi64`
- `_mm_i32gather_pd`
- `_mm_mask_i32gather_pd`
- `_mm256_i32gather_pd`
- `_mm256_mask_i32gather_pd`
- `_mm_i64gather_epi32`
- `_mm_mask_i64gather_epi32`
- `_mm256_i64gather_epi32`
- `_mm256_mask_i64gather_epi32`
- `_mm_i64gather_ps`
- `_mm_mask_i64gather_ps`
- `_mm256_i64gather_ps`
- `_mm256_mask_i64gather_ps`
- `_mm_i64gather_epi64`
- `_mm_mask_i64gather_epi64`
- `_mm256_i64gather_epi64`
- `_mm256_mask_i64gather_epi64`
- `_mm_i64gather_pd`
- `_mm_mask_i64gather_pd`
- `_mm256_i64gather_pd`
- `_mm256_mask_i64gather_pd`
- `_mm256_permute4x64_epi64`
- `_mm256_permute4x64_pd`
- `_mm256_shufflehi_epi16`
- `_mm256_shufflelo_epi16`
- `_mm256_inserti128_si256`
- `_mm256_extracti128_si256`
- `_mm_blend_epi32`
- `_mm256_blend_epi32`
- `_mm256_blend_epi16`

During my testing, some of the few remaining AVX2 intrinsics `_mm256_bslli_epi128`, `_mm256_bsrli_epi128`, `_mm256_slli_si256`, and `_mm256_srli_si256` (2 of those 4 are duplicates of the other 2) failed tests in debug mode, so I'll need to look into that before converting them.