### PR TITLE
Add a rudimentary `wasm64` module with intrinsics

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -162,6 +162,17 @@ pub mod arch {
         pub use crate::core_arch::wasm32::*;
     }
 
+    /// Platform-specific intrinsics for the `wasm64` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(any(target_arch = "wasm64", doc))]
+    #[doc(cfg(target_arch = "wasm64"))]
+    #[stable(feature = "simd_wasm32", since = "1.33.0")]
+    pub mod wasm64 {
+        #[stable(feature = "simd_wasm32", since = "1.33.0")]
+        pub use crate::core_arch::wasm32::*;
+    }
+
     /// Platform-specific intrinsics for the `mips` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
@@ -229,8 +240,8 @@ mod aarch64;
 #[doc(cfg(any(target_arch = "arm")))]
 mod arm;
 
-#[cfg(any(target_arch = "wasm32", doc))]
-#[doc(cfg(target_arch = "wasm32"))]
+#[cfg(any(target_arch = "wasm32", target_arch = "wasm64", doc))]
+#[doc(cfg(any(target_arch = "wasm32", target_arch = "wasm64")))]
 mod wasm32;
 
 #[cfg(any(target_arch = "mips", target_arch = "mips64", doc))]

--- a/crates/core_arch/src/wasm32/memory.rs
+++ b/crates/core_arch/src/wasm32/memory.rs
@@ -2,10 +2,10 @@
 use stdarch_test::assert_instr;
 
 extern "C" {
-    #[link_name = "llvm.wasm.memory.grow.i32"]
-    fn llvm_memory_grow(mem: u32, pages: i32) -> i32;
-    #[link_name = "llvm.wasm.memory.size.i32"]
-    fn llvm_memory_size(mem: u32) -> i32;
+    #[link_name = "llvm.wasm.memory.grow"]
+    fn llvm_memory_grow(mem: u32, pages: usize) -> usize;
+    #[link_name = "llvm.wasm.memory.size"]
+    fn llvm_memory_size(mem: u32) -> usize;
 }
 
 /// Corresponding intrinsic to wasm's [`memory.size` instruction][instr]
@@ -27,7 +27,7 @@ extern "C" {
 #[doc(alias("memory.size"))]
 pub fn memory_size<const MEM: u32>() -> usize {
     static_assert!(MEM: u32 where MEM == 0);
-    unsafe { llvm_memory_size(MEM) as usize }
+    unsafe { llvm_memory_size(MEM) }
 }
 
 /// Corresponding intrinsic to wasm's [`memory.grow` instruction][instr]
@@ -53,6 +53,6 @@ pub fn memory_size<const MEM: u32>() -> usize {
 pub fn memory_grow<const MEM: u32>(delta: usize) -> usize {
     unsafe {
         static_assert!(MEM: u32 where MEM == 0);
-        llvm_memory_grow(MEM, delta as i32) as isize as usize
+        llvm_memory_grow(MEM, delta)
     }
 }


### PR DESCRIPTION
This follows the x86/x86_64 pattern where `wasm64` simply reexports the
`wasm32` module for now. The documentation is pretty lacking since this
is just the start as well.