### PR TITLE
Fix parsing a doc block for `_mm_extract_ps`

### DIFF
--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -146,14 +146,14 @@ pub unsafe fn _mm_blend_ps<const IMM4: i32>(a: __m128, b: __m128) -> __m128 {
 ///
 /// # Example
 /// ```rust
-/// #[cfg(target_arch = "x86")]
-/// #use std::arch::x86::*;
-/// #[cfg(target_arch = "x86_64")]
-/// #use std::arch::x86_64::*;
-/// #fn main() {
+/// # #[cfg(target_arch = "x86")]
+/// # use std::arch::x86::*;
+/// # #[cfg(target_arch = "x86_64")]
+/// # use std::arch::x86_64::*;
+/// # fn main() {
 /// #    if is_x86_feature_detected!("sse4.1") {
-/// #        #[target_feature(enable = "sse4.1")]
-/// #        unsafe fn worker() {
+/// #       #[target_feature(enable = "sse4.1")]
+/// #       unsafe fn worker() {
 /// let mut float_store = vec![1.0, 1.0, 2.0, 3.0];
 /// unsafe {
 ///     let simd_floats = _mm_set_ps(2.5, 5.0, 7.5, 10.0);
@@ -161,9 +161,10 @@ pub unsafe fn _mm_blend_ps<const IMM4: i32>(a: __m128, b: __m128) -> __m128 {
 ///     float_store.push(f32::from_bits(x as u32));
 /// }
 /// assert_eq!(float_store, vec![1.0, 1.0, 2.0, 3.0, 5.0]);
-/// #        }
-/// #    unsafe { worker() }
-/// #}
+/// #       }
+/// #       unsafe { worker() }
+/// #   }
+/// # }
 /// ```
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_extract_ps)
 #[inline]


### PR DESCRIPTION
Came up during
https://github.com/rust-lang/rust/runs/4068713521?check_suite_focus=true