### PR TITLE
Fix typos “a”→“an”

### DIFF
--- a/crates/core_arch/src/arm/ex.rs
+++ b/crates/core_arch/src/arm/ex.rs
@@ -19,7 +19,7 @@ pub unsafe fn __clrex() {
     clrex()
 }
 
-/// Executes a exclusive LDR instruction for 8 bit value.
+/// Executes an exclusive LDR instruction for 8 bit value.
 // Supported: v6K, v7-M, v7-A, v7-R
 // Not supported: v5, v6, v6-M
 #[cfg(any(
@@ -35,7 +35,7 @@ pub unsafe fn __ldrexb(p: *const u8) -> u8 {
     ldrex8(p) as u8
 }
 
-/// Executes a exclusive LDR instruction for 16 bit value.
+/// Executes an exclusive LDR instruction for 16 bit value.
 // Supported: v6K, v7-M, v7-A, v7-R, v8
 // Not supported: v5, v6, v6-M
 #[cfg(any(
@@ -51,7 +51,7 @@ pub unsafe fn __ldrexh(p: *const u16) -> u16 {
     ldrex16(p) as u16
 }
 
-/// Executes a exclusive LDR instruction for 32 bit value.
+/// Executes an exclusive LDR instruction for 32 bit value.
 // Supported: v6, v7-M, v6K, v7-A, v7-R, v8
 // Not supported: v5, v6-M
 #[cfg(any(
@@ -68,7 +68,7 @@ pub unsafe fn __ldrex(p: *const u32) -> u32 {
     ldrex32(p)
 }
 
-/// Executes a exclusive STR instruction for 8 bit values
+/// Executes an exclusive STR instruction for 8 bit values
 ///
 /// Returns `0` if the operation succeeded, or `1` if it failed
 // supported: v6K, v7-M, v7-A, v7-R
@@ -86,7 +86,7 @@ pub unsafe fn __strexb(value: u32, addr: *mut u8) -> u32 {
     strex8(value, addr)
 }
 
-/// Executes a exclusive STR instruction for 16 bit values
+/// Executes an exclusive STR instruction for 16 bit values
 ///
 /// Returns `0` if the operation succeeded, or `1` if it failed
 // Supported: v6K, v7-M, v7-A, v7-R, v8
@@ -105,7 +105,7 @@ pub unsafe fn __strexh(value: u16, addr: *mut u16) -> u32 {
     strex16(value as u32, addr)
 }
 
-/// Executes a exclusive STR instruction for 32 bit values
+/// Executes an exclusive STR instruction for 32 bit values
 ///
 /// Returns `0` if the operation succeeded, or `1` if it failed
 // Supported: v6, v7-M, v6K, v7-A, v7-R, v8

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1000,7 +1000,7 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shuffle_ps)
 ///
 /// Note that there appears to be a mistake within Intel's Intrinsics Guide.
-/// `_mm_shuffle_ps` is supposed to take an `i32` instead of an `u32`
+/// `_mm_shuffle_ps` is supposed to take an `i32` instead of a `u32`
 /// as is the case for [other shuffle intrinsics](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shuffle_).
 /// Performing an implicit type conversion between an unsigned integer and a signed integer
 /// does not cause a problem in C, however Rust's commitment to strong typing does not allow this.

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -2,7 +2,7 @@
 //!
 //! The features are detected using the `detect_features` function below.
 //! This function uses the CPUID instruction to read the feature flags from the
-//! CPU and encodes them in an `usize` where each bit position represents
+//! CPU and encodes them in a `usize` where each bit position represents
 //! whether a feature is available (bit is set) or unavaiable (bit is cleared).
 //!
 //! The enum `Feature` is used to map bit positions to feature names, and the


### PR DESCRIPTION
See rust-lang/rust#88230