### PR TITLE
Fix WebAssembly Atomic intrinsic names

### DIFF
--- a/crates/core_arch/src/wasm32/atomic.rs
+++ b/crates/core_arch/src/wasm32/atomic.rs
@@ -12,9 +12,9 @@
 use stdarch_test::assert_instr;
 
 extern "C" {
-    #[link_name = "llvm.wasm.memory.atomic.wait.i32"]
+    #[link_name = "llvm.wasm.memory.atomic.wait32"]
     fn llvm_atomic_wait_i32(ptr: *mut i32, exp: i32, timeout: i64) -> i32;
-    #[link_name = "llvm.wasm.memory.atomic.wait.i64"]
+    #[link_name = "llvm.wasm.memory.atomic.wait64"]
     fn llvm_atomic_wait_i64(ptr: *mut i64, exp: i64, timeout: i64) -> i32;
     #[link_name = "llvm.wasm.memory.atomic.notify"]
     fn llvm_atomic_notify(ptr: *mut i32, cnt: i32) -> i32;


### PR DESCRIPTION
An error was introduced in #1073 in changing the atomic intrinsic to `memory.atomic.wait.iXX` instead of `memory.atomic.waitXX`.
See also the commit [902ea58 in the llvm project](https://github.com/llvm/llvm-project/commit/902ea588eab849e7254d3bc76abf32d833ac0dd6)

r? @alexcrichton