### PR TITLE
Remove trailing semicolon from macro expression

### DIFF
--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -18,7 +18,7 @@ macro_rules! features {
                 };
             )*
             $(
-                ($bind_feature) => { $macro_name!($feature_impl); };
+                ($bind_feature) => { $macro_name!($feature_impl) };
             )*
             $(
                 ($nort_feature) => {


### PR DESCRIPTION
Unblocks https://github.com/rust-lang/rust/pull/83089