### PR TITLE
expose `wasm` intrinsics using `target_family = "wasm"`

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -172,6 +172,17 @@ pub mod arch {
         #[stable(feature = "simd_wasm32", since = "1.33.0")]
         pub use crate::core_arch::wasm32::*;
     }
+    
+    /// Platform-specific intrinsics for the `wasm` target family.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(any(target_family = "wasm", doc))]
+    #[doc(cfg(target_family = "wasm"))]
+    #[stable(feature = "simd_wasm32", since = "1.33.0")]
+    pub mod wasm {
+        #[stable(feature = "simd_wasm32", since = "1.33.0")]
+        pub use crate::core_arch::wasm32::*;
+    }
 
     /// Platform-specific intrinsics for the `mips` platform.
     ///
@@ -240,8 +251,8 @@ mod aarch64;
 #[doc(cfg(any(target_arch = "arm")))]
 mod arm;
 
-#[cfg(any(target_arch = "wasm32", target_arch = "wasm64", doc))]
-#[doc(cfg(any(target_arch = "wasm32", target_arch = "wasm64")))]
+#[cfg(any(target_family = "wasm", doc))]
+#[doc(cfg(target_family = "wasm"))]
 mod wasm32;
 
 #[cfg(any(target_arch = "mips", target_arch = "mips64", doc))]

--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -172,7 +172,7 @@ pub mod arch {
         #[stable(feature = "simd_wasm32", since = "1.33.0")]
         pub use crate::core_arch::wasm32::*;
     }
-    
+
     /// Platform-specific intrinsics for the `wasm` target family.
     ///
     /// See the [module documentation](../index.html) for more details.


### PR DESCRIPTION
I think it should be idiomatic to use `target_family = "wasm"` instead of `target_arch = "wasmNN"`, so we encourage the ecosystem to write code that works for both. This makes it easier to do that by exporting a `wasm` in addition to `wasm32` and `wasm64`.