### PR TITLE
Fix unused link_name attribute.

### DIFF
--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -498,8 +498,8 @@ extern "C" {
     fn msa_fexp2_w(a: v4f32, b: v4i32) -> v4f32;
     #[link_name = "llvm.mips.fexp2.d"]
     fn msa_fexp2_d(a: v2f64, b: v2i64) -> v2f64;
-    #[link_name = "llvm.mips.fexupl.w"]
     // FIXME: 16-bit floats
+    // #[link_name = "llvm.mips.fexupl.w"]
     // fn msa_fexupl_w(a: f16x8) -> v4f32;
     #[link_name = "llvm.mips.fexupl.d"]
     fn msa_fexupl_d(a: v4f32) -> v2f64;


### PR DESCRIPTION
It looks like there was a mistake commenting out this function, which left an unused attribute. 

Unblocks https://github.com/rust-lang/rust/pull/88681 which is extending the unused_attributes lint to catch more situations.