### PR TITLE
Add RISC-V platform and PAUSE instruction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
         - arm-unknown-linux-gnueabihf
         - armv7-unknown-linux-gnueabihf
         - aarch64-unknown-linux-gnu
+        - riscv64gc-unknown-linux-gnu
         - powerpc64le-unknown-linux-gnu
         - mips-unknown-linux-gnu
         - mips64-unknown-linux-gnuabi64

--- a/crates/core_arch/src/core_arch_docs.md
+++ b/crates/core_arch/src/core_arch_docs.md
@@ -185,6 +185,7 @@ others at:
 * [`x86_64`]
 * [`arm`]
 * [`aarch64`]
+* [`riscv`]
 * [`mips`]
 * [`mips64`]
 * [`powerpc`]
@@ -196,6 +197,7 @@ others at:
 [`x86_64`]: x86_64/index.html
 [`arm`]: arm/index.html
 [`aarch64`]: aarch64/index.html
+[`riscv`]: riscv/index.html
 [`mips`]: mips/index.html
 [`mips64`]: mips64/index.html
 [`powerpc`]: powerpc/index.html

--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -55,6 +55,16 @@ pub mod arch {
         pub use crate::core_arch::aarch64::*;
     }
 
+    /// Platform-specific intrinsics for the `riscv` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64", doc))]
+    #[doc(cfg(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    #[unstable(feature = "stdsimd", issue = "27731")]
+    pub mod riscv {
+        pub use crate::core_arch::riscv::*;
+    }
+
     /// Platform-specific intrinsics for the `wasm32` platform.
     ///
     /// This module provides intrinsics specific to the WebAssembly
@@ -250,6 +260,10 @@ mod aarch64;
 #[cfg(any(target_arch = "arm", doc))]
 #[doc(cfg(any(target_arch = "arm")))]
 mod arm;
+
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64", doc))]
+#[doc(cfg(any(target_arch = "riscv32", target_arch = "riscv64")))]
+mod riscv;
 
 #[cfg(any(target_family = "wasm", doc))]
 #[doc(cfg(target_family = "wasm"))]

--- a/crates/core_arch/src/riscv/mod.rs
+++ b/crates/core_arch/src/riscv/mod.rs
@@ -1,1 +1,10 @@
 //! RISC-V intrinsics
+
+/// Generates the `PAUSE` instruction
+///
+/// The PAUSE instruction is a HINT that indicates the current hart's rate of instruction retirement
+/// should be temporarily reduced or paused. The duration of its effect must be bounded and may be zero.
+#[inline]
+pub fn pause() {
+    unsafe { asm!(".word 0x0100000F", options(nomem, nostack)) }
+}

--- a/crates/core_arch/src/riscv/mod.rs
+++ b/crates/core_arch/src/riscv/mod.rs
@@ -1,0 +1,1 @@
+//! RISC-V intrinsics


### PR DESCRIPTION
This pull request contains two parts: new RISC-V platform `core::arch` package, and a first platform specific instruction wrapper `pause()` function on RISC-V platform.

As is defined in RISC-V Unprivileged Specification version 20191214-draft (December 1, 2021, with Zihintpause 2.0 Ratified), the PAUSE instruction is defined as follows:

> Chapter 4
> 
> “Zihintpause” Pause Hint, Version 2.0
> 
> The PAUSE instruction is a HINT that indicates the current hart’s rate of instruction retirement
> should be temporarily reduced or paused. The duration of its effect must be bounded and may be
> zero. No architectural state is changed.
> 
> ...
> 
> PAUSE is encoded as a FENCE instruction with pred=W, succ=0, fm=0, rd=x0, and rs1=x0.

This instruction is useful when we need to implement `core::hint::spin_loop()` function for RISC-V platforms.

The function `pause()` is defined unsafe because caller must ensure it's called on RISC-V platforms. As is defined in the Specification, implementation of the corresponding pause instruction varies between platforms, it may be spin loop hint, a no-op or others, but will never throw illegal instruction exception. This instruction does not perform as a memory barrier.

For using `.word`: the `pause` pseudoinstruction would be supported after this LLVM review: [D93019](https://reviews.llvm.org/D93019), by now (if I am correct) I can't write this instruction in current version Rust's `asm!` macro. In case if I'm incorrect or this way is inappropriate, I'd submit this pull request as a draft.