### PR TITLE
Remove late specifiers in __cpuid_count

### DIFF
--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -62,27 +62,27 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     #[cfg(target_arch = "x86")]
     {
         asm!(
-            "movl %ebx, {0}",
+            "movl {0}, ebx",
             "cpuid",
-            "xchgl %ebx, {0}",
-            lateout(reg) ebx,
-            inlateout("eax") leaf => eax,
-            inlateout("ecx") sub_leaf => ecx,
-            lateout("edx") edx,
-            options(nostack, preserves_flags, att_syntax),
+            "xchgl {0}, ebx",
+            out(reg) ebx,
+            inout("eax") leaf => eax,
+            inout("ecx") sub_leaf => ecx,
+            out("edx") edx,
+            options(nostack, preserves_flags),
         );
     }
     #[cfg(target_arch = "x86_64")]
     {
         asm!(
-            "movq %rbx, {0:r}",
+            "movq {0:r}, rbx",
             "cpuid",
-            "xchgq %rbx, {0:r}",
-            lateout(reg) ebx,
-            inlateout("eax") leaf => eax,
-            inlateout("ecx") sub_leaf => ecx,
-            lateout("edx") edx,
-            options(nostack, preserves_flags, att_syntax),
+            "xchgq {0:r}, rbx",
+            out(reg) ebx,
+            inout("eax") leaf => eax,
+            inout("ecx") sub_leaf => ecx,
+            out("edx") edx,
+            options(nostack, preserves_flags),
         );
     }
     CpuidResult { eax, ebx, ecx, edx }

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -62,9 +62,9 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     #[cfg(target_arch = "x86")]
     {
         asm!(
-            "movl {0}, ebx",
+            "mov {0}, ebx",
             "cpuid",
-            "xchgl {0}, ebx",
+            "xchg {0}, ebx",
             out(reg) ebx,
             inout("eax") leaf => eax,
             inout("ecx") sub_leaf => ecx,
@@ -75,9 +75,9 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     #[cfg(target_arch = "x86_64")]
     {
         asm!(
-            "movq {0:r}, rbx",
+            "mov {0:r}, rbx",
             "cpuid",
-            "xchgq {0:r}, rbx",
+            "xchg {0:r}, rbx",
             out(reg) ebx,
             inout("eax") leaf => eax,
             inout("ecx") sub_leaf => ecx,


### PR DESCRIPTION
The `late` specifiers are useless in the case of `__cpuid_count`, there are no opportunities for correct register reuse.

Together with https://github.com/llvm/llvm-project/issues/57550 it causes https://github.com/rust-lang/rust/issues/101346. I strongly suggest checking use of `late` specifiers in other asm blocks as well.

This PR also changes the `__cpuid_count` asm to Intel syntax for consistency with asm in `has_cpuid`.