### PR TITLE
fixed documentation crc32 -> crc32-c (with x86(_64))

### DIFF
--- a/crates/core_arch/src/x86/sse42.rs
+++ b/crates/core_arch/src/x86/sse42.rs
@@ -520,7 +520,7 @@ pub unsafe fn _mm_cmpestra<const IMM8: i32>(a: __m128i, la: i32, b: __m128i, lb:
 }
 
 /// Starting with the initial value in `crc`, return the accumulated
-/// CRC32 value for unsigned 8-bit integer `v`.
+/// CRC32-C value for unsigned 8-bit integer `v`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_crc32_u8)
 #[inline]
@@ -532,7 +532,7 @@ pub unsafe fn _mm_crc32_u8(crc: u32, v: u8) -> u32 {
 }
 
 /// Starting with the initial value in `crc`, return the accumulated
-/// CRC32 value for unsigned 16-bit integer `v`.
+/// CRC32-C value for unsigned 16-bit integer `v`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_crc32_u16)
 #[inline]
@@ -544,7 +544,7 @@ pub unsafe fn _mm_crc32_u16(crc: u32, v: u16) -> u32 {
 }
 
 /// Starting with the initial value in `crc`, return the accumulated
-/// CRC32 value for unsigned 32-bit integer `v`.
+/// CRC32-C value for unsigned 32-bit integer `v`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_crc32_u32)
 #[inline]

--- a/crates/core_arch/src/x86_64/sse42.rs
+++ b/crates/core_arch/src/x86_64/sse42.rs
@@ -10,7 +10,7 @@ extern "C" {
 }
 
 /// Starting with the initial value in `crc`, return the accumulated
-/// CRC32 value for unsigned 64-bit integer `v`.
+/// CRC32-C value for unsigned 64-bit integer `v`.
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_crc32_u64)
 #[inline]


### PR DESCRIPTION
x86(-64) actually implements crc32-c and not crc32, the intel documentation fails to mention this properly.
The only indication is the polynomial they use (0x11EDC6F41) in the `Operation` section.
(See: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_crc32_&ig_expand=1495,1494,1493,1493)
Cross-referencing with this site, the polynomial is mentioned to be of crc32-c (https://sci.math.narkive.com/7MUM37mh/when-is-regular-crc32-better-or-worse-than-crc32-c).
And finally on Wikipedia it is mentioned in the description of `CRC32` that it is actually `CRC32C` (https://en.wikipedia.org/wiki/SSE4#SSE4.2).

Finally, I have tested this experimental with the `crc32c` crate:
```rs
fn main() {
    let intel = unsafe {
        std::arch::x86_64::_mm_crc32_u32(0xFFFF_FFFF, 0xDEADBEEF) ^ 0xFFFF_FFFF
    };
    assert_eq!(intel, crc32c::crc32c(&[0xEF, 0xBE, 0xAD, 0xDE]));
}
```
Note that _mm_crc32_u32 updates a crc32 state, the initial state is `0xFFFF_FFFF` and gets finalized by XORing it with `0xFFFF_FFFF`.