### PR TITLE
Remove simd_shuffle<n> usage in favor of simd_shuffle

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -101,11 +101,11 @@ macro_rules! simd_shuffle2 {
             const IDX: [u32; 2] = $idx;
         }
 
-        simd_shuffle2($x, $y, ConstParam::<$($imm),+>::IDX)
+        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
     }};
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
         const IDX: [u32; 2] = $idx;
-        simd_shuffle2($x, $y, IDX)
+        simd_shuffle($x, $y, IDX)
     }};
 }
 
@@ -117,11 +117,11 @@ macro_rules! simd_shuffle4 {
             const IDX: [u32; 4] = $idx;
         }
 
-        simd_shuffle4($x, $y, ConstParam::<$($imm),+>::IDX)
+        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
     }};
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
         const IDX: [u32; 4] = $idx;
-        simd_shuffle4($x, $y, IDX)
+        simd_shuffle($x, $y, IDX)
     }};
 }
 
@@ -133,11 +133,11 @@ macro_rules! simd_shuffle8 {
             const IDX: [u32; 8] = $idx;
         }
 
-        simd_shuffle8($x, $y, ConstParam::<$($imm),+>::IDX)
+        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
     }};
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
         const IDX: [u32; 8] = $idx;
-        simd_shuffle8($x, $y, IDX)
+        simd_shuffle($x, $y, IDX)
     }};
 }
 
@@ -149,11 +149,11 @@ macro_rules! simd_shuffle16 {
             const IDX: [u32; 16] = $idx;
         }
 
-        simd_shuffle16($x, $y, ConstParam::<$($imm),+>::IDX)
+        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
     }};
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
         const IDX: [u32; 16] = $idx;
-        simd_shuffle16($x, $y, IDX)
+        simd_shuffle($x, $y, IDX)
     }};
 }
 
@@ -165,11 +165,11 @@ macro_rules! simd_shuffle32 {
             const IDX: [u32; 32] = $idx;
         }
 
-        simd_shuffle32($x, $y, ConstParam::<$($imm),+>::IDX)
+        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
     }};
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
         const IDX: [u32; 32] = $idx;
-        simd_shuffle32($x, $y, IDX)
+        simd_shuffle($x, $y, IDX)
     }};
 }
 
@@ -181,10 +181,10 @@ macro_rules! simd_shuffle64 {
             const IDX: [u32; 64] = $idx;
         }
 
-        simd_shuffle64($x, $y, ConstParam::<$($imm),+>::IDX)
+        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
     }};
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
         const IDX: [u32; 64] = $idx;
-        simd_shuffle64($x, $y, IDX)
+        simd_shuffle($x, $y, IDX)
     }};
 }

--- a/crates/core_arch/src/simd_llvm.rs
+++ b/crates/core_arch/src/simd_llvm.rs
@@ -9,13 +9,7 @@ extern "platform-intrinsic" {
     pub fn simd_gt<T, U>(x: T, y: T) -> U;
     pub fn simd_ge<T, U>(x: T, y: T) -> U;
 
-    pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    pub fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
-    pub fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
-    pub fn simd_shuffle32<T, U>(x: T, y: T, idx: [u32; 32]) -> U;
-    pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
-    pub fn simd_shuffle128<T, U>(x: T, y: T, idx: [u32; 128]) -> U;
+    pub fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 
     #[rustc_const_unstable(feature = "const_simd_insert", issue = "none")]
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;

--- a/crates/core_arch/src/x86/sse3.rs
+++ b/crates/core_arch/src/x86/sse3.rs
@@ -1,11 +1,7 @@
 //! Streaming SIMD Extensions 3 (SSE3)
 
 use crate::{
-    core_arch::{
-        simd::*,
-        simd_llvm::{simd_shuffle2, simd_shuffle4},
-        x86::*,
-    },
+    core_arch::{simd::*, simd_llvm::simd_shuffle, x86::*},
     mem::transmute,
 };
 


### PR DESCRIPTION
This slightly reduces the amount of intrinsics codegen backends need to implement.