### PR TITLE
support for neon instructions vabal_* and vabal_high_*

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -2727,6 +2727,66 @@ pub unsafe fn vzip2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     simd_shuffle2(a, b, [1, 3])
 }
 
+/// Unsigned Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(add))]
+pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
+    let d: uint8x16_t = vabdq_u8(b, c);
+    let e: uint8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
+    simd_add(a, simd_cast(e))
+}
+
+/// Unsigned Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(add))]
+pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
+    let d: uint16x8_t = vabdq_u16(b, c);
+    let e: uint16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
+    simd_add(a, simd_cast(e))
+}
+
+/// Unsigned Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(add))]
+pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
+    let d: uint32x4_t = vabdq_u32(b, c);
+    let e: uint32x2_t = simd_shuffle2(d, d, [2, 3]);
+    simd_add(a, simd_cast(e))
+}
+
+/// Signed Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(add))]
+pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
+    let d: int8x16_t = vabdq_s8(b, c);
+    let e: int8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
+    simd_add(a, simd_cast(e))
+}
+
+/// Signed Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(add))]
+pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
+    let d: int16x8_t = vabdq_s16(b, c);
+    let e: int16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
+    simd_add(a, simd_cast(e))
+}
+
+/// Signed Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(add))]
+pub unsafe fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
+    let d: int32x4_t = vabdq_s32(b, c);
+    let e: int32x2_t = simd_shuffle2(d, d, [2, 3]);
+    simd_add(a, simd_cast(e))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -5316,6 +5376,66 @@ mod test {
         let b: f64x2 = f64x2::new(1., 9.);
         let e: f64x2 = f64x2::new(8., 9.);
         let r: f64x2 = transmute(vzip2q_f64(transmute(a), transmute(b)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_high_u8() {
+        let a: u16x8 = u16x8::new(9, 10, 11, 12, 13, 14, 15, 16);
+        let b: u8x16 = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+        let c: u8x16 = u8x16::new(10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12);
+        let e: u16x8 = u16x8::new(20, 20, 20, 20, 20, 20, 20, 20);
+        let r: u16x8 = transmute(vabal_high_u8(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_high_u16() {
+        let a: u32x4 = u32x4::new(9, 10, 11, 12);
+        let b: u16x8 = u16x8::new(1, 2, 3, 4, 9, 10, 11, 12);
+        let c: u16x8 = u16x8::new(10, 10, 10, 10, 20, 0, 2, 4);
+        let e: u32x4 = u32x4::new(20, 20, 20, 20);
+        let r: u32x4 = transmute(vabal_high_u16(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_high_u32() {
+        let a: u64x2 = u64x2::new(15, 16);
+        let b: u32x4 = u32x4::new(1, 2, 15, 16);
+        let c: u32x4 = u32x4::new(10, 10, 10, 12);
+        let e: u64x2 = u64x2::new(20, 20);
+        let r: u64x2 = transmute(vabal_high_u32(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_high_s8() {
+        let a: i16x8 = i16x8::new(9, 10, 11, 12, 13, 14, 15, 16);
+        let b: i8x16 = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+        let c: i8x16 = i8x16::new(10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12);
+        let e: i16x8 = i16x8::new(20, 20, 20, 20, 20, 20, 20, 20);
+        let r: i16x8 = transmute(vabal_high_s8(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_high_s16() {
+        let a: i32x4 = i32x4::new(9, 10, 11, 12);
+        let b: i16x8 = i16x8::new(1, 2, 3, 4, 9, 10, 11, 12);
+        let c: i16x8 = i16x8::new(10, 10, 10, 10, 20, 0, 2, 4);
+        let e: i32x4 = i32x4::new(20, 20, 20, 20);
+        let r: i32x4 = transmute(vabal_high_s16(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_high_s32() {
+        let a: i64x2 = i64x2::new(15, 16);
+        let b: i32x4 = i32x4::new(1, 2, 15, 16);
+        let c: i32x4 = i32x4::new(10, 10, 10, 12);
+        let e: i64x2 = i64x2::new(20, 20);
+        let r: i64x2 = transmute(vabal_high_s32(transmute(a), transmute(b), transmute(c)));
         assert_eq!(r, e);
     }
 }

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -2730,7 +2730,7 @@ pub unsafe fn vzip2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(add))]
+#[cfg_attr(test, assert_instr(uabal))]
 pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
     let d: uint8x16_t = vabdq_u8(b, c);
     let e: uint8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -2740,7 +2740,7 @@ pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(add))]
+#[cfg_attr(test, assert_instr(uabal))]
 pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
     let d: uint16x8_t = vabdq_u16(b, c);
     let e: uint16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
@@ -2750,7 +2750,7 @@ pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uin
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(add))]
+#[cfg_attr(test, assert_instr(uabal))]
 pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
     let d: uint32x4_t = vabdq_u32(b, c);
     let e: uint32x2_t = simd_shuffle2(d, d, [2, 3]);
@@ -2760,7 +2760,7 @@ pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uin
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(add))]
+#[cfg_attr(test, assert_instr(sabal))]
 pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
     let d: int8x16_t = vabdq_s8(b, c);
     let e: int8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -2770,7 +2770,7 @@ pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(add))]
+#[cfg_attr(test, assert_instr(sabal))]
 pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
     let d: int16x8_t = vabdq_s16(b, c);
     let e: int16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
@@ -2780,7 +2780,7 @@ pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(add))]
+#[cfg_attr(test, assert_instr(sabal))]
 pub unsafe fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
     let d: int32x4_t = vabdq_s32(b, c);
     let e: int32x2_t = simd_shuffle2(d, d, [2, 3]);

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -2730,7 +2730,7 @@ pub unsafe fn vzip2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabal))]
+#[cfg_attr(test, assert_instr(uabd))]
 pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
     let d: uint8x16_t = vabdq_u8(b, c);
     let e: uint8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -2740,7 +2740,7 @@ pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabal))]
+#[cfg_attr(test, assert_instr(uabd))]
 pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
     let d: uint16x8_t = vabdq_u16(b, c);
     let e: uint16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
@@ -2750,7 +2750,7 @@ pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uin
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabal))]
+#[cfg_attr(test, assert_instr(uabd))]
 pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
     let d: uint32x4_t = vabdq_u32(b, c);
     let e: uint32x2_t = simd_shuffle2(d, d, [2, 3]);
@@ -2760,7 +2760,7 @@ pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uin
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(sabal))]
+#[cfg_attr(test, assert_instr(sabd))]
 pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
     let d: int8x16_t = vabdq_s8(b, c);
     let e: int8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -2770,7 +2770,7 @@ pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(sabal))]
+#[cfg_attr(test, assert_instr(sabd))]
 pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
     let d: int16x8_t = vabdq_s16(b, c);
     let e: int16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
@@ -2780,7 +2780,7 @@ pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(sabal))]
+#[cfg_attr(test, assert_instr(sabd))]
 pub unsafe fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
     let d: int32x4_t = vabdq_s32(b, c);
     let e: int32x2_t = simd_shuffle2(d, d, [2, 3]);

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -2730,61 +2730,70 @@ pub unsafe fn vzip2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabd))]
+#[cfg_attr(test, assert_instr(uabal))]
 pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
-    let d: uint8x16_t = vabdq_u8(b, c);
-    let e: uint8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
-    simd_add(a, simd_cast(e))
+    let d: uint8x8_t = simd_shuffle8(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let e: uint8x8_t = simd_shuffle8(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let f: uint8x8_t = vabd_u8(d, e);
+    simd_add(a, simd_cast(f))
 }
 
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabd))]
+#[cfg_attr(test, assert_instr(uabal))]
 pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
-    let d: uint16x8_t = vabdq_u16(b, c);
-    let e: uint16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
-    simd_add(a, simd_cast(e))
+    let d: uint16x4_t = simd_shuffle4(b, b, [4, 5, 6, 7]);
+    let e: uint16x4_t = simd_shuffle4(c, c, [4, 5, 6, 7]);
+    let f: uint16x4_t = vabd_u16(d, e);
+    simd_add(a, simd_cast(f))
 }
 
 /// Unsigned Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabd))]
+#[cfg_attr(test, assert_instr(uabal))]
 pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
-    let d: uint32x4_t = vabdq_u32(b, c);
-    let e: uint32x2_t = simd_shuffle2(d, d, [2, 3]);
-    simd_add(a, simd_cast(e))
+    let d: uint32x2_t = simd_shuffle2(b, b, [2, 3]);
+    let e: uint32x2_t = simd_shuffle2(c, c, [2, 3]);
+    let f: uint32x2_t = vabd_u32(d, e);
+    simd_add(a, simd_cast(f))
 }
 
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(sabd))]
+#[cfg_attr(test, assert_instr(sabal))]
 pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
-    let d: int8x16_t = vabdq_s8(b, c);
-    let e: int8x8_t = simd_shuffle8(d, d, [8, 9, 10, 11, 12, 13, 14, 15]);
-    simd_add(a, simd_cast(e))
+    let d: int8x8_t = simd_shuffle8(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let e: int8x8_t = simd_shuffle8(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let f: int8x8_t = vabd_s8(d, e);
+    let f: uint8x8_t = simd_cast(f);
+    simd_add(a, simd_cast(f))
 }
 
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(sabd))]
+#[cfg_attr(test, assert_instr(sabal))]
 pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
-    let d: int16x8_t = vabdq_s16(b, c);
-    let e: int16x4_t = simd_shuffle4(d, d, [4, 5, 6, 7]);
-    simd_add(a, simd_cast(e))
+    let d: int16x4_t = simd_shuffle4(b, b, [4, 5, 6, 7]);
+    let e: int16x4_t = simd_shuffle4(c, c, [4, 5, 6, 7]);
+    let f: int16x4_t = vabd_s16(d, e);
+    let f: uint16x4_t = simd_cast(f);
+    simd_add(a, simd_cast(f))
 }
 
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(sabd))]
+#[cfg_attr(test, assert_instr(sabal))]
 pub unsafe fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
-    let d: int32x4_t = vabdq_s32(b, c);
-    let e: int32x2_t = simd_shuffle2(d, d, [2, 3]);
-    simd_add(a, simd_cast(e))
+    let d: int32x2_t = simd_shuffle2(b, b, [2, 3]);
+    let e: int32x2_t = simd_shuffle2(c, c, [2, 3]);
+    let f: int32x2_t = vabd_s32(d, e);
+    let f: uint32x2_t = simd_cast(f);
+    simd_add(a, simd_cast(f))
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/arm/neon/generated.rs
+++ b/crates/core_arch/src/arm/neon/generated.rs
@@ -4417,8 +4417,8 @@ vrecpeq_f32_(a)
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
 pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t {
     let d: uint8x8_t = vabd_u8(b, c);
     simd_add(a, simd_cast(d))
@@ -4428,8 +4428,8 @@ pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t 
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
 pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
     let d: uint16x4_t = vabd_u16(b, c);
     simd_add(a, simd_cast(d))
@@ -4439,8 +4439,8 @@ pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
 pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
     let d: uint32x2_t = vabd_u32(b, c);
     simd_add(a, simd_cast(d))
@@ -4450,8 +4450,8 @@ pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
 pub unsafe fn vabal_s8(a: int16x8_t, b: int8x8_t, c: int8x8_t) -> int16x8_t {
     let d: int8x8_t = vabd_s8(b, c);
     simd_add(a, simd_cast(d))
@@ -4461,8 +4461,8 @@ pub unsafe fn vabal_s8(a: int16x8_t, b: int8x8_t, c: int8x8_t) -> int16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
 pub unsafe fn vabal_s16(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
     let d: int16x4_t = vabd_s16(b, c);
     simd_add(a, simd_cast(d))
@@ -4472,8 +4472,8 @@ pub unsafe fn vabal_s16(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
 pub unsafe fn vabal_s32(a: int64x2_t, b: int32x2_t, c: int32x2_t) -> int64x2_t {
     let d: int32x2_t = vabd_s32(b, c);
     simd_add(a, simd_cast(d))

--- a/crates/core_arch/src/arm/neon/generated.rs
+++ b/crates/core_arch/src/arm/neon/generated.rs
@@ -4450,33 +4450,36 @@ pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.s8"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabd))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.s8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
 pub unsafe fn vabal_s8(a: int16x8_t, b: int8x8_t, c: int8x8_t) -> int16x8_t {
     let d: int8x8_t = vabd_s8(b, c);
-    simd_add(a, simd_cast(d))
+    let e: uint8x8_t = simd_cast(d);
+    simd_add(a, simd_cast(e))
 }
 
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.s16"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabd))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.s16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
 pub unsafe fn vabal_s16(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
     let d: int16x4_t = vabd_s16(b, c);
-    simd_add(a, simd_cast(d))
+    let e: uint16x4_t = simd_cast(d);
+    simd_add(a, simd_cast(e))
 }
 
 /// Signed Absolute difference and Accumulate Long
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.s32"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabd))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.s32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
 pub unsafe fn vabal_s32(a: int64x2_t, b: int32x2_t, c: int32x2_t) -> int64x2_t {
     let d: int32x2_t = vabd_s32(b, c);
-    simd_add(a, simd_cast(d))
+    let e: uint32x2_t = simd_cast(d);
+    simd_add(a, simd_cast(e))
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/arm/neon/generated.rs
+++ b/crates/core_arch/src/arm/neon/generated.rs
@@ -4417,7 +4417,7 @@ vrecpeq_f32_(a)
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.u8"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.u8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
 pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t {
     let d: uint8x8_t = vabd_u8(b, c);
@@ -4428,7 +4428,7 @@ pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t 
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.u16"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.u16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
 pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
     let d: uint16x4_t = vabd_u16(b, c);
@@ -4439,7 +4439,7 @@ pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.u32"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.u32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
 pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
     let d: uint32x2_t = vabd_u32(b, c);

--- a/crates/core_arch/src/arm/neon/generated.rs
+++ b/crates/core_arch/src/arm/neon/generated.rs
@@ -4413,6 +4413,72 @@ pub unsafe fn vrecpeq_f32(a: float32x4_t) -> float32x4_t {
 vrecpeq_f32_(a)
 }
 
+/// Unsigned Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t {
+    let d: uint8x8_t = vabd_u8(b, c);
+    simd_add(a, simd_cast(d))
+}
+
+/// Unsigned Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
+    let d: uint16x4_t = vabd_u16(b, c);
+    simd_add(a, simd_cast(d))
+}
+
+/// Unsigned Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
+    let d: uint32x2_t = vabd_u32(b, c);
+    simd_add(a, simd_cast(d))
+}
+
+/// Signed Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+pub unsafe fn vabal_s8(a: int16x8_t, b: int8x8_t, c: int8x8_t) -> int16x8_t {
+    let d: int8x8_t = vabd_s8(b, c);
+    simd_add(a, simd_cast(d))
+}
+
+/// Signed Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+pub unsafe fn vabal_s16(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
+    let d: int16x4_t = vabd_s16(b, c);
+    simd_add(a, simd_cast(d))
+}
+
+/// Signed Absolute difference and Accumulate Long
+#[inline]
+#[target_feature(enable = "neon")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(add))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
+pub unsafe fn vabal_s32(a: int64x2_t, b: int32x2_t, c: int32x2_t) -> int64x2_t {
+    let d: int32x2_t = vabd_s32(b, c);
+    simd_add(a, simd_cast(d))
+}
+
 #[cfg(test)]
 #[allow(overflowing_literals)]
 mod test {
@@ -7841,6 +7907,66 @@ mod test {
         let a: f32x4 = f32x4::new(4.0, 3.0, 2.0, 1.0);
         let e: f32x4 = f32x4::new(0.24951171875, 0.3330078125, 0.4990234375, 0.998046875);
         let r: f32x4 = transmute(vrecpeq_f32(transmute(a)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_u8() {
+        let a: u16x8 = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+        let b: u8x8 = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+        let c: u8x8 = u8x8::new(10, 10, 10, 10, 10, 10, 10, 10);
+        let e: u16x8 = u16x8::new(10, 10, 10, 10, 10, 10, 10, 10);
+        let r: u16x8 = transmute(vabal_u8(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_u16() {
+        let a: u32x4 = u32x4::new(1, 2, 3, 4);
+        let b: u16x4 = u16x4::new(1, 2, 3, 4);
+        let c: u16x4 = u16x4::new(10, 10, 10, 10);
+        let e: u32x4 = u32x4::new(10, 10, 10, 10);
+        let r: u32x4 = transmute(vabal_u16(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_u32() {
+        let a: u64x2 = u64x2::new(1, 2);
+        let b: u32x2 = u32x2::new(1, 2);
+        let c: u32x2 = u32x2::new(10, 10);
+        let e: u64x2 = u64x2::new(10, 10);
+        let r: u64x2 = transmute(vabal_u32(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_s8() {
+        let a: i16x8 = i16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+        let b: i8x8 = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+        let c: i8x8 = i8x8::new(10, 10, 10, 10, 10, 10, 10, 10);
+        let e: i16x8 = i16x8::new(10, 10, 10, 10, 10, 10, 10, 10);
+        let r: i16x8 = transmute(vabal_s8(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_s16() {
+        let a: i32x4 = i32x4::new(1, 2, 3, 4);
+        let b: i16x4 = i16x4::new(1, 2, 3, 4);
+        let c: i16x4 = i16x4::new(10, 10, 10, 10);
+        let e: i32x4 = i32x4::new(10, 10, 10, 10);
+        let r: i32x4 = transmute(vabal_s16(transmute(a), transmute(b), transmute(c)));
+        assert_eq!(r, e);
+    }
+
+    #[simd_test(enable = "neon")]
+    unsafe fn test_vabal_s32() {
+        let a: i64x2 = i64x2::new(1, 2);
+        let b: i32x2 = i32x2::new(1, 2);
+        let c: i32x2 = i32x2::new(10, 10);
+        let e: i64x2 = i64x2::new(10, 10);
+        let r: i64x2 = transmute(vabal_s32(transmute(a), transmute(b), transmute(c)));
         assert_eq!(r, e);
     }
 }

--- a/crates/core_arch/src/arm/neon/generated.rs
+++ b/crates/core_arch/src/arm/neon/generated.rs
@@ -4417,8 +4417,8 @@ vrecpeq_f32_(a)
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.u8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
 pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t {
     let d: uint8x8_t = vabd_u8(b, c);
     simd_add(a, simd_cast(d))
@@ -4428,8 +4428,8 @@ pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t 
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.u16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
 pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
     let d: uint16x4_t = vabd_u16(b, c);
     simd_add(a, simd_cast(d))
@@ -4439,8 +4439,8 @@ pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.u32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
 pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
     let d: uint32x2_t = vabd_u32(b, c);
     simd_add(a, simd_cast(d))
@@ -4450,8 +4450,8 @@ pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.s8"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabd))]
 pub unsafe fn vabal_s8(a: int16x8_t, b: int8x8_t, c: int8x8_t) -> int16x8_t {
     let d: int8x8_t = vabd_s8(b, c);
     simd_add(a, simd_cast(d))
@@ -4461,8 +4461,8 @@ pub unsafe fn vabal_s8(a: int16x8_t, b: int8x8_t, c: int8x8_t) -> int16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.s16"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabd))]
 pub unsafe fn vabal_s16(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
     let d: int16x4_t = vabd_s16(b, c);
     simd_add(a, simd_cast(d))
@@ -4472,8 +4472,8 @@ pub unsafe fn vabal_s16(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabal))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabal))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabd.s32"))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sabd))]
 pub unsafe fn vabal_s32(a: int64x2_t, b: int32x2_t, c: int32x2_t) -> int64x2_t {
     let d: int32x2_t = vabd_s32(b, c);
     simd_add(a, simd_cast(d))

--- a/crates/core_arch/src/arm/neon/generated.rs
+++ b/crates/core_arch/src/arm/neon/generated.rs
@@ -4418,7 +4418,7 @@ vrecpeq_f32_(a)
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.u8"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
 pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t {
     let d: uint8x8_t = vabd_u8(b, c);
     simd_add(a, simd_cast(d))
@@ -4429,7 +4429,7 @@ pub unsafe fn vabal_u8(a: uint16x8_t, b: uint8x8_t, c: uint8x8_t) -> uint16x8_t 
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.u16"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
 pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
     let d: uint16x4_t = vabd_u16(b, c);
     simd_add(a, simd_cast(d))
@@ -4440,7 +4440,7 @@ pub unsafe fn vabal_u16(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vabal.u32"))]
-#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabd))]
+#[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uabal))]
 pub unsafe fn vabal_u32(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
     let d: uint32x2_t = vabd_u32(b, c);
     simd_add(a, simd_cast(d))

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1399,7 +1399,6 @@ validate 20, 20
 aarch64 = add
 generate uint64x2_t:uint32x4_t:uint32x4_t:uint64x2_t
 
-
 ////////////////////
 // Signed Absolute difference and Accumulate Long
 ////////////////////

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1354,7 +1354,7 @@ c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
 arm = vabal.s
-aarch64 = uabd
+aarch64 = uabal
 generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16x4_t:uint32x4_t, uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t
 
 /// Unsigned Absolute difference and Accumulate Long

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1360,43 +1360,46 @@ generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16
 /// Unsigned Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = vabd-unsigned-noext, b, c, d:in_t
-multi_fn = simd_shuffle8, e:uint8x8_t, d, d, [8, 9, 10, 11, 12, 13, 14, 15]
-multi_fn = simd_add, a, {simd_cast, e}
+multi_fn = simd_shuffle8, d:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle8, e:uint8x8_t, c, c, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = vabd_u8, d, e, f:uint8x8_t
+multi_fn = simd_add, a, {simd_cast, f}
 a = 9, 10, 11, 12, 13, 14, 15, 16
 b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 20, 20, 20, 20, 20, 20, 20, 20
 
-aarch64 = uabd
+aarch64 = uabal
 generate uint16x8_t:uint8x16_t:uint8x16_t:uint16x8_t
 
 /// Unsigned Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = vabd-unsigned-noext, b, c, d:in_t
-multi_fn = simd_shuffle4, e:uint16x4_t, d, d, [4, 5, 6, 7]
-multi_fn = simd_add, a, {simd_cast, e}
+multi_fn = simd_shuffle4, d:uint16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle4, e:uint16x4_t, c, c, [4, 5, 6, 7]
+multi_fn = vabd_u16, d, e, f:uint16x4_t
+multi_fn = simd_add, a, {simd_cast, f}
 a = 9, 10, 11, 12
 b = 1, 2, 3, 4, 9, 10, 11, 12
 c = 10, 10, 10, 10, 20, 0, 2, 4
 validate 20, 20, 20, 20
 
-aarch64 = uabd
+aarch64 = uabal
 generate uint32x4_t:uint16x8_t:uint16x8_t:uint32x4_t
 
 /// Unsigned Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = vabd-unsigned-noext, b, c, d:in_t
-multi_fn = simd_shuffle2, e:uint32x2_t, d, d, [2, 3]
-multi_fn = simd_add, a, {simd_cast, e}
+multi_fn = simd_shuffle2, d:uint32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle2, e:uint32x2_t, c, c, [2, 3]
+multi_fn = vabd_u32, d, e, f:uint32x2_t
+multi_fn = simd_add, a, {simd_cast, f}
 a = 15, 16
 b = 1, 2, 15, 16
 c = 10, 10, 10, 12
 validate 20, 20
 
-aarch64 = uabd
+aarch64 = uabal
 generate uint64x2_t:uint32x4_t:uint32x4_t:uint64x2_t
 
 ////////////////////
@@ -1405,55 +1408,90 @@ generate uint64x2_t:uint32x4_t:uint32x4_t:uint64x2_t
 
 /// Signed Absolute difference and Accumulate Long
 name = vabal
-multi_fn = vabd-signed-noext, b, c, d:in_t
-multi_fn = simd_add, a, {simd_cast, d}
+multi_fn = vabd-signed-noext, b, c, d:int8x8_t
+multi_fn = simd_cast, e:uint8x8_t, d
+multi_fn = simd_add, a, {simd_cast, e}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
-arm = vabd.s
-aarch64 = sabd
-generate int16x8_t:int8x8_t:int8x8_t:int16x8_t, int32x4_t:int16x4_t:int16x4_t:int32x4_t, int64x2_t:int32x2_t:int32x2_t:int64x2_t
+arm = vabal.s
+aarch64 = sabal
+generate int16x8_t:int8x8_t:int8x8_t:int16x8_t
+
+/// Signed Absolute difference and Accumulate Long
+name = vabal
+multi_fn = vabd-signed-noext, b, c, d:int16x4_t
+multi_fn = simd_cast, e:uint16x4_t, d
+multi_fn = simd_add, a, {simd_cast, e}
+a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
+validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
+
+arm = vabal.s
+aarch64 = sabal
+generate int32x4_t:int16x4_t:int16x4_t:int32x4_t
+
+/// Signed Absolute difference and Accumulate Long
+name = vabal
+multi_fn = vabd-signed-noext, b, c, d:int32x2_t
+multi_fn = simd_cast, e:uint32x2_t, d
+multi_fn = simd_add, a, {simd_cast, e}
+a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
+validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
+
+arm = vabal.s
+aarch64 = sabal
+generate int64x2_t:int32x2_t:int32x2_t:int64x2_t
 
 /// Signed Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = vabd-signed-noext, b, c, d:in_t
-multi_fn = simd_shuffle8, e:int8x8_t, d, d, [8, 9, 10, 11, 12, 13, 14, 15]
-multi_fn = simd_add, a, {simd_cast, e}
+multi_fn = simd_shuffle8, d:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle8, e:int8x8_t, c, c, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = vabd_s8, d, e, f:int8x8_t
+multi_fn = simd_cast, f:uint8x8_t, f
+multi_fn = simd_add, a, {simd_cast, f}
 a = 9, 10, 11, 12, 13, 14, 15, 16
 b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 20, 20, 20, 20, 20, 20, 20, 20
 
-aarch64 = sabd
+aarch64 = sabal
 generate int16x8_t:int8x16_t:int8x16_t:int16x8_t
 
 /// Signed Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = vabd-signed-noext, b, c, d:in_t
-multi_fn = simd_shuffle4, e:int16x4_t, d, d, [4, 5, 6, 7]
-multi_fn = simd_add, a, {simd_cast, e}
+multi_fn = simd_shuffle4, d:int16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle4, e:int16x4_t, c, c, [4, 5, 6, 7]
+multi_fn = vabd_s16, d, e, f:int16x4_t
+multi_fn = simd_cast, f:uint16x4_t, f
+multi_fn = simd_add, a, {simd_cast, f}
 a = 9, 10, 11, 12
 b = 1, 2, 3, 4, 9, 10, 11, 12
 c = 10, 10, 10, 10, 20, 0, 2, 4
 validate 20, 20, 20, 20
 
-aarch64 = sabd
+aarch64 = sabal
 generate int32x4_t:int16x8_t:int16x8_t:int32x4_t
 
 /// Signed Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = vabd-signed-noext, b, c, d:in_t
-multi_fn = simd_shuffle2, e:int32x2_t, d, d, [2, 3]
-multi_fn = simd_add, a, {simd_cast, e}
+multi_fn = simd_shuffle2, d:int32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle2, e:int32x2_t, c, c, [2, 3]
+multi_fn = vabd_s32, d, e, f:int32x2_t
+multi_fn = simd_cast, f:uint32x2_t, f
+multi_fn = simd_add, a, {simd_cast, f}
 a = 15, 16
 b = 1, 2, 15, 16
 c = 10, 10, 10, 12
 validate 20, 20
 
-aarch64 = sabd
+aarch64 = sabal
 generate int64x2_t:int32x4_t:int32x4_t:int64x2_t

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1353,7 +1353,7 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
-arm = vabd.s
+arm = vabal.s
 aarch64 = uabd
 generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16x4_t:uint32x4_t, uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t
 

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1353,8 +1353,8 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
-arm = add
-aarch64 = add
+arm = vabal
+aarch64 = uabal
 generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16x4_t:uint32x4_t, uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -1368,7 +1368,7 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 20, 20, 20, 20, 20, 20, 20, 20
 
-aarch64 = add
+aarch64 = uabal
 generate uint16x8_t:uint8x16_t:uint8x16_t:uint16x8_t
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -1382,7 +1382,7 @@ b = 1, 2, 3, 4, 9, 10, 11, 12
 c = 10, 10, 10, 10, 20, 0, 2, 4
 validate 20, 20, 20, 20
 
-aarch64 = add
+aarch64 = uabal
 generate uint32x4_t:uint16x8_t:uint16x8_t:uint32x4_t
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -1396,7 +1396,7 @@ b = 1, 2, 15, 16
 c = 10, 10, 10, 12
 validate 20, 20
 
-aarch64 = add
+aarch64 = uabal
 generate uint64x2_t:uint32x4_t:uint32x4_t:uint64x2_t
 
 ////////////////////
@@ -1412,8 +1412,8 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
-arm = add
-aarch64 = add
+arm = vabal
+aarch64 = sabal
 generate int16x8_t:int8x8_t:int8x8_t:int16x8_t, int32x4_t:int16x4_t:int16x4_t:int32x4_t, int64x2_t:int32x2_t:int32x2_t:int64x2_t
 
 /// Signed Absolute difference and Accumulate Long
@@ -1427,7 +1427,7 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 20, 20, 20, 20, 20, 20, 20, 20
 
-aarch64 = add
+aarch64 = sabal
 generate int16x8_t:int8x16_t:int8x16_t:int16x8_t
 
 /// Signed Absolute difference and Accumulate Long
@@ -1441,7 +1441,7 @@ b = 1, 2, 3, 4, 9, 10, 11, 12
 c = 10, 10, 10, 10, 20, 0, 2, 4
 validate 20, 20, 20, 20
 
-aarch64 = add
+aarch64 = sabal
 generate int32x4_t:int16x8_t:int16x8_t:int32x4_t
 
 /// Signed Absolute difference and Accumulate Long
@@ -1455,5 +1455,5 @@ b = 1, 2, 15, 16
 c = 10, 10, 10, 12
 validate 20, 20
 
-aarch64 = add
+aarch64 = sabal
 generate int64x2_t:int32x4_t:int32x4_t:int64x2_t

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1339,3 +1339,122 @@ validate 8., 9., 10., 11., 12., 13., 14., 15.
 
 aarch64 = zip2
 generate float32x2_t, float32x4_t, float64x2_t
+
+////////////////////
+// Unsigned Absolute difference and Accumulate Long
+////////////////////
+
+/// Unsigned Absolute difference and Accumulate Long
+name = vabal
+multi_fn = vabd-unsigned-noext, b, c, d:in_t
+multi_fn = simd_add, a, {simd_cast, d}
+a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
+validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
+
+arm = add
+aarch64 = add
+generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16x4_t:uint32x4_t, uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t
+
+/// Unsigned Absolute difference and Accumulate Long
+name = vabal_high
+no-q
+multi_fn = vabd-unsigned-noext, b, c, d:in_t
+multi_fn = simd_shuffle8, e:uint8x8_t, d, d, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_add, a, {simd_cast, e}
+a = 9, 10, 11, 12, 13, 14, 15, 16
+b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
+validate 20, 20, 20, 20, 20, 20, 20, 20
+
+aarch64 = add
+generate uint16x8_t:uint8x16_t:uint8x16_t:uint16x8_t
+
+/// Unsigned Absolute difference and Accumulate Long
+name = vabal_high
+no-q
+multi_fn = vabd-unsigned-noext, b, c, d:in_t
+multi_fn = simd_shuffle4, e:uint16x4_t, d, d, [4, 5, 6, 7]
+multi_fn = simd_add, a, {simd_cast, e}
+a = 9, 10, 11, 12
+b = 1, 2, 3, 4, 9, 10, 11, 12
+c = 10, 10, 10, 10, 20, 0, 2, 4
+validate 20, 20, 20, 20
+
+aarch64 = add
+generate uint32x4_t:uint16x8_t:uint16x8_t:uint32x4_t
+
+/// Unsigned Absolute difference and Accumulate Long
+name = vabal_high
+no-q
+multi_fn = vabd-unsigned-noext, b, c, d:in_t
+multi_fn = simd_shuffle2, e:uint32x2_t, d, d, [2, 3]
+multi_fn = simd_add, a, {simd_cast, e}
+a = 15, 16
+b = 1, 2, 15, 16
+c = 10, 10, 10, 12
+validate 20, 20
+
+aarch64 = add
+generate uint64x2_t:uint32x4_t:uint32x4_t:uint64x2_t
+
+
+////////////////////
+// Signed Absolute difference and Accumulate Long
+////////////////////
+
+/// Signed Absolute difference and Accumulate Long
+name = vabal
+multi_fn = vabd-signed-noext, b, c, d:in_t
+multi_fn = simd_add, a, {simd_cast, d}
+a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
+validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
+
+arm = add
+aarch64 = add
+generate int16x8_t:int8x8_t:int8x8_t:int16x8_t, int32x4_t:int16x4_t:int16x4_t:int32x4_t, int64x2_t:int32x2_t:int32x2_t:int64x2_t
+
+/// Signed Absolute difference and Accumulate Long
+name = vabal_high
+no-q
+multi_fn = vabd-signed-noext, b, c, d:in_t
+multi_fn = simd_shuffle8, e:int8x8_t, d, d, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_add, a, {simd_cast, e}
+a = 9, 10, 11, 12, 13, 14, 15, 16
+b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
+validate 20, 20, 20, 20, 20, 20, 20, 20
+
+aarch64 = add
+generate int16x8_t:int8x16_t:int8x16_t:int16x8_t
+
+/// Signed Absolute difference and Accumulate Long
+name = vabal_high
+no-q
+multi_fn = vabd-signed-noext, b, c, d:in_t
+multi_fn = simd_shuffle4, e:int16x4_t, d, d, [4, 5, 6, 7]
+multi_fn = simd_add, a, {simd_cast, e}
+a = 9, 10, 11, 12
+b = 1, 2, 3, 4, 9, 10, 11, 12
+c = 10, 10, 10, 10, 20, 0, 2, 4
+validate 20, 20, 20, 20
+
+aarch64 = add
+generate int32x4_t:int16x8_t:int16x8_t:int32x4_t
+
+/// Signed Absolute difference and Accumulate Long
+name = vabal_high
+no-q
+multi_fn = vabd-signed-noext, b, c, d:in_t
+multi_fn = simd_shuffle2, e:int32x2_t, d, d, [2, 3]
+multi_fn = simd_add, a, {simd_cast, e}
+a = 15, 16
+b = 1, 2, 15, 16
+c = 10, 10, 10, 12
+validate 20, 20
+
+aarch64 = add
+generate int64x2_t:int32x4_t:int32x4_t:int64x2_t

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -1353,8 +1353,8 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
-arm = vabal
-aarch64 = uabal
+arm = vabd.s
+aarch64 = uabd
 generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16x4_t:uint32x4_t, uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -1368,7 +1368,7 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 20, 20, 20, 20, 20, 20, 20, 20
 
-aarch64 = uabal
+aarch64 = uabd
 generate uint16x8_t:uint8x16_t:uint8x16_t:uint16x8_t
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -1382,7 +1382,7 @@ b = 1, 2, 3, 4, 9, 10, 11, 12
 c = 10, 10, 10, 10, 20, 0, 2, 4
 validate 20, 20, 20, 20
 
-aarch64 = uabal
+aarch64 = uabd
 generate uint32x4_t:uint16x8_t:uint16x8_t:uint32x4_t
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -1396,7 +1396,7 @@ b = 1, 2, 15, 16
 c = 10, 10, 10, 12
 validate 20, 20
 
-aarch64 = uabal
+aarch64 = uabd
 generate uint64x2_t:uint32x4_t:uint32x4_t:uint64x2_t
 
 ////////////////////
@@ -1412,8 +1412,8 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20
 
-arm = vabal
-aarch64 = sabal
+arm = vabd.s
+aarch64 = sabd
 generate int16x8_t:int8x8_t:int8x8_t:int16x8_t, int32x4_t:int16x4_t:int16x4_t:int32x4_t, int64x2_t:int32x2_t:int32x2_t:int64x2_t
 
 /// Signed Absolute difference and Accumulate Long
@@ -1427,7 +1427,7 @@ b = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 c = 10, 10, 10, 10, 10, 10, 10, 10, 20, 0, 2, 4, 6, 8, 10, 12
 validate 20, 20, 20, 20, 20, 20, 20, 20
 
-aarch64 = sabal
+aarch64 = sabd
 generate int16x8_t:int8x16_t:int8x16_t:int16x8_t
 
 /// Signed Absolute difference and Accumulate Long
@@ -1441,7 +1441,7 @@ b = 1, 2, 3, 4, 9, 10, 11, 12
 c = 10, 10, 10, 10, 20, 0, 2, 4
 validate 20, 20, 20, 20
 
-aarch64 = sabal
+aarch64 = sabd
 generate int32x4_t:int16x8_t:int16x8_t:int32x4_t
 
 /// Signed Absolute difference and Accumulate Long
@@ -1455,5 +1455,5 @@ b = 1, 2, 15, 16
 c = 10, 10, 10, 12
 validate 20, 20
 
-aarch64 = sabal
+aarch64 = sabd
 generate int64x2_t:int32x4_t:int32x4_t:int64x2_t


### PR DESCRIPTION
vabal_s*:
Signed Absolute difference and Accumulate Long. This instruction subtracts the vector elements in the lower or upper half of the second source SIMD&FP register from the corresponding vector elements of the first source SIMD&FP register, and accumulates the absolute values of the results into the vector elements of the destination SIMD&FP register. The destination vector elements are twice as long as the source vector elements.
vabal_u*:
Unsigned Absolute difference and Accumulate Long. This instruction subtracts the vector elements in the lower or upper half of the second source SIMD&FP register from the corresponding vector elements of the first source SIMD&FP register, and accumulates the absolute values of the results into the vector elements of the destination SIMD&FP register. The destination vector elements are twice as long as the source vector elements. All the values in this instruction are unsigned integer values.