### PR TITLE
Use a lighter dedup guard in the assert_instr test shims.

### DIFF
--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -58,6 +58,10 @@ pub fn assert_instr(
         &format!("stdarch_test_shim_{}_{}", name, instr_str),
         name.span(),
     );
+    let shim_name_ptr = syn::Ident::new(
+        &format!("stdarch_test_shim_{}_{}_ptr", name, instr_str).to_ascii_uppercase(),
+        name.span(),
+    );
     let mut inputs = Vec::new();
     let mut input_vals = Vec::new();
     let mut const_vals = Vec::new();
@@ -125,6 +129,9 @@ pub fn assert_instr(
     };
     let shim_name_str = format!("{}{}", shim_name, assert_name);
     let to_test = quote! {
+
+        const #shim_name_ptr : *const u8 = #shim_name_str.as_ptr();
+
         #attrs
         #[no_mangle]
         #[inline(never)]
@@ -140,17 +147,7 @@ pub fn assert_instr(
             // generate some code that's hopefully very tight in terms of
             // codegen but is otherwise unique to prevent code from being
             // folded.
-            //
-            // This is avoided on Wasm32 right now since these functions aren't
-            // inlined which breaks our tests since each intrinsic looks like it
-            // calls functions. Turns out functions aren't similar enough to get
-            // merged on wasm32 anyway. This bug is tracked at
-            // rust-lang/rust#74320.
-            #[cfg(not(target_arch = "wasm32"))]
-            ::stdarch_test::_DONT_DEDUP.store(
-                std::mem::transmute(#shim_name_str.as_bytes().as_ptr()),
-                std::sync::atomic::Ordering::Relaxed,
-            );
+            ::stdarch_test::_DONT_DEDUP = #shim_name_ptr;
             #name::<#(#const_vals),*>(#(#input_vals),*)
         }
     };

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -103,7 +103,7 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
             // failed inlining something.
             s[0].starts_with("call ") && s[1].starts_with("pop") // FIXME: original logic but does not match comment
         })
-    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm") {
+    } else if cfg!(target_arch = "aarch64") {
         instrs.iter().any(|s| s.starts_with("bl "))
     } else {
         // FIXME: Add detection for other archs

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -14,7 +14,7 @@ extern crate cfg_if;
 
 pub use assert_instr_macro::*;
 pub use simd_test_macro::*;
-use std::{cmp, collections::HashSet, env, hash, hint::black_box, str, sync::atomic::AtomicPtr};
+use std::{cmp, collections::HashSet, env, hash, hint::black_box, str};
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
@@ -103,7 +103,7 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
             // failed inlining something.
             s[0].starts_with("call ") && s[1].starts_with("pop") // FIXME: original logic but does not match comment
         })
-    } else if cfg!(target_arch = "aarch64") {
+    } else if cfg!(target_arch = "aarch64") || cfg!(target_arch = "arm") {
         instrs.iter().any(|s| s.starts_with("bl "))
     } else {
         // FIXME: Add detection for other archs
@@ -189,4 +189,4 @@ pub fn assert_skip_test_ok(name: &str) {
 }
 
 // See comment in `assert-instr-macro` crate for why this exists
-pub static _DONT_DEDUP: AtomicPtr<u8> = AtomicPtr::new(b"".as_ptr() as *mut _);
+pub static mut _DONT_DEDUP: *const u8 = std::ptr::null();


### PR DESCRIPTION
The dedup guard currently used in the `assert_instr` shims is sometimes compiled to function calls on arm, the new one should also prevent LLVM from merging functions and is never compiled to a function call.

First PR towards implementing inlining checks for arm (#1210).