### PR TITLE
make is_{arch}_feature_detected! available for std

### DIFF
--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -43,6 +43,9 @@ macro_rules! features {
             };
         }
 
+        #[cfg(not(test))]
+        pub use $macro_name;
+
         /// Each variant denotes a position in a bitset for a particular feature.
         ///
         /// PLEASE: do not use this, it is an implementation detail subject

--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -29,35 +29,35 @@ cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         #[path = "arch/x86.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else if #[cfg(target_arch = "arm")] {
         #[path = "arch/arm.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else if #[cfg(target_arch = "aarch64")] {
         #[path = "arch/aarch64.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else if #[cfg(target_arch = "powerpc")] {
         #[path = "arch/powerpc.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else if #[cfg(target_arch = "powerpc64")] {
         #[path = "arch/powerpc64.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else if #[cfg(target_arch = "mips")] {
         #[path = "arch/mips.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else if #[cfg(target_arch = "mips64")] {
         #[path = "arch/mips64.rs"]
         #[macro_use]
-        mod arch;
+        pub(crate) mod arch;
     } else {
         // Unimplemented architecture:
         #[allow(dead_code)]
-        mod arch {
+        pub(crate) mod arch {
             #[doc(hidden)]
             pub(crate) enum Feature {
                 Null


### PR DESCRIPTION
The feature detection macros currently can't be used in std itself due to these errors.

```
error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
   --> library/std/src/time.rs:30:5
    |
30  | use super::is_x86_feature_detected;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
note: the macro is defined here
   --> library/std/src/../../stdarch/crates/std_detect/src/detect/macros.rs:14:9
```

The workaround in this PR was suggested in this [zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/using.20is_x86_feature_detected.20in.20std)

