### PR TITLE
Deny 2018 idiom lints

### DIFF
--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -7,6 +7,7 @@
 //! The procedural macro here is relatively simple, it simply appends a
 //! `#[test]` function to the original token stream which asserts that the
 //! function itself contains the relevant instruction.
+#![deny(rust_2018_idioms)]
 
 extern crate proc_macro;
 extern crate proc_macro2;
@@ -177,7 +178,7 @@ struct Invoc {
 }
 
 impl syn::parse::Parse for Invoc {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         use syn::{ext::IdentExt, Token};
 
         let mut instr = String::new();

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(improper_ctypes_definitions)]
 #![allow(dead_code)]
 #![allow(unused_features)]
+#![deny(rust_2018_idioms)]
 #![feature(
     asm,
     const_fn,
@@ -68,9 +69,6 @@ extern crate std;
 #[cfg(test)]
 #[macro_use]
 extern crate std_detect;
-#[cfg(test)]
-extern crate stdarch_test;
-
 #[path = "mod.rs"]
 mod core_arch;
 

--- a/crates/core_arch/src/x86/avx512vpclmulqdq.rs
+++ b/crates/core_arch/src/x86/avx512vpclmulqdq.rs
@@ -9,7 +9,7 @@ use crate::core_arch::x86::__m256i;
 use crate::core_arch::x86::__m512i;
 
 #[cfg(test)]
-use crate::stdarch_test::assert_instr;
+use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
 extern "C" {

--- a/crates/core_arch/src/x86/fxsr.rs
+++ b/crates/core_arch/src/x86/fxsr.rs
@@ -87,7 +87,7 @@ mod tests {
     }
 
     impl fmt::Debug for FxsaveArea {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "[")?;
             for i in 0..self.data.len() {
                 write!(f, "{}", self.data[i])?;

--- a/crates/core_arch/src/x86/pclmulqdq.rs
+++ b/crates/core_arch/src/x86/pclmulqdq.rs
@@ -8,7 +8,7 @@
 use crate::core_arch::x86::__m128i;
 
 #[cfg(test)]
-use crate::stdarch_test::assert_instr;
+use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
 extern "C" {

--- a/crates/core_arch/src/x86/xsave.rs
+++ b/crates/core_arch/src/x86/xsave.rs
@@ -196,7 +196,7 @@ mod tests {
     }
 
     impl fmt::Debug for XsaveArea {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "[")?;
             for i in 0..self.data.len() {
                 write!(f, "{}", self.data[i])?;

--- a/crates/core_arch/src/x86_64/fxsr.rs
+++ b/crates/core_arch/src/x86_64/fxsr.rs
@@ -87,7 +87,7 @@ mod tests {
     }
 
     impl fmt::Debug for FxsaveArea {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "[")?;
             for i in 0..self.data.len() {
                 write!(f, "{}", self.data[i])?;

--- a/crates/core_arch/src/x86_64/xsave.rs
+++ b/crates/core_arch/src/x86_64/xsave.rs
@@ -164,7 +164,7 @@ mod tests {
     }
 
     impl fmt::Debug for XsaveArea {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "[")?;
             for i in 0..self.data.len() {
                 write!(f, "{}", self.data[i])?;

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This macro expands to a `#[test]` function which tests the local machine
 //! for the appropriate cfg before calling the inner test function.
+#![deny(rust_2018_idioms)]
 
 extern crate proc_macro;
 extern crate proc_macro2;

--- a/crates/std_detect/src/detect/os/linux/cpuinfo.rs
+++ b/crates/std_detect/src/detect/os/linux/cpuinfo.rs
@@ -17,7 +17,7 @@ impl CpuInfo {
         })
     }
     /// Returns the value of the cpuinfo `field`.
-    pub(crate) fn field(&self, field: &str) -> CpuInfoField {
+    pub(crate) fn field(&self, field: &str) -> CpuInfoField<'_> {
         for l in self.raw.lines() {
             if l.trim().starts_with(field) {
                 return CpuInfoField::new(l.split(": ").nth(1));

--- a/crates/std_detect/src/lib.rs
+++ b/crates/std_detect/src/lib.rs
@@ -13,6 +13,7 @@
 
 #![unstable(feature = "stdsimd", issue = "27731")]
 #![feature(const_fn, staged_api, stdsimd, doc_cfg, allow_internal_unstable)]
+#![deny(rust_2018_idioms)]
 #![allow(clippy::shadow_reuse)]
 #![deny(clippy::missing_inline_in_public_items)]
 #![cfg_attr(all(target_os = "freebsd", target_arch = "aarch64"), feature(asm))]
@@ -20,7 +21,8 @@
 #![cfg_attr(feature = "std_detect_file_io", feature(vec_spare_capacity))]
 #![no_std]
 
-#[cfg_attr(feature = "rustc-dep-of-std", allow(unused_extern_crates))]
+// rust-lang/rust#83888: removing `extern crate` gives an error that `vec_spare_capacity` is unknown
+#[cfg_attr(feature = "std_detect_file_io", allow(unused_extern_crates))]
 #[cfg(feature = "std_detect_file_io")]
 extern crate alloc;
 

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -4,13 +4,12 @@
 //! output once globally and then provides the `assert` function which makes
 //! assertions about the disassembly of a function.
 #![feature(test)] // For black_box
+#![deny(rust_2018_idioms)]
 #![allow(clippy::missing_docs_in_private_items, clippy::print_stdout)]
 
 extern crate assert_instr_macro;
-extern crate cc;
 #[macro_use]
 extern crate lazy_static;
-extern crate rustc_demangle;
 extern crate simd_test_macro;
 #[macro_use]
 extern crate cfg_if;

--- a/crates/stdarch-verify/src/lib.rs
+++ b/crates/stdarch-verify/src/lib.rs
@@ -1,5 +1,4 @@
-extern crate proc_macro;
-extern crate proc_macro2;
+#![deny(rust_2018_idioms)]
 #[macro_use]
 extern crate quote;
 #[macro_use]
@@ -357,7 +356,7 @@ fn find_instrs(attrs: &[syn::Attribute]) -> Vec<String> {
     // TODO: should probably just reuse `Invoc` from the `assert-instr-macro`
     // crate.
     impl syn::parse::Parse for AssertInstr {
-        fn parse(content: syn::parse::ParseStream) -> syn::Result<Self> {
+        fn parse(content: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
             let input;
             parenthesized!(input in content);
             let _ = input.parse::<syn::Meta>()?;
@@ -443,7 +442,7 @@ struct RustcArgsRequiredConst {
 }
 
 impl syn::parse::Parse for RustcArgsRequiredConst {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let content;
         parenthesized!(content in input);
         let list =


### PR DESCRIPTION
```
error: hidden lifetime parameters in types are deprecated
  --> library/stdarch/crates/std_detect/src/detect/os/linux/cpuinfo.rs:20:48
   |
20 |     pub(crate) fn field(&self, field: &str) -> CpuInfoField {
   |                                                ^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
   |
   = note: `-D elided-lifetimes-in-paths` implied by `-D warnings`
```

This lint is allow by default, which is why this wasn't spotted earlier.

cc https://github.com/rust-lang/rust/pull/83776#issuecomment-813332275