### PR TITLE
Rename misleading features

### DIFF
--- a/crates/core_arch/src/x86/gfni.rs
+++ b/crates/core_arch/src/x86/gfni.rs
@@ -65,7 +65,7 @@ extern "C" {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm512_gf2p8mul_epi8(a: __m512i, b: __m512i) -> __m512i {
     transmute(vgf2p8mulb_512(a.as_i8x64(), b.as_i8x64()))
@@ -80,7 +80,7 @@ pub unsafe fn _mm512_gf2p8mul_epi8(a: __m512i, b: __m512i) -> __m512i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm512_mask_gf2p8mul_epi8(
     src: __m512i,
@@ -104,7 +104,7 @@ pub unsafe fn _mm512_mask_gf2p8mul_epi8(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm512_maskz_gf2p8mul_epi8(k: __mmask64, a: __m512i, b: __m512i) -> __m512i {
     let zero = _mm512_setzero_si512().as_i8x64();
@@ -121,7 +121,7 @@ pub unsafe fn _mm512_maskz_gf2p8mul_epi8(k: __mmask64, a: __m512i, b: __m512i) -
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx")]
+#[target_feature(enable = "gfni,avx")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm256_gf2p8mul_epi8(a: __m256i, b: __m256i) -> __m256i {
     transmute(vgf2p8mulb_256(a.as_i8x32(), b.as_i8x32()))
@@ -136,7 +136,7 @@ pub unsafe fn _mm256_gf2p8mul_epi8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm256_mask_gf2p8mul_epi8(
     src: __m256i,
@@ -160,7 +160,7 @@ pub unsafe fn _mm256_mask_gf2p8mul_epi8(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm256_maskz_gf2p8mul_epi8(k: __mmask32, a: __m256i, b: __m256i) -> __m256i {
     let zero = _mm256_setzero_si256().as_i8x32();
@@ -177,7 +177,7 @@ pub unsafe fn _mm256_maskz_gf2p8mul_epi8(k: __mmask32, a: __m256i, b: __m256i) -
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni")]
+#[target_feature(enable = "gfni")]
 #[cfg_attr(test, assert_instr(gf2p8mulb))]
 pub unsafe fn _mm_gf2p8mul_epi8(a: __m128i, b: __m128i) -> __m128i {
     transmute(vgf2p8mulb_128(a.as_i8x16(), b.as_i8x16()))
@@ -192,7 +192,7 @@ pub unsafe fn _mm_gf2p8mul_epi8(a: __m128i, b: __m128i) -> __m128i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm_mask_gf2p8mul_epi8(
     src: __m128i,
@@ -216,7 +216,7 @@ pub unsafe fn _mm_mask_gf2p8mul_epi8(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_gf2p8mul_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8mulb))]
 pub unsafe fn _mm_maskz_gf2p8mul_epi8(k: __mmask16, a: __m128i, b: __m128i) -> __m128i {
     let zero = _mm_setzero_si128().as_i8x16();
@@ -234,7 +234,7 @@ pub unsafe fn _mm_maskz_gf2p8mul_epi8(k: __mmask16, a: __m128i, b: __m128i) -> _
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_gf2p8affine_epi64_epi8<const B: i32>(x: __m512i, a: __m512i) -> __m512i {
@@ -256,7 +256,7 @@ pub unsafe fn _mm512_gf2p8affine_epi64_epi8<const B: i32>(x: __m512i, a: __m512i
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm512_maskz_gf2p8affine_epi64_epi8<const B: i32>(
@@ -283,7 +283,7 @@ pub unsafe fn _mm512_maskz_gf2p8affine_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(4)]
 pub unsafe fn _mm512_mask_gf2p8affine_epi64_epi8<const B: i32>(
@@ -307,7 +307,7 @@ pub unsafe fn _mm512_mask_gf2p8affine_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx")]
+#[target_feature(enable = "gfni,avx")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_gf2p8affine_epi64_epi8<const B: i32>(x: __m256i, a: __m256i) -> __m256i {
@@ -329,7 +329,7 @@ pub unsafe fn _mm256_gf2p8affine_epi64_epi8<const B: i32>(x: __m256i, a: __m256i
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm256_maskz_gf2p8affine_epi64_epi8<const B: i32>(
@@ -356,7 +356,7 @@ pub unsafe fn _mm256_maskz_gf2p8affine_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(4)]
 pub unsafe fn _mm256_mask_gf2p8affine_epi64_epi8<const B: i32>(
@@ -380,7 +380,7 @@ pub unsafe fn _mm256_mask_gf2p8affine_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni")]
+#[target_feature(enable = "gfni")]
 #[cfg_attr(test, assert_instr(gf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_gf2p8affine_epi64_epi8<const B: i32>(x: __m128i, a: __m128i) -> __m128i {
@@ -402,7 +402,7 @@ pub unsafe fn _mm_gf2p8affine_epi64_epi8<const B: i32>(x: __m128i, a: __m128i) -
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm_maskz_gf2p8affine_epi64_epi8<const B: i32>(
@@ -429,7 +429,7 @@ pub unsafe fn _mm_maskz_gf2p8affine_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_gf2p8affine_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineqb, B = 0))]
 #[rustc_legacy_const_generics(4)]
 pub unsafe fn _mm_mask_gf2p8affine_epi64_epi8<const B: i32>(
@@ -455,7 +455,7 @@ pub unsafe fn _mm_mask_gf2p8affine_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_gf2p8affineinv_epi64_epi8<const B: i32>(x: __m512i, a: __m512i) -> __m512i {
@@ -479,7 +479,7 @@ pub unsafe fn _mm512_gf2p8affineinv_epi64_epi8<const B: i32>(x: __m512i, a: __m5
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_maskz_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm512_maskz_gf2p8affineinv_epi64_epi8<const B: i32>(
@@ -508,7 +508,7 @@ pub unsafe fn _mm512_maskz_gf2p8affineinv_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512f")]
+#[target_feature(enable = "gfni,avx512bw,avx512f")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(4)]
 pub unsafe fn _mm512_mask_gf2p8affineinv_epi64_epi8<const B: i32>(
@@ -534,7 +534,7 @@ pub unsafe fn _mm512_mask_gf2p8affineinv_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx")]
+#[target_feature(enable = "gfni,avx")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_gf2p8affineinv_epi64_epi8<const B: i32>(x: __m256i, a: __m256i) -> __m256i {
@@ -558,7 +558,7 @@ pub unsafe fn _mm256_gf2p8affineinv_epi64_epi8<const B: i32>(x: __m256i, a: __m2
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_maskz_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm256_maskz_gf2p8affineinv_epi64_epi8<const B: i32>(
@@ -587,7 +587,7 @@ pub unsafe fn _mm256_maskz_gf2p8affineinv_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(4)]
 pub unsafe fn _mm256_mask_gf2p8affineinv_epi64_epi8<const B: i32>(
@@ -613,7 +613,7 @@ pub unsafe fn _mm256_mask_gf2p8affineinv_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni")]
+#[target_feature(enable = "gfni")]
 #[cfg_attr(test, assert_instr(gf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_gf2p8affineinv_epi64_epi8<const B: i32>(x: __m128i, a: __m128i) -> __m128i {
@@ -637,7 +637,7 @@ pub unsafe fn _mm_gf2p8affineinv_epi64_epi8<const B: i32>(x: __m128i, a: __m128i
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn _mm_maskz_gf2p8affineinv_epi64_epi8<const B: i32>(
@@ -666,7 +666,7 @@ pub unsafe fn _mm_maskz_gf2p8affineinv_epi64_epi8<const B: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_gf2p8affineinv_epi64_epi8)
 #[inline]
-#[target_feature(enable = "avx512gfni,avx512bw,avx512vl")]
+#[target_feature(enable = "gfni,avx512bw,avx512vl")]
 #[cfg_attr(test, assert_instr(vgf2p8affineinvqb, B = 0))]
 #[rustc_legacy_const_generics(4)]
 pub unsafe fn _mm_mask_gf2p8affineinv_epi64_epi8<const B: i32>(
@@ -847,7 +847,7 @@ mod tests {
         _mm512_loadu_si512(black_box(pointer))
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_gf2p8mul_epi8() {
         let (left, right, expected) = generate_byte_mul_test_data();
 
@@ -860,7 +860,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_maskz_gf2p8mul_epi8() {
         let (left, right, _expected) = generate_byte_mul_test_data();
 
@@ -879,7 +879,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_mask_gf2p8mul_epi8() {
         let (left, right, _expected) = generate_byte_mul_test_data();
 
@@ -897,7 +897,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_gf2p8mul_epi8() {
         let (left, right, expected) = generate_byte_mul_test_data();
 
@@ -910,7 +910,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_maskz_gf2p8mul_epi8() {
         let (left, right, _expected) = generate_byte_mul_test_data();
 
@@ -929,7 +929,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_mask_gf2p8mul_epi8() {
         let (left, right, _expected) = generate_byte_mul_test_data();
 
@@ -947,7 +947,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_gf2p8mul_epi8() {
         let (left, right, expected) = generate_byte_mul_test_data();
 
@@ -960,7 +960,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_maskz_gf2p8mul_epi8() {
         let (left, right, _expected) = generate_byte_mul_test_data();
 
@@ -979,7 +979,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_mask_gf2p8mul_epi8() {
         let (left, right, _expected) = generate_byte_mul_test_data();
 
@@ -997,7 +997,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_gf2p8affine_epi64_epi8() {
         let identity: i64 = 0x01_02_04_08_10_20_40_80;
         const IDENTITY_BYTE: i32 = 0;
@@ -1031,7 +1031,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_maskz_gf2p8affine_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1053,7 +1053,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_mask_gf2p8affine_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1074,7 +1074,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_gf2p8affine_epi64_epi8() {
         let identity: i64 = 0x01_02_04_08_10_20_40_80;
         const IDENTITY_BYTE: i32 = 0;
@@ -1108,7 +1108,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_maskz_gf2p8affine_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1130,7 +1130,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_mask_gf2p8affine_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1151,7 +1151,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_gf2p8affine_epi64_epi8() {
         let identity: i64 = 0x01_02_04_08_10_20_40_80;
         const IDENTITY_BYTE: i32 = 0;
@@ -1185,7 +1185,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_maskz_gf2p8affine_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1206,7 +1206,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_mask_gf2p8affine_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1227,7 +1227,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_gf2p8affineinv_epi64_epi8() {
         let identity: i64 = 0x01_02_04_08_10_20_40_80;
         const IDENTITY_BYTE: i32 = 0;
@@ -1271,7 +1271,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_maskz_gf2p8affineinv_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1293,7 +1293,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw")]
+    #[simd_test(enable = "gfni,avx512bw")]
     unsafe fn test_mm512_mask_gf2p8affineinv_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1315,7 +1315,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_gf2p8affineinv_epi64_epi8() {
         let identity: i64 = 0x01_02_04_08_10_20_40_80;
         const IDENTITY_BYTE: i32 = 0;
@@ -1359,7 +1359,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_maskz_gf2p8affineinv_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1381,7 +1381,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm256_mask_gf2p8affineinv_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1403,7 +1403,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_gf2p8affineinv_epi64_epi8() {
         let identity: i64 = 0x01_02_04_08_10_20_40_80;
         const IDENTITY_BYTE: i32 = 0;
@@ -1447,7 +1447,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_maskz_gf2p8affineinv_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
@@ -1469,7 +1469,7 @@ mod tests {
         }
     }
 
-    #[simd_test(enable = "avx512gfni,avx512bw,avx512vl")]
+    #[simd_test(enable = "gfni,avx512bw,avx512vl")]
     unsafe fn test_mm_mask_gf2p8affineinv_epi64_epi8() {
         const CONSTANT_BYTE: i32 = 0x63;
         let (matrices, vectors, _expected) = generate_affine_mul_test_data(CONSTANT_BYTE as u8);

--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -835,17 +835,17 @@ pub use self::avx512vnni::*;
 mod avx512bitalg;
 pub use self::avx512bitalg::*;
 
-mod avx512gfni;
-pub use self::avx512gfni::*;
+mod gfni;
+pub use self::gfni::*;
 
 mod avx512vpopcntdq;
 pub use self::avx512vpopcntdq::*;
 
-mod avx512vaes;
-pub use self::avx512vaes::*;
+mod vaes;
+pub use self::vaes::*;
 
-mod avx512vpclmulqdq;
-pub use self::avx512vpclmulqdq::*;
+mod vpclmulqdq;
+pub use self::vpclmulqdq::*;
 
 mod bt;
 pub use self::bt::*;

--- a/crates/core_arch/src/x86/vaes.rs
+++ b/crates/core_arch/src/x86/vaes.rs
@@ -38,7 +38,7 @@ extern "C" {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesenc_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes")]
+#[target_feature(enable = "vaes")]
 #[cfg_attr(test, assert_instr(vaesenc))]
 pub unsafe fn _mm256_aesenc_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesenc_256(a, round_key)
@@ -49,7 +49,7 @@ pub unsafe fn _mm256_aesenc_epi128(a: __m256i, round_key: __m256i) -> __m256i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesenclast_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes")]
+#[target_feature(enable = "vaes")]
 #[cfg_attr(test, assert_instr(vaesenclast))]
 pub unsafe fn _mm256_aesenclast_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesenclast_256(a, round_key)
@@ -60,7 +60,7 @@ pub unsafe fn _mm256_aesenclast_epi128(a: __m256i, round_key: __m256i) -> __m256
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesdec_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes")]
+#[target_feature(enable = "vaes")]
 #[cfg_attr(test, assert_instr(vaesdec))]
 pub unsafe fn _mm256_aesdec_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesdec_256(a, round_key)
@@ -71,7 +71,7 @@ pub unsafe fn _mm256_aesdec_epi128(a: __m256i, round_key: __m256i) -> __m256i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_aesdeclast_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes")]
+#[target_feature(enable = "vaes")]
 #[cfg_attr(test, assert_instr(vaesdeclast))]
 pub unsafe fn _mm256_aesdeclast_epi128(a: __m256i, round_key: __m256i) -> __m256i {
     aesdeclast_256(a, round_key)
@@ -82,7 +82,7 @@ pub unsafe fn _mm256_aesdeclast_epi128(a: __m256i, round_key: __m256i) -> __m256
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_aesenc_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512f")]
+#[target_feature(enable = "vaes,avx512f")]
 #[cfg_attr(test, assert_instr(vaesenc))]
 pub unsafe fn _mm512_aesenc_epi128(a: __m512i, round_key: __m512i) -> __m512i {
     aesenc_512(a, round_key)
@@ -93,7 +93,7 @@ pub unsafe fn _mm512_aesenc_epi128(a: __m512i, round_key: __m512i) -> __m512i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_aesenclast_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512f")]
+#[target_feature(enable = "vaes,avx512f")]
 #[cfg_attr(test, assert_instr(vaesenclast))]
 pub unsafe fn _mm512_aesenclast_epi128(a: __m512i, round_key: __m512i) -> __m512i {
     aesenclast_512(a, round_key)
@@ -104,7 +104,7 @@ pub unsafe fn _mm512_aesenclast_epi128(a: __m512i, round_key: __m512i) -> __m512
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_aesdec_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512f")]
+#[target_feature(enable = "vaes,avx512f")]
 #[cfg_attr(test, assert_instr(vaesdec))]
 pub unsafe fn _mm512_aesdec_epi128(a: __m512i, round_key: __m512i) -> __m512i {
     aesdec_512(a, round_key)
@@ -115,7 +115,7 @@ pub unsafe fn _mm512_aesdec_epi128(a: __m512i, round_key: __m512i) -> __m512i {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_aesdeclast_epi128)
 #[inline]
-#[target_feature(enable = "avx512vaes,avx512f")]
+#[target_feature(enable = "vaes,avx512f")]
 #[cfg_attr(test, assert_instr(vaesdeclast))]
 pub unsafe fn _mm512_aesdeclast_epi128(a: __m512i, round_key: __m512i) -> __m512i {
     aesdeclast_512(a, round_key)
@@ -138,7 +138,7 @@ mod tests {
     // ideally we'd be using quickcheck here instead
 
     #[target_feature(enable = "avx2")]
-    unsafe fn helper_for_256_avx512vaes(
+    unsafe fn helper_for_256_vaes(
         linear: unsafe fn(__m128i, __m128i) -> __m128i,
         vectorized: unsafe fn(__m256i, __m256i) -> __m256i,
     ) {
@@ -187,7 +187,7 @@ mod tests {
         setup_state_key(_mm512_broadcast_i32x4)
     }
 
-    #[simd_test(enable = "avx512vaes,avx512vl")]
+    #[simd_test(enable = "vaes,avx512vl")]
     unsafe fn test_mm256_aesdec_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
         let (a, k) = setup_state_key_256();
@@ -196,10 +196,10 @@ mod tests {
         let r = _mm256_aesdec_epi128(a, k);
         assert_eq_m256i(r, e);
 
-        helper_for_256_avx512vaes(_mm_aesdec_si128, _mm256_aesdec_epi128);
+        helper_for_256_vaes(_mm_aesdec_si128, _mm256_aesdec_epi128);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512vl")]
+    #[simd_test(enable = "vaes,avx512vl")]
     unsafe fn test_mm256_aesdeclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714178.aspx.
         let (a, k) = setup_state_key_256();
@@ -208,10 +208,10 @@ mod tests {
         let r = _mm256_aesdeclast_epi128(a, k);
         assert_eq_m256i(r, e);
 
-        helper_for_256_avx512vaes(_mm_aesdeclast_si128, _mm256_aesdeclast_epi128);
+        helper_for_256_vaes(_mm_aesdeclast_si128, _mm256_aesdeclast_epi128);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512vl")]
+    #[simd_test(enable = "vaes,avx512vl")]
     unsafe fn test_mm256_aesenc_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664810.aspx.
         // they are repeated appropriately
@@ -221,10 +221,10 @@ mod tests {
         let r = _mm256_aesenc_epi128(a, k);
         assert_eq_m256i(r, e);
 
-        helper_for_256_avx512vaes(_mm_aesenc_si128, _mm256_aesenc_epi128);
+        helper_for_256_vaes(_mm_aesenc_si128, _mm256_aesenc_epi128);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512vl")]
+    #[simd_test(enable = "vaes,avx512vl")]
     unsafe fn test_mm256_aesenclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714136.aspx.
         let (a, k) = setup_state_key_256();
@@ -233,11 +233,11 @@ mod tests {
         let r = _mm256_aesenclast_epi128(a, k);
         assert_eq_m256i(r, e);
 
-        helper_for_256_avx512vaes(_mm_aesenclast_si128, _mm256_aesenclast_epi128);
+        helper_for_256_vaes(_mm_aesenclast_si128, _mm256_aesenclast_epi128);
     }
 
     #[target_feature(enable = "avx512f")]
-    unsafe fn helper_for_512_avx512vaes(
+    unsafe fn helper_for_512_vaes(
         linear: unsafe fn(__m128i, __m128i) -> __m128i,
         vectorized: unsafe fn(__m512i, __m512i) -> __m512i,
     ) {
@@ -282,7 +282,7 @@ mod tests {
         assert_eq_m128i(_mm512_extracti32x4_epi32::<3>(r), e_decomp[3]);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512f")]
+    #[simd_test(enable = "vaes,avx512f")]
     unsafe fn test_mm512_aesdec_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
         let (a, k) = setup_state_key_512();
@@ -291,10 +291,10 @@ mod tests {
         let r = _mm512_aesdec_epi128(a, k);
         assert_eq_m512i(r, e);
 
-        helper_for_512_avx512vaes(_mm_aesdec_si128, _mm512_aesdec_epi128);
+        helper_for_512_vaes(_mm_aesdec_si128, _mm512_aesdec_epi128);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512f")]
+    #[simd_test(enable = "vaes,avx512f")]
     unsafe fn test_mm512_aesdeclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714178.aspx.
         let (a, k) = setup_state_key_512();
@@ -303,10 +303,10 @@ mod tests {
         let r = _mm512_aesdeclast_epi128(a, k);
         assert_eq_m512i(r, e);
 
-        helper_for_512_avx512vaes(_mm_aesdeclast_si128, _mm512_aesdeclast_epi128);
+        helper_for_512_vaes(_mm_aesdeclast_si128, _mm512_aesdeclast_epi128);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512f")]
+    #[simd_test(enable = "vaes,avx512f")]
     unsafe fn test_mm512_aesenc_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664810.aspx.
         let (a, k) = setup_state_key_512();
@@ -315,10 +315,10 @@ mod tests {
         let r = _mm512_aesenc_epi128(a, k);
         assert_eq_m512i(r, e);
 
-        helper_for_512_avx512vaes(_mm_aesenc_si128, _mm512_aesenc_epi128);
+        helper_for_512_vaes(_mm_aesenc_si128, _mm512_aesenc_epi128);
     }
 
-    #[simd_test(enable = "avx512vaes,avx512f")]
+    #[simd_test(enable = "vaes,avx512f")]
     unsafe fn test_mm512_aesenclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714136.aspx.
         let (a, k) = setup_state_key_512();
@@ -327,6 +327,6 @@ mod tests {
         let r = _mm512_aesenclast_epi128(a, k);
         assert_eq_m512i(r, e);
 
-        helper_for_512_avx512vaes(_mm_aesenclast_si128, _mm512_aesenclast_epi128);
+        helper_for_512_vaes(_mm_aesenclast_si128, _mm512_aesenclast_epi128);
     }
 }

--- a/crates/core_arch/src/x86/vpclmulqdq.rs
+++ b/crates/core_arch/src/x86/vpclmulqdq.rs
@@ -32,7 +32,7 @@ extern "C" {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_clmulepi64_epi128)
 #[inline]
-#[target_feature(enable = "avx512vpclmulqdq,avx512f")]
+#[target_feature(enable = "vpclmulqdq,avx512f")]
 // technically according to Intel's documentation we don't need avx512f here, however LLVM gets confused otherwise
 #[cfg_attr(test, assert_instr(vpclmul, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
@@ -50,7 +50,7 @@ pub unsafe fn _mm512_clmulepi64_epi128<const IMM8: i32>(a: __m512i, b: __m512i) 
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_clmulepi64_epi128)
 #[inline]
-#[target_feature(enable = "avx512vpclmulqdq")]
+#[target_feature(enable = "vpclmulqdq")]
 #[cfg_attr(test, assert_instr(vpclmul, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_clmulepi64_epi128<const IMM8: i32>(a: __m256i, b: __m256i) -> __m256i {
@@ -121,7 +121,7 @@ mod tests {
 
     // this function tests one of the possible 4 instances
     // with different inputs across lanes
-    #[target_feature(enable = "avx512vpclmulqdq,avx512f")]
+    #[target_feature(enable = "vpclmulqdq,avx512f")]
     unsafe fn verify_512_helper(
         linear: unsafe fn(__m128i, __m128i) -> __m128i,
         vectorized: unsafe fn(__m512i, __m512i) -> __m512i,
@@ -162,7 +162,7 @@ mod tests {
 
     // this function tests one of the possible 4 instances
     // with different inputs across lanes for the VL version
-    #[target_feature(enable = "avx512vpclmulqdq,avx512vl")]
+    #[target_feature(enable = "vpclmulqdq,avx512vl")]
     unsafe fn verify_256_helper(
         linear: unsafe fn(__m128i, __m128i) -> __m128i,
         vectorized: unsafe fn(__m256i, __m256i) -> __m256i,
@@ -204,7 +204,7 @@ mod tests {
         unroll! {assert_eq_m128i(_mm256_extracti128_si256::<2>(r),e_decomp[2]);}
     }
 
-    #[simd_test(enable = "avx512vpclmulqdq,avx512f")]
+    #[simd_test(enable = "vpclmulqdq,avx512f")]
     unsafe fn test_mm512_clmulepi64_epi128() {
         verify_kat_pclmul!(
             _mm512_broadcast_i32x4,
@@ -230,7 +230,7 @@ mod tests {
         );
     }
 
-    #[simd_test(enable = "avx512vpclmulqdq,avx512vl")]
+    #[simd_test(enable = "vpclmulqdq,avx512vl")]
     unsafe fn test_mm256_clmulepi64_epi128() {
         verify_kat_pclmul!(
             _mm256_broadcastsi128_si256,

--- a/crates/core_arch/tests/cpu-detection.rs
+++ b/crates/core_arch/tests/cpu-detection.rs
@@ -31,8 +31,11 @@ fn x86_all() {
         is_x86_feature_detected!("avx512vpopcntdq")
     );
     println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
+    println!("gfni {:?}", is_x86_feature_detected!("gfni"));
     println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
+    println!("vaes {:?}", is_x86_feature_detected!("vaes"));
     println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
+    println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
     println!(
         "avx512vpclmulqdq {:?}",
         is_x86_feature_detected!("avx512vpclmulqdq")

--- a/crates/core_arch/tests/cpu-detection.rs
+++ b/crates/core_arch/tests/cpu-detection.rs
@@ -32,14 +32,8 @@ fn x86_all() {
     );
     println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
     println!("gfni {:?}", is_x86_feature_detected!("gfni"));
-    println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
     println!("vaes {:?}", is_x86_feature_detected!("vaes"));
-    println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
     println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
-    println!(
-        "avx512vpclmulqdq {:?}",
-        is_x86_feature_detected!("avx512vpclmulqdq")
-    );
     println!("avx512vnni {:?}", is_x86_feature_detected!("avx512vnni"));
     println!(
         "avx512bitalg {:?}",
@@ -63,4 +57,16 @@ fn x86_all() {
     println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
     println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
     println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
+}
+
+#[test]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[allow(deprecated)]
+fn x86_deprecated() {
+    println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
+    println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
+    println!(
+        "avx512vpclmulqdq {:?}",
+        is_x86_feature_detected!("avx512vpclmulqdq")
+    );
 }

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -68,9 +68,9 @@ features! {
     /// * `"avx512vbmi"`
     /// * `"avx512vpopcntdq"`
     /// * `"avx512vbmi2"`
-    /// * `"avx512gfni"`
-    /// * `"avx512vaes"`
-    /// * `"avx512vpclmulqdq"`
+    /// * `"gfni"`
+    /// * `"vaes"`
+    /// * `"vpclmulqdq"`
     /// * `"avx512vnni"`
     /// * `"avx512bitalg"`
     /// * `"avx512bf16"`
@@ -95,6 +95,9 @@ features! {
     /// [docs]: https://software.intel.com/sites/landingpage/IntrinsicsGuide
     #[stable(feature = "simd_x86", since = "1.27.0")]
     @BIND_FEATURE_NAME: "abm"; "lzcnt"; // abm is a synonym for lzcnt
+    @BIND_FEATURE_NAME: "avx512gfni"; "gfni"; // avx512gfni was previously used for gnfi
+    @BIND_FEATURE_NAME: "avx512vaes"; "vaes"; // avx512vaes was previously used for vaes
+    @BIND_FEATURE_NAME: "avx512vpclmulqdq"; "vpclmulqdq"; // avx512vpclmulqdq was previously used for vpclmulqdq
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] aes: "aes";
     /// AES (Advanced Encryption Standard New Instructions AES-NI)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] pclmulqdq: "pclmulqdq";
@@ -150,11 +153,11 @@ features! {
     /// Quadword)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512vbmi2: "avx512vbmi2";
     /// AVX-512 VBMI2 (Additional byte, word, dword and qword capabilities)
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512gfni: "avx512gfni";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] gfni: "gfni";
     /// AVX-512 GFNI (Galois Field New Instruction)
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512vaes: "avx512vaes";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] vaes: "vaes";
     /// AVX-512 VAES (Vector AES instruction)
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512vpclmulqdq: "avx512vpclmulqdq";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] vpclmulqdq: "vpclmulqdq";
     /// AVX-512 VPCLMULQDQ (Vector PCLMULQDQ instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512vnni: "avx512vnni";
     /// AVX-512 VNNI (Vector Neural Network Instructions)

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -95,9 +95,9 @@ features! {
     /// [docs]: https://software.intel.com/sites/landingpage/IntrinsicsGuide
     #[stable(feature = "simd_x86", since = "1.27.0")]
     @BIND_FEATURE_NAME: "abm"; "lzcnt"; // abm is a synonym for lzcnt
-    @BIND_FEATURE_NAME: "avx512gfni"; "gfni"; // avx512gfni was previously used for gnfi
-    @BIND_FEATURE_NAME: "avx512vaes"; "vaes"; // avx512vaes was previously used for vaes
-    @BIND_FEATURE_NAME: "avx512vpclmulqdq"; "vpclmulqdq"; // avx512vpclmulqdq was previously used for vpclmulqdq
+    @BIND_FEATURE_NAME: "avx512gfni"; "gfni"; #[deprecated(since = "1.67.0", note = "the `avx512gfni` feature has been renamed to `gfni`")];
+    @BIND_FEATURE_NAME: "avx512vaes"; "vaes"; #[deprecated(since = "1.67.0", note = "the `avx512vaes` feature has been renamed to `vaes`")];
+    @BIND_FEATURE_NAME: "avx512vpclmulqdq"; "vpclmulqdq"; #[deprecated(since = "1.67.0", note = "the `avx512vpclmulqdq` feature has been renamed to `vpclmulqdq`")];
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] aes: "aes";
     /// AES (Advanced Encryption Standard New Instructions AES-NI)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] pclmulqdq: "pclmulqdq";

--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -17,7 +17,7 @@ macro_rules! features {
       @CFG: $cfg:meta;
       @MACRO_NAME: $macro_name:ident;
       @MACRO_ATTRS: $(#[$macro_attrs:meta])*
-      $(@BIND_FEATURE_NAME: $bind_feature:tt; $feature_impl:tt; )*
+      $(@BIND_FEATURE_NAME: $bind_feature:tt; $feature_impl:tt; $(#[$deprecate_attr:meta];)?)*
       $(@NO_RUNTIME_DETECTION: $nort_feature:tt; )*
       $(@FEATURE: #[$stability_attr:meta] $feature:ident: $feature_lit:tt;
           $(implied by target_features: [$($target_feature_lit:tt),*];)?
@@ -35,7 +35,15 @@ macro_rules! features {
                 };
             )*
             $(
-                ($bind_feature) => { $crate::$macro_name!($feature_impl) };
+                ($bind_feature) => {
+                    {
+                        $(
+                            #[$deprecate_attr] macro_rules! deprecated_feature { {} => {}; }
+                            deprecated_feature! {};
+                        )?
+                        $crate::$macro_name!($feature_impl)
+                    }
+                };
             )*
             $(
                 ($nort_feature) => {

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -211,10 +211,10 @@ pub(crate) fn detect_features() -> cache::Initializer {
                         enable(extended_features_ecx, 1, Feature::avx512vbmi);
                         enable(extended_features_ecx, 5, Feature::avx512bf16);
                         enable(extended_features_ecx, 6, Feature::avx512vbmi2);
-                        enable(extended_features_ecx, 8, Feature::avx512gfni);
+                        enable(extended_features_ecx, 8, Feature::gfni);
                         enable(extended_features_ecx, 8, Feature::avx512vp2intersect);
-                        enable(extended_features_ecx, 9, Feature::avx512vaes);
-                        enable(extended_features_ecx, 10, Feature::avx512vpclmulqdq);
+                        enable(extended_features_ecx, 9, Feature::vaes);
+                        enable(extended_features_ecx, 10, Feature::vpclmulqdq);
                         enable(extended_features_ecx, 11, Feature::avx512vnni);
                         enable(extended_features_ecx, 12, Feature::avx512bitalg);
                         enable(extended_features_ecx, 14, Feature::avx512vpopcntdq);

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -133,14 +133,8 @@ fn x86_all() {
     );
     println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
     println!("gfni {:?}", is_x86_feature_detected!("gfni"));
-    println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
     println!("vaes {:?}", is_x86_feature_detected!("vaes"));
-    println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
     println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
-    println!(
-        "avx512vpclmulqdq {:?}",
-        is_x86_feature_detected!("avx512vpclmulqdq")
-    );
     println!("avx512vnni {:?}", is_x86_feature_detected!("avx512vnni"));
     println!(
         "avx512bitalg {:?}",

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -132,8 +132,11 @@ fn x86_all() {
         is_x86_feature_detected!("avx512vpopcntdq")
     );
     println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
+    println!("gfni {:?}", is_x86_feature_detected!("gfni"));
     println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
+    println!("vaes {:?}", is_x86_feature_detected!("vaes"));
     println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
+    println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
     println!(
         "avx512vpclmulqdq {:?}",
         is_x86_feature_detected!("avx512vpclmulqdq")

--- a/crates/std_detect/tests/x86-specific.rs
+++ b/crates/std_detect/tests/x86-specific.rs
@@ -36,8 +36,11 @@ fn dump() {
         is_x86_feature_detected!("avx512vpopcntdq")
     );
     println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
+    println!("gfni {:?}", is_x86_feature_detected!("gfni"));
     println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
+    println!("vaes {:?}", is_x86_feature_detected!("vaes"));
     println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
+    println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
     println!(
         "avx512vpclmulqdq {:?}",
         is_x86_feature_detected!("avx512vpclmulqdq")

--- a/crates/std_detect/tests/x86-specific.rs
+++ b/crates/std_detect/tests/x86-specific.rs
@@ -37,14 +37,8 @@ fn dump() {
     );
     println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
     println!("gfni {:?}", is_x86_feature_detected!("gfni"));
-    println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
     println!("vaes {:?}", is_x86_feature_detected!("vaes"));
-    println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
     println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
-    println!(
-        "avx512vpclmulqdq {:?}",
-        is_x86_feature_detected!("avx512vpclmulqdq")
-    );
     println!("avx512vnni {:?}", is_x86_feature_detected!("avx512vnni"));
     println!(
         "avx512bitalg {:?}",


### PR DESCRIPTION
Renamed features according to rust-lang/rust#100752 (and #1325)

~This works on master, but rust-lang/rust#103750 hasn't hit nightly yet.~ landed on nightly

An open question: in `is_x86_feature_detected`, should `avx512gfni` be an alias for `gfni` (even though it doesn't actually check for `avx512f`), or should it be a separate feature that checks the multiple feature flags required to enable the AVX-512 GFNI instructions? (and the same goes for `avx512vaes` and `avx512vpclmulqdq`)