### PR TITLE
Remove references to the crates on crates.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,33 +8,11 @@ stdarch - Rust's standard library SIMD components
 
 This repository contains two main crates:
 
-* [![core_arch_crate_badge]][core_arch_crate_link]
-  [![core_arch_docs_badge]][core_arch_docs_link]
-  [`core_arch`](crates/core_arch/README.md) implements `core::arch` - Rust's
+* [`core_arch`](crates/core_arch/README.md) implements `core::arch` - Rust's
   core library architecture-specific intrinsics, and
   
-* [![std_detect_crate_badge]][std_detect_crate_link]
-  [![std_detect_docs_badge]][std_detect_docs_link]
-  [`std_detect`](crates/std_detect/README.md) implements `std::detect` - Rust's
+* [`std_detect`](crates/std_detect/README.md) implements `std::detect` - Rust's
   standard library run-time CPU feature detection.
 
 The `std::simd` component now lives in the
 [`packed_simd`](https://github.com/rust-lang-nursery/packed_simd) crate.
-
-# How to do a release
-
-To do a release of the `core_arch` and `std_detect` crates, 
-
-* bump up the version appropriately,
-* comment out the `dev-dependencies` in their `Cargo.toml` files (due to
-  https://github.com/rust-lang/cargo/issues/4242),
-* publish the crates.
-
-[core_arch_crate_badge]: https://img.shields.io/crates/v/core_arch.svg
-[core_arch_crate_link]: https://crates.io/crates/core_arch
-[core_arch_docs_badge]: https://docs.rs/core_arch/badge.svg
-[core_arch_docs_link]: https://docs.rs/core_arch/
-[std_detect_crate_badge]: https://img.shields.io/crates/v/std_detect.svg
-[std_detect_crate_link]: https://crates.io/crates/std_detect
-[std_detect_docs_badge]: https://docs.rs/std_detect/badge.svg
-[std_detect_docs_link]: https://docs.rs/std_detect/

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
 ]
 description = "`core::arch` - Rust's core library architecture-specific intrinsics."
-documentation = "https://docs.rs/core_arch"
 homepage = "https://github.com/rust-lang/stdarch"
 repository = "https://github.com/rust-lang/stdarch"
 readme = "README.md"

--- a/crates/core_arch/README.md
+++ b/crates/core_arch/README.md
@@ -1,9 +1,6 @@
 `core::arch` - Rust's core library architecture-specific intrinsics
 =======
 
-[![core_arch_crate_badge]][core_arch_crate_link] [![core_arch_docs_badge]][core_arch_docs_link]
-
-
 The `core::arch` module implements architecture-dependent intrinsics (e.g. SIMD).
 
 # Usage 
@@ -61,8 +58,3 @@ See LICENSE-APACHE, and LICENSE-MIT for details.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `core_arch` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
-
-[core_arch_crate_badge]: https://img.shields.io/crates/v/core_arch.svg
-[core_arch_crate_link]: https://crates.io/crates/core_arch
-[core_arch_docs_badge]: https://docs.rs/core_arch/badge.svg
-[core_arch_docs_link]: https://docs.rs/core_arch/

--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
 ]
 description = "`std::detect` - Rust's standard library run-time CPU feature detection."
-documentation = "https://docs.rs/std_detect"
 homepage = "https://github.com/rust-lang/stdarch"
 repository = "https://github.com/rust-lang/stdarch"
 readme = "README.md"

--- a/crates/std_detect/README.md
+++ b/crates/std_detect/README.md
@@ -1,9 +1,6 @@
 `std::detect` - Rust's standard library run-time CPU feature detection
 =======
 
-[![std_detect_crate_badge]][std_detect_crate_link] [![std_detect_docs_badge]][std_detect_docs_link]
-
-
 The private `std::detect` module implements run-time feature detection in Rust's
 standard library. This allows detecting whether the CPU the binary runs on
 supports certain features, like SIMD instructions.
@@ -74,8 +71,3 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `std_detect` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
-
-[std_detect_crate_badge]: https://img.shields.io/crates/v/std_detect.svg
-[std_detect_crate_link]: https://crates.io/crates/std_detect
-[std_detect_docs_badge]: https://docs.rs/std_detect/badge.svg
-[std_detect_docs_link]: https://docs.rs/std_detect/


### PR DESCRIPTION
They haven't been published in years. This removes the suggestion that the crates on crates.io are actively updated/maintained.