### PR TITLE
xcode-select no longer necessary on action runners.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,6 @@ jobs:
       if: "!endsWith(matrix.target, 'emulated')"
     - name: Setup (aarch64-apple-darwin)
       run: |
-        sudo xcode-select -s /Applications/Xcode_12.2.app/
         echo "SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)" >> $GITHUB_ENV
         echo "MACOS_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)" >> $GITHUB_ENV
       if: matrix.target == 'aarch64-apple-darwin'


### PR DESCRIPTION
The `macos-latest`action runners have been migrated to macos-11, which does not have `/Applications/Xcode_12.2.app/`. It makes sense to just default to the default Xcode so I am removing it completely.