### PR TITLE
wasm: Mark most simd intrinsics as safe

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -34,7 +34,6 @@
     adx_target_feature,
     rtm_target_feature,
     f16c_target_feature,
-    external_doc,
     allow_internal_unstable,
     decl_macro,
     bench_black_box


### PR DESCRIPTION
This updates all simd intrinsics to be safe to account for
rust-lang/rust#84988. In the spirit of more safety it also removes the
pervasive usage of `transmute` in the intrinsics in favor of more
targeted casts.