### PR TITLE
Import the asm! macro from core::arch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,8 @@ jobs:
           os: ubuntu-latest
         - target: thumbv7em-none-eabihf
           os: ubuntu-latest
+        - target: riscv64gc-unknown-linux-gnu
+          os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@master

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:21.10
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc libc6-dev qemu-user ca-certificates \
+        gcc-riscv64-linux-gnu libc6-dev-riscv64-cross \
+        qemu-user
+
+ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc \
+    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="qemu-riscv64 -L /usr/riscv64-linux-gnu" \
+    OBJDUMP=riscv64-linux-gnu-objdump

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -44,6 +44,11 @@ case ${TARGET} in
         export RUSTFLAGS="${RUSTFLAGS} -Ctarget-feature=+neon"
         export TARGET_CFLAGS="-mfpu=vfpv3-d16"
         ;;
+    # Some of our test dependencies use the deprecated `gcc` crates which
+    # doesn't detect RISC-V compilers automatically, so do it manually here.
+    riscv64*)
+        export TARGET_CC="riscv64-linux-gnu-gcc"
+        ;;
 esac
 
 echo "RUSTFLAGS=${RUSTFLAGS}"

--- a/crates/core_arch/src/aarch64/armclang.rs
+++ b/crates/core_arch/src/aarch64/armclang.rs
@@ -19,5 +19,5 @@ use stdarch_test::assert_instr;
 #[rustc_legacy_const_generics(0)]
 pub unsafe fn __breakpoint<const VAL: i32>() {
     static_assert_imm16!(VAL);
-    asm!("brk {}", const VAL);
+    crate::arch::asm!("brk {}", const VAL);
 }

--- a/crates/core_arch/src/arm/armclang.rs
+++ b/crates/core_arch/src/arm/armclang.rs
@@ -31,5 +31,5 @@ use stdarch_test::assert_instr;
 #[rustc_legacy_const_generics(0)]
 pub unsafe fn __breakpoint<const VAL: i32>() {
     static_assert_imm8!(VAL);
-    asm!("bkpt #{}", const VAL);
+    crate::arch::asm!("bkpt #{}", const VAL);
 }

--- a/crates/core_arch/src/arm_shared/barrier/cp15.rs
+++ b/crates/core_arch/src/arm_shared/barrier/cp15.rs
@@ -1,6 +1,8 @@
 // Reference: ARM11 MPCore Processor Technical Reference Manual (ARM DDI 0360E) Section 3.5 "Summary
 // of CP15 instructions"
 
+use crate::arch::asm;
+
 /// Full system is the required shareability domain, reads and writes are the
 /// required access types
 pub struct SY;

--- a/crates/core_arch/src/arm_shared/hints.rs
+++ b/crates/core_arch/src/arm_shared/hints.rs
@@ -77,7 +77,7 @@ pub unsafe fn __yield() {
 /// will increase execution time.
 #[inline(always)]
 pub unsafe fn __nop() {
-    asm!("nop", options(nomem, nostack, preserves_flags));
+    crate::arch::asm!("nop", options(nomem, nostack, preserves_flags));
 }
 
 extern "unadjusted" {

--- a/crates/core_arch/src/arm_shared/registers/mod.rs
+++ b/crates/core_arch/src/arm_shared/registers/mod.rs
@@ -4,7 +4,7 @@ macro_rules! rsr {
         impl super::super::sealed::Rsr for $R {
             unsafe fn __rsr(&self) -> u32 {
                 let r: u32;
-                asm!(concat!("mrs {},", stringify!($R)), out(reg) r, options(nomem, nostack));
+                crate::arch::asm!(concat!("mrs {},", stringify!($R)), out(reg) r, options(nomem, nostack));
                 r
             }
         }
@@ -17,7 +17,7 @@ macro_rules! rsrp {
         impl super::super::sealed::Rsrp for $R {
             unsafe fn __rsrp(&self) -> *const u8 {
                 let r: *const u8;
-                asm!(concat!("mrs {},", stringify!($R)), out(reg) r, options(nomem, nostack));
+                crate::arch::asm!(concat!("mrs {},", stringify!($R)), out(reg) r, options(nomem, nostack));
                 r
             }
         }
@@ -29,7 +29,7 @@ macro_rules! wsr {
     ($R:ident) => {
         impl super::super::sealed::Wsr for $R {
             unsafe fn __wsr(&self, value: u32) {
-                asm!(concat!("msr ", stringify!($R), ", {}"), in(reg) value, options(nomem, nostack));
+                crate::arch::asm!(concat!("msr ", stringify!($R), ", {}"), in(reg) value, options(nomem, nostack));
             }
         }
     };
@@ -40,7 +40,7 @@ macro_rules! wsrp {
     ($R:ident) => {
         impl super::super::sealed::Wsrp for $R {
             unsafe fn __wsrp(&self, value: *const u8) {
-                asm!(concat!("msr ", stringify!($R), ", {}"), in(reg) value, options(nomem, nostack));
+                crate::arch::asm!(concat!("msr ", stringify!($R), ", {}"), in(reg) value, options(nomem, nostack));
             }
         }
     };

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -68,7 +68,10 @@ extern crate std_detect;
 #[path = "mod.rs"]
 mod core_arch;
 
-pub use self::core_arch::arch;
+pub mod arch {
+    pub use crate::core_arch::arch::*;
+    pub use core::arch::asm;
+}
 
 #[allow(unused_imports)]
 use core::{convert, ffi, hint, intrinsics, marker, mem, ops, ptr, sync};

--- a/crates/core_arch/src/riscv/mod.rs
+++ b/crates/core_arch/src/riscv/mod.rs
@@ -6,5 +6,5 @@
 /// should be temporarily reduced or paused. The duration of its effect must be bounded and may be zero.
 #[inline]
 pub fn pause() {
-    unsafe { asm!(".word 0x0100000F", options(nomem, nostack)) }
+    unsafe { crate::arch::asm!(".word 0x0100000F", options(nomem, nostack)) }
 }

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -1,4 +1,5 @@
 use crate::{
+    arch::asm,
     core_arch::{simd::*, simd_llvm::*, x86::*},
     mem::{self, transmute},
     ptr,

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -1,4 +1,5 @@
 use crate::{
+    arch::asm,
     core_arch::{simd::*, simd_llvm::*, x86::*},
     mem::{self, transmute},
     ptr,

--- a/crates/core_arch/src/x86/bt.rs
+++ b/crates/core_arch/src/x86/bt.rs
@@ -1,3 +1,4 @@
+use crate::arch::asm;
 #[cfg(test)]
 use stdarch_test::assert_instr;
 

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -1,6 +1,7 @@
 //! `cpuid` intrinsics
 #![allow(clippy::module_name_repetitions)]
 
+use crate::arch::asm;
 #[cfg(test)]
 use stdarch_test::assert_instr;
 

--- a/crates/core_arch/src/x86/eflags.rs
+++ b/crates/core_arch/src/x86/eflags.rs
@@ -1,5 +1,7 @@
 //! `i386` intrinsics
 
+use crate::arch::asm;
+
 /// Reads EFLAGS.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=__readeflags)

--- a/crates/core_arch/src/x86_64/bt.rs
+++ b/crates/core_arch/src/x86_64/bt.rs
@@ -1,3 +1,4 @@
+use crate::arch::asm;
 #[cfg(test)]
 use stdarch_test::assert_instr;
 


### PR DESCRIPTION
It is going to be removed from the prelude due to the decision in https://github.com/rust-lang/rust/issues/87228.