### PR TITLE
Update atomic intrinsics

### DIFF
--- a/crates/core_arch/src/x86_64/cmpxchg16b.rs
+++ b/crates/core_arch/src/x86_64/cmpxchg16b.rs
@@ -54,15 +54,15 @@ pub unsafe fn cmpxchg16b(
     debug_assert!(dst as usize % 16 == 0);
 
     let (val, _ok) = match (success, failure) {
-        (Acquire, Acquire) => intrinsics::atomic_cxchg_acq(dst, old, new),
-        (Release, Relaxed) => intrinsics::atomic_cxchg_rel(dst, old, new),
-        (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel(dst, old, new),
-        (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed(dst, old, new),
-        (SeqCst, SeqCst) => intrinsics::atomic_cxchg(dst, old, new),
-        (Acquire, Relaxed) => intrinsics::atomic_cxchg_acq_failrelaxed(dst, old, new),
-        (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_failrelaxed(dst, old, new),
-        (SeqCst, Relaxed) => intrinsics::atomic_cxchg_failrelaxed(dst, old, new),
-        (SeqCst, Acquire) => intrinsics::atomic_cxchg_failacq(dst, old, new),
+        (Acquire, Acquire) => intrinsics::atomic_cxchg_acquire_acquire(dst, old, new),
+        (Release, Relaxed) => intrinsics::atomic_cxchg_release_relaxed(dst, old, new),
+        (AcqRel, Acquire) => intrinsics::atomic_cxchg_acqrel_acquire(dst, old, new),
+        (Relaxed, Relaxed) => intrinsics::atomic_cxchg_relaxed_relaxed(dst, old, new),
+        (SeqCst, SeqCst) => intrinsics::atomic_cxchg_seqcst_seqcst(dst, old, new),
+        (Acquire, Relaxed) => intrinsics::atomic_cxchg_acquire_relaxed(dst, old, new),
+        (AcqRel, Relaxed) => intrinsics::atomic_cxchg_acqrel_relaxed(dst, old, new),
+        (SeqCst, Relaxed) => intrinsics::atomic_cxchg_seqcst_relaxed(dst, old, new),
+        (SeqCst, Acquire) => intrinsics::atomic_cxchg_seqcst_acquire(dst, old, new),
 
         // The above block is all copied from libcore, and this statement is
         // also copied from libcore except that it's a panic in libcore and we


### PR DESCRIPTION
The names of atomic intrinsics have been modified in
rust-lang/rust#97423. This pull request updates the
stdarch to use the new naming scheme.

Requires nightly-2022-06-30.