### PR TITLE
Remove cfg(not(bootstrap)) for 1.54

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -1,6 +1,5 @@
 //! `core_arch`
 
-#![cfg_attr(not(bootstrap), allow(automatic_links))]
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
The cfg is not needed after bumping the bootstrap compiler.