### PR TITLE
Revert "Move `asm!` and `global_asm!` to `core::arch` (#1183)"

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -11,32 +11,6 @@ mod simd;
 #[doc = include_str!("core_arch_docs.md")]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
-    /// Inline assembly.
-    ///
-    /// Read the [unstable book] for the usage.
-    ///
-    /// [unstable book]: ../unstable-book/library-features/asm.html
-    #[unstable(
-        feature = "asm",
-        issue = "72016",
-        reason = "inline assembly is not stable enough for use and is subject to change"
-    )]
-    #[rustc_builtin_macro]
-    pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
-        /* compiler built-in */
-    }
-
-    /// Module-level inline assembly.
-    #[unstable(
-        feature = "global_asm",
-        issue = "35119",
-        reason = "`global_asm!` is not stable enough for use and is subject to change"
-    )]
-    #[rustc_builtin_macro]
-    pub macro global_asm("assembly template", $(operands,)* $(options($(option),*))?) {
-        /* compiler built-in */
-    }
-
     /// Platform-specific intrinsics for the `x86` platform.
     ///
     /// See the [module documentation](../index.html) for more details.


### PR DESCRIPTION
This reverts commit 9437b11cd4f42c5995eb41aa92ead877b9b7823a.

With some experimentation we've concluded that instead of forcing these macros to be defined in the stdarch repo, there are benefits to having it defined in a facade `arch` module inside of libcore itself.