### PR TITLE
Fix _mm_extract_ps example.

### DIFF
--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -155,11 +155,9 @@ pub unsafe fn _mm_blend_ps<const IMM4: i32>(a: __m128, b: __m128) -> __m128 {
 /// #       #[target_feature(enable = "sse4.1")]
 /// #       unsafe fn worker() {
 /// let mut float_store = vec![1.0, 1.0, 2.0, 3.0];
-/// unsafe {
-///     let simd_floats = _mm_set_ps(2.5, 5.0, 7.5, 10.0);
-///     let x: i32 = _mm_extract_ps::<2>(simd_floats);
-///     float_store.push(f32::from_bits(x as u32));
-/// }
+/// let simd_floats = _mm_set_ps(2.5, 5.0, 7.5, 10.0);
+/// let x: i32 = _mm_extract_ps::<2>(simd_floats);
+/// float_store.push(f32::from_bits(x as u32));
 /// assert_eq!(float_store, vec![1.0, 1.0, 2.0, 3.0, 5.0]);
 /// #       }
 /// #       unsafe { worker() }


### PR DESCRIPTION
The example fails when run with rustdoc since this crate denies warnings. The test has an unneeded `unsafe` block which triggers `unused_unsafe`.

This normally doesn't show up in CI since it requires testing with a `-C target-cpu` that has sse4.1.
