### PR TITLE
Typo fix: "it's purpose" -> "its purpose"

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -300,7 +300,7 @@ types! {
     /// 128-bit wide set of eight 'u16' types, x86-specific
     ///
     /// This type is representing a 128-bit SIMD register which internally is consisted of
-    /// eight packed `u16` instances. It's purpose is for bf16 related intrinsic
+    /// eight packed `u16` instances. Its purpose is for bf16 related intrinsic
     /// implementations.
     pub struct __m128bh(u16, u16, u16, u16, u16, u16, u16, u16);
 
@@ -308,7 +308,7 @@ types! {
     ///
     /// This type is the same as the `__m128bh` type defined by Intel,
     /// representing a 256-bit SIMD register which internally is consisted of
-    /// 16 packed `u16` instances. It's purpose is for bf16 related intrinsic
+    /// 16 packed `u16` instances. Its purpose is for bf16 related intrinsic
     /// implementations.
     pub struct __m256bh(
         u16, u16, u16, u16, u16, u16, u16, u16,
@@ -319,7 +319,7 @@ types! {
     ///
     /// This type is the same as the `__m128bh` type defined by Intel,
     /// representing a 512-bit SIMD register which internally is consisted of
-    /// 32 packed `u16` instances. It's purpose is for bf16 related intrinsic
+    /// 32 packed `u16` instances. Its purpose is for bf16 related intrinsic
     /// implementations.
     pub struct __m512bh(
         u16, u16, u16, u16, u16, u16, u16, u16,


### PR DESCRIPTION
:wave: 

Everything in the title.