### PR TITLE
Allow unused macro rules for simd_shuffle16 too

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -141,7 +141,7 @@ macro_rules! simd_shuffle8 {
     }};
 }
 
-#[allow(unused_macros)]
+#[allow(unused)]
 macro_rules! simd_shuffle16 {
     ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
         struct ConstParam<$(const $imm: $ty),+>;


### PR DESCRIPTION
Follow-up of #1305 