### PR TITLE
mark core::arch::wasm32::unreachable as safe

### DIFF
--- a/crates/core_arch/src/wasm32/mod.rs
+++ b/crates/core_arch/src/wasm32/mod.rs
@@ -12,10 +12,15 @@ pub use self::simd128::*;
 mod memory;
 pub use self::memory::*;
 
-/// Generates the trap instruction `UNREACHABLE`
+/// Generates the [`unreachable`] instruction, which causes an unconditional [trap].
+///
+/// This function is safe to call and immediately aborts the execution.
+///
+/// [`unreachable`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-control
+/// [trap]: https://webassembly.github.io/spec/core/intro/overview.html#trap
 #[cfg_attr(test, assert_instr(unreachable))]
 #[inline]
 #[stable(feature = "unreachable_wasm32", since = "1.37.0")]
-pub unsafe fn unreachable() -> ! {
+pub fn unreachable() -> ! {
     crate::intrinsics::abort()
 }


### PR DESCRIPTION
This intrinsic doesn't have any preconditions and is always safe to
call, so it can be safe.

This function is already stable, but dropping `unsafe` is a backwards
compatible change.

Note tha we already have a precedent for wasm intrinsics being safe --
wasm simd is safe.

It is relatively practically important to mark this safe --
wasm32::unreachable is directly useful in practice as more codesize
efficient `panic!()`.