### PR TITLE
Port all non-x86 uses of rustc_args_required_const to rustc_legacy_const_generics

### DIFF
--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -24,9 +24,9 @@ pub const _PREFETCH_LOCALITY2: i32 = 2;
 /// See [`prefetch`](fn._prefetch.html).
 pub const _PREFETCH_LOCALITY3: i32 = 3;
 
-/// Fetch the cache line that contains address `p` using the given `rw` and `locality`.
+/// Fetch the cache line that contains address `p` using the given `RW` and `LOCALITY`.
 ///
-/// The `rw` must be one of:
+/// The `RW` must be one of:
 ///
 /// * [`_PREFETCH_READ`](constant._PREFETCH_READ.html): the prefetch is preparing
 ///   for a read.
@@ -34,7 +34,7 @@ pub const _PREFETCH_LOCALITY3: i32 = 3;
 /// * [`_PREFETCH_WRITE`](constant._PREFETCH_WRITE.html): the prefetch is preparing
 ///   for a write.
 ///
-/// The `locality` must be one of:
+/// The `LOCALITY` must be one of:
 ///
 /// * [`_PREFETCH_LOCALITY0`](constant._PREFETCH_LOCALITY0.html): Streaming or
 ///   non-temporal prefetch, for data that is used only once.
@@ -55,35 +55,19 @@ pub const _PREFETCH_LOCALITY3: i32 = 3;
 ///
 /// [Arm's documentation](https://developer.arm.com/documentation/den0024/a/the-a64-instruction-set/memory-access-instructions/prefetching-memory?lang=en)
 #[inline(always)]
-#[cfg_attr(test, assert_instr("prfm pldl1strm", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY0))]
-#[cfg_attr(test, assert_instr("prfm pldl3keep", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY1))]
-#[cfg_attr(test, assert_instr("prfm pldl2keep", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY2))]
-#[cfg_attr(test, assert_instr("prfm pldl1keep", rw = _PREFETCH_READ, locality = _PREFETCH_LOCALITY3))]
-#[cfg_attr(test, assert_instr("prfm pstl1strm", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY0))]
-#[cfg_attr(test, assert_instr("prfm pstl3keep", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY1))]
-#[cfg_attr(test, assert_instr("prfm pstl2keep", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY2))]
-#[cfg_attr(test, assert_instr("prfm pstl1keep", rw = _PREFETCH_WRITE, locality = _PREFETCH_LOCALITY3))]
-#[rustc_args_required_const(1, 2)]
-pub unsafe fn _prefetch(p: *const i8, rw: i32, locality: i32) {
+#[cfg_attr(test, assert_instr("prfm pldl1strm", RW = _PREFETCH_READ, LOCALITY = _PREFETCH_LOCALITY0))]
+#[cfg_attr(test, assert_instr("prfm pldl3keep", RW = _PREFETCH_READ, LOCALITY = _PREFETCH_LOCALITY1))]
+#[cfg_attr(test, assert_instr("prfm pldl2keep", RW = _PREFETCH_READ, LOCALITY = _PREFETCH_LOCALITY2))]
+#[cfg_attr(test, assert_instr("prfm pldl1keep", RW = _PREFETCH_READ, LOCALITY = _PREFETCH_LOCALITY3))]
+#[cfg_attr(test, assert_instr("prfm pstl1strm", RW = _PREFETCH_WRITE, LOCALITY = _PREFETCH_LOCALITY0))]
+#[cfg_attr(test, assert_instr("prfm pstl3keep", RW = _PREFETCH_WRITE, LOCALITY = _PREFETCH_LOCALITY1))]
+#[cfg_attr(test, assert_instr("prfm pstl2keep", RW = _PREFETCH_WRITE, LOCALITY = _PREFETCH_LOCALITY2))]
+#[cfg_attr(test, assert_instr("prfm pstl1keep", RW = _PREFETCH_WRITE, LOCALITY = _PREFETCH_LOCALITY3))]
+#[rustc_legacy_const_generics(1, 2)]
+// FIXME: Replace this with the standard ACLE __pld/__pldx/__pli/__plix intrinsics
+pub unsafe fn _prefetch<const RW: i32, const LOCALITY: i32>(p: *const i8) {
     // We use the `llvm.prefetch` instrinsic with `cache type` = 1 (data cache).
-    // `rw` and `strategy` are based on the function parameters.
-    macro_rules! pref {
-        ($rdwr:expr, $local:expr) => {
-            match ($rdwr, $local) {
-                (0, 0) => prefetch(p, 0, 0, 1),
-                (0, 1) => prefetch(p, 0, 1, 1),
-                (0, 2) => prefetch(p, 0, 2, 1),
-                (0, 3) => prefetch(p, 0, 3, 1),
-                (1, 0) => prefetch(p, 1, 0, 1),
-                (1, 1) => prefetch(p, 1, 1, 1),
-                (1, 2) => prefetch(p, 1, 2, 1),
-                (1, 3) => prefetch(p, 1, 3, 1),
-                (_, _) => panic!(
-                    "Illegal (rw, locality) pair in prefetch, value ({}, {}).",
-                    $rdwr, $local
-                ),
-            }
-        };
-    }
-    pref!(rw, locality);
+    static_assert_imm1!(RW);
+    static_assert_imm2!(LOCALITY);
+    prefetch(p, RW, LOCALITY, 1);
 }

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -75,12 +75,13 @@ mod sealed {
 /// Vector permute.
 #[inline]
 #[target_feature(enable = "vsx")]
-#[rustc_args_required_const(2)]
-pub unsafe fn vec_xxpermdi<T>(a: T, b: T, dm: u8) -> T
+//#[rustc_legacy_const_generics(2)]
+pub unsafe fn vec_xxpermdi<T, const DM: i32>(a: T, b: T) -> T
 where
     T: sealed::VectorPermDI,
 {
-    a.vec_xxpermdi(b, dm)
+    static_assert_imm2!(DM);
+    a.vec_xxpermdi(b, DM as u8)
 }
 
 #[cfg(test)]
@@ -102,10 +103,10 @@ mod tests {
                 let a: $longtype = mem::transmute($shorttype::new($($a),+, $($b),+));
                 let b = mem::transmute($shorttype::new($($c),+, $($d),+));
 
-                assert_eq!($shorttype::new($($a),+, $($c),+), mem::transmute(vec_xxpermdi(a, b, 0)));
-                assert_eq!($shorttype::new($($b),+, $($c),+), mem::transmute(vec_xxpermdi(a, b, 1)));
-                assert_eq!($shorttype::new($($a),+, $($d),+), mem::transmute(vec_xxpermdi(a, b, 2)));
-                assert_eq!($shorttype::new($($b),+, $($d),+), mem::transmute(vec_xxpermdi(a, b, 3)));
+                assert_eq!($shorttype::new($($a),+, $($c),+), mem::transmute(vec_xxpermdi::<_, 0>(a, b)));
+                assert_eq!($shorttype::new($($b),+, $($c),+), mem::transmute(vec_xxpermdi::<_, 1>(a, b)));
+                assert_eq!($shorttype::new($($a),+, $($d),+), mem::transmute(vec_xxpermdi::<_, 2>(a, b)));
+                assert_eq!($shorttype::new($($b),+, $($d),+), mem::transmute(vec_xxpermdi::<_, 3>(a, b)));
             }
         }
     }

--- a/crates/core_arch/src/wasm32/memory.rs
+++ b/crates/core_arch/src/wasm32/memory.rs
@@ -13,7 +13,7 @@ extern "C" {
 /// This function, when called, will return the current memory size in units of
 /// pages. The current WebAssembly page size is 65536 bytes (64 KB).
 ///
-/// The argument `mem` is the numerical index of which memory to return the
+/// The argument `MEM` is the numerical index of which memory to return the
 /// size of. Note that currently the WebAssembly specification only supports one
 /// memory, so it is required that zero is passed in. The argument is present to
 /// be forward-compatible with future WebAssembly revisions. If a nonzero
@@ -21,12 +21,13 @@ extern "C" {
 ///
 /// [instr]: http://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-size
 #[inline]
-#[cfg_attr(test, assert_instr("memory.size", mem = 0))]
-#[rustc_args_required_const(0)]
+#[cfg_attr(test, assert_instr("memory.size", MEM = 0))]
+#[rustc_legacy_const_generics(0)]
 #[stable(feature = "simd_wasm32", since = "1.33.0")]
-pub fn memory_size(mem: u32) -> usize {
+pub fn memory_size<const MEM: u32>() -> usize {
     unsafe {
-        if mem != 0 {
+        // FIXME: Consider replacing with a static_assert!
+        if MEM != 0 {
             crate::intrinsics::abort();
         }
         llvm_memory_size(0) as usize
@@ -41,7 +42,7 @@ pub fn memory_size(mem: u32) -> usize {
 /// of memory, in pages, is returned. If memory cannot be grown then
 /// `usize::MAX` is returned.
 ///
-/// The argument `mem` is the numerical index of which memory to return the
+/// The argument `MEM` is the numerical index of which memory to return the
 /// size of. Note that currently the WebAssembly specification only supports one
 /// memory, so it is required that zero is passed in. The argument is present to
 /// be forward-compatible with future WebAssembly revisions. If a nonzero
@@ -49,12 +50,13 @@ pub fn memory_size(mem: u32) -> usize {
 ///
 /// [instr]: http://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-grow
 #[inline]
-#[cfg_attr(test, assert_instr("memory.grow", mem = 0))]
-#[rustc_args_required_const(0)]
+#[cfg_attr(test, assert_instr("memory.grow", MEM = 0))]
+#[rustc_legacy_const_generics(0)]
 #[stable(feature = "simd_wasm32", since = "1.33.0")]
-pub fn memory_grow(mem: u32, delta: usize) -> usize {
+pub fn memory_grow<const MEM: u32>(delta: usize) -> usize {
     unsafe {
-        if mem != 0 {
+        // FIXME: Consider replacing with a static_assert!
+        if MEM != 0 {
             crate::intrinsics::abort();
         }
         llvm_memory_grow(0, delta as i32) as isize as usize


### PR DESCRIPTION
Except for functions defined using `asm!`, which are ported in #1052.