### PR TITLE
Fix error message of is_*_feature_detected on nort_feature

### DIFF
--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -25,7 +25,7 @@ macro_rules! features {
                 ($nort_feature) => {
                     compile_error!(
                         concat!(
-                            stringify!(nort_feature),
+                            stringify!($nort_feature),
                             " feature cannot be detected at run-time"
                         )
                     )


### PR DESCRIPTION
In the current master, when the feature that cannot be detected at run-time is specified, "nort_feature feature" is mentioned instead of the specified feature name.

Code:
```rs
#![feature(stdsimd, arm_target_feature)]

fn f() {
    let _ = is_arm_feature_detected!("v7");
}
```

Command:
```
cross build --target arm-unknown-linux-gnueabi
```

Error(master):
```
error: nort_feature feature cannot be detected at run-time
```

Error(this PR):
```
error: "v7" feature cannot be detected at run-time
```