### PR TITLE
Remove useless conditional compilation

### DIFF
--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -22,9 +22,6 @@ dox() {
   rm -rf "target/doc/${arch}"
   mkdir "target/doc/${arch}"
 
-  export RUSTFLAGS="--cfg core_arch_docs"
-  export RUSTDOCFLAGS="--cfg core_arch_docs"
-
   cargo build --verbose --target "${target}" --manifest-path crates/core_arch/Cargo.toml
   cargo build --verbose --target "${target}" --manifest-path crates/std_detect/Cargo.toml
 
@@ -32,16 +29,14 @@ dox() {
           -o "target/doc/${arch}" crates/core_arch/src/lib.rs \
           --edition=2018 \
           --crate-name core_arch \
-          --library-path "target/${target}/debug/deps" \
-          --cfg core_arch_docs
+          --library-path "target/${target}/debug/deps"
   rustdoc --verbose --target "${target}" \
           -o "target/doc/${arch}" crates/std_detect/src/lib.rs \
           --edition=2018 \
           --crate-name std_detect \
           --library-path "target/${target}/debug/deps" \
           --extern cfg_if="$(ls target/"${target}"/debug/deps/libcfg_if-*.rlib)" \
-          --extern libc="$(ls target/"${target}"/debug/deps/liblibc-*.rlib)" \
-          --cfg core_arch_docs
+          --extern libc="$(ls target/"${target}"/debug/deps/liblibc-*.rlib)"
 }
 
 dox i686 i686-unknown-linux-gnu

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 keywords = ["core", "simd", "arch", "intrinsics"]
 categories = ["hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
-build = "build.rs"
 edition = "2018"
 
 [badges]

--- a/crates/core_arch/build.rs
+++ b/crates/core_arch/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("cargo:rustc-cfg=core_arch_docs");
-}

--- a/crates/core_arch/src/arm/v7.rs
+++ b/crates/core_arch/src/arm/v7.rs
@@ -76,7 +76,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(dont_compile_me)] // FIXME need to add `v7` upstream in rustc
     fn _rbit_u32() {
         unsafe {
             assert_eq!(


### PR DESCRIPTION
Context: `rustc` added a few month ago [`--check-cfg`](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/check-cfg.html) support and enable it in the `rust-lang/rust` repo for every build.

I found out that `stdarch` had condition that were triggering the unstable `unexpected_cfgs` lint:
 - `stdarch_intel_sde`: Internal to `stdarch`, status unknown, never set as far as I can tell. [bootstrap exception](https://github.com/rust-lang/rust/blob/1a97162cb245b5e2c7458c28859e3df779908c02/src/bootstrap/lib.rs#L201)
 - `dont_compile_me`: Used on the `_rbit_u32` test for armv7, with an outdated comment. [bootstrap exception](https://github.com/rust-lang/rust/blob/1a97162cb245b5e2c7458c28859e3df779908c02/src/bootstrap/lib.rs#L218-L219)
 - `core_arch_docs`: Set in `dox.sh` and in the `build.rs` of `core_arch`, but never used in the codebase. *no exception because never used*

This PR removes every cfg usage of `dont_compile_me` and `core_arch_docs` because they are useless. I tested the modifications and nothing failed on my side, so I think it's good to go.