### PR TITLE
riscv: K extension (part 1), floating-point control and state register

### DIFF
--- a/crates/core_arch/src/riscv64/mod.rs
+++ b/crates/core_arch/src/riscv64/mod.rs
@@ -10,7 +10,7 @@ use crate::arch::asm;
 /// This operation is not available under RV32 base instruction set.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.WU`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_wu(src: *const u32) -> u32 {
     let value: u32;
@@ -27,7 +27,7 @@ pub unsafe fn hlv_wu(src: *const u32) -> u32 {
 /// This operation is not available under RV32 base instruction set.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.D`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_d(src: *const i64) -> i64 {
     let value: i64;
@@ -42,7 +42,7 @@ pub unsafe fn hlv_d(src: *const i64) -> i64 {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HSV.D`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hsv_d(dst: *mut i64, src: i64) {
     asm!(".insn r 0x73, 0x4, 0x37, x0, {}, {}", in(reg) dst, in(reg) src, options(nostack));

--- a/crates/core_arch/src/riscv64/mod.rs
+++ b/crates/core_arch/src/riscv64/mod.rs
@@ -18,7 +18,7 @@ pub unsafe fn hlv_wu(src: *const u32) -> u32 {
     value
 }
 
-/// Loads virtual machine memory by unsigned double integer
+/// Loads virtual machine memory by double integer
 ///
 /// This instruction performs an explicit memory access as though `V=1`;
 /// i.e., with the address translation and protection, and the endianness, that apply to memory

--- a/crates/core_arch/src/riscv_shared/mod.rs
+++ b/crates/core_arch/src/riscv_shared/mod.rs
@@ -469,6 +469,111 @@ pub unsafe fn hinval_gvma_vmid(vmid: usize) {
     asm!(".insn r 0x73, 0, 0x33, x0, x0, {}", in(reg) vmid, options(nostack))
 }
 
+/// Reads the floating-point control and status register `fcsr`
+///
+/// Register `fcsr` is a 32-bit read/write register that selects the dynamic rounding mode
+/// for floating-point arithmetic operations and holds the accrued exception flag.
+///
+/// Accoding to "F" Standard Extension for Single-Precision Floating-Point, Version 2.2,
+/// register `fcsr` is defined as:
+///
+/// | Bit index | Meaning |
+/// |:----------|:--------|
+/// | 0..=4 | Accrued Exceptions (`fflags`) |
+/// | 5..=7 | Rounding Mode (`frm`) |
+/// | 8..=31 | _Reserved_ |
+///
+/// For definition of each field, visit [`frrm`] and [`frflags`].
+///
+/// [`frrm`]: fn.frrm.html
+/// [`frflags`]: fn.frflags.html
+#[inline]
+pub fn frcsr() -> u32 {
+    let value: u32;
+    unsafe { asm!("frcsr {}", out(reg) value, options(nomem, nostack)) };
+    value
+}
+
+/// Swaps the floating-point control and status register `fcsr`
+///
+/// This function swaps the value in `fcsr` by copying the original value to be returned,
+/// and then writing a new value obtained from input variable `value` into `fcsr`.
+#[inline]
+pub fn fscsr(value: u32) -> u32 {
+    let original: u32;
+    unsafe { asm!("fscsr {}, {}", out(reg) original, in(reg) value, options(nomem, nostack)) }
+    original
+}
+
+/// Reads the floating-point rounding mode register `frm`
+///
+/// Accoding to "F" Standard Extension for Single-Precision Floating-Point, Version 2.2,
+/// the rounding mode field is defined as listed in the table below:
+///
+/// | Rounding Mode | Mnemonic | Meaning |
+/// |:-------------|:----------|:---------|
+/// | 000 | RNE | Round to Nearest, ties to Even |
+/// | 001 | RTZ | Round towards Zero |
+/// | 010 | RDN | Round Down (towards −∞) |
+/// | 011 | RUP | Round Up (towards +∞) |
+/// | 100 | RMM | Round to Nearest, ties to Max Magnitude |
+/// | 101 |     | _Reserved for future use._ |
+/// | 110 |     | _Reserved for future use._ |
+/// | 111 | DYN | In Rounding Mode register, _reserved_. |
+#[inline]
+pub fn frrm() -> u32 {
+    let value: u32;
+    unsafe { asm!("frrm {}", out(reg) value, options(nomem, nostack)) };
+    value
+}
+
+/// Swaps the floating-point rounding mode register `frm`
+///
+/// This function swaps the value in `frm` by copying the original value to be returned,
+/// and then writing a new value obtained from the three least-significant bits of
+/// input variable `value` into `frm`.
+#[inline]
+pub fn fsrm(value: u32) -> u32 {
+    let original: u32;
+    unsafe { asm!("fsrm {}, {}", out(reg) original, in(reg) value, options(nomem, nostack)) }
+    original
+}
+
+/// Reads the floating-point accrued exception flags register `fflags`
+///
+/// The accrued exception flags indicate the exception conditions that have arisen
+/// on any floating-point arithmetic instruction since the field was last reset by software.
+///
+/// Accoding to "F" Standard Extension for Single-Precision Floating-Point, Version 2.2,
+/// the accured exception flags is defined as a bit vector of 5 bits.
+/// The meaning of each binary bit is listed in the table below.
+///
+/// | Bit index | Mnemonic | Meaning |
+/// |:--|:---|:-----------------|
+/// | 4 | NV | Invalid Operation |
+/// | 3 | DZ | Divide by Zero |
+/// | 2 | OF | Overflow |
+/// | 1 | UF | Underflow |
+/// | 0 | NX | Inexact |
+#[inline]
+pub fn frflags() -> u32 {
+    let value: u32;
+    unsafe { asm!("frflags {}", out(reg) value, options(nomem, nostack)) };
+    value
+}
+
+/// Swaps the floating-point accrued exception flags register `fflags`
+///
+/// This function swaps the value in `fflags` by copying the original value to be returned,
+/// and then writing a new value obtained from the five least-significant bits of
+/// input variable `value` into `fflags`.
+#[inline]
+pub fn fsflags(value: u32) -> u32 {
+    let original: u32;
+    unsafe { asm!("fsflags {}, {}", out(reg) original, in(reg) value, options(nomem, nostack)) }
+    original
+}
+
 /// Invalidate hypervisor translation cache for all virtual machines and guest physical addresses
 ///
 /// This instruction invalidates any address-translation cache entries that an

--- a/crates/core_arch/src/riscv_shared/mod.rs
+++ b/crates/core_arch/src/riscv_shared/mod.rs
@@ -685,7 +685,7 @@ pub fn sm3p1(x: u32) -> u32 {
 /// According to RISC-V Cryptography Extensions, Volume I, the execution latency of
 /// this instruction must always be independent from the data it operates on.
 pub fn sm4ed<const BS: u8>(x: u32, a: u32) -> u32 {
-    static_assert_imm2!(BS); // `bs` immediate value must be within [0, 3]
+    static_assert!(BS: u8 where BS <= 3);
     let ans: u32;
     match BS {
         0 => unsafe {
@@ -750,7 +750,7 @@ pub fn sm4ed<const BS: u8>(x: u32, a: u32) -> u32 {
 /// According to RISC-V Cryptography Extensions, Volume I, the execution latency of
 /// this instruction must always be independent from the data it operates on.
 pub fn sm4ks<const BS: u8>(x: u32, k: u32) -> u32 {
-    static_assert_imm2!(BS); // `bs` immediate value must be within [0, 3]
+    static_assert!(BS: u8 where BS <= 3);
     let ans: u32;
     match BS {
         0 => unsafe {

--- a/crates/core_arch/src/riscv_shared/mod.rs
+++ b/crates/core_arch/src/riscv_shared/mod.rs
@@ -153,7 +153,7 @@ pub unsafe fn sfence_inval_ir() {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.B`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_b(src: *const i8) -> i8 {
     let value: i8;
@@ -168,7 +168,7 @@ pub unsafe fn hlv_b(src: *const i8) -> i8 {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.BU`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_bu(src: *const u8) -> u8 {
     let value: u8;
@@ -183,7 +183,7 @@ pub unsafe fn hlv_bu(src: *const u8) -> u8 {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.H`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_h(src: *const i16) -> i16 {
     let value: i16;
@@ -198,7 +198,7 @@ pub unsafe fn hlv_h(src: *const i16) -> i16 {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.HU`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_hu(src: *const u16) -> u16 {
     let value: u16;
@@ -213,7 +213,7 @@ pub unsafe fn hlv_hu(src: *const u16) -> u16 {
 /// but read permission is not required.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLVX.HU`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlvx_hu(src: *const u16) -> u16 {
     let insn: u16;
@@ -228,7 +228,7 @@ pub unsafe fn hlvx_hu(src: *const u16) -> u16 {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLV.W`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlv_w(src: *const i32) -> i32 {
     let value: i32;
@@ -243,7 +243,7 @@ pub unsafe fn hlv_w(src: *const i32) -> i32 {
 /// but read permission is not required.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HLVX.WU`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hlvx_wu(src: *const u32) -> u32 {
     let insn: u32;
@@ -258,7 +258,7 @@ pub unsafe fn hlvx_wu(src: *const u32) -> u32 {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HSV.B`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hsv_b(dst: *mut i8, src: i8) {
     asm!(".insn r 0x73, 0x4, 0x31, x0, {}, {}", in(reg) dst, in(reg) src, options(nostack));
@@ -271,7 +271,7 @@ pub unsafe fn hsv_b(dst: *mut i8, src: i8) {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HSV.H`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hsv_h(dst: *mut i16, src: i16) {
     asm!(".insn r 0x73, 0x4, 0x33, x0, {}, {}", in(reg) dst, in(reg) src, options(nostack));
@@ -284,7 +284,7 @@ pub unsafe fn hsv_h(dst: *mut i16, src: i16) {
 /// accesses in either VS-mode or VU-mode.
 ///
 /// This function is unsafe for it accesses the virtual supervisor or user via a `HSV.W`
-/// instruction which is effectively an unreference to any memory address.
+/// instruction which is effectively a dereference to any memory address.
 #[inline]
 pub unsafe fn hsv_w(dst: *mut i32, src: i32) {
     asm!(".insn r 0x73, 0x4, 0x35, x0, {}, {}", in(reg) dst, in(reg) src, options(nostack));


### PR DESCRIPTION
This pull request includes:
- `Zksh`, `Zksed` extension in RISC-V K extension. There are four functions: `sm3p0`, `sm3p1`, `sm4ed` and `sm4ks` function.
- Floating point control and state register operations. They are three read instructions `frcsr`, `frrm`, `frflags`, and three swap instructions `fscsr`, `fsrm`, `fsflags` as is defined in the RISC-V unprivileged specification.
- Typo fixes in previous documents (thanks @dramforever).

The features above are all defined as safe Rust functions. Four K extension functions operates like arithmetic functions and does not visit on any memory addresses. The floating point control operations only reads or writes to floating point control configurations of the current hart.

~Note: choose of type `i32` in `sm4ks<const BS: i32>(x: u32, k: u32) -> u32` is required by an internal macro `statis_assert_imm2`.~ Fixed: uses BS: u8 and static_assert! internal macro. 

r? @Amanieu 