### PR TITLE
Add  stdsimd feature to allow_internal_unstable attribute in feature detect macros

### DIFF
--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -11,7 +11,7 @@ macro_rules! features {
     ) => {
         #[macro_export]
         $(#[$macro_attrs])*
-        #[allow_internal_unstable(stdsimd_internal)]
+        #[allow_internal_unstable(stdsimd_internal, stdsimd)]
         #[cfg($cfg)]
         #[doc(cfg($cfg))]
         macro_rules! $macro_name {


### PR DESCRIPTION
This is a blocker for https://github.com/rust-lang/rust/pull/95956

That PR modifies the stability checking logic of rustc so that it additionally checks the stability of the path segments used to name an item, rather than only checking the stability of the item itself. This is necessary to allow `std::error::Error` to be moved into a new unstable `core::error` module while still being available on stable via a re-export in the stable `std::error` module.

That change breaks the feature detection macros since they start encountering the `stdsimd` unstable feature which is not explicitly mentioned in those macros `allow_internal_unstable` attribute.