### PR TITLE
Remove S-waiting-on-review autolabel

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,3 @@
-[autolabel."S-waiting-on-review"]
-new_pr = true
-
 [assign]
 
 [assign.owners]


### PR DESCRIPTION
#1359 incorrectly added the `S-waiting-on-review` autolabel. This repo (and homu) are not configured to use S-waiting-on… labels, so this just removes it.