### PR TITLE
Change test tool to use a loop and load intrinsic.

### DIFF
--- a/crates/intrinsic-test/missing_aarch64.txt
+++ b/crates/intrinsic-test/missing_aarch64.txt
@@ -67,20 +67,6 @@ vrnd64xq_f64
 vrnd64z_f64
 vrnd64zq_f64
 
-# Takes too long to compile tests
-vcopyq_laneq_u8
-vcopyq_laneq_s8
-vcopyq_laneq_p8
-vcopyq_lane_u8
-vcopyq_lane_s8
-vcopyq_lane_p8
-vcopy_laneq_u8
-vcopy_laneq_s8
-vcopy_laneq_p8
-vcopy_lane_u8
-vcopy_lane_s8
-vcopy_lane_p8
-
 # QEMU 6.0 doesn't support these instructions
 vmmlaq_s32
 vmmlaq_u32

--- a/crates/intrinsic-test/src/values.rs
+++ b/crates/intrinsic-test/src/values.rs
@@ -1,9 +1,8 @@
-/// Gets a hex constant value for a single lane in in a determistic way
+/// Gets a hex constant value for a single value in the argument values array in a determistic way
 /// * `bits`: The number of bits for the type, only 8, 16, 32, 64 are valid values
-/// * `simd`: The index of the simd lane we are generating for
-/// * `pass`: The index of the pass we are generating the values for
-pub fn values_for_pass(bits: u32, simd: u32, pass: usize) -> String {
-    let index = pass + (simd as usize);
+/// * `index`: The position in the array we are generating for
+pub fn value_for_array(bits: u32, index: u32) -> String {
+    let index = index as usize;
 
     if bits == 8 {
         format!("{:#X}", VALUES_8[index % VALUES_8.len()])


### PR DESCRIPTION
The files generated by the intrinsic test tool currently repeat the lines for the call multiple times, which sometimes generates very large test files. Changing it to use a loop and a load intrinsic reduces the size of the generated files and gives some coverage for the load intrinsics. This seems to also reduce the run-time for the test tool, enough that some of the intrinsics that are currently skipped because they take too long can be added back and the Rust test files can be built with `--target` again.

Example generated C before:
```
{
    uint64x1_t a = { 0x10000000000000 };
    uint64x1_t b = { 0x10000000000000 };
    auto __return_value = vadd_u64(a, b);
    std::cout << "Result -1: uint64x1_t(" << std::fixed << std::setprecision(150) <<  cast<uint64_t>(__return_value) << ")" << std::endl;
}
{
    uint64x1_t a = { 0x3FDFFFFFFFFFFFFF };
    uint64x1_t b = { 0x3FDFFFFFFFFFFFFF };
    auto __return_value = vadd_u64(a, b);
    std::cout << "Result -2: uint64x1_t(" << std::fixed << std::setprecision(150) <<  cast<uint64_t>(__return_value) << ")" << std::endl;
}
...
// Several more similar blocks
```
Example generated after:
```
const uint64_t a_vals[] = { 0x0,0x10000000000000,0x3FDFFFFFFFFFFFFF,0x3FE0000000000000,0x3FE0000000000001,0x3FEFFFFFFFFFFFFF,0x3FF0000000000000,0x3FF0000000000001,0x3FF8000000000000,0x4024000000000000,  0x7FEFFFFFFFFFFFFF,0x7FF0000000000000,0x7FF923456789ABCD,0x7FF8000000000000,0x7FF123456789ABCD,0x7FF0000000000000,0x123456789ABCD,0xFFFFFFFFFFFFF,0x1,0x8000000000000000 };
const uint64_t b_vals[] = { 0x0,0x10000000000000,0x3FDFFFFFFFFFFFFF,0x3FE0000000000000,0x3FE0000000000001,0x3FEFFFFFFFFFFFFF,0x3FF0000000000000,0x3FF0000000000001,0x3FF8000000000000,0x4024000000000000,  0x7FEFFFFFFFFFFFFF,0x7FF0000000000000,0x7FF923456789ABCD,0x7FF8000000000000,0x7FF123456789ABCD,0x7FF0000000000000,0x123456789ABCD,0xFFFFFFFFFFFFF,0x1,0x8000000000000000 };

...

{
    for (int i=0; i<20; i++) {
        uint64x1_t a = vld1_u64(&a_vals[i]);
        uint64x1_t b = vld1_u64(&b_vals[i]);
        auto __return_value = vadd_u64(a, b);
        std::cout << "Result -" << i+1 << ": uint64x1_t(" << std::fixed << std::setprecision(150) <<  cast<uint64_t>(__return_value) << ")" << std::endl;
    }
}
```
