### PR TITLE
Use LLVM objdump on Macos instead of otool for CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,9 +138,8 @@ jobs:
           norun: true
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
-        # Temporarily disabled because otool crashes with "Out of memory", seems Github CI issue
-        #- target: x86_64-apple-darwin
-        #  os: macos-latest
+        - target: x86_64-apple-darwin
+          os: macos-11
         - target: x86_64-pc-windows-msvc
           os: windows-latest
         - target: i686-pc-windows-msvc

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -125,16 +125,7 @@ fn parse(output: &str) -> HashSet<Function> {
                 cached_header = None;
                 break;
             }
-            let parts = if cfg!(target_os = "macos") {
-                // Each line of instructions should look like:
-                //
-                //      $addr    $instruction...
-                instruction
-                    .split_whitespace()
-                    .skip(1)
-                    .map(std::string::ToString::to_string)
-                    .collect::<Vec<String>>()
-            } else if cfg!(target_env = "msvc") {
+            let parts = if cfg!(target_env = "msvc") {
                 // Each line looks like:
                 //
                 // >  $addr: ab cd ef     $instr..

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -71,7 +71,7 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
         let objdump = env::var("OBJDUMP").unwrap_or_else(|_| "objdump".to_string());
         let add_args = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
             // Target features need to be enabled for LLVM objdump on Macos ARM64
-            vec!["--mattr=+crc,+crypto,+tme"]
+            vec!["--mattr=+v8.6a,+crypto,+tme"]
         } else {
             vec![]
         };

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -67,6 +67,24 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
         String::from_utf8_lossy(Vec::leak(output.stdout))
     } else if cfg!(target_os = "windows") {
         panic!("disassembly unimplemented")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        // use LLVM objdump because it is not possible to enable TME support with otool
+        let objdump = env::var("OBJDUMP").unwrap_or_else(|_| "objdump".to_string());
+        let output = Command::new(objdump.clone())
+            .arg("--disassemble")
+            .arg("--no-show-raw-insn")
+            .arg("--mattr=+crc,+crypto,+tme")
+            .arg(&me)
+            .output()
+            .unwrap_or_else(|_| panic!("failed to execute objdump. OBJDUMP={}", objdump));
+        println!(
+            "{}\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.status.success());
+
+        String::from_utf8_lossy(Vec::leak(output.stdout))
     } else if cfg!(target_os = "macos") {
         let output = Command::new("otool")
             .arg("-vt")


### PR DESCRIPTION
Enabling target features is not possible with otool. Setting a target CPU is possible but the Transactional Memory Extension (TME) is not supported by any CPU yet so that does not help. LLVM objdump is installed with the developer tools out of the box and can be used instead.

Edit: Now uses LLVM objdump for x86_64 as well.