### PR TITLE
Adding doc links for arm crypto and aes intrinsics

### DIFF
--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -664,6 +664,8 @@ pub unsafe fn vld1q_p16(ptr: *const p16) -> poly16x8_t {
 }
 
 /// Load multiple single-element structures to one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(ldr))]
@@ -673,6 +675,8 @@ pub unsafe fn vld1_p64(ptr: *const p64) -> poly64x1_t {
 }
 
 /// Load multiple single-element structures to one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(ldr))]
@@ -959,6 +963,8 @@ pub unsafe fn vst1q_p16(ptr: *mut p16, a: poly16x8_t) {
 }
 
 // Store multiple single-element structures from one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(str))]
@@ -969,6 +975,8 @@ pub unsafe fn vst1_p64(ptr: *mut p64, a: poly64x1_t) {
 }
 
 // Store multiple single-element structures from one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(str))]
@@ -3387,7 +3395,10 @@ pub unsafe fn vsliq_n_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x
     static_assert_imm4!(N);
     transmute(vsliq_n_s16_(transmute(a), transmute(b), N))
 }
+
 /// Shift Left and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsli_n_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(sli, N = 1))]
@@ -3397,7 +3408,10 @@ pub unsafe fn vsli_n_p64<const N: i32>(a: poly64x1_t, b: poly64x1_t) -> poly64x1
     static_assert!(N: i32 where N >= 0 && N <= 63);
     transmute(vsli_n_s64_(transmute(a), transmute(b), N))
 }
+
 /// Shift Left and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsliq_n_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(sli, N = 1))]
@@ -3607,7 +3621,10 @@ pub unsafe fn vsriq_n_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x
     static_assert!(N: i32 where N >= 1 && N <= 16);
     transmute(vsriq_n_s16_(transmute(a), transmute(b), N))
 }
+
 /// Shift Right and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsri_n_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(sri, N = 1))]
@@ -3617,7 +3634,10 @@ pub unsafe fn vsri_n_p64<const N: i32>(a: poly64x1_t, b: poly64x1_t) -> poly64x1
     static_assert!(N: i32 where N >= 1 && N <= 64);
     transmute(vsri_n_s64_(transmute(a), transmute(b), N))
 }
+
 /// Shift Right and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsriq_n_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(sri, N = 1))]

--- a/crates/core_arch/src/arm/neon.rs
+++ b/crates/core_arch/src/arm/neon.rs
@@ -289,6 +289,8 @@ pub unsafe fn vld1q_p16(ptr: *const p16) -> poly16x8_t {
 }
 
 /// Load multiple single-element structures to one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(vldr))]
@@ -297,6 +299,8 @@ pub unsafe fn vld1_p64(ptr: *const p64) -> poly64x1_t {
 }
 
 /// Load multiple single-element structures to one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr("vld1.64"))]
@@ -481,6 +485,8 @@ pub unsafe fn vst1q_p16(ptr: *mut p16, a: poly16x8_t) {
 }
 
 /// Store multiple single-element structures from one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p64)
 #[inline]
 #[target_feature(enable = "neon,aes,v8")]
 #[cfg_attr(test, assert_instr("vst1.64"))]
@@ -489,6 +495,8 @@ pub unsafe fn vst1_p64(ptr: *mut p64, a: poly64x1_t) {
 }
 
 /// Store multiple single-element structures from one, two, three, or four registers.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p64)
 #[inline]
 #[target_feature(enable = "neon,aes,v8")]
 #[cfg_attr(test, assert_instr("vst1.64"))]
@@ -1033,6 +1041,7 @@ pub unsafe fn vsli_n_p16<const N: i32>(a: poly16x4_t, b: poly16x4_t) -> poly16x4
         int16x4_t(n, n, n, n),
     ))
 }
+
 /// Shift Left and Insert (immediate)
 #[inline]
 #[target_feature(enable = "neon,v7")]
@@ -1047,7 +1056,10 @@ pub unsafe fn vsliq_n_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x
         int16x8_t(n, n, n, n, n, n, n, n),
     ))
 }
+
 /// Shift Left and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsli_n_p64)
 #[inline]
 #[target_feature(enable = "neon,v7,aes")]
 #[cfg_attr(test, assert_instr("vsli.64", N = 1))]
@@ -1060,7 +1072,10 @@ pub unsafe fn vsli_n_p64<const N: i32>(a: poly64x1_t, b: poly64x1_t) -> poly64x1
         int64x1_t(N as i64),
     ))
 }
+
 /// Shift Left and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsliq_n_p64)
 #[inline]
 #[target_feature(enable = "neon,v7,aes")]
 #[cfg_attr(test, assert_instr("vsli.64", N = 1))]
@@ -1317,7 +1332,10 @@ pub unsafe fn vsriq_n_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x
         int16x8_t(n, n, n, n, n, n, n, n),
     ))
 }
+
 /// Shift Right and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsri_n_p64)
 #[inline]
 #[target_feature(enable = "neon,v7,aes")]
 #[cfg_attr(test, assert_instr("vsri.64", N = 1))]
@@ -1330,7 +1348,10 @@ pub unsafe fn vsri_n_p64<const N: i32>(a: poly64x1_t, b: poly64x1_t) -> poly64x1
         int64x1_t(-N as i64),
     ))
 }
+
 /// Shift Right and Insert (immediate)
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsriq_n_p64)
 #[inline]
 #[target_feature(enable = "neon,v7,aes")]
 #[cfg_attr(test, assert_instr("vsri.64", N = 1))]

--- a/crates/core_arch/src/arm_shared/crypto.rs
+++ b/crates/core_arch/src/arm_shared/crypto.rs
@@ -52,6 +52,8 @@ extern "unadjusted" {
 use stdarch_test::assert_instr;
 
 /// AES single round encryption.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaeseq_u8)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -61,6 +63,8 @@ pub unsafe fn vaeseq_u8(data: uint8x16_t, key: uint8x16_t) -> uint8x16_t {
 }
 
 /// AES single round decryption.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaesdq_u8)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -70,6 +74,8 @@ pub unsafe fn vaesdq_u8(data: uint8x16_t, key: uint8x16_t) -> uint8x16_t {
 }
 
 /// AES mix columns.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaesmcq_u8)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -79,6 +85,8 @@ pub unsafe fn vaesmcq_u8(data: uint8x16_t) -> uint8x16_t {
 }
 
 /// AES inverse mix columns.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaesimcq_u8)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -88,6 +96,8 @@ pub unsafe fn vaesimcq_u8(data: uint8x16_t) -> uint8x16_t {
 }
 
 /// SHA1 fixed rotate.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1h_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -97,6 +107,8 @@ pub unsafe fn vsha1h_u32(hash_e: u32) -> u32 {
 }
 
 /// SHA1 hash update accelerator, choose.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1cq_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -106,6 +118,8 @@ pub unsafe fn vsha1cq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) ->
 }
 
 /// SHA1 hash update accelerator, majority.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1mq_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -115,6 +129,8 @@ pub unsafe fn vsha1mq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) ->
 }
 
 /// SHA1 hash update accelerator, parity.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1pq_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -124,6 +140,8 @@ pub unsafe fn vsha1pq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) ->
 }
 
 /// SHA1 schedule update accelerator, first part.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1su0q_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -133,6 +151,8 @@ pub unsafe fn vsha1su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_
 }
 
 /// SHA1 schedule update accelerator, second part.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1su1q_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -142,6 +162,8 @@ pub unsafe fn vsha1su1q_u32(tw0_3: uint32x4_t, w12_15: uint32x4_t) -> uint32x4_t
 }
 
 /// SHA256 hash update accelerator.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256hq_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -155,6 +177,8 @@ pub unsafe fn vsha256hq_u32(
 }
 
 /// SHA256 hash update accelerator, upper part.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256h2q_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -168,6 +192,8 @@ pub unsafe fn vsha256h2q_u32(
 }
 
 /// SHA256 schedule update accelerator, first part.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256su0q_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
@@ -177,6 +203,8 @@ pub unsafe fn vsha256su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t 
 }
 
 /// SHA256 schedule update accelerator, second part.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256su1q_u32)
 #[inline]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]

--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -1284,6 +1284,8 @@ pub unsafe fn vld1q_lane_p16<const LANE: i32>(ptr: *const p16, src: poly16x8_t) 
 }
 
 /// Load one single-element structure to one lane of one register.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_lane_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
@@ -1300,6 +1302,8 @@ pub unsafe fn vld1_lane_p64<const LANE: i32>(ptr: *const p64, src: poly64x1_t) -
 }
 
 /// Load one single-element structure to one lane of one register.
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_lane_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
@@ -1675,6 +1679,8 @@ pub unsafe fn vld1_dup_f32(ptr: *const f32) -> float32x2_t {
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
@@ -1696,6 +1702,8 @@ pub unsafe fn vld1_dup_p64(ptr: *const p64) -> poly64x1_t {
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
+///
+/// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]


### PR DESCRIPTION
Hello,

This is followup of #1316 .
This PR has doc links for arms aes and crypto intrinsics. This should cover most of the non neon intrinsics.

Hopefully, for the neon intrinsics I shall work on it later since it would need changes in stdarch-gen .