### PR TITLE
Remove unnecessary stability attribute

### DIFF
--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -54,7 +54,6 @@ macro_rules! conversions {
         $(
             impl $ty {
                 #[inline(always)]
-                #[rustc_const_stable(feature = "wasm_simd_const", since = "1.56.0")]
                 const fn v128(self) -> v128 {
                     unsafe { mem::transmute(self) }
                 }


### PR DESCRIPTION
This was caught when creating an internal rustc lint: rust-lang/rust#90356. As this method is not `pub`, it does not need a stability attribute.