### PR TITLE
Allow unused macro rules for two macros

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -93,7 +93,7 @@ macro_rules! types {
     )*)
 }
 
-#[allow(unused_macros)]
+#[allow(unused)]
 macro_rules! simd_shuffle2 {
     ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;

--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -356,6 +356,7 @@ mod sealed {
 
     }
 
+    #[allow(unknown_lints, unused_macro_rules)]
     macro_rules! impl_vec_trait {
         ([$Trait:ident $m:ident] $fun:ident ($a:ty)) => {
             impl $Trait for $a {


### PR DESCRIPTION
The unused macro rules lint is an upcoming lint
for the rust compiler: https://github.com/rust-lang/rust/pull/96150. This PR prepares
for the introduction [so that the CI passes](https://github.com/rust-lang/rust/pull/96150#issuecomment-1119861986).

I have not tested whether this is all of the changes needed. If any more pop up I guess one can just add an `allow` to lib.rs.