### PR TITLE
Implemented `is_x86_feature_detected!("ermsb")`

### DIFF
--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -92,6 +92,7 @@ features! {
     /// * `"adx"`
     /// * `"rtm"`
     /// * `"movbe"`
+    /// * `"ermsb"`
     ///
     /// [docs]: https://software.intel.com/sites/landingpage/IntrinsicsGuide
     #[stable(feature = "simd_x86", since = "1.27.0")]
@@ -200,4 +201,6 @@ features! {
     /// RTM, Intel (Restricted Transactional Memory)
     @FEATURE: #[stable(feature = "movbe_target_feature", since = "1.67.0")] movbe: "movbe";
     /// MOVBE (Move Data After Swapping Bytes)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] ermsb: "ermsb";
+    /// ERMSB, Enhanced REP MOVSB and STOSB
 }

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -129,6 +129,8 @@ pub(crate) fn detect_features() -> cache::Initializer {
         enable(extended_features_ebx, 3, Feature::bmi1);
         enable(extended_features_ebx, 8, Feature::bmi2);
 
+        enable(extended_features_ebx, 9, Feature::ermsb);
+
         // `XSAVE` and `AVX` support:
         let cpu_xsave = bit::test(proc_info_ecx as usize, 26);
         if cpu_xsave {


### PR DESCRIPTION
Allows users to detect the ERMSB (Enhanced REP MOVSB and STOSB) CPU feature on x86 machines