### PR TITLE
Fix a bunch of typos

### DIFF
--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -17,7 +17,7 @@ COPY android-install-ndk.sh /android/
 RUN sh /android/android-install-ndk.sh $ANDROID_ARCH
 
 # We do not run x86_64-linux-android tests on an android emulator.
-# See ci/android-sysimage.sh for informations about how tests are run.
+# See ci/android-sysimage.sh for information about how tests are run.
 COPY android-sysimage.sh /android/
 RUN bash /android/android-sysimage.sh x86_64 x86_64-24_r07.zip
 

--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -66,7 +66,7 @@ pub const _PREFETCH_LOCALITY3: i32 = 3;
 #[rustc_legacy_const_generics(1, 2)]
 // FIXME: Replace this with the standard ACLE __pld/__pldx/__pli/__plix intrinsics
 pub unsafe fn _prefetch<const RW: i32, const LOCALITY: i32>(p: *const i8) {
-    // We use the `llvm.prefetch` instrinsic with `cache type` = 1 (data cache).
+    // We use the `llvm.prefetch` intrinsic with `cache type` = 1 (data cache).
     static_assert_imm1!(RW);
     static_assert_imm2!(LOCALITY);
     prefetch(p, RW, LOCALITY, 1);

--- a/crates/core_arch/src/arm/mod.rs
+++ b/crates/core_arch/src/arm/mod.rs
@@ -93,7 +93,7 @@ pub unsafe fn udf() -> ! {
 /// This provides a hint to debugging and related systems. The argument must be
 /// a constant integer from 0 to 15 inclusive. See implementation documentation
 /// for the effect (if any) of this instruction and the meaning of the
-/// argument. This is available only when compliling for AArch32.
+/// argument. This is available only when compiling for AArch32.
 // Section 10.1 of ACLE says that the supported arches are: 7, 7-M
 // "The DBG hint instruction is added in ARMv7. It is UNDEFINED in the ARMv6 base architecture, and
 // executes as a NOP instruction in ARMv6K and ARMv6T2." - ARM Architecture Reference Manual ARMv7-A

--- a/crates/core_arch/src/arm_shared/barrier/v8.rs
+++ b/crates/core_arch/src/arm_shared/barrier/v8.rs
@@ -16,7 +16,7 @@ pub struct NSHLD;
 
 dmb_dsb!(NSHLD);
 
-/// Outher Shareable is the required shareability domain, reads are the required
+/// Outer Shareable is the required shareability domain, reads are the required
 /// access type
 pub struct OSHLD;
 

--- a/crates/core_arch/src/wasm32/atomic.rs
+++ b/crates/core_arch/src/wasm32/atomic.rs
@@ -16,7 +16,7 @@ extern "C" {
 /// pointed to by `ptr` is equal to `expression` (performing this action
 /// atomically).
 ///
-/// The argument `timeout_ns` is a maxinum number of nanoseconds the calling
+/// The argument `timeout_ns` is a maximum number of nanoseconds the calling
 /// thread will be blocked for, if it blocks. If the timeout is negative then
 /// the calling thread will be blocked forever.
 ///
@@ -46,7 +46,7 @@ pub unsafe fn memory_atomic_wait32(ptr: *mut i32, expression: i32, timeout_ns: i
 /// pointed to by `ptr` is equal to `expression` (performing this action
 /// atomically).
 ///
-/// The argument `timeout_ns` is a maxinum number of nanoseconds the calling
+/// The argument `timeout_ns` is a maximum number of nanoseconds the calling
 /// thread will be blocked for, if it blocks. If the timeout is negative then
 /// the calling thread will be blocked forever.
 ///

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -33,7 +33,7 @@ types! {
     /// * four 32-bit floats (`f32`)
     /// * two 64-bit floats (`f64`)
     ///
-    /// The `v128` type in Rust is intended to be quite analagous to the `v128`
+    /// The `v128` type in Rust is intended to be quite analogous to the `v128`
     /// type in WebAssembly. Operations on `v128` can only be performed with the
     /// functions in this module.
     // N.B., internals here are arbitrary.
@@ -2305,7 +2305,7 @@ pub fn i8x16_abs(a: v128) -> v128 {
     }
 }
 
-/// Negates a 128-bit vectors intepreted as sixteen 8-bit signed integers
+/// Negates a 128-bit vectors interpreted as sixteen 8-bit signed integers
 #[inline]
 #[cfg_attr(test, assert_instr(i8x16.neg))]
 #[target_feature(enable = "simd128")]
@@ -2602,7 +2602,7 @@ pub fn i16x8_abs(a: v128) -> v128 {
     }
 }
 
-/// Negates a 128-bit vectors intepreted as eight 16-bit signed integers
+/// Negates a 128-bit vectors interpreted as eight 16-bit signed integers
 #[inline]
 #[cfg_attr(test, assert_instr(i16x8.neg))]
 #[target_feature(enable = "simd128")]
@@ -3090,7 +3090,7 @@ pub fn i32x4_abs(a: v128) -> v128 {
     }
 }
 
-/// Negates a 128-bit vectors intepreted as four 32-bit signed integers
+/// Negates a 128-bit vectors interpreted as four 32-bit signed integers
 #[inline]
 #[cfg_attr(test, assert_instr(i32x4.neg))]
 #[target_feature(enable = "simd128")]
@@ -3472,7 +3472,7 @@ pub fn i64x2_abs(a: v128) -> v128 {
     }
 }
 
-/// Negates a 128-bit vectors intepreted as two 64-bit signed integers
+/// Negates a 128-bit vectors interpreted as two 64-bit signed integers
 #[inline]
 #[cfg_attr(test, assert_instr(i64x2.neg))]
 #[target_feature(enable = "simd128")]

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -53,7 +53,7 @@ pub unsafe fn _mm256_add_ps(a: __m256, b: __m256) -> __m256 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_and_pd)
 #[inline]
 #[target_feature(enable = "avx")]
-// FIXME: Should be 'vandpd' instuction.
+// FIXME: Should be 'vandpd' instruction.
 // See https://github.com/rust-lang/stdarch/issues/71
 #[cfg_attr(test, assert_instr(vandps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
@@ -83,7 +83,7 @@ pub unsafe fn _mm256_and_ps(a: __m256, b: __m256) -> __m256 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_or_pd)
 #[inline]
 #[target_feature(enable = "avx")]
-// FIXME: should be `vorpd` instuction.
+// FIXME: should be `vorpd` instruction.
 // See <https://github.com/rust-lang/stdarch/issues/71>.
 #[cfg_attr(test, assert_instr(vorps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -19479,7 +19479,7 @@ pub unsafe fn _mm_maskz_permute_pd<const IMM2: i32>(k: __mmask8, a: __m128d) -> 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_permutex_epi64&expand=4208)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermq
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermq
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_permutex_epi64<const MASK: i32>(a: __m512i) -> __m512i {
     static_assert_imm8!(MASK);
@@ -19535,7 +19535,7 @@ pub unsafe fn _mm512_maskz_permutex_epi64<const MASK: i32>(k: __mmask8, a: __m51
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_permutex_epi64&expand=4205)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermq
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermq
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_permutex_epi64<const MASK: i32>(a: __m256i) -> __m256i {
     static_assert_imm8!(MASK);
@@ -19587,7 +19587,7 @@ pub unsafe fn _mm256_maskz_permutex_epi64<const MASK: i32>(k: __mmask8, a: __m25
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_permutex_pd&expand=4214)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermpd
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermpd
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_permutex_pd<const MASK: i32>(a: __m512d) -> __m512d {
     static_assert_imm8!(MASK);
@@ -19612,7 +19612,7 @@ pub unsafe fn _mm512_permutex_pd<const MASK: i32>(a: __m512d) -> __m512d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_permutex_pd&expand=4212)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermpd
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermpd
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm512_mask_permutex_pd<const MASK: i32>(
     src: __m512d,
@@ -19628,7 +19628,7 @@ pub unsafe fn _mm512_mask_permutex_pd<const MASK: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_permutex_pd&expand=4213)
 #[inline]
 #[target_feature(enable = "avx512f")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermpd
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermpd
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_permutex_pd<const MASK: i32>(k: __mmask8, a: __m512d) -> __m512d {
     let r = _mm512_permutex_pd::<MASK>(a);
@@ -19641,7 +19641,7 @@ pub unsafe fn _mm512_maskz_permutex_pd<const MASK: i32>(k: __mmask8, a: __m512d)
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_permutex_pd&expand=4211)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermpd
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermpd
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_permutex_pd<const MASK: i32>(a: __m256d) -> __m256d {
     static_assert_imm8!(MASK);
@@ -19662,7 +19662,7 @@ pub unsafe fn _mm256_permutex_pd<const MASK: i32>(a: __m256d) -> __m256d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_permutex_pd&expand=4209)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermpd
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermpd
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm256_mask_permutex_pd<const MASK: i32>(
     src: __m256d,
@@ -19679,7 +19679,7 @@ pub unsafe fn _mm256_mask_permutex_pd<const MASK: i32>(
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_permutex_pd&expand=4210)
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")]
-#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //shoud be vpermpd
+#[cfg_attr(test, assert_instr(vperm, MASK = 0b10_01_10_11))] //should be vpermpd
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_permutex_pd<const MASK: i32>(k: __mmask8, a: __m256d) -> __m256d {
     static_assert_imm8!(MASK);

--- a/crates/core_arch/src/x86/fxsr.rs
+++ b/crates/core_arch/src/x86/fxsr.rs
@@ -1,4 +1,4 @@
-//! FXSR floating-point context fast save and restor.
+//! FXSR floating-point context fast save and restore.
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1412,19 +1412,19 @@ pub unsafe fn _mm_getcsr() -> u32 {
 /// * `_MM_EXCEPT_DENORM`: An operation attempted to operate on a denormalized
 ///   number. Mainly this can cause loss of precision.
 ///
-/// * `_MM_EXCEPT_DIV_ZERO`: Division by zero occured.
+/// * `_MM_EXCEPT_DIV_ZERO`: Division by zero occurred.
 ///
-/// * `_MM_EXCEPT_OVERFLOW`: A numeric overflow exception occured, i.e., a
+/// * `_MM_EXCEPT_OVERFLOW`: A numeric overflow exception occurred, i.e., a
 /// result was too large to be represented (e.g., an `f32` with absolute
 /// value
 ///   greater than `2^128`).
 ///
-/// * `_MM_EXCEPT_UNDERFLOW`: A numeric underflow exception occured, i.e., a
+/// * `_MM_EXCEPT_UNDERFLOW`: A numeric underflow exception occurred, i.e., a
 /// result was too small to be represented in a normalized way (e.g., an
 /// `f32`
 ///   with absulte value smaller than `2^-126`.)
 ///
-/// * `_MM_EXCEPT_INEXACT`: An inexact-result exception occured (a.k.a.
+/// * `_MM_EXCEPT_INEXACT`: An inexact-result exception occurred (a.k.a.
 ///   precision exception). This means some precision was lost due to rounding.
 ///   For example, the fraction `1/3` cannot be represented accurately in a
 ///   32 or 64 bit float and computing it would cause this exception to be
@@ -1752,7 +1752,7 @@ pub const _MM_HINT_ET1: i32 = 6;
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_prefetch<const STRATEGY: i32>(p: *const i8) {
-    // We use the `llvm.prefetch` instrinsic with `cache type` = 1 (data cache).
+    // We use the `llvm.prefetch` intrinsic with `cache type` = 1 (data cache).
     // `locality` and `rw` are based on our `STRATEGY`.
     prefetch(p, (STRATEGY >> 2) & 1, STRATEGY & 3, 1);
 }

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -8,7 +8,7 @@ use crate::{
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-// SSE4 rounding constans
+// SSE4 rounding constants
 /// round to nearest
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub const _MM_FROUND_TO_NEAREST_INT: i32 = 0x00;
@@ -830,7 +830,7 @@ pub unsafe fn _mm_round_sd<const ROUNDING: i32>(a: __m128d, b: __m128d) -> __m12
 /// using the `ROUNDING` parameter, store the result as a single-precision
 /// floating-point element in the lower element of the intrinsic result,
 /// and copies the upper 3 packed elements from `a` to the upper elements
-/// of the instrinsic result.
+/// of the intrinsic result.
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
 /// ```

--- a/crates/core_arch/src/x86/sse42.rs
+++ b/crates/core_arch/src/x86/sse42.rs
@@ -146,7 +146,7 @@ pub unsafe fn _mm_cmpistrm<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i {
 /// # }
 /// ```
 ///
-/// The `_mm_cmpistri` intrinsic may also be used to find the existance of
+/// The `_mm_cmpistri` intrinsic may also be used to find the existence of
 /// one or more of a given set of characters in the haystack.
 ///
 /// ```

--- a/crates/core_arch/src/x86/sse4a.rs
+++ b/crates/core_arch/src/x86/sse4a.rs
@@ -32,7 +32,7 @@ extern "C" {
 /// If the length is zero, it is interpreted as `64`. If the length and index
 /// are zero, the lower 64 bits of `x` are extracted.
 ///
-/// If `length == 0 && index > 0` or `lenght + index > 64` the result is
+/// If `length == 0 && index > 0` or `length + index > 64` the result is
 /// undefined.
 #[inline]
 #[target_feature(enable = "sse4a")]

--- a/crates/core_arch/src/x86_64/fxsr.rs
+++ b/crates/core_arch/src/x86_64/fxsr.rs
@@ -1,4 +1,4 @@
-//! FXSR floating-point context fast save and restor.
+//! FXSR floating-point context fast save and restore.
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/intrinsic-test/src/argument.rs
+++ b/crates/intrinsic-test/src/argument.rs
@@ -55,7 +55,7 @@ pub struct ArgumentList {
 }
 
 impl ArgumentList {
-    /// Converts the argument list into the call paramters for a C function call.
+    /// Converts the argument list into the call parameters for a C function call.
     /// e.g. this would generate something like `a, &b, c`
     pub fn as_call_param_c(&self) -> String {
         self.args
@@ -70,7 +70,7 @@ impl ArgumentList {
             .join(", ")
     }
 
-    /// Converts the argument list into the call paramters for a Rust function.
+    /// Converts the argument list into the call parameters for a Rust function.
     /// e.g. this would generate something like `a, b, c`
     pub fn as_call_param_rust(&self) -> String {
         self.args

--- a/crates/intrinsic-test/src/intrinsic.rs
+++ b/crates/intrinsic-test/src/intrinsic.rs
@@ -8,7 +8,7 @@ pub struct Intrinsic {
     /// The function name of this intrinsic.
     pub name: String,
 
-    /// Any arguments for this intrinsinc.
+    /// Any arguments for this intrinsic.
     pub arguments: ArgumentList,
 
     /// The return type of this intrinsic.

--- a/crates/std_detect/src/detect/arch/aarch64.rs
+++ b/crates/std_detect/src/detect/arch/aarch64.rs
@@ -8,7 +8,7 @@ features! {
     /// Currently most features are only supported on linux-based platforms.
     ///
     /// This macro takes one argument which is a string literal of the feature being tested for.
-    /// The feature names are mostly taken from their FEAT_* definitiions in the [ARM Architecture
+    /// The feature names are mostly taken from their FEAT_* definitions in the [ARM Architecture
     /// Reference Manual][docs].
     ///
     /// ## Supported arguments
@@ -104,9 +104,9 @@ features! {
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] pauth: "pauth";
     /// FEAT_PAuth (pointer authentication)
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] dpb: "dpb";
-    /// FEAT_DPB (aka dcpop - data cache clean to point of persistance)
+    /// FEAT_DPB (aka dcpop - data cache clean to point of persistence)
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] dpb2: "dpb2";
-    /// FEAT_DPB2 (aka dcpodp - data cache clean to point of deep persistance)
+    /// FEAT_DPB2 (aka dcpodp - data cache clean to point of deep persistence)
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] sve2: "sve2";
     /// FEAT_SVE2 (Scalable Vector Extension 2)
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] sve2_aes: "sve2-aes";

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -3,7 +3,7 @@
 //! The features are detected using the `detect_features` function below.
 //! This function uses the CPUID instruction to read the feature flags from the
 //! CPU and encodes them in a `usize` where each bit position represents
-//! whether a feature is available (bit is set) or unavaiable (bit is cleared).
+//! whether a feature is available (bit is set) or unavailable (bit is cleared).
 //!
 //! The enum `Feature` is used to map bit positions to feature names, and the
 //! the `__crate::detect::check_for!` macro is used to map string literals (e.g.,
@@ -178,7 +178,7 @@ features! {
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] popcnt: "popcnt";
     /// POPCNT (Population Count)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] fxsr: "fxsr";
-    /// FXSR (Floating-point context fast save and restor)
+    /// FXSR (Floating-point context fast save and restore)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] xsave: "xsave";
     /// XSAVE (Save Processor Extended States)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] xsaveopt: "xsaveopt";

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -56,7 +56,7 @@
 // MAX - maximal value proper to overflow
 //
 // # validate <values>
-// Validates a and b aginst the expected result of the test.
+// Validates a and b against the expected result of the test.
 // The special values 'TRUE' and 'FALSE' can be used to
 // represent the correct NEON representation of true or
 // false values. It too gets scaled to the type.
@@ -4685,7 +4685,7 @@ link-arm = vmaxs._EXT_
 link-aarch64 = fmax._EXT_
 generate float*_t
 
-/// Floating-point Maximun Number (vector)
+/// Floating-point Maximum Number (vector)
 name = vmaxnm
 a = 1.0, 2.0, 3.0, -4.0
 b = 8.0, 16.0, -1.0, 6.0
@@ -4789,7 +4789,7 @@ link-arm = vmins._EXT_
 link-aarch64 = fmin._EXT_
 generate float*_t
 
-/// Floating-point Minimun Number (vector)
+/// Floating-point Minimum Number (vector)
 name = vminnm
 a = 1.0, 2.0, 3.0, -4.0
 b = 8.0, 16.0, -1.0, 6.0

--- a/crates/stdarch-gen/src/main.rs
+++ b/crates/stdarch-gen/src/main.rs
@@ -2806,7 +2806,7 @@ fn get_call(
         let s = &params[i];
         if s.starts_with('{') {
             let mut sub_fn = String::new();
-            let mut paranthes = 0;
+            let mut parentheses = 0;
             while i < params.len() {
                 if !sub_fn.is_empty() {
                     sub_fn.push_str(", ");
@@ -2815,19 +2815,19 @@ fn get_call(
                 let l = params[i].len();
                 for j in 0..l {
                     if &params[i][j..j + 1] == "{" {
-                        paranthes += 1;
+                        parentheses += 1;
                     } else {
                         break;
                     }
                 }
                 for j in 0..l {
                     if &params[i][l - j - 1..l - j] == "}" {
-                        paranthes -= 1;
+                        parentheses -= 1;
                     } else {
                         break;
                     }
                 }
-                if paranthes == 0 {
+                if parentheses == 0 {
                     break;
                 }
                 i += 1;


### PR DESCRIPTION
I took some liberty of changing the variable name to from `paranthes` to `parentheses` instead of `parenthes`.

I hope that none of these files is not supposed to be modified.