### PR TITLE
use simd_shuffle macros on wasm32

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -95,7 +95,7 @@ macro_rules! types {
 
 #[allow(unused_macros)]
 macro_rules! simd_shuffle2 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $idx:expr $(,)?) => {{
+    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;
         impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
             const IDX: [u32; 2] = $idx;
@@ -111,7 +111,7 @@ macro_rules! simd_shuffle2 {
 
 #[allow(unused_macros)]
 macro_rules! simd_shuffle4 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $idx:expr $(,)?) => {{
+    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;
         impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
             const IDX: [u32; 4] = $idx;
@@ -127,7 +127,7 @@ macro_rules! simd_shuffle4 {
 
 #[allow(unused_macros)]
 macro_rules! simd_shuffle8 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $idx:expr $(,)?) => {{
+    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;
         impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
             const IDX: [u32; 8] = $idx;
@@ -143,7 +143,7 @@ macro_rules! simd_shuffle8 {
 
 #[allow(unused_macros)]
 macro_rules! simd_shuffle16 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $idx:expr $(,)?) => {{
+    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;
         impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
             const IDX: [u32; 16] = $idx;
@@ -159,7 +159,7 @@ macro_rules! simd_shuffle16 {
 
 #[allow(unused_macros)]
 macro_rules! simd_shuffle32 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $idx:expr $(,)?) => {{
+    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $(,)? $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;
         impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
             const IDX: [u32; 32] = $idx;
@@ -175,7 +175,7 @@ macro_rules! simd_shuffle32 {
 
 #[allow(unused_macros)]
 macro_rules! simd_shuffle64 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $idx:expr $(,)?) => {{
+    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;
         impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
             const IDX: [u32; 64] = $idx;

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -769,10 +769,27 @@ pub unsafe fn i8x16_shuffle<
     static_assert!(I13: usize where I13 < 32);
     static_assert!(I14: usize where I14 < 32);
     static_assert!(I15: usize where I15 < 32);
-    let shuf = simd_shuffle16::<simd::u8x16, simd::u8x16>(
+    let shuf: simd::u8x16 = simd_shuffle16!(
         a.as_u8x16(),
         b.as_u8x16(),
-        [
+        <
+            const I0: usize,
+            const I1: usize,
+            const I2: usize,
+            const I3: usize,
+            const I4: usize,
+            const I5: usize,
+            const I6: usize,
+            const I7: usize,
+            const I8: usize,
+            const I9: usize,
+            const I10: usize,
+            const I11: usize,
+            const I12: usize,
+            const I13: usize,
+            const I14: usize,
+            const I15: usize,
+        > [
             I0 as u32, I1 as u32, I2 as u32, I3 as u32, I4 as u32, I5 as u32, I6 as u32, I7 as u32,
             I8 as u32, I9 as u32, I10 as u32, I11 as u32, I12 as u32, I13 as u32, I14 as u32,
             I15 as u32,
@@ -825,10 +842,19 @@ pub unsafe fn i16x8_shuffle<
     static_assert!(I5: usize where I5 < 16);
     static_assert!(I6: usize where I6 < 16);
     static_assert!(I7: usize where I7 < 16);
-    let shuf = simd_shuffle8::<simd::u16x8, simd::u16x8>(
+    let shuf: simd::u16x8 = simd_shuffle8!(
         a.as_u16x8(),
         b.as_u16x8(),
-        [
+        <
+            const I0: usize,
+            const I1: usize,
+            const I2: usize,
+            const I3: usize,
+            const I4: usize,
+            const I5: usize,
+            const I6: usize,
+            const I7: usize,
+        > [
             I0 as u32, I1 as u32, I2 as u32, I3 as u32, I4 as u32, I5 as u32, I6 as u32, I7 as u32,
         ],
     );
@@ -854,10 +880,10 @@ pub unsafe fn i32x4_shuffle<const I0: usize, const I1: usize, const I2: usize, c
     static_assert!(I1: usize where I1 < 8);
     static_assert!(I2: usize where I2 < 8);
     static_assert!(I3: usize where I3 < 8);
-    let shuf = simd_shuffle4::<simd::u32x4, simd::u32x4>(
+    let shuf: simd::u32x4 = simd_shuffle4!(
         a.as_u32x4(),
         b.as_u32x4(),
-        [I0 as u32, I1 as u32, I2 as u32, I3 as u32],
+        <const I0: usize, const I1: usize, const I2: usize, const I3: usize> [I0 as u32, I1 as u32, I2 as u32, I3 as u32],
     );
     transmute(shuf)
 }
@@ -876,10 +902,10 @@ pub unsafe fn i32x4_shuffle<const I0: usize, const I1: usize, const I2: usize, c
 pub unsafe fn i64x2_shuffle<const I0: usize, const I1: usize>(a: v128, b: v128) -> v128 {
     static_assert!(I0: usize where I0 < 4);
     static_assert!(I1: usize where I1 < 4);
-    let shuf = simd_shuffle2::<simd::u64x2, simd::u64x2>(
+    let shuf: simd::u64x2 = simd_shuffle2!(
         a.as_u64x2(),
         b.as_u64x2(),
-        [I0 as u32, I1 as u32],
+        <const I0: usize, const I1: usize> [I0 as u32, I1 as u32],
     );
     transmute(shuf)
 }
@@ -2288,7 +2314,7 @@ pub unsafe fn u16x8_narrow_i32x4(a: v128, b: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.extend_low_i8x16_s"))]
 pub unsafe fn i16x8_extend_low_i8x16(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i16x8>(simd_shuffle8::<_, simd::i8x8>(
+    transmute(simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
         a.as_i8x16(),
         a.as_i8x16(),
         [0, 1, 2, 3, 4, 5, 6, 7],
@@ -2302,7 +2328,7 @@ pub unsafe fn i16x8_extend_low_i8x16(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.extend_high_i8x16_s"))]
 pub unsafe fn i16x8_extend_high_i8x16(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i16x8>(simd_shuffle8::<_, simd::i8x8>(
+    transmute(simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
         a.as_i8x16(),
         a.as_i8x16(),
         [8, 9, 10, 11, 12, 13, 14, 15],
@@ -2316,7 +2342,7 @@ pub unsafe fn i16x8_extend_high_i8x16(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.extend_low_i8x16_u"))]
 pub unsafe fn i16x8_extend_low_u8x16(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::u16x8>(simd_shuffle8::<_, simd::u8x8>(
+    transmute(simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
         a.as_u8x16(),
         a.as_u8x16(),
         [0, 1, 2, 3, 4, 5, 6, 7],
@@ -2330,7 +2356,7 @@ pub unsafe fn i16x8_extend_low_u8x16(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.extend_high_i8x16_u"))]
 pub unsafe fn i16x8_extend_high_u8x16(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::u16x8>(simd_shuffle8::<_, simd::u8x8>(
+    transmute(simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
         a.as_u8x16(),
         a.as_u8x16(),
         [8, 9, 10, 11, 12, 13, 14, 15],
@@ -2618,9 +2644,11 @@ pub unsafe fn i32x4_bitmask(a: v128) -> i32 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.extend_low_i16x8_s"))]
 pub unsafe fn i32x4_extend_low_i16x8(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i32x4>(
-        simd_shuffle4::<_, simd::i16x4>(a.as_i16x8(), a.as_i16x8(), [0, 1, 2, 3]),
-    ))
+    transmute(simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        a.as_i16x8(),
+        a.as_i16x8(),
+        [0, 1, 2, 3]
+    )))
 }
 
 /// Converts high half of the smaller lane vector to a larger lane
@@ -2630,9 +2658,11 @@ pub unsafe fn i32x4_extend_low_i16x8(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.extend_high_i16x8_s"))]
 pub unsafe fn i32x4_extend_high_i16x8(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i32x4>(
-        simd_shuffle4::<_, simd::i16x4>(a.as_i16x8(), a.as_i16x8(), [4, 5, 6, 7]),
-    ))
+    transmute(simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        a.as_i16x8(),
+        a.as_i16x8(),
+        [4, 5, 6, 7]
+    )))
 }
 
 /// Converts low half of the smaller lane vector to a larger lane
@@ -2642,9 +2672,11 @@ pub unsafe fn i32x4_extend_high_i16x8(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.extend_low_i16x8_u"))]
 pub unsafe fn i32x4_extend_low_u16x8(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::u32x4>(
-        simd_shuffle4::<_, simd::u16x4>(a.as_u16x8(), a.as_u16x8(), [0, 1, 2, 3]),
-    ))
+    transmute(simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        a.as_u16x8(),
+        a.as_u16x8(),
+        [0, 1, 2, 3]
+    )))
 }
 
 /// Converts high half of the smaller lane vector to a larger lane
@@ -2654,9 +2686,11 @@ pub unsafe fn i32x4_extend_low_u16x8(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.extend_high_i16x8_u"))]
 pub unsafe fn i32x4_extend_high_u16x8(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::u32x4>(
-        simd_shuffle4::<_, simd::u16x4>(a.as_u16x8(), a.as_u16x8(), [4, 5, 6, 7]),
-    ))
+    transmute(simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        a.as_u16x8(),
+        a.as_u16x8(),
+        [4, 5, 6, 7]
+    )))
 }
 
 /// Shifts each lane to the left by the specified number of bits.
@@ -2881,9 +2915,11 @@ pub unsafe fn i64x2_bitmask(a: v128) -> i32 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.extend_low_i32x4_s"))]
 pub unsafe fn i64x2_extend_low_i32x4(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i64x2>(
-        simd_shuffle2::<_, simd::i32x2>(a.as_i32x4(), a.as_i32x4(), [0, 1]),
-    ))
+    transmute(simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(
+        a.as_i32x4(),
+        a.as_i32x4(),
+        [0, 1]
+    )))
 }
 
 /// Converts high half of the smaller lane vector to a larger lane
@@ -2893,9 +2929,11 @@ pub unsafe fn i64x2_extend_low_i32x4(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.extend_high_i32x4_s"))]
 pub unsafe fn i64x2_extend_high_i32x4(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i64x2>(
-        simd_shuffle2::<_, simd::i32x2>(a.as_i32x4(), a.as_i32x4(), [2, 3]),
-    ))
+    transmute(simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(
+        a.as_i32x4(),
+        a.as_i32x4(),
+        [2, 3]
+    )))
 }
 
 /// Converts low half of the smaller lane vector to a larger lane
@@ -2905,9 +2943,11 @@ pub unsafe fn i64x2_extend_high_i32x4(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.extend_low_i32x4_u"))]
 pub unsafe fn i64x2_extend_low_u32x4(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i64x2>(
-        simd_shuffle2::<_, simd::u32x2>(a.as_u32x4(), a.as_u32x4(), [0, 1]),
-    ))
+    transmute(simd_cast::<simd::u32x2, simd::i64x2>(simd_shuffle2!(
+        a.as_u32x4(),
+        a.as_u32x4(),
+        [0, 1]
+    )))
 }
 
 /// Converts high half of the smaller lane vector to a larger lane
@@ -2917,9 +2957,11 @@ pub unsafe fn i64x2_extend_low_u32x4(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.extend_high_i32x4_u"))]
 pub unsafe fn i64x2_extend_high_u32x4(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::i64x2>(
-        simd_shuffle2::<_, simd::u32x2>(a.as_u32x4(), a.as_u32x4(), [2, 3]),
-    ))
+    transmute(simd_cast::<simd::u32x2, simd::i64x2>(simd_shuffle2!(
+        a.as_u32x4(),
+        a.as_u32x4(),
+        [2, 3]
+    )))
 }
 
 /// Shifts each lane to the left by the specified number of bits.
@@ -3386,7 +3428,7 @@ pub unsafe fn f32x4_convert_u32x4(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.trunc_sat_f64x2_s_zero"))]
 pub unsafe fn i32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
-    transmute(simd_shuffle4::<simd::i32x2, simd::i32x4>(
+    transmute::<simd::i32x4, v128>(simd_shuffle4!(
         llvm_i32x2_trunc_sat_f64x2_s(a.as_f64x2()),
         simd::i32x2::splat(0),
         [0, 1, 2, 3],
@@ -3406,7 +3448,7 @@ pub unsafe fn i32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.trunc_sat_f64x2_u_zero"))]
 pub unsafe fn u32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
-    transmute(simd_shuffle4::<simd::i32x2, simd::i32x4>(
+    transmute::<simd::i32x4, v128>(simd_shuffle4!(
         llvm_i32x2_trunc_sat_f64x2_u(a.as_f64x2()),
         simd::i32x2::splat(0),
         [0, 1, 2, 3],
@@ -3419,10 +3461,7 @@ pub unsafe fn u32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("f64x2.convert_low_i32x4_s"))]
 pub unsafe fn f64x2_convert_low_i32x4(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::f64x2>(simd_shuffle2::<
-        simd::i32x4,
-        simd::i32x2,
-    >(
+    transmute(simd_cast::<simd::i32x2, simd::f64x2>(simd_shuffle2!(
         a.as_i32x4(),
         a.as_i32x4(),
         [0, 1],
@@ -3435,10 +3474,7 @@ pub unsafe fn f64x2_convert_low_i32x4(a: v128) -> v128 {
 #[target_feature(enable = "simd128")]
 #[doc(alias("f64x2.convert_low_i32x4_u"))]
 pub unsafe fn f64x2_convert_low_u32x4(a: v128) -> v128 {
-    transmute(simd_cast::<_, simd::f64x2>(simd_shuffle2::<
-        simd::u32x4,
-        simd::u32x2,
-    >(
+    transmute(simd_cast::<simd::u32x2, simd::f64x2>(simd_shuffle2!(
         a.as_u32x4(),
         a.as_u32x4(),
         [0, 1],


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/stdarch/pull/1160.
Looks like very recently, more users of `simd_shuffle` were added, and thus evaded my grepping for them previously... hopefully this is all of them now. :)