### PR TITLE
Use `#![feature(const_panic)]` to produce better assertion errors

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -7,6 +7,7 @@
     asm,
     const_fn_union,
     const_fn_transmute,
+    const_panic,
     custom_inner_attributes,
     link_llvm_intrinsics,
     platform_intrinsics,

--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -71,7 +71,7 @@ macro_rules! static_assert {
         struct Validate<const $imm: $ty>();
         impl<const $imm: $ty> Validate<$imm> {
             const VALID: () = {
-                assert!($e, "Assertion failed");
+                assert!($e, concat!("Assertion failed: ", stringify!($e)));
             };
         }
         let _ = Validate::<$imm>::VALID;

--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -5,7 +5,7 @@
 pub(crate) struct ValidateConstImm<const IMM: i32, const MIN: i32, const MAX: i32>;
 impl<const IMM: i32, const MIN: i32, const MAX: i32> ValidateConstImm<IMM, MIN, MAX> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
+        assert!(IMM >= MIN && IMM <= MAX, "IMM value not in expected range");
     };
 }
 
@@ -71,7 +71,7 @@ macro_rules! static_assert {
         struct Validate<const $imm: $ty>();
         impl<const $imm: $ty> Validate<$imm> {
             const VALID: () = {
-                let _ = 1 / ($e as usize);
+                assert!($e, "Assertion failed");
             };
         }
         let _ = Validate::<$imm>::VALID;

--- a/crates/core_arch/src/x86/macros.rs
+++ b/crates/core_arch/src/x86/macros.rs
@@ -5,7 +5,7 @@
 pub(crate) struct ValidateConstRound<const IMM: i32>;
 impl<const IMM: i32> ValidateConstRound<IMM> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM == 4 || IMM == 8 || IMM == 9 || IMM == 10 || IMM == 11) as usize);
+        assert!(IMM == 4 || IMM == 8 || IMM == 9 || IMM == 10 || IMM == 11, "Invalid IMM value");
     };
 }
 
@@ -21,7 +21,7 @@ macro_rules! static_assert_rounding {
 pub(crate) struct ValidateConstSae<const IMM: i32>;
 impl<const IMM: i32> ValidateConstSae<IMM> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM == 4 || IMM == 8) as usize);
+        assert!(IMM == 4 || IMM == 8, "Invalid IMM value");
     };
 }
 
@@ -37,7 +37,7 @@ macro_rules! static_assert_sae {
 pub(crate) struct ValidateConstMantissasSae<const IMM: i32>;
 impl<const IMM: i32> ValidateConstMantissasSae<IMM> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM == 4 || IMM == 8 || IMM == 12) as usize);
+        assert!(IMM == 4 || IMM == 8 || IMM == 12, "Invalid IMM value");
     };
 }
 
@@ -53,7 +53,7 @@ macro_rules! static_assert_mantissas_sae {
 pub(crate) struct ValidateConstImmU32<const IMM: u32, const MIN: u32, const MAX: u32>;
 impl<const IMM: u32, const MIN: u32, const MAX: u32> ValidateConstImmU32<IMM, MIN, MAX> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM >= MIN && IMM <= MAX) as usize);
+        assert!(IMM >= MIN && IMM <= MAX, "IMM value not in expected range");
     };
 }
 
@@ -70,7 +70,7 @@ macro_rules! static_assert_imm_u8 {
 pub(crate) struct ValidateConstGatherScale<const SCALE: i32>;
 impl<const SCALE: i32> ValidateConstGatherScale<SCALE> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((SCALE == 1 || SCALE == 2 || SCALE == 4 || SCALE == 8) as usize);
+        assert!(SCALE == 1 || SCALE == 2 || SCALE == 4 || SCALE == 8, "Invalid SCALE value");
     };
 }
 

--- a/crates/core_arch/src/x86_64/macros.rs
+++ b/crates/core_arch/src/x86_64/macros.rs
@@ -5,7 +5,7 @@
 pub(crate) struct ValidateConstRound<const IMM: i32>;
 impl<const IMM: i32> ValidateConstRound<IMM> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM == 4 || IMM == 8 || IMM == 9 || IMM == 10 || IMM == 11) as usize);
+        assert!(IMM == 4 || IMM == 8 || IMM == 9 || IMM == 10 || IMM == 11, "Invalid IMM value");
     };
 }
 
@@ -21,7 +21,7 @@ macro_rules! static_assert_rounding {
 pub(crate) struct ValidateConstSae<const IMM: i32>;
 impl<const IMM: i32> ValidateConstSae<IMM> {
     pub(crate) const VALID: () = {
-        let _ = 1 / ((IMM == 4 || IMM == 8) as usize);
+        assert!(IMM == 4 || IMM == 8, "Invalid IMM value");
     };
 }
 


### PR DESCRIPTION
Currently, `core_arch` uses `1 / (bool_expr as usize)` to generate a
post-monomorphization error when a condition is false. However, this
approach generates opaque error messages
('evaluation of constant value failed'), which could easily be mistaken
for an internal compiler error by users.

Using the `const_panic` feature, we can `panic!()` with a more
descriptive error message. Unfortunately, we cannot include any of the
actual values in our message, since `const` traits do not yet exist.

Helps with https://github.com/rust-lang/rust/issues/85155