### PR TITLE
Don't import from core

### DIFF
--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -11,11 +11,11 @@ pub use self::generated::*;
 
 use crate::{
     core_arch::{arm::*, simd::*, simd_llvm::*},
+    hint::unreachable_unchecked,
     mem::{transmute, zeroed},
 };
 #[cfg(test)]
 use stdarch_test::assert_instr;
-use core::hint::unreachable_unchecked;
 
 types! {
     /// ARM-specific 64-bit wide vector of one packed `f64`.

--- a/crates/core_arch/src/arm/neon/mod.rs
+++ b/crates/core_arch/src/arm/neon/mod.rs
@@ -8,9 +8,9 @@ pub use self::generated::*;
 #[cfg(target_arch = "arm")]
 use crate::mem::align_of;
 use crate::{
-    core_arch::simd::*, core_arch::simd_llvm::*, hint::unreachable_unchecked, mem::transmute,
+    convert::TryInto, core_arch::simd::*, core_arch::simd_llvm::*, hint::unreachable_unchecked,
+    mem::transmute,
 };
-use core::convert::TryInto;
 #[cfg(test)]
 use stdarch_test::assert_instr;
 

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -75,4 +75,4 @@ mod core_arch;
 pub use self::core_arch::arch;
 
 #[allow(unused_imports)]
-use core::{ffi, hint, intrinsics, marker, mem, ops, ptr, sync};
+use core::{convert, ffi, hint, intrinsics, marker, mem, ops, ptr, sync};

--- a/crates/stdarch-verify/tests/arm.rs
+++ b/crates/stdarch-verify/tests/arm.rs
@@ -396,7 +396,13 @@ fn verify_all_signatures() {
         }
         // Skip some intrinsics that are present in GCC and Clang but
         // are missing from the official documentation.
-        let skip_intrinsic_verify = ["vmov_n_p64", "vmovq_n_p64", "vreinterpret_p64_s64", "vreinterpret_f32_p64", "vreinterpretq_f32_p64"];
+        let skip_intrinsic_verify = [
+            "vmov_n_p64",
+            "vmovq_n_p64",
+            "vreinterpret_p64_s64",
+            "vreinterpret_f32_p64",
+            "vreinterpretq_f32_p64",
+        ];
         let arm = match map.get(rust.name) {
             Some(i) => i,
             None => {


### PR DESCRIPTION
This breaks when core_arch is included as a module in core.