### PR TITLE
[DO NOT MERGE] Migrate from highfive to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,7 @@
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
 [assign]
+
+[assign.owners]
+"*" = ["@Amanieu"]


### PR DESCRIPTION
This migrates this repository from using the highfive bot to using triagebot (aka rustbot).

This should not be merged without coordinating the removal of the highfive webhook and/or merging https://github.com/rust-lang/highfive/pull/438.