### PR TITLE
Remove documentation for std_detect error_macros

### DIFF
--- a/crates/std_detect/src/detect/error_macros.rs
+++ b/crates/std_detect/src/detect/error_macros.rs
@@ -2,8 +2,8 @@
 //! architecture. These macros provide a better error messages when the user
 //! attempts to call them in a different architecture.
 
-/// Prevents compilation if `is_x86_feature_detected` is used somewhere
-/// else than `x86` and `x86_64` targets.
+// Prevents compilation if `is_x86_feature_detected` is used somewhere
+// else than `x86` and `x86_64` targets.
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]
@@ -23,8 +23,8 @@ macro_rules! is_x86_feature_detected {
     };
 }
 
-/// Prevents compilation if `is_arm_feature_detected` is used somewhere else
-/// than `ARM` targets.
+// Prevents compilation if `is_arm_feature_detected` is used somewhere else
+// than `ARM` targets.
 #[cfg(not(target_arch = "arm"))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]
@@ -44,8 +44,8 @@ macro_rules! is_arm_feature_detected {
     };
 }
 
-/// Prevents compilation if `is_aarch64_feature_detected` is used somewhere else
-/// than `aarch64` targets.
+// Prevents compilation if `is_aarch64_feature_detected` is used somewhere else
+// than `aarch64` targets.
 #[cfg(not(target_arch = "aarch64"))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]
@@ -65,8 +65,8 @@ macro_rules! is_aarch64_feature_detected {
     };
 }
 
-/// Prevents compilation if `is_powerpc_feature_detected` is used somewhere else
-/// than `PowerPC` targets.
+// Prevents compilation if `is_powerpc_feature_detected` is used somewhere else
+// than `PowerPC` targets.
 #[cfg(not(target_arch = "powerpc"))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]
@@ -86,8 +86,8 @@ guarding it behind a cfg(target_arch) as follows:
     };
 }
 
-/// Prevents compilation if `is_powerpc64_feature_detected` is used somewhere
-/// else than `PowerPC64` targets.
+// Prevents compilation if `is_powerpc64_feature_detected` is used somewhere
+// else than `PowerPC64` targets.
 #[cfg(not(target_arch = "powerpc64"))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]
@@ -107,8 +107,8 @@ guarding it behind a cfg(target_arch) as follows:
     };
 }
 
-/// Prevents compilation if `is_mips_feature_detected` is used somewhere else
-/// than `MIPS` targets.
+// Prevents compilation if `is_mips_feature_detected` is used somewhere else
+// than `MIPS` targets.
 #[cfg(not(target_arch = "mips"))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]
@@ -128,8 +128,8 @@ macro_rules! is_mips_feature_detected {
     };
 }
 
-/// Prevents compilation if `is_mips64_feature_detected` is used somewhere else
-/// than `MIPS64` targets.
+// Prevents compilation if `is_mips64_feature_detected` is used somewhere else
+// than `MIPS64` targets.
 #[cfg(not(target_arch = "mips64"))]
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "27731")]


### PR DESCRIPTION
These comments show up when there's proper documentation for the runtime feature detection macros, such as here: https://doc.rust-lang.org/nightly/std/macro.is_aarch64_feature_detected.html

The messages also make no sense from an API user's perspective.