### PR TITLE
Detect CPU features with Linux methods on Android for non-Intel CPUs.

### DIFF
--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -47,7 +47,7 @@ cfg_if! {
         // On x86/x86_64 no OS specific functionality is required.
         #[path = "os/x86.rs"]
         mod os;
-    } else if #[cfg(all(target_os = "linux", feature = "libc"))] {
+    } else if #[cfg(any(all(target_os = "linux", feature = "libc"), target_os = "android"))] {
         #[path = "os/linux/mod.rs"]
         mod os;
     } else if #[cfg(all(target_os = "freebsd", feature = "libc"))] {

--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -47,7 +47,7 @@ cfg_if! {
         // On x86/x86_64 no OS specific functionality is required.
         #[path = "os/x86.rs"]
         mod os;
-    } else if #[cfg(any(all(target_os = "linux", feature = "libc"), target_os = "android"))] {
+    } else if #[cfg(all(any(target_os = "linux", target_os = "android"), feature = "libc"))] {
         #[path = "os/linux/mod.rs"]
         mod os;
     } else if #[cfg(all(target_os = "freebsd", feature = "libc"))] {


### PR DESCRIPTION
After digging into why the [`is_aarch64_feature_detected!`](https://doc.rust-lang.org/std/arch/macro.is_aarch64_feature_detected.html) macro didn't work as I expected on my Android device (only `asimd`, `fp`, `neon` were detected by the macro), I came to this line that dispatches the detection depending on the OS.

My understanding is that Android should behave like Linux w.r.t. CPU feature detection on ARM - at least on the devices I've tested with the various methods (`getauxval`, checking `/proc/cpuinfo`) worked fine. However, Rust defines a distinct `target_os` for Android (https://github.com/rust-lang/rust/blob/1.65.0/compiler/rustc_target/src/spec/android_base.rs#L5), so the filtering by `target_os = "linux"` doesn't work (even though Android is arguably a flavor of Linux).

I've tested this patch manually on a stage 1 compiler and it worked on physical devices (Samsung Galaxy S7 and Samsung Galaxy S20).

I wonder if the `feature = "libc"` is relevant on Android?

I didn't try the CI script but I guess it's not so relevant at the moment since Android CI was removed (#1346)? I wonder if this PR makes a CI for Android more relevant - although it may be that under the hood qemu doesn't implement as many CPU features as physical devices do?