### PR TITLE
Don't require AVX512 for 256-bit VAES intrinsics

### DIFF
--- a/crates/core_arch/src/x86/avx512vaes.rs
+++ b/crates/core_arch/src/x86/avx512vaes.rs
@@ -38,7 +38,7 @@ extern "C" {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesenc_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512vl")]
+#[target_feature(enable = "avx512vaes")]
 #[cfg_attr(test, assert_instr(vaesenc))]
 pub unsafe fn _mm256_aesenc_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesenc_256(a, round_key)
@@ -49,7 +49,7 @@ pub unsafe fn _mm256_aesenc_epi128(a: __m256i, round_key: __m256i) -> __m256i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesenclast_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512vl")]
+#[target_feature(enable = "avx512vaes")]
 #[cfg_attr(test, assert_instr(vaesenclast))]
 pub unsafe fn _mm256_aesenclast_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesenclast_256(a, round_key)
@@ -60,7 +60,7 @@ pub unsafe fn _mm256_aesenclast_epi128(a: __m256i, round_key: __m256i) -> __m256
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesdec_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512vl")]
+#[target_feature(enable = "avx512vaes")]
 #[cfg_attr(test, assert_instr(vaesdec))]
 pub unsafe fn _mm256_aesdec_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesdec_256(a, round_key)
@@ -71,7 +71,7 @@ pub unsafe fn _mm256_aesdec_epi128(a: __m256i, round_key: __m256i) -> __m256i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesdeclast_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512vl")]
+#[target_feature(enable = "avx512vaes")]
 #[cfg_attr(test, assert_instr(vaesdeclast))]
 pub unsafe fn _mm256_aesdeclast_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesdeclast_256(a, round_key)

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -471,6 +471,12 @@ fn matches(rust: &Function, intel: &Intrinsic) -> Result<(), String> {
             continue;
         }
 
+        // Some AMD CPUs support VAES without AVX512, even though the Intel
+        // documentation states that those instructions require AVX512VL.
+        if *cpuid == "AVX512VL" && intel.cpuid.contains(&"VAES".to_string()) {
+            continue;
+        }
+
         let cpuid = cpuid
             .chars()
             .flat_map(|c| c.to_lowercase())


### PR DESCRIPTION
These are available on AMD CPUs without AVX512,

Fixes #1343