### PR TITLE
remove const_fn leftovers

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(rust_2018_idioms)]
 #![feature(
     asm,
-    const_fn,
     const_fn_union,
     const_fn_transmute,
     custom_inner_attributes,


### PR DESCRIPTION
The `const_fn` feature is dead, it does not do anything any more and we'd like to remove it.