### PR TITLE
Fix avx512f build on x86-32; fix avx512gfni test fail

### DIFF
--- a/crates/core_arch/src/x86/avx512gfni.rs
+++ b/crates/core_arch/src/x86/avx512gfni.rs
@@ -819,7 +819,7 @@ mod tests {
 
         for i in 0..NUM_TEST_ENTRIES {
             left[i] = (i % 256) as u8;
-            right[i] = left[i] * 101;
+            right[i] = left[i].wrapping_mul(101);
             result[i] = mulbyte(left[i], right[i]);
         }
 


### PR DESCRIPTION
This pull request includes:

- Fix rollup failure on https://github.com/rust-lang/rust/pull/91658#issuecomment-988725791
- Fix test fail on avx512gfni extension

Note: after I finished fixes I tested with a CPU that supports avx512gfni. The test failed with:

<details>

```
The failed test cases are:
    core_arch::x86::avx512gfni::tests::test_mm256_gf2p8affine_epi64_epi8
    core_arch::x86::avx512gfni::tests::test_mm256_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm256_mask_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm256_maskz_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm512_gf2p8affine_epi64_epi8
    core_arch::x86::avx512gfni::tests::test_mm512_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm512_mask_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm512_maskz_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm_gf2p8affine_epi64_epi8
    core_arch::x86::avx512gfni::tests::test_mm_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm_mask_gf2p8mul_epi8
    core_arch::x86::avx512gfni::tests::test_mm_maskz_gf2p8mul_epi8
    ---- core_arch::x86::avx512gfni::tests::test_mm256_gf2p8affine_epi64_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm256_gf2p8affine_epi64_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- core_arch::x86::avx512gfni::tests::test_mm256_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm256_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm256_mask_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm256_mask_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm256_maskz_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm256_maskz_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm512_gf2p8affine_epi64_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm512_gf2p8affine_epi64_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm512_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm512_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm512_mask_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm512_mask_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm512_maskz_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm512_maskz_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm_gf2p8affine_epi64_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm_gf2p8affine_epi64_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm_mask_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm_mask_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24

---- core_arch::x86::avx512gfni::tests::test_mm_maskz_gf2p8mul_epi8 stdout ----
thread 'core_arch::x86::avx512gfni::tests::test_mm_maskz_gf2p8mul_epi8' panicked at 'attempt to multiply with overflow', crates\core_arch\src\x86\avx512gfni.rs:822:24
```
</details>

... the cause of this test failure is a multiplication with overflow in test case generating function. I included fix to this function in this pull request.

Please review with error given by https://github.com/rust-lang/rust/pull/91658#issuecomment-988725791. After this pull request is merged, pull request https://github.com/rust-lang/rust/pull/91548 is updated with latest stdarch submodule change.