### PR TITLE
Edition 2021, apply clippy::uninlined_format_args fix

### DIFF
--- a/crates/assert-instr-macro/Cargo.toml
+++ b/crates/assert-instr-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "assert-instr-macro"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -56,14 +56,14 @@ pub fn assert_instr(
         .replace('/', "_")
         .replace(':', "_")
         .replace(char::is_whitespace, "");
-    let assert_name = syn::Ident::new(&format!("assert_{}_{}", name, instr_str), name.span());
+    let assert_name = syn::Ident::new(&format!("assert_{name}_{instr_str}"), name.span());
     // These name has to be unique enough for us to find it in the disassembly later on:
     let shim_name = syn::Ident::new(
-        &format!("stdarch_test_shim_{}_{}", name, instr_str),
+        &format!("stdarch_test_shim_{name}_{instr_str}"),
         name.span(),
     );
     let shim_name_ptr = syn::Ident::new(
-        &format!("stdarch_test_shim_{}_{}_ptr", name, instr_str).to_ascii_uppercase(),
+        &format!("stdarch_test_shim_{name}_{instr_str}_ptr").to_ascii_uppercase(),
         name.span(),
     );
     let mut inputs = Vec::new();
@@ -131,7 +131,7 @@ pub fn assert_instr(
     } else {
         syn::LitStr::new("C", proc_macro2::Span::call_site())
     };
-    let shim_name_str = format!("{}{}", shim_name, assert_name);
+    let shim_name_str = format!("{shim_name}{assert_name}");
     let to_test = if disable_dedup_guard {
         quote! {
             #attrs

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["core", "simd", "arch", "intrinsics"]
 categories = ["hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "rust-lang/stdarch" }

--- a/crates/intrinsic-test/Cargo.toml
+++ b/crates/intrinsic-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "intrinsic-test"
 version = "0.1.0"
 authors = ["Jamie Cunliffe <Jamie.Cunliffe@arm.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/crates/intrinsic-test/src/acle_csv_parser.rs
+++ b/crates/intrinsic-test/src/acle_csv_parser.rs
@@ -59,8 +59,8 @@ impl Into<Intrinsic> for ACLEIntrinsicLine {
         let signature = self.intrinsic;
         let (ret_ty, remaining) = signature.split_once(' ').unwrap();
 
-        let results = type_from_c(ret_ty)
-            .unwrap_or_else(|_| panic!("Failed to parse return type: {}", ret_ty));
+        let results =
+            type_from_c(ret_ty).unwrap_or_else(|_| panic!("Failed to parse return type: {ret_ty}"));
 
         let (name, args) = remaining.split_once('(').unwrap();
         let args = args.trim_end_matches(')');
@@ -177,7 +177,7 @@ fn from_c(pos: usize, s: &str) -> Argument {
     Argument {
         pos,
         name,
-        ty: type_from_c(s).unwrap_or_else(|_| panic!("Failed to parse type: {}", s)),
+        ty: type_from_c(s).unwrap_or_else(|_| panic!("Failed to parse type: {s}")),
         constraints: vec![],
     }
 }

--- a/crates/intrinsic-test/src/intrinsic.rs
+++ b/crates/intrinsic-test/src/intrinsic.rs
@@ -109,7 +109,7 @@ impl Intrinsic {
     pub fn generate_loop_rust(&self, additional: &str, passes: u32) -> String {
         let constraints = self.arguments.as_constraint_parameters_rust();
         let constraints = if !constraints.is_empty() {
-            format!("::<{}>", constraints)
+            format!("::<{constraints}>")
         } else {
             constraints
         };

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -58,7 +58,7 @@ fn gen_code_c(
                     pass = gen_code_c(
                         intrinsic,
                         constraints,
-                        format!("{}-{}", name, i),
+                        format!("{name}-{i}"),
                         p64_armv7_workaround
                     )
                 )
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {{
 }}"#,
         header_files = header_files
             .iter()
-            .map(|header| format!("#include <{}>", header))
+            .map(|header| format!("#include <{header}>"))
             .collect::<Vec<_>>()
             .join("\n"),
         arglists = intrinsic.arguments.gen_arglists_c(PASSES),
@@ -148,7 +148,7 @@ fn gen_code_rust(intrinsic: &Intrinsic, constraints: &[&Argument], name: String)
                     name = current.name,
                     ty = current.ty.rust_type(),
                     val = i,
-                    pass = gen_code_rust(intrinsic, constraints, format!("{}-{}", name, i))
+                    pass = gen_code_rust(intrinsic, constraints, format!("{name}-{i}"))
                 )
             })
             .collect()
@@ -237,7 +237,7 @@ fn build_rust(intrinsics: &Vec<Intrinsic>, toolchain: &str, a32: bool) -> bool {
     intrinsics.iter().for_each(|i| {
         let rust_dir = format!(r#"rust_programs/{}"#, i.name);
         let _ = std::fs::create_dir_all(&rust_dir);
-        let rust_filename = format!(r#"{}/main.rs"#, rust_dir);
+        let rust_filename = format!(r#"{rust_dir}/main.rs"#);
         let mut file = File::create(&rust_filename).unwrap();
 
         let c_code = generate_rust_program(&i, a32);
@@ -355,7 +355,7 @@ fn main() {
     let filename = matches.value_of("INPUT").unwrap();
     let toolchain = matches
         .value_of("TOOLCHAIN")
-        .map_or("".into(), |t| format!("+{}", t));
+        .map_or("".into(), |t| format!("+{t}"));
 
     let cpp_compiler = matches.value_of("CPPCOMPILER").unwrap();
     let c_runner = matches.value_of("RUNNER").unwrap_or("");
@@ -443,7 +443,7 @@ fn compare_outputs(intrinsics: &Vec<Intrinsic>, toolchain: &str, runner: &str, a
 
             let (c, rust) = match (c, rust) {
                 (Ok(c), Ok(rust)) => (c, rust),
-                a => panic!("{:#?}", a),
+                a => panic!("{a:#?}"),
             };
 
             if !c.status.success() {
@@ -480,20 +480,20 @@ fn compare_outputs(intrinsics: &Vec<Intrinsic>, toolchain: &str, runner: &str, a
 
     intrinsics.iter().for_each(|reason| match reason {
         FailureReason::Difference(intrinsic, c, rust) => {
-            println!("Difference for intrinsic: {}", intrinsic);
+            println!("Difference for intrinsic: {intrinsic}");
             let diff = diff::lines(c, rust);
             diff.iter().for_each(|diff| match diff {
-                diff::Result::Left(c) => println!("C: {}", c),
-                diff::Result::Right(rust) => println!("Rust: {}", rust),
+                diff::Result::Left(c) => println!("C: {c}"),
+                diff::Result::Right(rust) => println!("Rust: {rust}"),
                 diff::Result::Both(_, _) => (),
             });
             println!("****************************************************************");
         }
         FailureReason::RunC(intrinsic) => {
-            println!("Failed to run C program for intrinsic {}", intrinsic)
+            println!("Failed to run C program for intrinsic {intrinsic}")
         }
         FailureReason::RunRust(intrinsic) => {
-            println!("Failed to run rust program for intrinsic {}", intrinsic)
+            println!("Failed to run rust program for intrinsic {intrinsic}")
         }
     });
     println!("{} differences found", intrinsics.len());

--- a/crates/intrinsic-test/src/types.rs
+++ b/crates/intrinsic-test/src/types.rs
@@ -25,7 +25,7 @@ impl FromStr for TypeKind {
             "poly" => Ok(Self::Poly),
             "uint" | "unsigned" => Ok(Self::UInt),
             "void" => Ok(Self::Void),
-            _ => Err(format!("Impossible to parse argument kind {}", s)),
+            _ => Err(format!("Impossible to parse argument kind {s}")),
         }
     }
 }
@@ -199,14 +199,14 @@ impl IntrinsicType {
                 simd_len: Some(simd_len),
                 vec_len: None,
                 ..
-            } => format!("{}{}x{}_t", kind.c_prefix(), bit_len, simd_len),
+            } => format!("{}{bit_len}x{simd_len}_t", kind.c_prefix()),
             IntrinsicType::Type {
                 kind,
                 bit_len: Some(bit_len),
                 simd_len: Some(simd_len),
                 vec_len: Some(vec_len),
                 ..
-            } => format!("{}{}x{}x{}_t", kind.c_prefix(), bit_len, simd_len, vec_len),
+            } => format!("{}{bit_len}x{simd_len}x{vec_len}_t", kind.c_prefix()),
             _ => todo!("{:#?}", self),
         }
     }
@@ -220,7 +220,7 @@ impl IntrinsicType {
                 simd_len: Some(simd_len),
                 vec_len: Some(_),
                 ..
-            } => format!("{}{}x{}_t", kind.c_prefix(), bit_len, simd_len),
+            } => format!("{}{bit_len}x{simd_len}_t", kind.c_prefix()),
             _ => unreachable!("Shouldn't be called on this type"),
         }
     }
@@ -234,21 +234,21 @@ impl IntrinsicType {
                 simd_len: None,
                 vec_len: None,
                 ..
-            } => format!("{}{}", kind.rust_prefix(), bit_len),
+            } => format!("{}{bit_len}", kind.rust_prefix()),
             IntrinsicType::Type {
                 kind,
                 bit_len: Some(bit_len),
                 simd_len: Some(simd_len),
                 vec_len: None,
                 ..
-            } => format!("{}{}x{}_t", kind.c_prefix(), bit_len, simd_len),
+            } => format!("{}{bit_len}x{simd_len}_t", kind.c_prefix()),
             IntrinsicType::Type {
                 kind,
                 bit_len: Some(bit_len),
                 simd_len: Some(simd_len),
                 vec_len: Some(vec_len),
                 ..
-            } => format!("{}{}x{}x{}_t", kind.c_prefix(), bit_len, simd_len, vec_len),
+            } => format!("{}{bit_len}x{simd_len}x{vec_len}_t", kind.c_prefix()),
             _ => todo!("{:#?}", self),
         }
     }

--- a/crates/intrinsic-test/src/values.rs
+++ b/crates/intrinsic-test/src/values.rs
@@ -13,7 +13,7 @@ pub fn value_for_array(bits: u32, index: u32) -> String {
     } else if bits == 64 {
         format!("{:#X}", VALUES_64[index % VALUES_64.len()])
     } else {
-        panic!("Unknown size: {}", bits);
+        panic!("Unknown size: {bits}");
     }
 }
 

--- a/crates/simd-test-macro/Cargo.toml
+++ b/crates/simd-test-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "simd-test-macro"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -59,7 +59,7 @@ pub fn simd_test(
     let macro_test = match target
         .split('-')
         .next()
-        .unwrap_or_else(|| panic!("target triple contained no \"-\": {}", target))
+        .unwrap_or_else(|| panic!("target triple contained no \"-\": {target}"))
     {
         "i686" | "x86_64" | "i586" => "is_x86_feature_detected",
         "arm" | "armv7" => "is_arm_feature_detected",
@@ -82,7 +82,7 @@ pub fn simd_test(
             force_test = true;
             "is_mips64_feature_detected"
         }
-        t => panic!("unknown target: {}", t),
+        t => panic!("unknown target: {t}"),
     };
     let macro_test = Ident::new(macro_test, Span::call_site());
 

--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["std", "run-time", "feature", "detection"]
 categories = ["hardware-support"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "rust-lang/stdarch" }

--- a/crates/std_detect/src/detect/os/linux/aarch64.rs
+++ b/crates/std_detect/src/detect/os/linux/aarch64.rs
@@ -329,7 +329,7 @@ mod tests {
                 env!("CARGO_MANIFEST_DIR"),
                 "/src/detect/test_data/linux-empty-hwcap2-aarch64.auxv"
             );
-            println!("file: {}", file);
+            println!("file: {file}");
             let v = auxv_from_file(file).unwrap();
             println!("HWCAP : 0x{:0x}", v.hwcap);
             println!("HWCAP2: 0x{:0x}", v.hwcap2);
@@ -341,7 +341,7 @@ mod tests {
                 env!("CARGO_MANIFEST_DIR"),
                 "/src/detect/test_data/linux-no-hwcap2-aarch64.auxv"
             );
-            println!("file: {}", file);
+            println!("file: {file}");
             let v = auxv_from_file(file).unwrap();
             println!("HWCAP : 0x{:0x}", v.hwcap);
             println!("HWCAP2: 0x{:0x}", v.hwcap2);
@@ -353,7 +353,7 @@ mod tests {
                 env!("CARGO_MANIFEST_DIR"),
                 "/src/detect/test_data/linux-hwcap2-aarch64.auxv"
             );
-            println!("file: {}", file);
+            println!("file: {file}");
             let v = auxv_from_file(file).unwrap();
             println!("HWCAP : 0x{:0x}", v.hwcap);
             println!("HWCAP2: 0x{:0x}", v.hwcap2);

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -313,7 +313,7 @@ mod tests {
             #[test]
             fn linux_rpi3() {
                 let file = concat!(env!("CARGO_MANIFEST_DIR"), "/src/detect/test_data/linux-rpi3.auxv");
-                println!("file: {}", file);
+                println!("file: {file}");
                 let v = auxv_from_file(file).unwrap();
                 assert_eq!(v.hwcap, 4174038);
                 assert_eq!(v.hwcap2, 16);
@@ -322,7 +322,7 @@ mod tests {
             #[test]
             fn linux_macos_vb() {
                 let file = concat!(env!("CARGO_MANIFEST_DIR"), "/src/detect/test_data/macos-virtualbox-linux-x86-4850HQ.auxv");
-                println!("file: {}", file);
+                println!("file: {file}");
                 // The file contains HWCAP but not HWCAP2. In that case, we treat HWCAP2 as zero.
                 let v = auxv_from_file(file).unwrap();
                 assert_eq!(v.hwcap, 126614527);
@@ -332,7 +332,7 @@ mod tests {
             #[test]
             fn linux_artificial_aarch64() {
                 let file = concat!(env!("CARGO_MANIFEST_DIR"), "/src/detect/test_data/linux-artificial-aarch64.auxv");
-                println!("file: {}", file);
+                println!("file: {file}");
                 let v = auxv_from_file(file).unwrap();
                 assert_eq!(v.hwcap, 0x0123456789abcdef);
                 assert_eq!(v.hwcap2, 0x02468ace13579bdf);
@@ -340,7 +340,7 @@ mod tests {
             #[test]
             fn linux_no_hwcap2_aarch64() {
                 let file = concat!(env!("CARGO_MANIFEST_DIR"), "/src/detect/test_data/linux-no-hwcap2-aarch64.auxv");
-                println!("file: {}", file);
+                println!("file: {file}");
                 let v = auxv_from_file(file).unwrap();
                 // An absent HWCAP2 is treated as zero, and does not prevent acceptance of HWCAP.
                 assert_ne!(v.hwcap, 0);

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -15,7 +15,7 @@ extern crate std_detect;
 #[test]
 fn all() {
     for (f, e) in std_detect::detect::features() {
-        println!("{}: {}", f, e);
+        println!("{f}: {e}");
     }
 }
 

--- a/crates/stdarch-gen/Cargo.toml
+++ b/crates/stdarch-gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stdarch-gen"
 version = "0.1.0"
 authors = ["Heinz Gies <heinz@licenser.net>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/stdarch-gen/src/main.rs
+++ b/crates/stdarch-gen/src/main.rs
@@ -59,7 +59,7 @@ fn type_len(t: &str) -> usize {
             "4_" => 4,
             "8_" => 8,
             "16" => 16,
-            _ => panic!("unknown type: {}", t),
+            _ => panic!("unknown type: {t}"),
         }
     } else if s.len() == 3 {
         s[1].parse::<usize>().unwrap() * type_sub_len(t)
@@ -77,7 +77,7 @@ fn type_sub_len(t: &str) -> usize {
             "2_t" => 2,
             "3_t" => 3,
             "4_t" => 4,
-            _ => panic!("unknown type len: {}", t),
+            _ => panic!("unknown type len: {t}"),
         }
     }
 }
@@ -92,7 +92,7 @@ fn type_bits(t: &str) -> usize {
         | "float32x4_t" | "f32" => 32,
         "int64x1_t" | "int64x2_t" | "uint64x1_t" | "uint64x2_t" | "poly64x1_t" | "poly64x2_t"
         | "i64" | "u64" | "float64x1_t" | "float64x2_t" | "f64" => 64,
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -105,7 +105,7 @@ fn type_exp_len(t: &str, base_len: usize) -> usize {
         4 => 2,
         8 => 3,
         16 => 4,
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -118,7 +118,7 @@ fn type_bits_exp_len(t: &str) -> usize {
         "int32x2_t" | "int32x4_t" | "uint32x2_t" | "uint32x4_t" | "i32" | "u32" => 5,
         "int64x1_t" | "int64x2_t" | "uint64x1_t" | "uint64x2_t" | "poly64x1_t" | "poly64x2_t"
         | "i64" | "u64" => 6,
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -243,7 +243,7 @@ fn type_to_suffix(t: &str) -> &str {
         "p8" => "b_p8",
         "p16" => "h_p16",
         "p128" => "q_p128",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -297,7 +297,7 @@ fn type_to_n_suffix(t: &str) -> &str {
         "u16" => "h_n_u16",
         "u32" => "s_n_u32",
         "u64" => "d_n_u64",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -325,7 +325,7 @@ fn type_to_noq_n_suffix(t: &str) -> &str {
         "u16" => "h_n_u16",
         "u32" => "s_n_u32",
         "u64" => "d_n_u64",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -354,7 +354,7 @@ fn type_to_rot_suffix(c_name: &str, suf: &str) -> String {
     if suf.starts_with("q") {
         format!("{}q_{}{}", ns[0], ns[1], &suf[1..])
     } else {
-        format!("{}{}", c_name, suf)
+        format!("{c_name}{suf}")
     }
 }
 
@@ -426,7 +426,7 @@ fn type_to_noq_suffix(t: &str) -> &str {
         "poly16x4_t" | "poly16x8_t" => "_p16",
         "poly64x1_t" | "poly64x2_t" | "p64" => "_p64",
         "p128" => "_p128",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -521,7 +521,7 @@ fn type_to_global_type(t: &str) -> &str {
         "p16" => "p16",
         "p64" => "p64",
         "p128" => "p128",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -530,7 +530,7 @@ fn type_to_sub_type(t: &str) -> String {
     match s.len() {
         2 => String::from(t),
         3 => format!("{}x{}_t", s[0], s[1]),
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -547,9 +547,9 @@ fn type_to_native_type(t: &str) -> String {
             "uin" => format!("u{}", &s[0][4..]),
             "flo" => format!("f{}", &s[0][5..]),
             "pol" => format!("u{}", &s[0][4..]),
-            _ => panic!("unknown type: {}", t),
+            _ => panic!("unknown type: {t}"),
         },
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -566,7 +566,7 @@ fn native_type_to_type(t: &str) -> &str {
         "f16" => "float16x4_t",
         "f32" => "float32x2_t",
         "f64" => "float64x1_t",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -583,7 +583,7 @@ fn native_type_to_long_type(t: &str) -> &str {
         "f16" => "float16x8_t",
         "f32" => "float32x4_t",
         "f64" => "float64x2_t",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -601,7 +601,7 @@ fn type_to_half(t: &str) -> &str {
         "poly16x8_t" => "poly16x4_t",
         "float32x4_t" => "float32x2_t",
         "float64x2_t" => "float64x1_t",
-        _ => panic!("unknown half type for {}", t),
+        _ => panic!("unknown half type for {t}"),
     }
 }
 
@@ -624,7 +624,7 @@ fn transpose1(x: usize) -> &'static str {
         4 => "[0, 4, 2, 6]",
         8 => "[0, 8, 2, 10, 4, 12, 6, 14]",
         16 => "[0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]",
-        _ => panic!("unknown transpose order of len {}", x),
+        _ => panic!("unknown transpose order of len {x}"),
     }
 }
 
@@ -634,7 +634,7 @@ fn transpose2(x: usize) -> &'static str {
         4 => "[1, 5, 3, 7]",
         8 => "[1, 9, 3, 11, 5, 13, 7, 15]",
         16 => "[1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]",
-        _ => panic!("unknown transpose order of len {}", x),
+        _ => panic!("unknown transpose order of len {x}"),
     }
 }
 
@@ -644,7 +644,7 @@ fn zip1(x: usize) -> &'static str {
         4 => "[0, 4, 1, 5]",
         8 => "[0, 8, 1, 9, 2, 10, 3, 11]",
         16 => "[0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]",
-        _ => panic!("unknown zip order of len {}", x),
+        _ => panic!("unknown zip order of len {x}"),
     }
 }
 
@@ -654,7 +654,7 @@ fn zip2(x: usize) -> &'static str {
         4 => "[2, 6, 3, 7]",
         8 => "[4, 12, 5, 13, 6, 14, 7, 15]",
         16 => "[8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]",
-        _ => panic!("unknown zip order of len {}", x),
+        _ => panic!("unknown zip order of len {x}"),
     }
 }
 
@@ -664,7 +664,7 @@ fn unzip1(x: usize) -> &'static str {
         4 => "[0, 2, 4, 6]",
         8 => "[0, 2, 4, 6, 8, 10, 12, 14]",
         16 => "[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]",
-        _ => panic!("unknown unzip order of len {}", x),
+        _ => panic!("unknown unzip order of len {x}"),
     }
 }
 
@@ -674,13 +674,13 @@ fn unzip2(x: usize) -> &'static str {
         4 => "[1, 3, 5, 7]",
         8 => "[1, 3, 5, 7, 9, 11, 13, 15]",
         16 => "[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]",
-        _ => panic!("unknown unzip order of len {}", x),
+        _ => panic!("unknown unzip order of len {x}"),
     }
 }
 
 fn values(t: &str, vs: &[String]) -> String {
     if vs.len() == 1 && !t.contains('x') {
-        format!(": {} = {}", t, vs[0])
+        format!(": {t} = {}", vs[0])
     } else if vs.len() == 1 && type_to_global_type(t) == "f64" {
         format!(": {} = {}", type_to_global_type(t), vs[0])
     } else {
@@ -723,7 +723,7 @@ fn max_val(t: &str) -> &'static str {
         "i64" => "0x7F_FF_FF_FF_FF_FF_FF_FF",
         "f32" => "3.40282347e+38",
         "f64" => "1.7976931348623157e+308",
-        _ => panic!("No TRUE for type {}", t),
+        _ => panic!("No TRUE for type {t}"),
     }
 }
 
@@ -739,7 +739,7 @@ fn min_val(t: &str) -> &'static str {
         "i64" => "-9223372036854775808",
         "f32" => "-3.40282347e+38",
         "f64" => "-1.7976931348623157e+308",
-        _ => panic!("No TRUE for type {}", t),
+        _ => panic!("No TRUE for type {t}"),
     }
 }
 
@@ -749,7 +749,7 @@ fn true_val(t: &str) -> &'static str {
         "u16" => "0xFF_FF",
         "u32" => "0xFF_FF_FF_FF",
         "u64" => "0xFF_FF_FF_FF_FF_FF_FF_FF",
-        _ => panic!("No TRUE for type {}", t),
+        _ => panic!("No TRUE for type {t}"),
     }
 }
 
@@ -763,7 +763,7 @@ fn ff_val(t: &str) -> &'static str {
         "i16" => "0xFF_FF",
         "i32" => "0xFF_FF_FF_FF",
         "i64" => "0xFF_FF_FF_FF_FF_FF_FF_FF",
-        _ => panic!("No TRUE for type {}", t),
+        _ => panic!("No TRUE for type {t}"),
     }
 }
 
@@ -784,7 +784,7 @@ fn bits(t: &str) -> &'static str {
         "p8x" => "8",
         "p16" => "16",
         "p64" => "64",
-        _ => panic!("Unknown bits for type {}", t),
+        _ => panic!("Unknown bits for type {t}"),
     }
 }
 
@@ -801,7 +801,7 @@ fn bits_minus_one(t: &str) -> &'static str {
         "p8x" => "7",
         "p16" => "15",
         "p64" => "63",
-        _ => panic!("Unknown bits for type {}", t),
+        _ => panic!("Unknown bits for type {t}"),
     }
 }
 
@@ -818,7 +818,7 @@ fn half_bits(t: &str) -> &'static str {
         "p8x" => "4",
         "p16" => "8",
         "p64" => "32",
-        _ => panic!("Unknown bits for type {}", t),
+        _ => panic!("Unknown bits for type {t}"),
     }
 }
 
@@ -852,7 +852,7 @@ fn type_len_str(t: &str) -> &'static str {
         "poly16x8_t" => "8",
         "poly64x1_t" => "1",
         "poly64x2_t" => "2",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -886,7 +886,7 @@ fn type_len_minus_one_str(t: &str) -> &'static str {
         "poly16x8_t" => "7",
         "poly64x1_t" => "0",
         "poly64x2_t" => "1",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -920,7 +920,7 @@ fn type_half_len_str(t: &str) -> &'static str {
         "poly16x8_t" => "4",
         "poly64x1_t" => "0",
         "poly64x2_t" => "1",
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     }
 }
 
@@ -954,12 +954,12 @@ fn type_to_ext(t: &str, v: bool, r: bool, pi8: bool) -> String {
             native
         ),
         _ if pi8 => format!(".p0i8"),
-        _ => format!(".p0{}", native),
+        _ => format!(".p0{native}"),
     };
     let sub_type = match &native[0..1] {
         "i" | "f" => native,
         "u" => native.replace("u", "i"),
-        _ => panic!("unknown type: {}", t),
+        _ => panic!("unknown type: {t}"),
     };
     let ext = format!(
         "v{}{}{}",
@@ -1041,8 +1041,8 @@ fn gen_aarch64(
     fn_type: Fntype,
 ) -> (String, String) {
     let name = match suffix {
-        Normal => format!("{}{}", current_name, type_to_suffix(in_t[1])),
-        NoQ => format!("{}{}", current_name, type_to_noq_suffix(in_t[1])),
+        Normal => format!("{current_name}{}", type_to_suffix(in_t[1])),
+        NoQ => format!("{current_name}{}", type_to_noq_suffix(in_t[1])),
         Double => format!(
             "{}{}",
             current_name,
@@ -1053,15 +1053,15 @@ fn gen_aarch64(
             current_name,
             type_to_noq_double_suffixes(out_t, in_t[1])
         ),
-        NSuffix => format!("{}{}", current_name, type_to_n_suffix(in_t[1])),
+        NSuffix => format!("{current_name}{}", type_to_n_suffix(in_t[1])),
         DoubleN => format!(
             "{}{}",
             current_name,
             type_to_double_n_suffixes(out_t, in_t[1])
         ),
-        NoQNSuffix => format!("{}{}", current_name, type_to_noq_n_suffix(in_t[1])),
-        OutSuffix => format!("{}{}", current_name, type_to_suffix(out_t)),
-        OutNSuffix => format!("{}{}", current_name, type_to_n_suffix(out_t)),
+        NoQNSuffix => format!("{current_name}{}", type_to_noq_n_suffix(in_t[1])),
+        OutSuffix => format!("{current_name}{}", type_to_suffix(out_t)),
+        OutNSuffix => format!("{current_name}{}", type_to_n_suffix(out_t)),
         OutNox => format!(
             "{}{}",
             current_name,
@@ -1092,7 +1092,7 @@ fn gen_aarch64(
             current_name,
             type_to_lane_suffixes(out_t, in_t[1], false)
         ),
-        In2 => format!("{}{}", current_name, type_to_suffix(in_t[2])),
+        In2 => format!("{current_name}{}", type_to_suffix(in_t[2])),
         In2Lane => format!(
             "{}{}",
             current_name,
@@ -1122,11 +1122,11 @@ fn gen_aarch64(
     };
     let current_fn = if let Some(current_fn) = current_fn.clone() {
         if link_aarch64.is_some() {
-            panic!("[{}] Can't specify link and fn at the same time.", name)
+            panic!("[{name}] Can't specify link and fn at the same time.")
         }
         current_fn
     } else if link_aarch64.is_some() {
-        format!("{}_", name)
+        format!("{name}_")
     } else {
         if multi_fn.is_empty() {
             panic!(
@@ -1174,8 +1174,8 @@ fn gen_aarch64(
                     let sub = type_to_sub_type(in_t[1]);
                     (
                         match type_sub_len(in_t[1]) {
-                            1 => format!("a: {}, n: i64, ptr: {}", sub, ptr_type),
-                            2 => format!("a: {}, b: {}, n: i64, ptr: {}", sub, sub, ptr_type),
+                            1 => format!("a: {sub}, n: i64, ptr: {ptr_type}"),
+                            2 => format!("a: {sub}, b: {sub}, n: i64, ptr: {ptr_type}"),
                             3 => format!(
                                 "a: {}, b: {}, c: {}, n: i64, ptr: {}",
                                 sub, sub, sub, ptr_type
@@ -1187,7 +1187,7 @@ fn gen_aarch64(
                             _ => panic!("unsupported type: {}", in_t[1]),
                         },
                         if out_t != "void" {
-                            format!(" -> {}", out_t)
+                            format!(" -> {out_t}")
                         } else {
                             String::new()
                         },
@@ -1200,7 +1200,7 @@ fn gen_aarch64(
                             3 => format!("a: {}, b: {}, c: {}, n: i32", in_t[0], in_t[1], in_t[2]),
                             _ => unimplemented!("unknown para_num"),
                         },
-                        format!(" -> {}", out_t),
+                        format!(" -> {out_t}"),
                     )
                 }
             } else if matches!(fn_type, Fntype::Store) {
@@ -1211,23 +1211,20 @@ fn gen_aarch64(
                     type_to_native_type(in_t[1])
                 };
                 let subs = match type_sub_len(in_t[1]) {
-                    1 => format!("a: {}", sub),
-                    2 => format!("a: {}, b: {}", sub, sub),
-                    3 => format!("a: {}, b: {}, c: {}", sub, sub, sub),
-                    4 => format!("a: {}, b: {}, c: {}, d: {}", sub, sub, sub, sub),
+                    1 => format!("a: {sub}"),
+                    2 => format!("a: {sub}, b: {sub}"),
+                    3 => format!("a: {sub}, b: {sub}, c: {sub}"),
+                    4 => format!("a: {sub}, b: {sub}, c: {sub}, d: {sub}"),
                     _ => panic!("unsupported type: {}", in_t[1]),
                 };
-                (format!("{}, ptr: *mut {}", subs, ptr_type), String::new())
+                (format!("{subs}, ptr: *mut {ptr_type}"), String::new())
             } else if is_vldx(&name) {
                 let ptr_type = if name.contains("dup") {
                     type_to_native_type(out_t)
                 } else {
                     type_to_sub_type(out_t)
                 };
-                (
-                    format!("ptr: *const {}", ptr_type),
-                    format!(" -> {}", out_t),
-                )
+                (format!("ptr: *const {ptr_type}"), format!(" -> {out_t}"))
             } else {
                 (
                     match para_num {
@@ -1256,7 +1253,7 @@ fn gen_aarch64(
             assert_eq!(constns.len(), 2);
             format!(r#"<const {}: i32, const {}: i32>"#, constns[0], constns[1])
         } else {
-            format!(r#"<const {}: i32>"#, constn)
+            format!(r#"<const {constn}: i32>"#)
         }
     } else {
         String::new()
@@ -1314,7 +1311,7 @@ fn gen_aarch64(
                 para_num + 1
             )
         } else {
-            format!("\n#[rustc_legacy_const_generics({})]", para_num)
+            format!("\n#[rustc_legacy_const_generics({para_num})]")
         }
     } else {
         String::new()
@@ -1323,7 +1320,7 @@ fn gen_aarch64(
         let fn_output = if out_t == "void" {
             String::new()
         } else {
-            format!("-> {} ", out_t)
+            format!("-> {out_t} ")
         };
         let fn_inputs = match para_num {
             1 => format!("(a: {})", in_t[0]),
@@ -1373,14 +1370,14 @@ fn gen_aarch64(
         } else if link_aarch64.is_some() && matches!(fn_type, Fntype::Store) {
             let cast = if is_vstx(&name) { " as _" } else { "" };
             match type_sub_len(in_t[1]) {
-                1 => format!(r#"{}{}(b, a{})"#, ext_c, current_fn, cast),
-                2 => format!(r#"{}{}(b.0, b.1, a{})"#, ext_c, current_fn, cast),
-                3 => format!(r#"{}{}(b.0, b.1, b.2, a{})"#, ext_c, current_fn, cast),
-                4 => format!(r#"{}{}(b.0, b.1, b.2, b.3, a{})"#, ext_c, current_fn, cast),
+                1 => format!(r#"{ext_c}{current_fn}(b, a{cast})"#),
+                2 => format!(r#"{ext_c}{current_fn}(b.0, b.1, a{cast})"#),
+                3 => format!(r#"{ext_c}{current_fn}(b.0, b.1, b.2, a{cast})"#),
+                4 => format!(r#"{ext_c}{current_fn}(b.0, b.1, b.2, b.3, a{cast})"#),
                 _ => panic!("unsupported type: {}", in_t[1]),
             }
         } else if link_aarch64.is_some() && is_vldx(&name) {
-            format!(r#"{}{}(a as _)"#, ext_c, current_fn,)
+            format!(r#"{ext_c}{current_fn}(a as _)"#,)
         } else {
             let trans: [&str; 2] = if link_t[3] != out_t {
                 ["transmute(", ")"]
@@ -1388,7 +1385,7 @@ fn gen_aarch64(
                 ["", ""]
             };
             match (multi_calls.len(), para_num, fixed.len()) {
-                (0, 1, 0) => format!(r#"{}{}{}(a){}"#, ext_c, trans[0], current_fn, trans[1]),
+                (0, 1, 0) => format!(r#"{ext_c}{}{current_fn}(a){}"#, trans[0], trans[1]),
                 (0, 1, _) => {
                     let fixed: Vec<String> =
                         fixed.iter().take(type_len(in_t[0])).cloned().collect();
@@ -1402,11 +1399,11 @@ fn gen_aarch64(
                         trans[1],
                     )
                 }
-                (0, 2, _) => format!(r#"{}{}{}(a, b){}"#, ext_c, trans[0], current_fn, trans[1],),
-                (0, 3, _) => format!(r#"{}{}(a, b, c)"#, ext_c, current_fn,),
-                (_, 1, _) => format!(r#"{}{}"#, ext_c, multi_calls,),
-                (_, 2, _) => format!(r#"{}{}"#, ext_c, multi_calls,),
-                (_, 3, _) => format!(r#"{}{}"#, ext_c, multi_calls,),
+                (0, 2, _) => format!(r#"{ext_c}{}{current_fn}(a, b){}"#, trans[0], trans[1],),
+                (0, 3, _) => format!(r#"{ext_c}{current_fn}(a, b, c)"#,),
+                (_, 1, _) => format!(r#"{ext_c}{multi_calls}"#,),
+                (_, 2, _) => format!(r#"{ext_c}{multi_calls}"#,),
+                (_, 3, _) => format!(r#"{ext_c}{multi_calls}"#,),
                 (_, _, _) => String::new(),
             }
         }
@@ -1768,8 +1765,8 @@ fn gen_arm(
     separate: bool,
 ) -> (String, String) {
     let name = match suffix {
-        Normal => format!("{}{}", current_name, type_to_suffix(in_t[1])),
-        NoQ => format!("{}{}", current_name, type_to_noq_suffix(in_t[1])),
+        Normal => format!("{current_name}{}", type_to_suffix(in_t[1])),
+        NoQ => format!("{current_name}{}", type_to_noq_suffix(in_t[1])),
         Double => format!(
             "{}{}",
             current_name,
@@ -1780,15 +1777,15 @@ fn gen_arm(
             current_name,
             type_to_noq_double_suffixes(out_t, in_t[1])
         ),
-        NSuffix => format!("{}{}", current_name, type_to_n_suffix(in_t[1])),
+        NSuffix => format!("{current_name}{}", type_to_n_suffix(in_t[1])),
         DoubleN => format!(
             "{}{}",
             current_name,
             type_to_double_n_suffixes(out_t, in_t[1])
         ),
-        NoQNSuffix => format!("{}{}", current_name, type_to_noq_n_suffix(in_t[1])),
-        OutSuffix => format!("{}{}", current_name, type_to_suffix(out_t)),
-        OutNSuffix => format!("{}{}", current_name, type_to_n_suffix(out_t)),
+        NoQNSuffix => format!("{current_name}{}", type_to_noq_n_suffix(in_t[1])),
+        OutSuffix => format!("{current_name}{}", type_to_suffix(out_t)),
+        OutNSuffix => format!("{current_name}{}", type_to_n_suffix(out_t)),
         OutNox => format!(
             "{}{}",
             current_name,
@@ -1819,7 +1816,7 @@ fn gen_arm(
             current_name,
             type_to_lane_suffixes(out_t, in_t[1], false)
         ),
-        In2 => format!("{}{}", current_name, type_to_suffix(in_t[2])),
+        In2 => format!("{current_name}{}", type_to_suffix(in_t[2])),
         In2Lane => format!(
             "{}{}",
             current_name,
@@ -1873,7 +1870,7 @@ fn gen_arm(
         }
         current_fn
     } else if link_aarch64.is_some() || link_arm.is_some() {
-        format!("{}_", name)
+        format!("{name}_")
     } else {
         if multi_fn.is_empty() {
             panic!(
@@ -1980,9 +1977,9 @@ fn gen_arm(
                     };
                     let sub_type = type_to_sub_type(in_t[1]);
                     let inputs = match type_sub_len(in_t[1]) {
-                        1 => format!("a: {}", sub_type),
-                        2 => format!("a: {}, b: {}", sub_type, sub_type,),
-                        3 => format!("a: {}, b: {}, c: {}", sub_type, sub_type, sub_type,),
+                        1 => format!("a: {sub_type}"),
+                        2 => format!("a: {sub_type}, b: {sub_type}",),
+                        3 => format!("a: {sub_type}, b: {sub_type}, c: {sub_type}",),
                         4 => format!(
                             "a: {}, b: {}, c: {}, d: {}",
                             sub_type, sub_type, sub_type, sub_type,
@@ -1992,12 +1989,9 @@ fn gen_arm(
                     let out = if out_t == "void" {
                         String::new()
                     } else {
-                        format!(" -> {}", out_t)
+                        format!(" -> {out_t}")
                     };
-                    (
-                        format!("ptr: {}, {}, n: i32, size: i32", ptr_type, inputs),
-                        out,
-                    )
+                    (format!("ptr: {ptr_type}, {inputs}, n: i32, size: i32"), out)
                 } else {
                     let (_, const_type) = if const_arm.contains(":") {
                         let consts: Vec<_> =
@@ -2011,15 +2005,15 @@ fn gen_arm(
                     };
                     (
                         match para_num {
-                            1 => format!("a: {}, n: {}", in_t[0], const_type),
-                            2 => format!("a: {}, b: {}, n: {}", in_t[0], in_t[1], const_type),
+                            1 => format!("a: {}, n: {const_type}", in_t[0]),
+                            2 => format!("a: {}, b: {}, n: {const_type}", in_t[0], in_t[1]),
                             3 => format!(
-                                "a: {}, b: {}, c: {}, n: {}",
-                                in_t[0], in_t[1], in_t[2], const_type
+                                "a: {}, b: {}, c: {}, n: {const_type}",
+                                in_t[0], in_t[1], in_t[2]
                             ),
                             _ => unimplemented!("unknown para_num"),
                         },
-                        format!(" -> {}", out_t),
+                        format!(" -> {out_t}"),
                     )
                 }
             } else if out_t != link_arm_t[3] {
@@ -2038,9 +2032,9 @@ fn gen_arm(
             } else if matches!(fn_type, Fntype::Store) {
                 let sub_type = type_to_sub_type(in_t[1]);
                 let inputs = match type_sub_len(in_t[1]) {
-                    1 => format!("a: {}", sub_type),
-                    2 => format!("a: {}, b: {}", sub_type, sub_type,),
-                    3 => format!("a: {}, b: {}, c: {}", sub_type, sub_type, sub_type,),
+                    1 => format!("a: {sub_type}"),
+                    2 => format!("a: {sub_type}, b: {sub_type}",),
+                    3 => format!("a: {sub_type}, b: {sub_type}, c: {sub_type}",),
                     4 => format!(
                         "a: {}, b: {}, c: {}, d: {}",
                         sub_type, sub_type, sub_type, sub_type,
@@ -2053,14 +2047,11 @@ fn gen_arm(
                     (type_to_native_type(in_t[1]), "")
                 };
                 (
-                    format!("ptr: *mut {}, {}{}", ptr_type, inputs, size),
+                    format!("ptr: *mut {ptr_type}, {inputs}{size}"),
                     String::new(),
                 )
             } else if is_vldx(&name) {
-                (
-                    format!("ptr: *const i8, size: i32"),
-                    format!(" -> {}", out_t),
-                )
+                (format!("ptr: *const i8, size: i32"), format!(" -> {out_t}"))
             } else {
                 (String::new(), String::new())
             }
@@ -2084,20 +2075,20 @@ fn gen_arm(
                     };
                     let sub_type = type_to_sub_type(in_t[1]);
                     let mut inputs = match type_sub_len(in_t[1]) {
-                        1 => format!("a: {}", sub_type,),
-                        2 => format!("a: {}, b: {}", sub_type, sub_type,),
-                        3 => format!("a: {}, b: {}, c: {}", sub_type, sub_type, sub_type,),
+                        1 => format!("a: {sub_type}",),
+                        2 => format!("a: {sub_type}, b: {sub_type}",),
+                        3 => format!("a: {sub_type}, b: {sub_type}, c: {sub_type}",),
                         4 => format!(
                             "a: {}, b: {}, c: {}, d: {}",
                             sub_type, sub_type, sub_type, sub_type,
                         ),
                         _ => panic!("unknown type: {}", in_t[1]),
                     };
-                    inputs.push_str(&format!(", n: i64, ptr: {}", ptr_type));
+                    inputs.push_str(&format!(", n: i64, ptr: {ptr_type}"));
                     let out = if out_t == "void" {
                         String::new()
                     } else {
-                        format!(" -> {}", out_t)
+                        format!(" -> {out_t}")
                     };
                     (inputs, out)
                 } else if const_aarch64.contains("dup-in_len-N as ttn") {
@@ -2111,7 +2102,7 @@ fn gen_arm(
                             ),
                             _ => unimplemented!("unknown para_num"),
                         },
-                        format!(" -> {}", out_t),
+                        format!(" -> {out_t}"),
                     )
                 } else {
                     (
@@ -2121,7 +2112,7 @@ fn gen_arm(
                             3 => format!("a: {}, b: {}, c: {}, n: i32", in_t[0], in_t[1], in_t[2]),
                             _ => unimplemented!("unknown para_num"),
                         },
-                        format!(" -> {}", out_t),
+                        format!(" -> {out_t}"),
                     )
                 }
             } else if out_t != link_aarch64_t[3] {
@@ -2140,9 +2131,9 @@ fn gen_arm(
             } else if matches!(fn_type, Fntype::Store) {
                 let sub_type = type_to_sub_type(in_t[1]);
                 let mut inputs = match type_sub_len(in_t[1]) {
-                    1 => format!("a: {}", sub_type,),
-                    2 => format!("a: {}, b: {}", sub_type, sub_type,),
-                    3 => format!("a: {}, b: {}, c: {}", sub_type, sub_type, sub_type,),
+                    1 => format!("a: {sub_type}",),
+                    2 => format!("a: {sub_type}, b: {sub_type}",),
+                    3 => format!("a: {sub_type}, b: {sub_type}, c: {sub_type}",),
                     4 => format!(
                         "a: {}, b: {}, c: {}, d: {}",
                         sub_type, sub_type, sub_type, sub_type,
@@ -2154,7 +2145,7 @@ fn gen_arm(
                 } else {
                     type_to_native_type(in_t[1])
                 };
-                inputs.push_str(&format!(", ptr: *mut {}", ptr_type));
+                inputs.push_str(&format!(", ptr: *mut {ptr_type}"));
                 (inputs, String::new())
             } else if is_vldx(&name) {
                 let ptr_type = if name.contains("dup") {
@@ -2162,10 +2153,7 @@ fn gen_arm(
                 } else {
                     type_to_sub_type(out_t)
                 };
-                (
-                    format!("ptr: *const {}", ptr_type),
-                    format!(" -> {}", out_t),
-                )
+                (format!("ptr: *const {ptr_type}"), format!(" -> {out_t}"))
             } else {
                 (String::new(), String::new())
             }
@@ -2181,7 +2169,7 @@ fn gen_arm(
         ));
     };
     let const_declare = if let Some(constn) = constn {
-        format!(r#"<const {}: i32>"#, constn)
+        format!(r#"<const {constn}: i32>"#)
     } else {
         String::new()
     };
@@ -2216,7 +2204,7 @@ fn gen_arm(
         String::new()
     };
     let const_legacy = if constn.is_some() {
-        format!("\n#[rustc_legacy_const_generics({})]", para_num)
+        format!("\n#[rustc_legacy_const_generics({para_num})]")
     } else {
         String::new()
     };
@@ -2224,7 +2212,7 @@ fn gen_arm(
         let fn_output = if out_t == "void" {
             String::new()
         } else {
-            format!("-> {} ", out_t)
+            format!("-> {out_t} ")
         };
         let fn_inputs = match para_num {
             1 => format!("(a: {})", in_t[0]),
@@ -2274,15 +2262,15 @@ fn gen_arm(
                         cnt
                     };
                     match para_num {
-                        1 => format!("{}(a, {})", current_fn, cnt),
-                        2 => format!("{}(a, b, {})", current_fn, cnt),
+                        1 => format!("{current_fn}(a, {cnt})"),
+                        2 => format!("{current_fn}(a, b, {cnt})"),
                         _ => String::new(),
                     }
                 }
             } else if out_t != link_arm_t[3] {
                 match para_num {
-                    1 => format!("transmute({}(a))", current_fn,),
-                    2 => format!("transmute({}(transmute(a), transmute(b)))", current_fn,),
+                    1 => format!("transmute({current_fn}(a))",),
+                    2 => format!("transmute({current_fn}(transmute(a), transmute(b)))",),
                     _ => String::new(),
                 }
             } else if matches!(fn_type, Fntype::Store) {
@@ -2295,10 +2283,10 @@ fn gen_arm(
                     ("", String::new())
                 };
                 match type_sub_len(in_t[1]) {
-                    1 => format!("{}(a{}, b{})", current_fn, cast, size),
-                    2 => format!("{}(a{}, b.0, b.1{})", current_fn, cast, size),
-                    3 => format!("{}(a{}, b.0, b.1, b.2{})", current_fn, cast, size),
-                    4 => format!("{}(a{}, b.0, b.1, b.2, b.3{})", current_fn, cast, size),
+                    1 => format!("{current_fn}(a{cast}, b{size})"),
+                    2 => format!("{current_fn}(a{cast}, b.0, b.1{size})"),
+                    3 => format!("{current_fn}(a{cast}, b.0, b.1, b.2{size})"),
+                    4 => format!("{current_fn}(a{cast}, b.0, b.1, b.2, b.3{size})"),
                     _ => String::new(),
                 }
             } else if link_arm.is_some() && is_vldx(&name) {
@@ -2345,31 +2333,31 @@ fn gen_arm(
                             cnt.push_str(&const_aarch64);
                         }
                         cnt.push_str(")");
-                        format!("{}(a, {})", current_fn, cnt)
+                        format!("{current_fn}(a, {cnt})")
                     } else {
                         match para_num {
-                            1 => format!("{}(a, {})", current_fn, const_aarch64),
-                            2 => format!("{}(a, b, {})", current_fn, const_aarch64),
+                            1 => format!("{current_fn}(a, {const_aarch64})"),
+                            2 => format!("{current_fn}(a, b, {const_aarch64})"),
                             _ => String::new(),
                         }
                     }
                 } else if out_t != link_aarch64_t[3] {
                     match para_num {
-                        1 => format!("transmute({}(a))", current_fn,),
-                        2 => format!("transmute({}(a, b))", current_fn,),
+                        1 => format!("transmute({current_fn}(a))",),
+                        2 => format!("transmute({current_fn}(a, b))",),
                         _ => String::new(),
                     }
                 } else if matches!(fn_type, Fntype::Store) {
                     let cast = if is_vstx(&name) { " as _" } else { "" };
                     match type_sub_len(in_t[1]) {
-                        1 => format!("{}(b, a{})", current_fn, cast),
-                        2 => format!("{}(b.0, b.1, a{})", current_fn, cast),
-                        3 => format!("{}(b.0, b.1, b.2, a{})", current_fn, cast),
-                        4 => format!("{}(b.0, b.1, b.2, b.3, a{})", current_fn, cast),
+                        1 => format!("{current_fn}(b, a{cast})"),
+                        2 => format!("{current_fn}(b.0, b.1, a{cast})"),
+                        3 => format!("{current_fn}(b.0, b.1, b.2, a{cast})"),
+                        4 => format!("{current_fn}(b.0, b.1, b.2, b.3, a{cast})"),
                         _ => String::new(),
                     }
                 } else if link_aarch64.is_some() && is_vldx(&name) {
-                    format!("{}(a as _)", current_fn)
+                    format!("{current_fn}(a as _)")
                 } else {
                     String::new()
                 };
@@ -2421,7 +2409,7 @@ fn gen_arm(
     } else {
         let call = {
             let stmts = match (multi_calls.len(), para_num, fixed.len()) {
-                (0, 1, 0) => format!(r#"{}{}(a)"#, ext_c, current_fn,),
+                (0, 1, 0) => format!(r#"{ext_c}{current_fn}(a)"#,),
                 (0, 1, _) => {
                     let fixed: Vec<String> =
                         fixed.iter().take(type_len(in_t[0])).cloned().collect();
@@ -2433,11 +2421,11 @@ fn gen_arm(
                         current_fn,
                     )
                 }
-                (0, 2, _) => format!(r#"{}{}(a, b)"#, ext_c, current_fn,),
-                (0, 3, _) => format!(r#"{}{}(a, b, c)"#, ext_c, current_fn,),
-                (_, 1, _) => format!(r#"{}{}"#, ext_c, multi_calls,),
-                (_, 2, _) => format!(r#"{}{}"#, ext_c, multi_calls,),
-                (_, 3, _) => format!(r#"{}{}"#, ext_c, multi_calls,),
+                (0, 2, _) => format!(r#"{ext_c}{current_fn}(a, b)"#,),
+                (0, 3, _) => format!(r#"{ext_c}{current_fn}(a, b, c)"#,),
+                (_, 1, _) => format!(r#"{ext_c}{multi_calls}"#,),
+                (_, 2, _) => format!(r#"{ext_c}{multi_calls}"#,),
+                (_, 3, _) => format!(r#"{ext_c}{multi_calls}"#,),
                 (_, _, _) => String::new(),
             };
             if stmts != String::new() {
@@ -2536,9 +2524,9 @@ fn expand_intrinsic(intr: &str, t: &str) -> String {
             "poly64x1_t" => "i64x1",
             "poly64x2_t" => "i64x2",
             */
-            _ => panic!("unknown type for extension: {}", t),
+            _ => panic!("unknown type for extension: {t}"),
         };
-        format!(r#""{}{}""#, intr, ext)
+        format!(r#""{intr}{ext}""#)
     } else if intr.ends_with(".s") {
         let ext = match t {
             "int8x8_t" => "s8",
@@ -2571,9 +2559,9 @@ fn expand_intrinsic(intr: &str, t: &str) -> String {
             "poly64x1_t" => "i64x1",
             "poly64x2_t" => "i64x2",
             */
-            _ => panic!("unknown type for extension: {}", t),
+            _ => panic!("unknown type for extension: {t}"),
         };
-        format!(r#""{}{}""#, &intr[..intr.len() - 1], ext)
+        format!(r#""{}{ext}""#, &intr[..intr.len() - 1])
     } else if intr.ends_with(".l") {
         let ext = match t {
             "int8x8_t" => "8",
@@ -2604,9 +2592,9 @@ fn expand_intrinsic(intr: &str, t: &str) -> String {
             "float64x2_t" => "64",
             "poly64x1_t" => "64",
             "poly64x2_t" => "64",
-            _ => panic!("unknown type for extension: {}", t),
+            _ => panic!("unknown type for extension: {t}"),
         };
-        format!(r#""{}{}""#, &intr[..intr.len() - 1], ext)
+        format!(r#""{}{ext}""#, &intr[..intr.len() - 1])
     } else {
         intr.to_string()
     }
@@ -2655,7 +2643,7 @@ fn get_call(
             "halflen" => type_len(in_t[1]) / 2,
             _ => 0,
         };
-        let mut s = format!("{} [", const_declare);
+        let mut s = format!("{const_declare} [");
         for i in 0..len {
             if i != 0 {
                 s.push_str(", ");
@@ -2693,9 +2681,9 @@ fn get_call(
                 if i != 0 || j != 0 {
                     s.push_str(", ");
                 }
-                s.push_str(&format!("{} * {} as u32", base_len, &fn_format[2]));
+                s.push_str(&format!("{base_len} * {} as u32", &fn_format[2]));
                 if j != 0 {
-                    s.push_str(&format!(" + {}", j));
+                    s.push_str(&format!(" + {j}"));
                 }
             }
         }
@@ -2709,7 +2697,7 @@ fn get_call(
             "in_ttn" => type_to_native_type(in_t[1]),
             _ => String::new(),
         };
-        return format!("{} as {}", &fn_format[1], t);
+        return format!("{} as {t}", &fn_format[1]);
     }
     if fn_name.starts_with("ins") {
         let fn_format: Vec<_> = fn_name.split('-').map(|v| v.to_string()).collect();
@@ -2726,7 +2714,7 @@ fn get_call(
             "in0_len" => type_len(in_t[0]),
             _ => 0,
         };
-        let mut s = format!("{} [", const_declare);
+        let mut s = format!("{const_declare} [");
         for i in 0..len {
             if i != 0 {
                 s.push_str(", ");
@@ -2760,7 +2748,7 @@ fn get_call(
                 fn_format[2], fn_format[2]
             );
         } else {
-            return format!(r#"static_assert_imm{}!({});"#, len, fn_format[2]);
+            return format!(r#"static_assert_imm{len}!({});"#, fn_format[2]);
         }
     }
     if fn_name.starts_with("static_assert") {
@@ -2781,13 +2769,13 @@ fn get_call(
         };
         if lim1 == lim2 {
             return format!(
-                r#"static_assert!({} : i32 where {} == {});"#,
-                fn_format[1], fn_format[1], lim1
+                r#"static_assert!({} : i32 where {} == {lim1});"#,
+                fn_format[1], fn_format[1]
             );
         } else {
             return format!(
-                r#"static_assert!({} : i32 where {} >= {} && {} <= {});"#,
-                fn_format[1], fn_format[1], lim1, fn_format[1], lim2
+                r#"static_assert!({} : i32 where {} >= {lim1} && {} <= {lim2});"#,
+                fn_format[1], fn_format[1], fn_format[1]
             );
         }
     }
@@ -2945,7 +2933,7 @@ fn get_call(
     if fn_name == "fixed" {
         let (re_name, re_type) = re.unwrap();
         let fixed: Vec<String> = fixed.iter().take(type_len(in_t[1])).cloned().collect();
-        return format!(r#"let {}{};"#, re_name, values(&re_type, &fixed));
+        return format!(r#"let {re_name}{};"#, values(&re_type, &fixed));
     }
     if fn_name == "fixed-half-right" {
         let fixed: Vec<String> = fixed.iter().take(type_len(in_t[1])).cloned().collect();
@@ -3083,9 +3071,9 @@ fn get_call(
             re_name, re_type, fn_name, param_str
         )
     } else if fn_name.starts_with("*") {
-        format!(r#"{} = {};"#, fn_name, param_str)
+        format!(r#"{fn_name} = {param_str};"#)
     } else {
-        format!(r#"{}({})"#, fn_name, param_str)
+        format!(r#"{fn_name}({param_str})"#)
     };
     return fn_str;
 }
@@ -3337,7 +3325,7 @@ mod test {
                     in_t = [spec[0], spec[1], spec[2]];
                     out_t = spec[3];
                 } else {
-                    panic!("Bad spec: {}", line)
+                    panic!("Bad spec: {line}")
                 }
                 if b.len() == 0 {
                     if matches!(fn_type, Fntype::Store) {
@@ -3430,8 +3418,8 @@ mod test {
         .arg(&arm_out_path)
         .arg(&aarch64_out_path)
         .status() {
-            eprintln!("Could not format `{}`: {}", arm_out_path.to_str().unwrap(), e);
-            eprintln!("Could not format `{}`: {}", aarch64_out_path.to_str().unwrap(), e);
+            eprintln!("Could not format `{}`: {e}", arm_out_path.to_str().unwrap());
+            eprintln!("Could not format `{}`: {e}", aarch64_out_path.to_str().unwrap());
     };
     */
     Ok(())

--- a/crates/stdarch-test/Cargo.toml
+++ b/crates/stdarch-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stdarch-test"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 assert-instr-macro = { path = "../assert-instr-macro" }

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -81,7 +81,7 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
             .args(add_args)
             .arg(&me)
             .output()
-            .unwrap_or_else(|_| panic!("failed to execute objdump. OBJDUMP={}", objdump));
+            .unwrap_or_else(|_| panic!("failed to execute objdump. OBJDUMP={objdump}"));
         println!(
             "{}\n{}",
             output.status,
@@ -103,7 +103,7 @@ fn parse(output: &str) -> HashSet<Function> {
         lines.clone().count()
     );
     for line in output.lines().take(100) {
-        println!("{}", line);
+        println!("{line}");
     }
 
     let mut functions = HashSet::new();
@@ -112,9 +112,9 @@ fn parse(output: &str) -> HashSet<Function> {
         if !header.ends_with(':') || !header.contains("stdarch_test_shim") {
             continue;
         }
-        eprintln!("header: {}", header);
+        eprintln!("header: {header}");
         let symbol = normalize(header);
-        eprintln!("normalized symbol: {}", symbol);
+        eprintln!("normalized symbol: {symbol}");
         let mut instructions = Vec::new();
         while let Some(instruction) = lines.next() {
             if instruction.ends_with(':') {

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -64,10 +64,10 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
     // Make sure that the shim is not removed
     black_box(shim_addr);
 
-    //eprintln!("shim name: {}", fnname);
+    //eprintln!("shim name: {fnname}");
     let function = &DISASSEMBLY
         .get(&Function::new(fnname))
-        .unwrap_or_else(|| panic!("function \"{}\" not found in the disassembly", fnname));
+        .unwrap_or_else(|| panic!("function \"{fnname}\" not found in the disassembly"));
     //eprintln!("  function: {:?}", function);
 
     let mut instrs = &function.instrs[..];
@@ -165,9 +165,9 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
 
     // Help debug by printing out the found disassembly, and then panic as we
     // didn't find the instruction.
-    println!("disassembly for {}: ", fnname,);
+    println!("disassembly for {fnname}: ",);
     for (i, instr) in instrs.iter().enumerate() {
-        println!("\t{:2}: {}", i, instr);
+        println!("\t{i:2}: {instr}");
     }
 
     if !found {
@@ -194,7 +194,7 @@ pub fn assert_skip_test_ok(name: &str) {
     if env::var("STDARCH_TEST_EVERYTHING").is_err() {
         return;
     }
-    panic!("skipped test `{}` when it shouldn't be skipped", name);
+    panic!("skipped test `{name}` when it shouldn't be skipped");
 }
 
 // See comment in `assert-instr-macro` crate for why this exists

--- a/crates/stdarch-verify/Cargo.toml
+++ b/crates/stdarch-verify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stdarch-verify"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/crates/stdarch-verify/src/lib.rs
+++ b/crates/stdarch-verify/src/lib.rs
@@ -85,20 +85,20 @@ fn functions(input: TokenStream, dirs: &[&str]) -> TokenStream {
         .iter()
         .map(|&(ref f, path)| {
             let name = &f.sig.ident;
-            // println!("{}", name);
+            // println!("{name}");
             let mut arguments = Vec::new();
             let mut const_arguments = Vec::new();
             for input in f.sig.inputs.iter() {
                 let ty = match *input {
                     syn::FnArg::Typed(ref c) => &c.ty,
-                    _ => panic!("invalid argument on {}", name),
+                    _ => panic!("invalid argument on {name}"),
                 };
                 arguments.push(to_type(ty));
             }
             for generic in f.sig.generics.params.iter() {
                 let ty = match *generic {
                     syn::GenericParam::Const(ref c) => &c.ty,
-                    _ => panic!("invalid generic argument on {}", name),
+                    _ => panic!("invalid generic argument on {name}"),
                 };
                 const_arguments.push(to_type(ty));
             }
@@ -144,12 +144,12 @@ fn functions(input: TokenStream, dirs: &[&str]) -> TokenStream {
 
             // strip leading underscore from fn name when building a test
             // _mm_foo -> mm_foo such that the test name is test_mm_foo.
-            let test_name_string = format!("{}", name);
+            let test_name_string = format!("{name}");
             let mut test_name_id = test_name_string.as_str();
             while test_name_id.starts_with('_') {
                 test_name_id = &test_name_id[1..];
             }
-            let has_test = tests.contains(&format!("test_{}", test_name_id));
+            let has_test = tests.contains(&format!("test_{test_name_id}"));
 
             quote! {
                 Function {
@@ -167,7 +167,7 @@ fn functions(input: TokenStream, dirs: &[&str]) -> TokenStream {
         .collect::<Vec<_>>();
 
     let ret = quote! { #input: &[Function] = &[#(#functions),*]; };
-    // println!("{}", ret);
+    // println!("{ret}");
     ret.into()
 }
 
@@ -336,7 +336,7 @@ fn to_type(t: &syn::Type) -> proc_macro2::TokenStream {
             "v4f32" => quote! { &v4f32 },
             "v2f64" => quote! { &v2f64 },
 
-            s => panic!("unsupported type: \"{}\"", s),
+            s => panic!("unsupported type: \"{s}\""),
         },
         syn::Type::Ptr(syn::TypePtr {
             ref elem,

--- a/crates/stdarch-verify/tests/arm.rs
+++ b/crates/stdarch-verify/tests/arm.rs
@@ -628,7 +628,7 @@ fn verify_all_signatures() {
 
         if let Err(e) = matches(rust, arm) {
             println!("failed to verify `{}`", rust.name);
-            println!("  * {}", e);
+            println!("  * {e}");
             all_valid = false;
         }
     }
@@ -801,7 +801,7 @@ fn parse_intrinsic(node: &Rc<Node>) -> Intrinsic {
 
     let instruction = match instruction {
         Some(s) => s.trim().to_lowercase(),
-        None => panic!("can't find instruction for `{}`", name),
+        None => panic!("can't find instruction for `{name}`"),
     };
 
     Intrinsic {
@@ -973,7 +973,7 @@ fn parse_ty_base(s: &str) -> &'static Type {
         "uint8x8x3_t" => &U8X8X3,
         "uint8x8x4_t" => &U8X8X4,
 
-        _ => panic!("failed to parse html type {:?}", s),
+        _ => panic!("failed to parse html type {s:?}"),
     }
 }
 

--- a/crates/stdarch-verify/tests/mips.rs
+++ b/crates/stdarch-verify/tests/mips.rs
@@ -125,7 +125,7 @@ impl<'a> From<&'a str> for MsaTy {
             "u64" => MsaTy::u64,
             "void" => MsaTy::Void,
             "void *" => MsaTy::MutVoidPtr,
-            v => panic!("unknown ty: \"{}\"", v),
+            v => panic!("unknown ty: \"{v}\""),
         }
     }
 }
@@ -198,8 +198,8 @@ fn verify_all_signatures() {
         }
 
         use std::convert::TryFrom;
-        let intrinsic: MsaIntrinsic = TryFrom::try_from(line)
-            .unwrap_or_else(|_| panic!("failed to parse line: \"{}\"", line));
+        let intrinsic: MsaIntrinsic =
+            TryFrom::try_from(line).unwrap_or_else(|_| panic!("failed to parse line: \"{line}\""));
         assert!(!intrinsics.contains_key(&intrinsic.id));
         intrinsics.insert(intrinsic.id.clone(), intrinsic);
     }
@@ -253,7 +253,7 @@ fn verify_all_signatures() {
 
         if let Err(e) = matches(rust, mips) {
             println!("failed to verify `{}`", rust.name);
-            println!("  * {}", e);
+            println!("  * {e}");
             all_valid = false;
         }
     }

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -367,7 +367,7 @@ fn verify_all_signatures() {
         }
         println!("failed to verify `{}`", rust.name);
         for error in errors {
-            println!("  * {}", error);
+            println!("  * {error}");
         }
         all_valid = false;
     }
@@ -403,18 +403,18 @@ fn verify_all_signatures() {
     if PRINT_MISSING_LISTS || PRINT_MISSING_LISTS_MARKDOWN {
         for (k, v) in missing {
             if PRINT_MISSING_LISTS_MARKDOWN {
-                println!("\n<details><summary>{:?}</summary><p>\n", k);
+                println!("\n<details><summary>{k:?}</summary><p>\n");
                 for intel in v {
                     let url = format!(
                         "https://software.intel.com/sites/landingpage\
                          /IntrinsicsGuide/#text={}&expand=5236",
                         intel.name
                     );
-                    println!("  * [ ] [`{}`]({})", intel.name, url);
+                    println!("  * [ ] [`{}`]({url})", intel.name);
                 }
                 println!("</p></details>\n");
             } else {
-                println!("\n{:?}\n", k);
+                println!("\n{k:?}\n");
                 for intel in v {
                     println!("\t{}", intel.name);
                 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
 ]
 description = "Examples of the stdarch crate."
-edition = "2018"
+edition = "2021"
 default-run = "hex"
 
 [dependencies]

--- a/examples/connect5.rs
+++ b/examples/connect5.rs
@@ -1256,7 +1256,7 @@ fn main() {
             pos_disp(&test1);
 
             if pos_is_end(&test1) {
-                println!("Game over!!!!!! at Move {}", i);
+                println!("Game over!!!!!! at Move {i}");
                 count = i + 1;
                 break;
             }

--- a/examples/hex.rs
+++ b/examples/hex.rs
@@ -40,7 +40,7 @@ fn main() {
     io::stdin().read_to_end(&mut input).unwrap();
     let mut dst = vec![0; 2 * input.len()];
     let s = hex_encode(&input, &mut dst).unwrap();
-    println!("{}", s);
+    println!("{s}");
 }
 
 fn hex_encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, usize> {


### PR DESCRIPTION
Switch to the 2021 edition.

Add the result of running `clippy::uninlined_format_args` lint. Currently the lint is in `pedantic`, but there are plans/hopes to move it to `style`.

Locally, I ran this to generate the changes.  Not ideal because it has produced a number of compilation errors.

```bash
rustup run nightly cargo clippy --fix --no-deps --allow-dirty -- -A clippy::all -W clippy::uninlined_format_args
```