### PR TITLE
Add neon instruction vdup

### DIFF
--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -690,7 +690,7 @@ pub unsafe fn vld1q_f64(ptr: *const f64) -> float64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(dup))]
-pub unsafe fn vdup_n_p64(value: u64) -> poly64x1_t {
+pub unsafe fn vdup_n_p64(value: p64) -> poly64x1_t {
     transmute(u64x1(value))
 }
 
@@ -706,7 +706,7 @@ pub unsafe fn vdup_n_f64(value: f64) -> float64x1_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(dup))]
-pub unsafe fn vdupq_n_p64(value: u64) -> poly64x2_t {
+pub unsafe fn vdupq_n_p64(value: p64) -> poly64x2_t {
     transmute(u64x2(value, value))
 }
 
@@ -3983,7 +3983,7 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vdup_n_p64() {
-        let v: u64 = 64;
+        let v: p64 = 64;
         let e = u64x1::new(64);
         let r: u64x1 = transmute(vdup_n_p64(v));
         assert_eq!(r, e);
@@ -3997,7 +3997,7 @@ mod tests {
     }
     #[simd_test(enable = "neon")]
     unsafe fn test_vdupq_n_p64() {
-        let v: u64 = 64;
+        let v: p64 = 64;
         let e = u64x2::new(64, 64);
         let r: u64x2 = transmute(vdupq_n_p64(v));
         assert_eq!(r, e);

--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -681,43 +681,6 @@ pub unsafe fn vld1q_f64(ptr: *const f64) -> float64x2_t {
     transmute(f64x2::new(*ptr, *ptr.offset(1)))
 }
 
-/// Duplicate vector element to vector or scalar.
-/// This instruction duplicates the vector element at the specified element index
-/// in the source SIMD&FP register into a scalar or each element in a vector,
-/// and writes the result to the destination SIMD&FP register.
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(dup))]
-pub unsafe fn vdup_n_p64(value: p64) -> poly64x1_t {
-    transmute(u64x1(value))
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(dup))]
-pub unsafe fn vdup_n_f64(value: f64) -> float64x1_t {
-    float64x1_t(value)
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(dup))]
-pub unsafe fn vdupq_n_p64(value: p64) -> poly64x2_t {
-    transmute(u64x2(value, value))
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(dup))]
-pub unsafe fn vdupq_n_f64(value: f64) -> float64x2_t {
-    float64x2_t(value, value)
-}
-
 /// Absolute Value (wrapping).
 #[inline]
 #[target_feature(enable = "neon")]
@@ -3978,35 +3941,6 @@ mod tests {
         let a = i64x2::new(i64::MIN, i64::MIN + 1);
         let r: i64x2 = transmute(vabsq_s64(transmute(a)));
         let e = i64x2::new(i64::MIN, i64::MAX);
-        assert_eq!(r, e);
-    }
-
-    #[simd_test(enable = "neon")]
-    unsafe fn test_vdup_n_p64() {
-        let v: p64 = 64;
-        let e = u64x1::new(64);
-        let r: u64x1 = transmute(vdup_n_p64(v));
-        assert_eq!(r, e);
-    }
-    #[simd_test(enable = "neon")]
-    unsafe fn test_vdup_n_f64() {
-        let v: f64 = 64.0;
-        let e = f64x1::new(64.0);
-        let r: f64x1 = transmute(vdup_n_f64(v));
-        assert_eq!(r, e);
-    }
-    #[simd_test(enable = "neon")]
-    unsafe fn test_vdupq_n_p64() {
-        let v: p64 = 64;
-        let e = u64x2::new(64, 64);
-        let r: u64x2 = transmute(vdupq_n_p64(v));
-        assert_eq!(r, e);
-    }
-    #[simd_test(enable = "neon")]
-    unsafe fn test_vdupq_n_f64() {
-        let v: f64 = 64.0;
-        let e = f64x2::new(64.0, 64.0);
-        let r: f64x2 = transmute(vdupq_n_f64(v));
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -681,6 +681,43 @@ pub unsafe fn vld1q_f64(ptr: *const f64) -> float64x2_t {
     transmute(f64x2::new(*ptr, *ptr.offset(1)))
 }
 
+/// Duplicate vector element to vector or scalar.
+/// This instruction duplicates the vector element at the specified element index
+/// in the source SIMD&FP register into a scalar or each element in a vector,
+/// and writes the result to the destination SIMD&FP register.
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(dup))]
+pub unsafe fn vdup_n_p64(value: u64) -> poly64x1_t {
+    transmute(u64x1(value))
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(dup))]
+pub unsafe fn vdup_n_f64(value: f64) -> float64x1_t {
+    float64x1_t(value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(dup))]
+pub unsafe fn vdupq_n_p64(value: u64) -> poly64x2_t {
+    transmute(u64x2(value, value))
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(dup))]
+pub unsafe fn vdupq_n_f64(value: f64) -> float64x2_t {
+    float64x2_t(value, value)
+}
+
 /// Absolute Value (wrapping).
 #[inline]
 #[target_feature(enable = "neon")]
@@ -3941,6 +3978,35 @@ mod tests {
         let a = i64x2::new(i64::MIN, i64::MIN + 1);
         let r: i64x2 = transmute(vabsq_s64(transmute(a)));
         let e = i64x2::new(i64::MIN, i64::MAX);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_p64() {
+        let v: u64 = 64;
+        let e = u64x1::new(64);
+        let r: u64x1 = transmute(vdup_n_p64(v));
+        assert_eq!(r, e);
+    }
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_f64() {
+        let v: f64 = 64.0;
+        let e = f64x1::new(64.0);
+        let r: f64x1 = transmute(vdup_n_f64(v));
+        assert_eq!(r, e);
+    }
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_p64() {
+        let v: u64 = 64;
+        let e = u64x2::new(64, 64);
+        let r: u64x2 = transmute(vdupq_n_p64(v));
+        assert_eq!(r, e);
+    }
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_f64() {
+        let v: f64 = 64.0;
+        let e = f64x2::new(64.0, 64.0);
+        let r: f64x2 = transmute(vdupq_n_f64(v));
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3833,7 +3833,7 @@ pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdupq_n_p8(value: u8) -> poly8x16_t {
+pub unsafe fn vdupq_n_p8(value: p8) -> poly8x16_t {
     poly8x16_t(
         value, value, value, value, value, value, value, value, value, value, value, value, value,
         value, value, value,
@@ -3846,7 +3846,7 @@ pub unsafe fn vdupq_n_p8(value: u8) -> poly8x16_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdupq_n_p16(value: u16) -> poly16x8_t {
+pub unsafe fn vdupq_n_p16(value: p16) -> poly16x8_t {
     poly16x8_t(value, value, value, value, value, value, value, value)
 }
 
@@ -3951,7 +3951,7 @@ pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdup_n_p8(value: u8) -> poly8x8_t {
+pub unsafe fn vdup_n_p8(value: p8) -> poly8x8_t {
     poly8x8_t(value, value, value, value, value, value, value, value)
 }
 
@@ -3961,7 +3961,7 @@ pub unsafe fn vdup_n_p8(value: u8) -> poly8x8_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdup_n_p16(value: u16) -> poly16x4_t {
+pub unsafe fn vdup_n_p16(value: p16) -> poly16x4_t {
     poly16x4_t(value, value, value, value)
 }
 
@@ -5806,19 +5806,19 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vdupq_n_p8() {
-        let v: u8 = 64;
+        let v: p8 = 64;
         let e = u8x16::new(
             64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
         );
-        let r: u8x16 = transmute(vdupq_n_u8(v));
+        let r: u8x16 = transmute(vdupq_n_p8(v));
         assert_eq!(r, e);
     }
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vdupq_n_p16() {
-        let v: u16 = 64;
+        let v: p16 = 64;
         let e = u16x8::new(64, 64, 64, 64, 64, 64, 64, 64);
-        let r: u16x8 = transmute(vdupq_n_u16(v));
+        let r: u16x8 = transmute(vdupq_n_p16(v));
         assert_eq!(r, e);
     }
 
@@ -5896,17 +5896,17 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vdup_n_p8() {
-        let v: u8 = 64;
+        let v: p8 = 64;
         let e = u8x8::new(64, 64, 64, 64, 64, 64, 64, 64);
-        let r: u8x8 = transmute(vdup_n_u8(v));
+        let r: u8x8 = transmute(vdup_n_p8(v));
         assert_eq!(r, e);
     }
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vdup_n_p16() {
-        let v: u16 = 64;
+        let v: p16 = 64;
         let e = u16x4::new(64, 64, 64, 64);
-        let r: u16x4 = transmute(vdup_n_u16(v));
+        let r: u16x4 = transmute(vdup_n_p16(v));
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3778,16 +3778,6 @@ pub unsafe fn vdupq_n_s32(value: i32) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdupq_n_s64(value: i64) -> int64x2_t {
-    int64x2_t(value, value)
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_u8(value: u8) -> uint8x16_t {
@@ -3815,16 +3805,6 @@ pub unsafe fn vdupq_n_u16(value: u16) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_u32(value: u32) -> uint32x4_t {
     uint32x4_t(value, value, value, value)
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
-    uint64x2_t(value, value)
 }
 
 /// Duplicate vector element to vector or scalar
@@ -3899,16 +3879,6 @@ pub unsafe fn vdup_n_s32(value: i32) -> int32x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdup_n_s64(value: i64) -> int64x1_t {
-    int64x1_t(value)
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdup_n_u8(value: u8) -> uint8x8_t {
@@ -3933,16 +3903,6 @@ pub unsafe fn vdup_n_u16(value: u16) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdup_n_u32(value: u32) -> uint32x2_t {
     uint32x2_t(value, value)
-}
-
-/// Duplicate vector element to vector or scalar
-#[inline]
-#[target_feature(enable = "neon")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
-pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
-    uint64x1_t(value)
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5763,14 +5723,6 @@ mod tests {
     }
 
     #[simd_test(enable = "neon")]
-    unsafe fn test_vdupq_n_s64() {
-        let v: i64 = 64;
-        let e = i64x2::new(64, 64);
-        let r: i64x2 = transmute(vdupq_n_s64(v));
-        assert_eq!(r, e);
-    }
-
-    #[simd_test(enable = "neon")]
     unsafe fn test_vdupq_n_u8() {
         let v: u8 = 42;
         let e = u8x16::new(
@@ -5793,14 +5745,6 @@ mod tests {
         let v: u32 = 64;
         let e = u32x4::new(64, 64, 64, 64);
         let r: u32x4 = transmute(vdupq_n_u32(v));
-        assert_eq!(r, e);
-    }
-
-    #[simd_test(enable = "neon")]
-    unsafe fn test_vdupq_n_u64() {
-        let v: u64 = 64;
-        let e = u64x2::new(64, 64);
-        let r: u64x2 = transmute(vdupq_n_u64(v));
         assert_eq!(r, e);
     }
 
@@ -5855,14 +5799,6 @@ mod tests {
     }
 
     #[simd_test(enable = "neon")]
-    unsafe fn test_vdup_n_s64() {
-        let v: i64 = 64;
-        let e = i64x1::new(64);
-        let r: i64x1 = transmute(vdup_n_s64(v));
-        assert_eq!(r, e);
-    }
-
-    #[simd_test(enable = "neon")]
     unsafe fn test_vdup_n_u8() {
         let v: u8 = 42;
         let e = u8x8::new(42, 42, 42, 42, 42, 42, 42, 42);
@@ -5883,14 +5819,6 @@ mod tests {
         let v: u32 = 64;
         let e = u32x2::new(64, 64);
         let r: u32x2 = transmute(vdup_n_u32(v));
-        assert_eq!(r, e);
-    }
-
-    #[simd_test(enable = "neon")]
-    unsafe fn test_vdup_n_u64() {
-        let v: u64 = 64;
-        let e = u64x1::new(64);
-        let r: u64x1 = transmute(vdup_n_u64(v));
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3778,7 +3778,7 @@ pub unsafe fn vdupq_n_s32(value: i32) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_s64(value: i64) -> int64x2_t {
     int64x2_t(value, value)
@@ -3821,7 +3821,7 @@ pub unsafe fn vdupq_n_u32(value: u32) -> uint32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
     uint64x2_t(value, value)
@@ -3899,7 +3899,7 @@ pub unsafe fn vdup_n_s32(value: i32) -> int32x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdup_n_s64(value: i64) -> int64x1_t {
     int64x1_t(value)
@@ -3939,7 +3939,7 @@ pub unsafe fn vdup_n_u32(value: u32) -> uint32x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
     uint64x1_t(value)

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3736,11 +3736,6 @@ pub unsafe fn vget_lane_u8<const IMM5: i32>(v: uint8x8_t) -> u8 {
     simd_extract(v, IMM5 as u32)
 }
 
-/// Duplicate vector element to vector or scalar.
-/// This instruction duplicates the vector element at the specified element index
-/// in the source SIMD&FP register into a scalar or each element in a vector,
-/// and writes the result to the destination SIMD&FP register.
-
 /// Duplicate vector element to vector or scalar
 #[inline]
 #[target_feature(enable = "neon")]

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3778,7 +3778,7 @@ pub unsafe fn vdupq_n_s32(value: i32) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_s64(value: i64) -> int64x2_t {
     int64x2_t(value, value)
@@ -3821,7 +3821,7 @@ pub unsafe fn vdupq_n_u32(value: u32) -> uint32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
     uint64x2_t(value, value)
@@ -3899,7 +3899,7 @@ pub unsafe fn vdup_n_s32(value: i32) -> int32x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdup_n_s64(value: i64) -> int64x1_t {
     int64x1_t(value)
@@ -3939,7 +3939,7 @@ pub unsafe fn vdup_n_u32(value: u32) -> uint32x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
     uint64x1_t(value)

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3753,6 +3753,36 @@ pub unsafe fn vdupq_n_s8(value: i8) -> int8x16_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_s16(value: i16) -> int16x8_t {
+    int16x8_t(value, value, value, value, value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_s32(value: i32) -> int32x4_t {
+    int32x4_t(value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_s64(value: i64) -> int64x2_t {
+    int64x2_t(value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 pub unsafe fn vdupq_n_u8(value: u8) -> uint8x16_t {
@@ -3760,6 +3790,184 @@ pub unsafe fn vdupq_n_u8(value: u8) -> uint8x16_t {
         value, value, value, value, value, value, value, value, value, value, value, value, value,
         value, value, value,
     )
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_u16(value: u16) -> uint16x8_t {
+    uint16x8_t(value, value, value, value, value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_u32(value: u32) -> uint32x4_t {
+    uint32x4_t(value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
+    uint64x2_t(value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_p8(value: u8) -> poly8x16_t {
+    poly8x16_t(
+        value, value, value, value, value, value, value, value, value, value, value, value, value,
+        value, value, value,
+    )
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_p16(value: u16) -> poly16x8_t {
+    poly16x8_t(value, value, value, value, value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdupq_n_f32(value: f32) -> float32x4_t {
+    float32x4_t(value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar.
+/// This instruction duplicates the vector element at the specified element index
+/// in the source SIMD&FP register into a scalar or each element in a vector,
+/// and writes the result to the destination SIMD&FP register.
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_s8(value: i8) -> int8x8_t {
+    int8x8_t(value, value, value, value, value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_s16(value: i16) -> int16x4_t {
+    int16x4_t(value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_s32(value: i32) -> int32x2_t {
+    int32x2_t(value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_s64(value: i64) -> int64x1_t {
+    int64x1_t(value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_u8(value: u8) -> uint8x8_t {
+    uint8x8_t(value, value, value, value, value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_u16(value: u16) -> uint16x4_t {
+    uint16x4_t(value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_u32(value: u32) -> uint32x2_t {
+    uint32x2_t(value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.64"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
+    uint64x1_t(value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_p8(value: u8) -> poly8x8_t {
+    poly8x8_t(value, value, value, value, value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_p16(value: u16) -> poly16x4_t {
+    poly16x4_t(value, value, value, value)
+}
+
+/// Duplicate vector element to vector or scalar
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
+pub unsafe fn vdup_n_f32(value: f32) -> float32x2_t {
+    float32x2_t(value, value)
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5534,12 +5742,174 @@ mod tests {
     }
 
     #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_s16() {
+        let v: i16 = 64;
+        let e = i16x8::new(64, 64, 64, 64, 64, 64, 64, 64);
+        let r: i16x8 = transmute(vdupq_n_s16(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_s32() {
+        let v: i32 = 64;
+        let e = i32x4::new(64, 64, 64, 64);
+        let r: i32x4 = transmute(vdupq_n_s32(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_s64() {
+        let v: i64 = 64;
+        let e = i64x2::new(64, 64);
+        let r: i64x2 = transmute(vdupq_n_s64(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
     unsafe fn test_vdupq_n_u8() {
         let v: u8 = 42;
         let e = u8x16::new(
             42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
         );
         let r: u8x16 = transmute(vdupq_n_u8(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_u16() {
+        let v: u16 = 64;
+        let e = u16x8::new(64, 64, 64, 64, 64, 64, 64, 64);
+        let r: u16x8 = transmute(vdupq_n_u16(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_u32() {
+        let v: u32 = 64;
+        let e = u32x4::new(64, 64, 64, 64);
+        let r: u32x4 = transmute(vdupq_n_u32(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_u64() {
+        let v: u64 = 64;
+        let e = u64x2::new(64, 64);
+        let r: u64x2 = transmute(vdupq_n_u64(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_p8() {
+        let v: u8 = 64;
+        let e = u8x16::new(
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        );
+        let r: u8x16 = transmute(vdupq_n_u8(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_p16() {
+        let v: u16 = 64;
+        let e = u16x8::new(64, 64, 64, 64, 64, 64, 64, 64);
+        let r: u16x8 = transmute(vdupq_n_u16(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdupq_n_f32() {
+        let v: f32 = 64.0;
+        let e = f32x4::new(64.0, 64.0, 64.0, 64.0);
+        let r: f32x4 = transmute(vdupq_n_f32(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_s8() {
+        let v: i8 = 64;
+        let e = i8x8::new(64, 64, 64, 64, 64, 64, 64, 64);
+        let r: i8x8 = transmute(vdup_n_s8(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_s16() {
+        let v: i16 = 64;
+        let e = i16x4::new(64, 64, 64, 64);
+        let r: i16x4 = transmute(vdup_n_s16(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_s32() {
+        let v: i32 = 64;
+        let e = i32x2::new(64, 64);
+        let r: i32x2 = transmute(vdup_n_s32(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_s64() {
+        let v: i64 = 64;
+        let e = i64x1::new(64);
+        let r: i64x1 = transmute(vdup_n_s64(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_u8() {
+        let v: u8 = 42;
+        let e = u8x8::new(42, 42, 42, 42, 42, 42, 42, 42);
+        let r: u8x8 = transmute(vdup_n_u8(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_u16() {
+        let v: u16 = 64;
+        let e = u16x4::new(64, 64, 64, 64);
+        let r: u16x4 = transmute(vdup_n_u16(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_u32() {
+        let v: u32 = 64;
+        let e = u32x2::new(64, 64);
+        let r: u32x2 = transmute(vdup_n_u32(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_u64() {
+        let v: u64 = 64;
+        let e = u64x1::new(64);
+        let r: u64x1 = transmute(vdup_n_u64(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_p8() {
+        let v: u8 = 64;
+        let e = u8x8::new(64, 64, 64, 64, 64, 64, 64, 64);
+        let r: u8x8 = transmute(vdup_n_u8(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_p16() {
+        let v: u16 = 64;
+        let e = u16x4::new(64, 64, 64, 64);
+        let r: u16x4 = transmute(vdup_n_u16(v));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vdup_n_f32() {
+        let v: f32 = 64.0;
+        let e = f32x2::new(64.0, 64.0);
+        let r: f32x2 = transmute(vdup_n_f32(v));
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -3736,6 +3736,11 @@ pub unsafe fn vget_lane_u8<const IMM5: i32>(v: uint8x8_t) -> u8 {
     simd_extract(v, IMM5 as u32)
 }
 
+/// Duplicate vector element to vector or scalar.
+/// This instruction duplicates the vector element at the specified element index
+/// in the source SIMD&FP register into a scalar or each element in a vector,
+/// and writes the result to the destination SIMD&FP register.
+
 /// Duplicate vector element to vector or scalar
 #[inline]
 #[target_feature(enable = "neon")]


### PR DESCRIPTION
add neon instruction   vdup_n_*    vdupq_n_*

vdup_n: Duplicate vector element to vector or scalar. This instruction duplicates the vector element at the specified element index in the source SIMD&FP register into a scalar or each element in a vector, and writes the result to the destination SIMD&FP register.