### PR TITLE
Move `asm!` and `global_asm!` to `core::arch`

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -11,6 +11,32 @@ mod simd;
 #[doc = include_str!("core_arch_docs.md")]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
+    /// Inline assembly.
+    ///
+    /// Read the [unstable book] for the usage.
+    ///
+    /// [unstable book]: ../unstable-book/library-features/asm.html
+    #[unstable(
+        feature = "asm",
+        issue = "72016",
+        reason = "inline assembly is not stable enough for use and is subject to change"
+    )]
+    #[rustc_builtin_macro]
+    pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
+        /* compiler built-in */
+    }
+
+    /// Module-level inline assembly.
+    #[unstable(
+        feature = "global_asm",
+        issue = "35119",
+        reason = "`global_asm!` is not stable enough for use and is subject to change"
+    )]
+    #[rustc_builtin_macro]
+    pub macro global_asm("assembly template", $(operands,)* $(options($(option),*))?) {
+        /* compiler built-in */
+    }
+
     /// Platform-specific intrinsics for the `x86` platform.
     ///
     /// See the [module documentation](../index.html) for more details.


### PR DESCRIPTION
Implements the first part of the libs team decision given at https://github.com/rust-lang/rust/issues/84019#issuecomment-875880229 .

The first step is to define these items in stdarch. Once this PR is accepted, I have another patch prepared for the Rust repo that will simultaneously remove the definitions in libcore and bump the stdarch submodule.

cc @Amanieu 