### PR TITLE
Allow mapping a runtime feature to a set of target_features

### DIFF
--- a/crates/std_detect/src/detect/arch/aarch64.rs
+++ b/crates/std_detect/src/detect/arch/aarch64.rs
@@ -72,7 +72,8 @@ features! {
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] pmull: "pmull";
     /// FEAT_PMULL (Polynomial Multiply)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] fp: "fp";
-    /// FEAT_FP (Floating point support)
+    implied by target_features: ["neon"];
+    /// FEAT_FP (Floating point support) - Implied by `neon` target_feature
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] fp16: "fp16";
     /// FEAT_FP16 (Half-float support)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sve: "sve";


### PR DESCRIPTION
Now that runtime features and `target_features`are logically separate https://github.com/rust-lang/rust/pull/91608, there's a need to map between the two. Usually runtime feature detection short-circuits if a matching `target_feature` is enabled. However, on `aarch64-apple-darwin` there's no backup runtime detection yet so we rely purely on this behaviour.

Notably this fixes `std::arch::is_aarch64_feature_detected!("fp")` returning false on `aarch64-apple-darwin` and allows for multiple `target_features` to be specified in the future.