### PR TITLE
Fix generated Neon simd_test features.

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -22346,7 +22346,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vmull_p64() {
         let a: p64 = 15;
         let b: p64 = 3;
@@ -22364,7 +22364,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vmull_high_p64() {
         let a: i64x2 = i64x2::new(1, 15);
         let b: i64x2 = i64x2::new(1, 3);
@@ -23329,7 +23329,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcadd_rot270_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23338,7 +23338,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcaddq_rot270_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23347,7 +23347,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcaddq_rot270_f64() {
         let a: f64x2 = f64x2::new(1., -1.);
         let b: f64x2 = f64x2::new(-1., 1.);
@@ -23356,7 +23356,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcadd_rot90_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23365,7 +23365,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcaddq_rot90_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23374,7 +23374,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcaddq_rot90_f64() {
         let a: f64x2 = f64x2::new(1., -1.);
         let b: f64x2 = f64x2::new(-1., 1.);
@@ -23383,7 +23383,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23393,7 +23393,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23403,7 +23403,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_f64() {
         let a: f64x2 = f64x2::new(1., -1.);
         let b: f64x2 = f64x2::new(-1., 1.);
@@ -23413,7 +23413,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot90_f32() {
         let a: f32x2 = f32x2::new(1., 1.);
         let b: f32x2 = f32x2::new(1., -1.);
@@ -23423,7 +23423,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot90_f32() {
         let a: f32x4 = f32x4::new(1., 1., 1., 1.);
         let b: f32x4 = f32x4::new(1., -1., 1., -1.);
@@ -23433,7 +23433,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot90_f64() {
         let a: f64x2 = f64x2::new(1., 1.);
         let b: f64x2 = f64x2::new(1., -1.);
@@ -23443,7 +23443,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot180_f32() {
         let a: f32x2 = f32x2::new(1., 1.);
         let b: f32x2 = f32x2::new(1., -1.);
@@ -23453,7 +23453,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot180_f32() {
         let a: f32x4 = f32x4::new(1., 1., 1., 1.);
         let b: f32x4 = f32x4::new(1., -1., 1., -1.);
@@ -23463,7 +23463,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot180_f64() {
         let a: f64x2 = f64x2::new(1., 1.);
         let b: f64x2 = f64x2::new(1., -1.);
@@ -23473,7 +23473,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot270_f32() {
         let a: f32x2 = f32x2::new(1., 1.);
         let b: f32x2 = f32x2::new(1., -1.);
@@ -23483,7 +23483,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot270_f32() {
         let a: f32x4 = f32x4::new(1., 1., 1., 1.);
         let b: f32x4 = f32x4::new(1., -1., 1., -1.);
@@ -23493,7 +23493,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot270_f64() {
         let a: f64x2 = f64x2::new(1., 1.);
         let b: f64x2 = f64x2::new(1., -1.);
@@ -23503,7 +23503,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_lane_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23513,7 +23513,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_laneq_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23523,7 +23523,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_lane_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23533,7 +23533,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_laneq_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23543,7 +23543,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot90_lane_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23553,7 +23553,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot90_laneq_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23563,7 +23563,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot90_lane_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23573,7 +23573,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot90_laneq_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23583,7 +23583,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot180_lane_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23593,7 +23593,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot180_laneq_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23603,7 +23603,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot180_lane_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23613,7 +23613,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot180_laneq_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23623,7 +23623,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot270_lane_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23633,7 +23633,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmla_rot270_laneq_f32() {
         let a: f32x2 = f32x2::new(1., -1.);
         let b: f32x2 = f32x2::new(-1., 1.);
@@ -23643,7 +23643,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot270_lane_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23653,7 +23653,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,fcma")]
     unsafe fn test_vcmlaq_rot270_laneq_f32() {
         let a: f32x4 = f32x4::new(1., -1., 1., -1.);
         let b: f32x4 = f32x4::new(-1., 1., -1., 1.);
@@ -23663,7 +23663,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdot_s32() {
         let a: i32x2 = i32x2::new(1, 2);
         let b: i8x8 = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
@@ -23673,7 +23673,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdotq_s32() {
         let a: i32x4 = i32x4::new(1, 2, 1, 2);
         let b: i8x16 = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -23683,7 +23683,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdot_u32() {
         let a: u32x2 = u32x2::new(1, 2);
         let b: u8x8 = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
@@ -23693,7 +23693,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdotq_u32() {
         let a: u32x4 = u32x4::new(1, 2, 1, 2);
         let b: u8x16 = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -23703,7 +23703,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdot_lane_s32() {
         let a: i32x2 = i32x2::new(1, 2);
         let b: i8x8 = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
@@ -23713,7 +23713,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdot_laneq_s32() {
         let a: i32x2 = i32x2::new(1, 2);
         let b: i8x8 = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
@@ -23723,7 +23723,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdotq_lane_s32() {
         let a: i32x4 = i32x4::new(1, 2, 1, 2);
         let b: i8x16 = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -23733,7 +23733,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdotq_laneq_s32() {
         let a: i32x4 = i32x4::new(1, 2, 1, 2);
         let b: i8x16 = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -23743,7 +23743,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdot_lane_u32() {
         let a: u32x2 = u32x2::new(1, 2);
         let b: u8x8 = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
@@ -23753,7 +23753,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdot_laneq_u32() {
         let a: u32x2 = u32x2::new(1, 2);
         let b: u8x8 = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
@@ -23763,7 +23763,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdotq_lane_u32() {
         let a: u32x4 = u32x4::new(1, 2, 1, 2);
         let b: u8x16 = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -23773,7 +23773,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,dotprod")]
     unsafe fn test_vdotq_laneq_u32() {
         let a: u32x4 = u32x4::new(1, 2, 1, 2);
         let b: u8x16 = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -24864,7 +24864,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlah_s16() {
         let a: i16x4 = i16x4::new(1, 1, 1, 1);
         let b: i16x4 = i16x4::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -24874,7 +24874,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahq_s16() {
         let a: i16x8 = i16x8::new(1, 1, 1, 1, 1, 1, 1, 1);
         let b: i16x8 = i16x8::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -24884,7 +24884,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlah_s32() {
         let a: i32x2 = i32x2::new(1, 1);
         let b: i32x2 = i32x2::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -24894,7 +24894,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahq_s32() {
         let a: i32x4 = i32x4::new(1, 1, 1, 1);
         let b: i32x4 = i32x4::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -24904,7 +24904,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahh_s16() {
         let a: i16 = 1;
         let b: i16 = 1;
@@ -24914,7 +24914,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahs_s32() {
         let a: i32 = 1;
         let b: i32 = 1;
@@ -24924,7 +24924,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlah_lane_s16() {
         let a: i16x4 = i16x4::new(1, 1, 1, 1);
         let b: i16x4 = i16x4::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -24934,7 +24934,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlah_laneq_s16() {
         let a: i16x4 = i16x4::new(1, 1, 1, 1);
         let b: i16x4 = i16x4::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -24944,7 +24944,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahq_lane_s16() {
         let a: i16x8 = i16x8::new(1, 1, 1, 1, 1, 1, 1, 1);
         let b: i16x8 = i16x8::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -24954,7 +24954,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahq_laneq_s16() {
         let a: i16x8 = i16x8::new(1, 1, 1, 1, 1, 1, 1, 1);
         let b: i16x8 = i16x8::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -24964,7 +24964,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlah_lane_s32() {
         let a: i32x2 = i32x2::new(1, 1);
         let b: i32x2 = i32x2::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -24974,7 +24974,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlah_laneq_s32() {
         let a: i32x2 = i32x2::new(1, 1);
         let b: i32x2 = i32x2::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -24984,7 +24984,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahq_lane_s32() {
         let a: i32x4 = i32x4::new(1, 1, 1, 1);
         let b: i32x4 = i32x4::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -24994,7 +24994,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahq_laneq_s32() {
         let a: i32x4 = i32x4::new(1, 1, 1, 1);
         let b: i32x4 = i32x4::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25004,7 +25004,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahh_lane_s16() {
         let a: i16 = 1;
         let b: i16 = 1;
@@ -25014,7 +25014,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahh_laneq_s16() {
         let a: i16 = 1;
         let b: i16 = 1;
@@ -25024,7 +25024,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahs_lane_s32() {
         let a: i32 = 1;
         let b: i32 = 1;
@@ -25034,7 +25034,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlahs_laneq_s32() {
         let a: i32 = 1;
         let b: i32 = 1;
@@ -25044,7 +25044,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlsh_s16() {
         let a: i16x4 = i16x4::new(1, 1, 1, 1);
         let b: i16x4 = i16x4::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -25054,7 +25054,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshq_s16() {
         let a: i16x8 = i16x8::new(1, 1, 1, 1, 1, 1, 1, 1);
         let b: i16x8 = i16x8::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -25064,7 +25064,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlsh_s32() {
         let a: i32x2 = i32x2::new(1, 1);
         let b: i32x2 = i32x2::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25074,7 +25074,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshq_s32() {
         let a: i32x4 = i32x4::new(1, 1, 1, 1);
         let b: i32x4 = i32x4::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25084,7 +25084,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshh_s16() {
         let a: i16 = 1;
         let b: i16 = 1;
@@ -25094,7 +25094,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshs_s32() {
         let a: i32 = 1;
         let b: i32 = 1;
@@ -25104,7 +25104,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlsh_lane_s16() {
         let a: i16x4 = i16x4::new(1, 1, 1, 1);
         let b: i16x4 = i16x4::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -25114,7 +25114,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlsh_laneq_s16() {
         let a: i16x4 = i16x4::new(1, 1, 1, 1);
         let b: i16x4 = i16x4::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -25124,7 +25124,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshq_lane_s16() {
         let a: i16x8 = i16x8::new(1, 1, 1, 1, 1, 1, 1, 1);
         let b: i16x8 = i16x8::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -25134,7 +25134,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshq_laneq_s16() {
         let a: i16x8 = i16x8::new(1, 1, 1, 1, 1, 1, 1, 1);
         let b: i16x8 = i16x8::new(0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF, 0x7F_FF);
@@ -25144,7 +25144,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlsh_lane_s32() {
         let a: i32x2 = i32x2::new(1, 1);
         let b: i32x2 = i32x2::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25154,7 +25154,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlsh_laneq_s32() {
         let a: i32x2 = i32x2::new(1, 1);
         let b: i32x2 = i32x2::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25164,7 +25164,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshq_lane_s32() {
         let a: i32x4 = i32x4::new(1, 1, 1, 1);
         let b: i32x4 = i32x4::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25174,7 +25174,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshq_laneq_s32() {
         let a: i32x4 = i32x4::new(1, 1, 1, 1);
         let b: i32x4 = i32x4::new(0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF, 0x7F_FF_FF_FF);
@@ -25184,7 +25184,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshh_lane_s16() {
         let a: i16 = 1;
         let b: i16 = 1;
@@ -25194,7 +25194,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshh_laneq_s16() {
         let a: i16 = 1;
         let b: i16 = 1;
@@ -25204,7 +25204,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshs_lane_s32() {
         let a: i32 = 1;
         let b: i32 = 1;
@@ -25214,7 +25214,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "rdm")]
     unsafe fn test_vqrdmlshs_laneq_s32() {
         let a: i32 = 1;
         let b: i32 = 1;

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -2793,7 +2793,7 @@ pub unsafe fn vcreate_p16(a: u64) -> poly16x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vcreate_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8341,7 +8341,7 @@ pub unsafe fn vld1q_p16_x4(a: *const p16) -> poly16x8x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p64_x2)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vld1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8354,7 +8354,7 @@ pub unsafe fn vld1_p64_x2(a: *const p64) -> poly64x1x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p64_x3)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8367,7 +8367,7 @@ pub unsafe fn vld1_p64_x3(a: *const p64) -> poly64x1x3_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p64_x4)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8380,7 +8380,7 @@ pub unsafe fn vld1_p64_x4(a: *const p64) -> poly64x1x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p64_x2)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8393,7 +8393,7 @@ pub unsafe fn vld1q_p64_x2(a: *const p64) -> poly64x2x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p64_x3)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8406,7 +8406,7 @@ pub unsafe fn vld1q_p64_x3(a: *const p64) -> poly64x2x3_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p64_x4)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -8907,7 +8907,7 @@ pub unsafe fn vld2_u64(a: *const u64) -> uint64x1x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld2_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -9360,7 +9360,7 @@ pub unsafe fn vld2_dup_u64(a: *const u64) -> uint64x1x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld2_dup_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld2r))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -10192,7 +10192,7 @@ pub unsafe fn vld3_u64(a: *const u64) -> uint64x1x3_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld3_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -10645,7 +10645,7 @@ pub unsafe fn vld3_dup_u64(a: *const u64) -> uint64x1x3_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld3_dup_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld3r))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -11477,7 +11477,7 @@ pub unsafe fn vld4_u64(a: *const u64) -> uint64x1x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld4_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -11930,7 +11930,7 @@ pub unsafe fn vld4_dup_u64(a: *const u64) -> uint64x1x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld4_dup_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld4r))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -12688,7 +12688,7 @@ pub unsafe fn vst1q_lane_p16<const LANE: i32>(a: *mut p16, b: poly16x8_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_lane_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop, LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
@@ -12703,7 +12703,7 @@ pub unsafe fn vst1_lane_p64<const LANE: i32>(a: *mut p64, b: poly64x1_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_lane_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop, LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
@@ -14008,7 +14008,7 @@ pub unsafe fn vst1q_p16_x4(a: *mut p16, b: poly16x8x4_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p64_x2)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vst1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(st1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -14021,7 +14021,7 @@ pub unsafe fn vst1_p64_x2(a: *mut p64, b: poly64x1x2_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p64_x3)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(st1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -14034,7 +14034,7 @@ pub unsafe fn vst1_p64_x3(a: *mut p64, b: poly64x1x3_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p64_x4)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(st1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -14047,7 +14047,7 @@ pub unsafe fn vst1_p64_x4(a: *mut p64, b: poly64x1x4_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p64_x2)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(st1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -14060,7 +14060,7 @@ pub unsafe fn vst1q_p64_x2(a: *mut p64, b: poly64x2x2_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p64_x3)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(st1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -14073,7 +14073,7 @@ pub unsafe fn vst1q_p64_x3(a: *mut p64, b: poly64x2x3_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p64_x4)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(st1))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -14658,7 +14658,7 @@ pub unsafe fn vst2_u64(a: *mut u64, b: uint64x1x2_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst2_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -15490,7 +15490,7 @@ pub unsafe fn vst3_u64(a: *mut u64, b: uint64x1x3_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst3_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -16322,7 +16322,7 @@ pub unsafe fn vst4_u64(a: *mut u64, b: uint64x1x4_t) {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst4_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23196,7 +23196,7 @@ pub unsafe fn vreinterpretq_p16_u32(a: uint32x4_t) -> poly16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_s32_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23209,7 +23209,7 @@ pub unsafe fn vreinterpret_s32_p64(a: poly64x1_t) -> int32x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_u32_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23222,7 +23222,7 @@ pub unsafe fn vreinterpret_u32_p64(a: poly64x1_t) -> uint32x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s32_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23235,7 +23235,7 @@ pub unsafe fn vreinterpretq_s32_p64(a: poly64x2_t) -> int32x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u32_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23248,7 +23248,7 @@ pub unsafe fn vreinterpretq_u32_p64(a: poly64x2_t) -> uint32x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s64_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23261,7 +23261,7 @@ pub unsafe fn vreinterpretq_s64_p128(a: p128) -> int64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u64_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23274,7 +23274,7 @@ pub unsafe fn vreinterpretq_u64_p128(a: p128) -> uint64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23781,7 +23781,7 @@ pub unsafe fn vreinterpretq_p16_u8(a: uint8x16_t) -> poly16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_s32)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23794,7 +23794,7 @@ pub unsafe fn vreinterpret_p64_s32(a: int32x2_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_u32)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23807,7 +23807,7 @@ pub unsafe fn vreinterpret_p64_u32(a: uint32x2_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_s32)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23820,7 +23820,7 @@ pub unsafe fn vreinterpretq_p64_s32(a: int32x4_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_u32)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23833,7 +23833,7 @@ pub unsafe fn vreinterpretq_p64_u32(a: uint32x4_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_s64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23846,7 +23846,7 @@ pub unsafe fn vreinterpretq_p128_s64(a: int64x2_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_u64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -23859,7 +23859,7 @@ pub unsafe fn vreinterpretq_p128_u64(a: uint64x2_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24184,7 +24184,7 @@ pub unsafe fn vreinterpretq_p16_u64(a: uint64x2_t) -> poly16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_s16_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24197,7 +24197,7 @@ pub unsafe fn vreinterpret_s16_p64(a: poly64x1_t) -> int16x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_u16_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24210,7 +24210,7 @@ pub unsafe fn vreinterpret_u16_p64(a: poly64x1_t) -> uint16x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p16_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24223,7 +24223,7 @@ pub unsafe fn vreinterpret_p16_p64(a: poly64x1_t) -> poly16x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s16_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24236,7 +24236,7 @@ pub unsafe fn vreinterpretq_s16_p64(a: poly64x2_t) -> int16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u16_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24249,7 +24249,7 @@ pub unsafe fn vreinterpretq_u16_p64(a: poly64x2_t) -> uint16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p16_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24262,7 +24262,7 @@ pub unsafe fn vreinterpretq_p16_p64(a: poly64x2_t) -> poly16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s32_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24275,7 +24275,7 @@ pub unsafe fn vreinterpretq_s32_p128(a: p128) -> int32x4_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u32_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24600,7 +24600,7 @@ pub unsafe fn vreinterpretq_u64_u16(a: uint16x8_t) -> uint64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_p16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24613,7 +24613,7 @@ pub unsafe fn vreinterpret_p64_p16(a: poly16x4_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_s16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24626,7 +24626,7 @@ pub unsafe fn vreinterpret_p64_s16(a: int16x4_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_u16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24639,7 +24639,7 @@ pub unsafe fn vreinterpret_p64_u16(a: uint16x4_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_p16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24652,7 +24652,7 @@ pub unsafe fn vreinterpretq_p64_p16(a: poly16x8_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_s16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24665,7 +24665,7 @@ pub unsafe fn vreinterpretq_p64_s16(a: int16x8_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_u16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24678,7 +24678,7 @@ pub unsafe fn vreinterpretq_p64_u16(a: uint16x8_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_s32)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24691,7 +24691,7 @@ pub unsafe fn vreinterpretq_p128_s32(a: int32x4_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_u32)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24860,7 +24860,7 @@ pub unsafe fn vreinterpretq_p8_u64(a: uint64x2_t) -> poly8x16_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_s8_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24873,7 +24873,7 @@ pub unsafe fn vreinterpret_s8_p64(a: poly64x1_t) -> int8x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_u8_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24886,7 +24886,7 @@ pub unsafe fn vreinterpret_u8_p64(a: poly64x1_t) -> uint8x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p8_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24899,7 +24899,7 @@ pub unsafe fn vreinterpret_p8_p64(a: poly64x1_t) -> poly8x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s8_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24912,7 +24912,7 @@ pub unsafe fn vreinterpretq_s8_p64(a: poly64x2_t) -> int8x16_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u8_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24925,7 +24925,7 @@ pub unsafe fn vreinterpretq_u8_p64(a: poly64x2_t) -> uint8x16_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p8_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24938,7 +24938,7 @@ pub unsafe fn vreinterpretq_p8_p64(a: poly64x2_t) -> poly8x16_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s16_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24951,7 +24951,7 @@ pub unsafe fn vreinterpretq_s16_p128(a: p128) -> int16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u16_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -24964,7 +24964,7 @@ pub unsafe fn vreinterpretq_u16_p128(a: p128) -> uint16x8_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p16_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25133,7 +25133,7 @@ pub unsafe fn vreinterpretq_u64_u8(a: uint8x16_t) -> uint64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_p8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25146,7 +25146,7 @@ pub unsafe fn vreinterpret_p64_p8(a: poly8x8_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_s8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25159,7 +25159,7 @@ pub unsafe fn vreinterpret_p64_s8(a: int8x8_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpret_p64_u8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25172,7 +25172,7 @@ pub unsafe fn vreinterpret_p64_u8(a: uint8x8_t) -> poly64x1_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_p8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25185,7 +25185,7 @@ pub unsafe fn vreinterpretq_p64_p8(a: poly8x16_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_s8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25198,7 +25198,7 @@ pub unsafe fn vreinterpretq_p64_s8(a: int8x16_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p64_u8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25211,7 +25211,7 @@ pub unsafe fn vreinterpretq_p64_u8(a: uint8x16_t) -> poly64x2_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_s16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25224,7 +25224,7 @@ pub unsafe fn vreinterpretq_p128_s16(a: int16x8_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_u16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25237,7 +25237,7 @@ pub unsafe fn vreinterpretq_p128_u16(a: uint16x8_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_p16)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25250,7 +25250,7 @@ pub unsafe fn vreinterpretq_p128_p16(a: poly16x8_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_s8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25263,7 +25263,7 @@ pub unsafe fn vreinterpretq_p128_s8(a: int8x16_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_u8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25276,7 +25276,7 @@ pub unsafe fn vreinterpretq_p128_u8(a: uint8x16_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p128_p8)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25289,7 +25289,7 @@ pub unsafe fn vreinterpretq_p128_p8(a: poly8x16_t) -> p128 {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_s8_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25302,7 +25302,7 @@ pub unsafe fn vreinterpretq_s8_p128(a: p128) -> int8x16_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u8_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -25315,7 +25315,7 @@ pub unsafe fn vreinterpretq_u8_p128(a: p128) -> uint8x16_t {
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_p8_p128)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
@@ -27060,7 +27060,7 @@ pub unsafe fn vset_lane_p16<const LANE: i32>(a: p16, b: poly16x4_t) -> poly16x4_
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vset_lane_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop, LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
@@ -27225,7 +27225,7 @@ pub unsafe fn vsetq_lane_p16<const LANE: i32>(a: p16, b: poly16x8_t) -> poly16x8
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsetq_lane_p64)
 #[inline]
 #[target_feature(enable = "neon,aes")]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "aes,v8"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop, LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop, LANE = 0))]
 #[rustc_legacy_const_generics(2)]

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -31448,7 +31448,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vcreate_p64() {
         let a: u64 = 1;
         let e: i64x1 = i64x1::new(1);
@@ -33836,7 +33836,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vrndn_f32() {
         let a: f32x2 = f32x2::new(-1.5, 0.5);
         let e: f32x2 = f32x2::new(-2.0, 0.0);
@@ -33844,7 +33845,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vrndnq_f32() {
         let a: f32x4 = f32x4::new(-1.5, 0.5, 1.5, 2.5);
         let e: f32x4 = f32x4::new(-2.0, 0.0, 2.0, 2.0);
@@ -38406,7 +38408,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfma_f32() {
         let a: f32x2 = f32x2::new(8.0, 18.0);
         let b: f32x2 = f32x2::new(6.0, 4.0);
@@ -38416,7 +38419,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfmaq_f32() {
         let a: f32x4 = f32x4::new(8.0, 18.0, 12.0, 10.0);
         let b: f32x4 = f32x4::new(6.0, 4.0, 7.0, 8.0);
@@ -38426,7 +38430,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfma_n_f32() {
         let a: f32x2 = f32x2::new(2.0, 3.0);
         let b: f32x2 = f32x2::new(6.0, 4.0);
@@ -38436,7 +38441,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfmaq_n_f32() {
         let a: f32x4 = f32x4::new(2.0, 3.0, 4.0, 5.0);
         let b: f32x4 = f32x4::new(6.0, 4.0, 7.0, 8.0);
@@ -38446,7 +38452,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfms_f32() {
         let a: f32x2 = f32x2::new(20.0, 30.0);
         let b: f32x2 = f32x2::new(6.0, 4.0);
@@ -38456,7 +38463,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfmsq_f32() {
         let a: f32x4 = f32x4::new(20.0, 30.0, 40.0, 50.0);
         let b: f32x4 = f32x4::new(6.0, 4.0, 7.0, 8.0);
@@ -38466,7 +38474,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfms_n_f32() {
         let a: f32x2 = f32x2::new(50.0, 35.0);
         let b: f32x2 = f32x2::new(6.0, 4.0);
@@ -38476,7 +38485,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vfmsq_n_f32() {
         let a: f32x4 = f32x4::new(50.0, 35.0, 60.0, 69.0);
         let b: f32x4 = f32x4::new(6.0, 4.0, 7.0, 8.0);
@@ -39167,7 +39177,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vmaxnm_f32() {
         let a: f32x2 = f32x2::new(1.0, 2.0);
         let b: f32x2 = f32x2::new(8.0, 16.0);
@@ -39176,7 +39187,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vmaxnmq_f32() {
         let a: f32x4 = f32x4::new(1.0, 2.0, 3.0, -4.0);
         let b: f32x4 = f32x4::new(8.0, 16.0, -1.0, 6.0);
@@ -39311,7 +39323,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vminnm_f32() {
         let a: f32x2 = f32x2::new(1.0, 2.0);
         let b: f32x2 = f32x2::new(8.0, 16.0);
@@ -39320,7 +39333,8 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[cfg_attr(target_arch = "arm", simd_test(enable = "neon,crc"))]
+    #[cfg_attr(target_arch = "aarch64", simd_test(enable = "neon"))]
     unsafe fn test_vminnmq_f32() {
         let a: f32x4 = f32x4::new(1.0, 2.0, 3.0, -4.0);
         let b: f32x4 = f32x4::new(8.0, 16.0, -1.0, 6.0);
@@ -41120,7 +41134,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_s32_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: i32x2 = i32x2::new(0, 0);
@@ -41128,7 +41142,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_u32_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: u32x2 = u32x2::new(0, 0);
@@ -41136,7 +41150,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s32_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: i32x4 = i32x4::new(0, 0, 1, 0);
@@ -41144,7 +41158,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u32_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: u32x4 = u32x4::new(0, 0, 1, 0);
@@ -41152,7 +41166,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s64_p128() {
         let a: p128 = 0;
         let e: i64x2 = i64x2::new(0, 0);
@@ -41160,7 +41174,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u64_p128() {
         let a: p128 = 0;
         let e: u64x2 = u64x2::new(0, 0);
@@ -41168,7 +41182,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_p128() {
         let a: p128 = 0;
         let e: i64x2 = i64x2::new(0, 0);
@@ -41480,7 +41494,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_s32() {
         let a: i32x2 = i32x2::new(0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -41488,7 +41502,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_u32() {
         let a: u32x2 = u32x2::new(0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -41496,7 +41510,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_s32() {
         let a: i32x4 = i32x4::new(0, 0, 1, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -41504,7 +41518,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_u32() {
         let a: u32x4 = u32x4::new(0, 0, 1, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -41512,7 +41526,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_s64() {
         let a: i64x2 = i64x2::new(0, 0);
         let e: p128 = 0;
@@ -41520,7 +41534,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_u64() {
         let a: u64x2 = u64x2::new(0, 0);
         let e: p128 = 0;
@@ -41528,7 +41542,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_p64() {
         let a: i64x2 = i64x2::new(0, 0);
         let e: p128 = 0;
@@ -41728,7 +41742,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_s16_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: i16x4 = i16x4::new(0, 0, 0, 0);
@@ -41736,7 +41750,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_u16_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: u16x4 = u16x4::new(0, 0, 0, 0);
@@ -41744,7 +41758,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p16_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: i16x4 = i16x4::new(0, 0, 0, 0);
@@ -41752,7 +41766,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s16_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: i16x8 = i16x8::new(0, 0, 0, 0, 1, 0, 0, 0);
@@ -41760,7 +41774,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u16_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: u16x8 = u16x8::new(0, 0, 0, 0, 1, 0, 0, 0);
@@ -41768,7 +41782,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p16_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: i16x8 = i16x8::new(0, 0, 0, 0, 1, 0, 0, 0);
@@ -41776,7 +41790,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s32_p128() {
         let a: p128 = 0;
         let e: i32x4 = i32x4::new(0, 0, 0, 0);
@@ -41784,7 +41798,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u32_p128() {
         let a: p128 = 0;
         let e: u32x4 = u32x4::new(0, 0, 0, 0);
@@ -41984,7 +41998,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_p16() {
         let a: i16x4 = i16x4::new(0, 0, 0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -41992,7 +42006,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_s16() {
         let a: i16x4 = i16x4::new(0, 0, 0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -42000,7 +42014,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_u16() {
         let a: u16x4 = u16x4::new(0, 0, 0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -42008,7 +42022,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_p16() {
         let a: i16x8 = i16x8::new(0, 0, 0, 0, 1, 0, 0, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -42016,7 +42030,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_s16() {
         let a: i16x8 = i16x8::new(0, 0, 0, 0, 1, 0, 0, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -42024,7 +42038,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_u16() {
         let a: u16x8 = u16x8::new(0, 0, 0, 0, 1, 0, 0, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -42032,7 +42046,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_s32() {
         let a: i32x4 = i32x4::new(0, 0, 0, 0);
         let e: p128 = 0;
@@ -42040,7 +42054,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_u32() {
         let a: u32x4 = u32x4::new(0, 0, 0, 0);
         let e: p128 = 0;
@@ -42144,7 +42158,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_s8_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: i8x8 = i8x8::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -42152,7 +42166,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_u8_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: u8x8 = u8x8::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -42160,7 +42174,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p8_p64() {
         let a: i64x1 = i64x1::new(0);
         let e: i8x8 = i8x8::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -42168,7 +42182,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s8_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: i8x16 = i8x16::new(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
@@ -42176,7 +42190,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u8_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: u8x16 = u8x16::new(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
@@ -42184,7 +42198,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p8_p64() {
         let a: i64x2 = i64x2::new(0, 1);
         let e: i8x16 = i8x16::new(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
@@ -42192,7 +42206,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s16_p128() {
         let a: p128 = 0;
         let e: i16x8 = i16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -42200,7 +42214,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u16_p128() {
         let a: p128 = 0;
         let e: u16x8 = u16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -42208,7 +42222,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p16_p128() {
         let a: p128 = 0;
         let e: i16x8 = i16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -42312,7 +42326,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_p8() {
         let a: i8x8 = i8x8::new(0, 0, 0, 0, 0, 0, 0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -42320,7 +42334,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_s8() {
         let a: i8x8 = i8x8::new(0, 0, 0, 0, 0, 0, 0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -42328,7 +42342,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpret_p64_u8() {
         let a: u8x8 = u8x8::new(0, 0, 0, 0, 0, 0, 0, 0);
         let e: i64x1 = i64x1::new(0);
@@ -42336,7 +42350,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_p8() {
         let a: i8x16 = i8x16::new(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -42344,7 +42358,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_s8() {
         let a: i8x16 = i8x16::new(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -42352,7 +42366,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p64_u8() {
         let a: u8x16 = u8x16::new(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
         let e: i64x2 = i64x2::new(0, 1);
@@ -42360,7 +42374,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_s16() {
         let a: i16x8 = i16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
         let e: p128 = 0;
@@ -42368,7 +42382,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_u16() {
         let a: u16x8 = u16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
         let e: p128 = 0;
@@ -42376,7 +42390,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_p16() {
         let a: i16x8 = i16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
         let e: p128 = 0;
@@ -42384,7 +42398,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_s8() {
         let a: i8x16 = i8x16::new(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let e: p128 = 1;
@@ -42392,7 +42406,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_u8() {
         let a: u8x16 = u8x16::new(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let e: p128 = 1;
@@ -42400,7 +42414,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p128_p8() {
         let a: i8x16 = i8x16::new(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let e: p128 = 1;
@@ -42408,7 +42422,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_s8_p128() {
         let a: p128 = 1;
         let e: i8x16 = i8x16::new(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -42416,7 +42430,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_u8_p128() {
         let a: p128 = 1;
         let e: u8x16 = u8x16::new(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -42424,7 +42438,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vreinterpretq_p8_p128() {
         let a: p128 = 1;
         let e: i8x16 = i8x16::new(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -43376,7 +43390,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vset_lane_p64() {
         let a: p64 = 1;
         let b: i64x1 = i64x1::new(0);
@@ -43475,7 +43489,7 @@ mod test {
         assert_eq!(r, e);
     }
 
-    #[simd_test(enable = "neon")]
+    #[simd_test(enable = "neon,aes")]
     unsafe fn test_vsetq_lane_p64() {
         let a: p64 = 1;
         let b: i64x2 = i64x2::new(0, 2);

--- a/crates/core_arch/src/x86_64/cmpxchg16b.rs
+++ b/crates/core_arch/src/x86_64/cmpxchg16b.rs
@@ -76,7 +76,7 @@ pub unsafe fn cmpxchg16b(
         (_, Release) => panic!("there is no such thing as a release failure ordering"),
 
         // `atomic::Ordering` is non_exhaustive. It warns when `core_arch` is built as a part of `core`.
-        #[allow(unreachable_patterns)] 
+        #[allow(unreachable_patterns)]
         (_, _) => unreachable!(),
     };
     val

--- a/crates/stdarch-gen/src/main.rs
+++ b/crates/stdarch-gen/src/main.rs
@@ -494,22 +494,7 @@ impl TargetFeature {
 
     /// A string for use with #[simd_test(...)] (or `is_aarch64_feature_detected!(...)`).
     fn as_simd_test_arg_aarch64(&self) -> &str {
-        match *self {
-            // Features included with AArch64 NEON.
-            Self::Default => "neon",
-            Self::ArmV7 => "neon",
-            Self::Vfp4 => "neon",
-            Self::FPArmV8 => "neon",
-            // Optional features.
-            Self::AES => "neon",     // TODO: Missing "aes".
-            Self::FCMA => "neon",    // TODO: Missing "fcma".
-            Self::Dotprod => "neon", // TODO: Missing "dotprod".
-            Self::I8MM => "neon,i8mm",
-            Self::SHA3 => "neon,sha3",
-            Self::RDM => "neon", // TODO: Should be "rdm".
-            Self::SM4 => "neon,sm4",
-            Self::FTTS => "neon,frintts",
-        }
+        self.as_target_feature_arg_aarch64()
     }
 
     /// A string for use with `#[target_feature(...)]`.
@@ -533,7 +518,35 @@ impl TargetFeature {
 
     /// A string for use with #[simd_test(...)] (or `is_arm_feature_detected!(...)`).
     fn as_simd_test_arg_arm(&self) -> &str {
-        self.as_simd_test_arg_aarch64()
+        // TODO: Ideally, these would match the target_feature strings (as for AArch64).
+        match *self {
+            // We typically specify the "v7" or "v8" target_features for codegen, but we can't test
+            // them at runtime. However, in many cases we can test a specific named feature, and
+            // this is sufficient. For example, Neon always requires at least Armv7.
+
+            // "v7" extensions.
+            Self::Default => "neon",
+            Self::ArmV7 => "neon",
+
+            // TODO: We can specify these features for code generation, but they have no runtime
+            // detection, so we can't provide an accurate string for simd_test. For now, we use a
+            // common Armv8 feature as a proxy, but we should improve std_detect support here and
+            // update these accordingly.
+            Self::Vfp4 => "neon,crc",
+            Self::FPArmV8 => "neon,crc",
+
+            // "v8" extensions.
+            Self::AES => "neon,aes",
+            Self::FCMA => "neon,fcma",
+            Self::Dotprod => "neon,dotprod",
+            Self::I8MM => "neon,i8mm",
+
+            // Features not supported on 32-bit "arm".
+            Self::SHA3 => unimplemented!(),
+            Self::RDM => unimplemented!(),
+            Self::SM4 => unimplemented!(),
+            Self::FTTS => unimplemented!(),
+        }
     }
 
     fn attr(name: &str, value: impl fmt::Display) -> String {


### PR DESCRIPTION
The tests can run if and only if the target_features for the corresponding intrinsics are detected at run-time, so make sure that the tests have an appropriate `simd_test()`.

This fixes some failures due to tests running when they shouldn't. For example, some tests would fail on hardware that lacks "fcma".

This decouples the feature names in the generator, since "arm" and "arm64" use different names, and for "arm" the dynamic `simd_test` features don't match the static `target_feature` names.

There are several changes to the tests, but changes to the generated intrinsics themselves are minimal, and cosmetic.