### PR TITLE
Allow internal use of stdsimd from detect_feature

### DIFF
--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -1,4 +1,5 @@
 #[macro_export]
+#[allow_internal_unstable(stdsimd)]
 macro_rules! detect_feature {
     ($feature:tt, $feature_lit:tt) => {
         $crate::detect_feature!($feature, $feature_lit : $feature_lit)


### PR DESCRIPTION
This allows using feature detection macros, without placing a
requirement of enabled stdsimd feature gate from end users.

A follow-up to changes from #1311, which introduced the new macro.

Noticed while preparing a bump of stdarch submodule in the standard library.