### PR TITLE
Convert all crates to 2018 edition

### DIFF
--- a/crates/assert-instr-macro/Cargo.toml
+++ b/crates/assert-instr-macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assert-instr-macro"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -9,11 +9,8 @@
 //! function itself contains the relevant instruction.
 #![deny(rust_2018_idioms)]
 
-extern crate proc_macro;
-extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
-extern crate syn;
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;

--- a/crates/simd-test-macro/Cargo.toml
+++ b/crates/simd-test-macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simd-test-macro"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -4,8 +4,6 @@
 //! for the appropriate cfg before calling the inner test function.
 #![deny(rust_2018_idioms)]
 
-extern crate proc_macro;
-extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 

--- a/crates/stdarch-test/Cargo.toml
+++ b/crates/stdarch-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stdarch-test"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [dependencies]
 assert-instr-macro = { path = "../assert-instr-macro" }

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -7,10 +7,8 @@
 #![deny(rust_2018_idioms)]
 #![allow(clippy::missing_docs_in_private_items, clippy::print_stdout)]
 
-extern crate assert_instr_macro;
 #[macro_use]
 extern crate lazy_static;
-extern crate simd_test_macro;
 #[macro_use]
 extern crate cfg_if;
 
@@ -24,7 +22,7 @@ cfg_if! {
         use wasm::disassemble_myself;
     } else {
         mod disassembly;
-        use disassembly::disassemble_myself;
+        use crate::disassembly::disassemble_myself;
     }
 }
 


### PR DESCRIPTION
Builds on https://github.com/rust-lang/stdarch/pull/1108.