### PR TITLE
Remove use of `#[rustc_deprecated]` in favor of `#[deprecated]`

### DIFF
--- a/crates/core_arch/src/x86/eflags.rs
+++ b/crates/core_arch/src/x86/eflags.rs
@@ -8,9 +8,9 @@ use crate::arch::asm;
 #[cfg(target_arch = "x86")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[rustc_deprecated(
+#[deprecated(
     since = "1.29.0",
-    reason = "See issue #51810 - use inline assembly instead"
+    note = "See issue #51810 - use inline assembly instead"
 )]
 #[doc(hidden)]
 pub unsafe fn __readeflags() -> u32 {
@@ -25,9 +25,9 @@ pub unsafe fn __readeflags() -> u32 {
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[rustc_deprecated(
+#[deprecated(
     since = "1.29.0",
-    reason = "See issue #51810 - use inline assembly instead"
+    note = "See issue #51810 - use inline assembly instead"
 )]
 #[doc(hidden)]
 pub unsafe fn __readeflags() -> u64 {
@@ -42,9 +42,9 @@ pub unsafe fn __readeflags() -> u64 {
 #[cfg(target_arch = "x86")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[rustc_deprecated(
+#[deprecated(
     since = "1.29.0",
-    reason = "See issue #51810 - use inline assembly instead"
+    note = "See issue #51810 - use inline assembly instead"
 )]
 #[doc(hidden)]
 pub unsafe fn __writeeflags(eflags: u32) {
@@ -57,9 +57,9 @@ pub unsafe fn __writeeflags(eflags: u32) {
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[rustc_deprecated(
+#[deprecated(
     since = "1.29.0",
-    reason = "See issue #51810 - use inline assembly instead"
+    note = "See issue #51810 - use inline assembly instead"
 )]
 #[doc(hidden)]
 pub unsafe fn __writeeflags(eflags: u64) {


### PR DESCRIPTION
In rust-lang/rust#94635, `#[deprecated]` and `#[rustc_deprecated]` were merged. Now that a bootstrap has occurred, I'm migrating all uses of `#[rustc_deprecated]`. This has to occur in submodules (such as `stdarch` here) before it can turn into an error in the compiler.