### PR TITLE
use inline const for last simd_shuffle argument

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -191,8 +191,8 @@ pub unsafe fn vabdd_f64(a: f64, b: f64) -> f64 {
 #[cfg_attr(test, assert_instr(uabdl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabdl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
-    let c: uint8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let d: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let d: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     simd_cast(vabd_u8(c, d))
 }
 
@@ -204,8 +204,8 @@ pub unsafe fn vabdl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(uabdl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabdl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
-    let c: uint16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let d: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let c: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let d: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     simd_cast(vabd_u16(c, d))
 }
 
@@ -217,8 +217,8 @@ pub unsafe fn vabdl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(uabdl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabdl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
-    let c: uint32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let d: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let c: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let d: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
     simd_cast(vabd_u32(c, d))
 }
 
@@ -230,8 +230,8 @@ pub unsafe fn vabdl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(sabdl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabdl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
-    let c: int8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let d: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let d: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let e: uint8x8_t = simd_cast(vabd_s8(c, d));
     simd_cast(e)
 }
@@ -244,8 +244,8 @@ pub unsafe fn vabdl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(sabdl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabdl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
-    let c: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let d: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let c: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let d: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let e: uint16x4_t = simd_cast(vabd_s16(c, d));
     simd_cast(e)
 }
@@ -258,8 +258,8 @@ pub unsafe fn vabdl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(sabdl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabdl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
-    let c: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let d: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let c: int32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let d: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     let e: uint32x2_t = simd_cast(vabd_s32(c, d));
     simd_cast(e)
 }
@@ -2280,14 +2280,14 @@ pub unsafe fn vcopy_lane_s8<const LANE1: i32, const LANE2: i32>(a: int8x8_t, b: 
     static_assert_imm3!(LANE1);
     static_assert_imm3!(LANE2);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2304,22 +2304,22 @@ pub unsafe fn vcopyq_laneq_s8<const LANE1: i32, const LANE2: i32>(a: int8x16_t, 
     static_assert_imm4!(LANE1);
     static_assert_imm4!(LANE2);
     match LANE1 & 0b1111 {
-        0 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        2 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        3 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        4 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        5 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        6 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        7 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
-        8 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
-        9 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
-        10 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
-        11 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
-        12 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
-        13 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
-        14 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
-        15 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
+        9 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
+        10 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
+        11 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
+        12 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
+        13 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
+        14 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
+        15 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2336,10 +2336,10 @@ pub unsafe fn vcopy_lane_s16<const LANE1: i32, const LANE2: i32>(a: int16x4_t, b
     static_assert_imm2!(LANE1);
     static_assert_imm2!(LANE2);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2356,14 +2356,14 @@ pub unsafe fn vcopyq_laneq_s16<const LANE1: i32, const LANE2: i32>(a: int16x8_t,
     static_assert_imm3!(LANE1);
     static_assert_imm3!(LANE2);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2380,8 +2380,8 @@ pub unsafe fn vcopy_lane_s32<const LANE1: i32, const LANE2: i32>(a: int32x2_t, b
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2398,10 +2398,10 @@ pub unsafe fn vcopyq_laneq_s32<const LANE1: i32, const LANE2: i32>(a: int32x4_t,
     static_assert_imm2!(LANE1);
     static_assert_imm2!(LANE2);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2418,8 +2418,8 @@ pub unsafe fn vcopyq_laneq_s64<const LANE1: i32, const LANE2: i32>(a: int64x2_t,
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2436,14 +2436,14 @@ pub unsafe fn vcopy_lane_u8<const LANE1: i32, const LANE2: i32>(a: uint8x8_t, b:
     static_assert_imm3!(LANE1);
     static_assert_imm3!(LANE2);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2460,22 +2460,22 @@ pub unsafe fn vcopyq_laneq_u8<const LANE1: i32, const LANE2: i32>(a: uint8x16_t,
     static_assert_imm4!(LANE1);
     static_assert_imm4!(LANE2);
     match LANE1 & 0b1111 {
-        0 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        2 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        3 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        4 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        5 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        6 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        7 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
-        8 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
-        9 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
-        10 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
-        11 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
-        12 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
-        13 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
-        14 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
-        15 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
+        9 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
+        10 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
+        11 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
+        12 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
+        13 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
+        14 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
+        15 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2492,10 +2492,10 @@ pub unsafe fn vcopy_lane_u16<const LANE1: i32, const LANE2: i32>(a: uint16x4_t, 
     static_assert_imm2!(LANE1);
     static_assert_imm2!(LANE2);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2512,14 +2512,14 @@ pub unsafe fn vcopyq_laneq_u16<const LANE1: i32, const LANE2: i32>(a: uint16x8_t
     static_assert_imm3!(LANE1);
     static_assert_imm3!(LANE2);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2536,8 +2536,8 @@ pub unsafe fn vcopy_lane_u32<const LANE1: i32, const LANE2: i32>(a: uint32x2_t, 
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2554,10 +2554,10 @@ pub unsafe fn vcopyq_laneq_u32<const LANE1: i32, const LANE2: i32>(a: uint32x4_t
     static_assert_imm2!(LANE1);
     static_assert_imm2!(LANE2);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2574,8 +2574,8 @@ pub unsafe fn vcopyq_laneq_u64<const LANE1: i32, const LANE2: i32>(a: uint64x2_t
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2592,14 +2592,14 @@ pub unsafe fn vcopy_lane_p8<const LANE1: i32, const LANE2: i32>(a: poly8x8_t, b:
     static_assert_imm3!(LANE1);
     static_assert_imm3!(LANE2);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2616,22 +2616,22 @@ pub unsafe fn vcopyq_laneq_p8<const LANE1: i32, const LANE2: i32>(a: poly8x16_t,
     static_assert_imm4!(LANE1);
     static_assert_imm4!(LANE2);
     match LANE1 & 0b1111 {
-        0 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        2 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        3 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        4 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        5 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        6 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        7 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
-        8 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
-        9 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
-        10 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
-        11 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
-        12 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
-        13 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
-        14 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
-        15 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
+        9 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
+        10 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
+        11 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
+        12 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
+        13 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
+        14 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
+        15 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2648,10 +2648,10 @@ pub unsafe fn vcopy_lane_p16<const LANE1: i32, const LANE2: i32>(a: poly16x4_t, 
     static_assert_imm2!(LANE1);
     static_assert_imm2!(LANE2);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2668,14 +2668,14 @@ pub unsafe fn vcopyq_laneq_p16<const LANE1: i32, const LANE2: i32>(a: poly16x8_t
     static_assert_imm3!(LANE1);
     static_assert_imm3!(LANE2);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2692,8 +2692,8 @@ pub unsafe fn vcopyq_laneq_p64<const LANE1: i32, const LANE2: i32>(a: poly64x2_t
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2710,8 +2710,8 @@ pub unsafe fn vcopy_lane_f32<const LANE1: i32, const LANE2: i32>(a: float32x2_t,
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2728,10 +2728,10 @@ pub unsafe fn vcopyq_laneq_f32<const LANE1: i32, const LANE2: i32>(a: float32x4_
     static_assert_imm2!(LANE1);
     static_assert_imm2!(LANE2);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2748,8 +2748,8 @@ pub unsafe fn vcopyq_laneq_f64<const LANE1: i32, const LANE2: i32>(a: float64x2_
     static_assert_imm1!(LANE1);
     static_assert_imm1!(LANE2);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2765,16 +2765,16 @@ pub unsafe fn vcopyq_laneq_f64<const LANE1: i32, const LANE2: i32>(a: float64x2_
 pub unsafe fn vcopy_laneq_s8<const LANE1: i32, const LANE2: i32>(a: int8x8_t, b: int8x16_t) -> int8x8_t {
     static_assert_imm3!(LANE1);
     static_assert_imm4!(LANE2);
-    let a: int8x16_t = simd_shuffle16!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: int8x16_t = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2790,12 +2790,12 @@ pub unsafe fn vcopy_laneq_s8<const LANE1: i32, const LANE2: i32>(a: int8x8_t, b:
 pub unsafe fn vcopy_laneq_s16<const LANE1: i32, const LANE2: i32>(a: int16x4_t, b: int16x8_t) -> int16x4_t {
     static_assert_imm2!(LANE1);
     static_assert_imm3!(LANE2);
-    let a: int16x8_t = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let a: int16x8_t = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2811,10 +2811,10 @@ pub unsafe fn vcopy_laneq_s16<const LANE1: i32, const LANE2: i32>(a: int16x4_t, 
 pub unsafe fn vcopy_laneq_s32<const LANE1: i32, const LANE2: i32>(a: int32x2_t, b: int32x4_t) -> int32x2_t {
     static_assert_imm1!(LANE1);
     static_assert_imm2!(LANE2);
-    let a: int32x4_t = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: int32x4_t = simd_shuffle!(a, a, [0, 1, 2, 3]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2830,16 +2830,16 @@ pub unsafe fn vcopy_laneq_s32<const LANE1: i32, const LANE2: i32>(a: int32x2_t, 
 pub unsafe fn vcopy_laneq_u8<const LANE1: i32, const LANE2: i32>(a: uint8x8_t, b: uint8x16_t) -> uint8x8_t {
     static_assert_imm3!(LANE1);
     static_assert_imm4!(LANE2);
-    let a: uint8x16_t = simd_shuffle16!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: uint8x16_t = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2855,12 +2855,12 @@ pub unsafe fn vcopy_laneq_u8<const LANE1: i32, const LANE2: i32>(a: uint8x8_t, b
 pub unsafe fn vcopy_laneq_u16<const LANE1: i32, const LANE2: i32>(a: uint16x4_t, b: uint16x8_t) -> uint16x4_t {
     static_assert_imm2!(LANE1);
     static_assert_imm3!(LANE2);
-    let a: uint16x8_t = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let a: uint16x8_t = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2876,10 +2876,10 @@ pub unsafe fn vcopy_laneq_u16<const LANE1: i32, const LANE2: i32>(a: uint16x4_t,
 pub unsafe fn vcopy_laneq_u32<const LANE1: i32, const LANE2: i32>(a: uint32x2_t, b: uint32x4_t) -> uint32x2_t {
     static_assert_imm1!(LANE1);
     static_assert_imm2!(LANE2);
-    let a: uint32x4_t = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: uint32x4_t = simd_shuffle!(a, a, [0, 1, 2, 3]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2895,16 +2895,16 @@ pub unsafe fn vcopy_laneq_u32<const LANE1: i32, const LANE2: i32>(a: uint32x2_t,
 pub unsafe fn vcopy_laneq_p8<const LANE1: i32, const LANE2: i32>(a: poly8x8_t, b: poly8x16_t) -> poly8x8_t {
     static_assert_imm3!(LANE1);
     static_assert_imm4!(LANE2);
-    let a: poly8x16_t = simd_shuffle16!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: poly8x16_t = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2920,12 +2920,12 @@ pub unsafe fn vcopy_laneq_p8<const LANE1: i32, const LANE2: i32>(a: poly8x8_t, b
 pub unsafe fn vcopy_laneq_p16<const LANE1: i32, const LANE2: i32>(a: poly16x4_t, b: poly16x8_t) -> poly16x4_t {
     static_assert_imm2!(LANE1);
     static_assert_imm3!(LANE2);
-    let a: poly16x8_t = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let a: poly16x8_t = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2941,10 +2941,10 @@ pub unsafe fn vcopy_laneq_p16<const LANE1: i32, const LANE2: i32>(a: poly16x4_t,
 pub unsafe fn vcopy_laneq_f32<const LANE1: i32, const LANE2: i32>(a: float32x2_t, b: float32x4_t) -> float32x2_t {
     static_assert_imm1!(LANE1);
     static_assert_imm2!(LANE2);
-    let a: float32x4_t = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: float32x4_t = simd_shuffle!(a, a, [0, 1, 2, 3]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2960,24 +2960,24 @@ pub unsafe fn vcopy_laneq_f32<const LANE1: i32, const LANE2: i32>(a: float32x2_t
 pub unsafe fn vcopyq_lane_s8<const LANE1: i32, const LANE2: i32>(a: int8x16_t, b: int8x8_t) -> int8x16_t {
     static_assert_imm4!(LANE1);
     static_assert_imm3!(LANE2);
-    let b: int8x16_t = simd_shuffle16!(b, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x16_t = simd_shuffle!(b, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     match LANE1 & 0b1111 {
-        0 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        2 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        3 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        4 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        5 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        6 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        7 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
-        8 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
-        9 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
-        10 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
-        11 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
-        12 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
-        13 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
-        14 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
-        15 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
+        9 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
+        10 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
+        11 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
+        12 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
+        13 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
+        14 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
+        15 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -2993,16 +2993,16 @@ pub unsafe fn vcopyq_lane_s8<const LANE1: i32, const LANE2: i32>(a: int8x16_t, b
 pub unsafe fn vcopyq_lane_s16<const LANE1: i32, const LANE2: i32>(a: int16x8_t, b: int16x4_t) -> int16x8_t {
     static_assert_imm3!(LANE1);
     static_assert_imm2!(LANE2);
-    let b: int16x8_t = simd_shuffle8!(b, b, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let b: int16x8_t = simd_shuffle!(b, b, [0, 1, 2, 3, 4, 5, 6, 7]);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3018,12 +3018,12 @@ pub unsafe fn vcopyq_lane_s16<const LANE1: i32, const LANE2: i32>(a: int16x8_t, 
 pub unsafe fn vcopyq_lane_s32<const LANE1: i32, const LANE2: i32>(a: int32x4_t, b: int32x2_t) -> int32x4_t {
     static_assert_imm2!(LANE1);
     static_assert_imm1!(LANE2);
-    let b: int32x4_t = simd_shuffle4!(b, b, [0, 1, 2, 3]);
+    let b: int32x4_t = simd_shuffle!(b, b, [0, 1, 2, 3]);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3039,24 +3039,24 @@ pub unsafe fn vcopyq_lane_s32<const LANE1: i32, const LANE2: i32>(a: int32x4_t, 
 pub unsafe fn vcopyq_lane_u8<const LANE1: i32, const LANE2: i32>(a: uint8x16_t, b: uint8x8_t) -> uint8x16_t {
     static_assert_imm4!(LANE1);
     static_assert_imm3!(LANE2);
-    let b: uint8x16_t = simd_shuffle16!(b, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x16_t = simd_shuffle!(b, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     match LANE1 & 0b1111 {
-        0 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        2 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        3 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        4 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        5 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        6 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        7 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
-        8 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
-        9 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
-        10 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
-        11 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
-        12 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
-        13 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
-        14 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
-        15 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
+        9 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
+        10 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
+        11 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
+        12 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
+        13 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
+        14 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
+        15 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3072,16 +3072,16 @@ pub unsafe fn vcopyq_lane_u8<const LANE1: i32, const LANE2: i32>(a: uint8x16_t, 
 pub unsafe fn vcopyq_lane_u16<const LANE1: i32, const LANE2: i32>(a: uint16x8_t, b: uint16x4_t) -> uint16x8_t {
     static_assert_imm3!(LANE1);
     static_assert_imm2!(LANE2);
-    let b: uint16x8_t = simd_shuffle8!(b, b, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let b: uint16x8_t = simd_shuffle!(b, b, [0, 1, 2, 3, 4, 5, 6, 7]);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3097,12 +3097,12 @@ pub unsafe fn vcopyq_lane_u16<const LANE1: i32, const LANE2: i32>(a: uint16x8_t,
 pub unsafe fn vcopyq_lane_u32<const LANE1: i32, const LANE2: i32>(a: uint32x4_t, b: uint32x2_t) -> uint32x4_t {
     static_assert_imm2!(LANE1);
     static_assert_imm1!(LANE2);
-    let b: uint32x4_t = simd_shuffle4!(b, b, [0, 1, 2, 3]);
+    let b: uint32x4_t = simd_shuffle!(b, b, [0, 1, 2, 3]);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3118,24 +3118,24 @@ pub unsafe fn vcopyq_lane_u32<const LANE1: i32, const LANE2: i32>(a: uint32x4_t,
 pub unsafe fn vcopyq_lane_p8<const LANE1: i32, const LANE2: i32>(a: poly8x16_t, b: poly8x8_t) -> poly8x16_t {
     static_assert_imm4!(LANE1);
     static_assert_imm3!(LANE2);
-    let b: poly8x16_t = simd_shuffle16!(b, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: poly8x16_t = simd_shuffle!(b, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
     match LANE1 & 0b1111 {
-        0 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        2 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        3 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        4 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        5 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        6 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        7 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
-        8 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
-        9 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
-        10 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
-        11 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
-        12 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
-        13 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
-        14 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
-        15 => simd_shuffle16!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [16 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [0, 16 + LANE2 as u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        2 => simd_shuffle!(a, b, [0, 1, 16 + LANE2 as u32, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 16 + LANE2 as u32, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 16 + LANE2 as u32, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 16 + LANE2 as u32, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 16 + LANE2 as u32, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 16 + LANE2 as u32, 8, 9, 10, 11, 12, 13, 14, 15]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 16 + LANE2 as u32, 9, 10, 11, 12, 13, 14, 15]),
+        9 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16 + LANE2 as u32, 10, 11, 12, 13, 14, 15]),
+        10 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 16 + LANE2 as u32, 11, 12, 13, 14, 15]),
+        11 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16 + LANE2 as u32, 12, 13, 14, 15]),
+        12 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16 + LANE2 as u32, 13, 14, 15]),
+        13 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16 + LANE2 as u32, 14, 15]),
+        14 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16 + LANE2 as u32, 15]),
+        15 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3151,16 +3151,16 @@ pub unsafe fn vcopyq_lane_p8<const LANE1: i32, const LANE2: i32>(a: poly8x16_t, 
 pub unsafe fn vcopyq_lane_p16<const LANE1: i32, const LANE2: i32>(a: poly16x8_t, b: poly16x4_t) -> poly16x8_t {
     static_assert_imm3!(LANE1);
     static_assert_imm2!(LANE2);
-    let b: poly16x8_t = simd_shuffle8!(b, b, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let b: poly16x8_t = simd_shuffle!(b, b, [0, 1, 2, 3, 4, 5, 6, 7]);
     match LANE1 & 0b111 {
-        0 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
-        2 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
-        3 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
-        4 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
-        5 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
-        6 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
-        7 => simd_shuffle8!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [8 + LANE2 as u32, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [0, 8 + LANE2 as u32, 2, 3, 4, 5, 6, 7]),
+        2 => simd_shuffle!(a, b, [0, 1, 8 + LANE2 as u32, 3, 4, 5, 6, 7]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 8 + LANE2 as u32, 4, 5, 6, 7]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3, 8 + LANE2 as u32, 5, 6, 7]),
+        5 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 8 + LANE2 as u32, 6, 7]),
+        6 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 8 + LANE2 as u32, 7]),
+        7 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 8 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3176,10 +3176,10 @@ pub unsafe fn vcopyq_lane_p16<const LANE1: i32, const LANE2: i32>(a: poly16x8_t,
 pub unsafe fn vcopyq_lane_s64<const LANE1: i32, const LANE2: i32>(a: int64x2_t, b: int64x1_t) -> int64x2_t {
     static_assert_imm1!(LANE1);
     static_assert!(LANE2 : i32 where LANE2 == 0);
-    let b: int64x2_t = simd_shuffle2!(b, b, [0, 1]);
+    let b: int64x2_t = simd_shuffle!(b, b, [0, 1]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3195,10 +3195,10 @@ pub unsafe fn vcopyq_lane_s64<const LANE1: i32, const LANE2: i32>(a: int64x2_t, 
 pub unsafe fn vcopyq_lane_u64<const LANE1: i32, const LANE2: i32>(a: uint64x2_t, b: uint64x1_t) -> uint64x2_t {
     static_assert_imm1!(LANE1);
     static_assert!(LANE2 : i32 where LANE2 == 0);
-    let b: uint64x2_t = simd_shuffle2!(b, b, [0, 1]);
+    let b: uint64x2_t = simd_shuffle!(b, b, [0, 1]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3214,10 +3214,10 @@ pub unsafe fn vcopyq_lane_u64<const LANE1: i32, const LANE2: i32>(a: uint64x2_t,
 pub unsafe fn vcopyq_lane_p64<const LANE1: i32, const LANE2: i32>(a: poly64x2_t, b: poly64x1_t) -> poly64x2_t {
     static_assert_imm1!(LANE1);
     static_assert!(LANE2 : i32 where LANE2 == 0);
-    let b: poly64x2_t = simd_shuffle2!(b, b, [0, 1]);
+    let b: poly64x2_t = simd_shuffle!(b, b, [0, 1]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3233,12 +3233,12 @@ pub unsafe fn vcopyq_lane_p64<const LANE1: i32, const LANE2: i32>(a: poly64x2_t,
 pub unsafe fn vcopyq_lane_f32<const LANE1: i32, const LANE2: i32>(a: float32x4_t, b: float32x2_t) -> float32x4_t {
     static_assert_imm2!(LANE1);
     static_assert_imm1!(LANE2);
-    let b: float32x4_t = simd_shuffle4!(b, b, [0, 1, 2, 3]);
+    let b: float32x4_t = simd_shuffle!(b, b, [0, 1, 2, 3]);
     match LANE1 & 0b11 {
-        0 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [4 + LANE2 as u32, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 4 + LANE2 as u32, 2, 3]),
-        2 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 4 + LANE2 as u32, 3]),
-        3 => simd_shuffle4!(a, b, <const LANE1: i32, const LANE2: i32> [0, 1, 2, 4 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [4 + LANE2 as u32, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [0, 4 + LANE2 as u32, 2, 3]),
+        2 => simd_shuffle!(a, b, [0, 1, 4 + LANE2 as u32, 3]),
+        3 => simd_shuffle!(a, b, [0, 1, 2, 4 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3254,10 +3254,10 @@ pub unsafe fn vcopyq_lane_f32<const LANE1: i32, const LANE2: i32>(a: float32x4_t
 pub unsafe fn vcopyq_lane_f64<const LANE1: i32, const LANE2: i32>(a: float64x2_t, b: float64x1_t) -> float64x2_t {
     static_assert_imm1!(LANE1);
     static_assert!(LANE2 : i32 where LANE2 == 0);
-    let b: float64x2_t = simd_shuffle2!(b, b, [0, 1]);
+    let b: float64x2_t = simd_shuffle!(b, b, [0, 1]);
     match LANE1 & 0b1 {
-        0 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [2 + LANE2 as u32, 1]),
-        1 => simd_shuffle2!(a, b, <const LANE1: i32, const LANE2: i32> [0, 2 + LANE2 as u32]),
+        0 => simd_shuffle!(a, b, [2 + LANE2 as u32, 1]),
+        1 => simd_shuffle!(a, b, [0, 2 + LANE2 as u32]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3336,7 +3336,7 @@ pub unsafe fn vcvt_f64_f32(a: float32x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(fcvtl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcvt_high_f64_f32(a: float32x4_t) -> float64x2_t {
-    let b: float32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let b: float32x2_t = simd_shuffle!(a, a, [2, 3]);
     simd_cast(b)
 }
 
@@ -3359,7 +3359,7 @@ pub unsafe fn vcvt_f32_f64(a: float64x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(fcvtn))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcvt_high_f32_f64(a: float32x2_t, b: float64x2_t) -> float32x4_t {
-    simd_shuffle4!(a, simd_cast(b), [0, 1, 2, 3])
+    simd_shuffle!(a, simd_cast(b), [0, 1, 2, 3])
 }
 
 /// Floating-point convert to lower precision narrow, rounding to odd
@@ -3397,7 +3397,7 @@ pub unsafe fn vcvtxd_f32_f64(a: f64) -> f32 {
 #[cfg_attr(test, assert_instr(fcvtxn))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcvtx_high_f32_f64(a: float32x2_t, b: float64x2_t) -> float32x4_t {
-    simd_shuffle4!(a, vcvtx_f32_f64(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vcvtx_f32_f64(b), [0, 1, 2, 3])
 }
 
 /// Fixed-point convert to floating-point
@@ -4618,7 +4618,7 @@ pub unsafe fn vcvtpd_u64_f64(a: f64) -> u64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vdupq_laneq_p64<const N: i32>(a: poly64x2_t) -> poly64x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -4631,7 +4631,7 @@ pub unsafe fn vdupq_laneq_p64<const N: i32>(a: poly64x2_t) -> poly64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vdupq_lane_p64<const N: i32>(a: poly64x1_t) -> poly64x2_t {
     static_assert!(N : i32 where N == 0);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -4644,7 +4644,7 @@ pub unsafe fn vdupq_lane_p64<const N: i32>(a: poly64x1_t) -> poly64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vdupq_laneq_f64<const N: i32>(a: float64x2_t) -> float64x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -4657,7 +4657,7 @@ pub unsafe fn vdupq_laneq_f64<const N: i32>(a: float64x2_t) -> float64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vdupq_lane_f64<const N: i32>(a: float64x1_t) -> float64x2_t {
     static_assert!(N : i32 where N == 0);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -5035,8 +5035,8 @@ pub unsafe fn vdupd_laneq_f64<const N: i32>(a: float64x2_t) -> f64 {
 pub unsafe fn vextq_p64<const N: i32>(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -5052,8 +5052,8 @@ pub unsafe fn vextq_p64<const N: i32>(a: poly64x2_t, b: poly64x2_t) -> poly64x2_
 pub unsafe fn vextq_f64<const N: i32>(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -5088,8 +5088,8 @@ pub unsafe fn vmlaq_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float
 #[cfg_attr(test, assert_instr(smlal2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
-    let b: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let c: int8x8_t = simd_shuffle8!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: int8x8_t = simd_shuffle!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmlal_s8(a, b, c)
 }
 
@@ -5101,8 +5101,8 @@ pub unsafe fn vmlal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8
 #[cfg_attr(test, assert_instr(smlal2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
-    let b: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
-    let c: int16x4_t = simd_shuffle4!(c, c, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
+    let c: int16x4_t = simd_shuffle!(c, c, [4, 5, 6, 7]);
     vmlal_s16(a, b, c)
 }
 
@@ -5114,8 +5114,8 @@ pub unsafe fn vmlal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x
 #[cfg_attr(test, assert_instr(smlal2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
-    let b: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
-    let c: int32x2_t = simd_shuffle2!(c, c, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [2, 3]);
+    let c: int32x2_t = simd_shuffle!(c, c, [2, 3]);
     vmlal_s32(a, b, c)
 }
 
@@ -5127,8 +5127,8 @@ pub unsafe fn vmlal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x
 #[cfg_attr(test, assert_instr(umlal2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
-    let b: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let c: uint8x8_t = simd_shuffle8!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: uint8x8_t = simd_shuffle!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmlal_u8(a, b, c)
 }
 
@@ -5140,8 +5140,8 @@ pub unsafe fn vmlal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint
 #[cfg_attr(test, assert_instr(umlal2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
-    let b: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
-    let c: uint16x4_t = simd_shuffle4!(c, c, [4, 5, 6, 7]);
+    let b: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
+    let c: uint16x4_t = simd_shuffle!(c, c, [4, 5, 6, 7]);
     vmlal_u16(a, b, c)
 }
 
@@ -5153,8 +5153,8 @@ pub unsafe fn vmlal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uin
 #[cfg_attr(test, assert_instr(umlal2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
-    let b: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
-    let c: uint32x2_t = simd_shuffle2!(c, c, [2, 3]);
+    let b: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
+    let c: uint32x2_t = simd_shuffle!(c, c, [2, 3]);
     vmlal_u32(a, b, c)
 }
 
@@ -5212,7 +5212,7 @@ pub unsafe fn vmlal_high_n_u32(a: uint64x2_t, b: uint32x4_t, c: u32) -> uint64x2
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, c: int16x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmlal_high_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5225,7 +5225,7 @@ pub unsafe fn vmlal_high_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, c
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
     static_assert_imm3!(LANE);
-    vmlal_high_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5238,7 +5238,7 @@ pub unsafe fn vmlal_high_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, c: int32x2_t) -> int64x2_t {
     static_assert_imm1!(LANE);
-    vmlal_high_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5251,7 +5251,7 @@ pub unsafe fn vmlal_high_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, c
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
     static_assert_imm2!(LANE);
-    vmlal_high_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5264,7 +5264,7 @@ pub unsafe fn vmlal_high_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t, c: uint16x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmlal_high_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5277,7 +5277,7 @@ pub unsafe fn vmlal_high_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t,
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
     static_assert_imm3!(LANE);
-    vmlal_high_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5290,7 +5290,7 @@ pub unsafe fn vmlal_high_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t, c: uint32x2_t) -> uint64x2_t {
     static_assert_imm1!(LANE);
-    vmlal_high_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-add long
@@ -5303,7 +5303,7 @@ pub unsafe fn vmlal_high_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t,
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlal_high_laneq_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
     static_assert_imm2!(LANE);
-    vmlal_high_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_high_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply-subtract from accumulator
@@ -5336,8 +5336,8 @@ pub unsafe fn vmlsq_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float
 #[cfg_attr(test, assert_instr(smlsl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
-    let b: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let c: int8x8_t = simd_shuffle8!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: int8x8_t = simd_shuffle!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmlsl_s8(a, b, c)
 }
 
@@ -5349,8 +5349,8 @@ pub unsafe fn vmlsl_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8
 #[cfg_attr(test, assert_instr(smlsl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
-    let b: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
-    let c: int16x4_t = simd_shuffle4!(c, c, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
+    let c: int16x4_t = simd_shuffle!(c, c, [4, 5, 6, 7]);
     vmlsl_s16(a, b, c)
 }
 
@@ -5362,8 +5362,8 @@ pub unsafe fn vmlsl_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x
 #[cfg_attr(test, assert_instr(smlsl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
-    let b: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
-    let c: int32x2_t = simd_shuffle2!(c, c, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [2, 3]);
+    let c: int32x2_t = simd_shuffle!(c, c, [2, 3]);
     vmlsl_s32(a, b, c)
 }
 
@@ -5375,8 +5375,8 @@ pub unsafe fn vmlsl_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x
 #[cfg_attr(test, assert_instr(umlsl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
-    let b: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let c: uint8x8_t = simd_shuffle8!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: uint8x8_t = simd_shuffle!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmlsl_u8(a, b, c)
 }
 
@@ -5388,8 +5388,8 @@ pub unsafe fn vmlsl_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint
 #[cfg_attr(test, assert_instr(umlsl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
-    let b: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
-    let c: uint16x4_t = simd_shuffle4!(c, c, [4, 5, 6, 7]);
+    let b: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
+    let c: uint16x4_t = simd_shuffle!(c, c, [4, 5, 6, 7]);
     vmlsl_u16(a, b, c)
 }
 
@@ -5401,8 +5401,8 @@ pub unsafe fn vmlsl_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uin
 #[cfg_attr(test, assert_instr(umlsl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
-    let b: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
-    let c: uint32x2_t = simd_shuffle2!(c, c, [2, 3]);
+    let b: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
+    let c: uint32x2_t = simd_shuffle!(c, c, [2, 3]);
     vmlsl_u32(a, b, c)
 }
 
@@ -5460,7 +5460,7 @@ pub unsafe fn vmlsl_high_n_u32(a: uint64x2_t, b: uint32x4_t, c: u32) -> uint64x2
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, c: int16x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmlsl_high_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5473,7 +5473,7 @@ pub unsafe fn vmlsl_high_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, c
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
     static_assert_imm3!(LANE);
-    vmlsl_high_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5486,7 +5486,7 @@ pub unsafe fn vmlsl_high_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x8_t, 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, c: int32x2_t) -> int64x2_t {
     static_assert_imm1!(LANE);
-    vmlsl_high_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5499,7 +5499,7 @@ pub unsafe fn vmlsl_high_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, c
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
     static_assert_imm2!(LANE);
-    vmlsl_high_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5512,7 +5512,7 @@ pub unsafe fn vmlsl_high_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x4_t, 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t, c: uint16x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmlsl_high_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5525,7 +5525,7 @@ pub unsafe fn vmlsl_high_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t,
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
     static_assert_imm3!(LANE);
-    vmlsl_high_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5538,7 +5538,7 @@ pub unsafe fn vmlsl_high_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x8_t
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t, c: uint32x2_t) -> uint64x2_t {
     static_assert_imm1!(LANE);
-    vmlsl_high_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract long
@@ -5551,7 +5551,7 @@ pub unsafe fn vmlsl_high_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t,
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmlsl_high_laneq_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
     static_assert_imm2!(LANE);
-    vmlsl_high_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_high_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Extract narrow
@@ -5563,7 +5563,7 @@ pub unsafe fn vmlsl_high_laneq_u32<const LANE: i32>(a: uint64x2_t, b: uint32x4_t
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovn_high_s16(a: int8x8_t, b: int16x8_t) -> int8x16_t {
     let c: int8x8_t = simd_cast(b);
-    simd_shuffle16!(a, c, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, c, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Extract narrow
@@ -5575,7 +5575,7 @@ pub unsafe fn vmovn_high_s16(a: int8x8_t, b: int16x8_t) -> int8x16_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovn_high_s32(a: int16x4_t, b: int32x4_t) -> int16x8_t {
     let c: int16x4_t = simd_cast(b);
-    simd_shuffle8!(a, c, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, c, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Extract narrow
@@ -5587,7 +5587,7 @@ pub unsafe fn vmovn_high_s32(a: int16x4_t, b: int32x4_t) -> int16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovn_high_s64(a: int32x2_t, b: int64x2_t) -> int32x4_t {
     let c: int32x2_t = simd_cast(b);
-    simd_shuffle4!(a, c, [0, 1, 2, 3])
+    simd_shuffle!(a, c, [0, 1, 2, 3])
 }
 
 /// Extract narrow
@@ -5599,7 +5599,7 @@ pub unsafe fn vmovn_high_s64(a: int32x2_t, b: int64x2_t) -> int32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovn_high_u16(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
     let c: uint8x8_t = simd_cast(b);
-    simd_shuffle16!(a, c, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, c, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Extract narrow
@@ -5611,7 +5611,7 @@ pub unsafe fn vmovn_high_u16(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovn_high_u32(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
     let c: uint16x4_t = simd_cast(b);
-    simd_shuffle8!(a, c, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, c, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Extract narrow
@@ -5623,7 +5623,7 @@ pub unsafe fn vmovn_high_u32(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovn_high_u64(a: uint32x2_t, b: uint64x2_t) -> uint32x4_t {
     let c: uint32x2_t = simd_cast(b);
-    simd_shuffle4!(a, c, [0, 1, 2, 3])
+    simd_shuffle!(a, c, [0, 1, 2, 3])
 }
 
 /// Negate
@@ -8433,7 +8433,7 @@ pub unsafe fn vmul_laneq_f64<const LANE: i32>(a: float64x1_t, b: float64x2_t) ->
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulq_lane_f64<const LANE: i32>(a: float64x2_t, b: float64x1_t) -> float64x2_t {
     static_assert!(LANE : i32 where LANE == 0);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply
@@ -8446,7 +8446,7 @@ pub unsafe fn vmulq_lane_f64<const LANE: i32>(a: float64x2_t, b: float64x1_t) ->
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulq_laneq_f64<const LANE: i32>(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply
@@ -8513,8 +8513,8 @@ pub unsafe fn vmuld_laneq_f64<const LANE: i32>(a: f64, b: float64x2_t) -> f64 {
 #[cfg_attr(test, assert_instr(smull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
-    let a: int8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let b: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmull_s8(a, b)
 }
 
@@ -8526,8 +8526,8 @@ pub unsafe fn vmull_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(smull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     vmull_s16(a, b)
 }
 
@@ -8539,8 +8539,8 @@ pub unsafe fn vmull_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(smull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     vmull_s32(a, b)
 }
 
@@ -8552,8 +8552,8 @@ pub unsafe fn vmull_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(umull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
-    let a: uint8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let b: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmull_u8(a, b)
 }
 
@@ -8565,8 +8565,8 @@ pub unsafe fn vmull_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(umull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
-    let a: uint16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let a: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     vmull_u16(a, b)
 }
 
@@ -8578,8 +8578,8 @@ pub unsafe fn vmull_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(umull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
-    let a: uint32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let a: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
     vmull_u32(a, b)
 }
 
@@ -8607,8 +8607,8 @@ pub unsafe fn vmull_p64(a: p64, b: p64) -> p128 {
 #[cfg_attr(test, assert_instr(pmull))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_p8(a: poly8x16_t, b: poly8x16_t) -> poly16x8_t {
-    let a: poly8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let b: poly8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: poly8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: poly8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmull_p8(a, b)
 }
 
@@ -8677,7 +8677,7 @@ pub unsafe fn vmull_high_n_u32(a: uint32x4_t, b: u32) -> uint64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmull_high_s16(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_s16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8690,7 +8690,7 @@ pub unsafe fn vmull_high_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x4_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t) -> int32x4_t {
     static_assert_imm3!(LANE);
-    vmull_high_s16(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_s16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8703,7 +8703,7 @@ pub unsafe fn vmull_high_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t) 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x2_t) -> int64x2_t {
     static_assert_imm1!(LANE);
-    vmull_high_s32(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_s32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8716,7 +8716,7 @@ pub unsafe fn vmull_high_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x2_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t) -> int64x2_t {
     static_assert_imm2!(LANE);
-    vmull_high_s32(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_s32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8729,7 +8729,7 @@ pub unsafe fn vmull_high_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t) 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmull_high_u16(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_u16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8742,7 +8742,7 @@ pub unsafe fn vmull_high_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x4_t)
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
     static_assert_imm3!(LANE);
-    vmull_high_u16(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_u16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8755,7 +8755,7 @@ pub unsafe fn vmull_high_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x2_t) -> uint64x2_t {
     static_assert_imm1!(LANE);
-    vmull_high_u32(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_u32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply long
@@ -8768,7 +8768,7 @@ pub unsafe fn vmull_high_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x2_t)
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmull_high_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
     static_assert_imm2!(LANE);
-    vmull_high_u32(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_high_u32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -8871,7 +8871,7 @@ pub unsafe fn vmulx_laneq_f64<const LANE: i32>(a: float64x1_t, b: float64x2_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulx_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    vmulx_f32(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmulx_f32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -8884,7 +8884,7 @@ pub unsafe fn vmulx_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t) ->
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulx_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x4_t) -> float32x2_t {
     static_assert_imm2!(LANE);
-    vmulx_f32(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmulx_f32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -8897,7 +8897,7 @@ pub unsafe fn vmulx_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x4_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulxq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x2_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    vmulxq_f32(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmulxq_f32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -8910,7 +8910,7 @@ pub unsafe fn vmulxq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x2_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulxq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     static_assert_imm2!(LANE);
-    vmulxq_f32(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmulxq_f32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -8923,7 +8923,7 @@ pub unsafe fn vmulxq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t) 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulxq_lane_f64<const LANE: i32>(a: float64x2_t, b: float64x1_t) -> float64x2_t {
     static_assert!(LANE : i32 where LANE == 0);
-    vmulxq_f64(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmulxq_f64(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -8936,7 +8936,7 @@ pub unsafe fn vmulxq_lane_f64<const LANE: i32>(a: float64x2_t, b: float64x1_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmulxq_laneq_f64<const LANE: i32>(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     static_assert_imm1!(LANE);
-    vmulxq_f64(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmulxq_f64(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply extended
@@ -9749,7 +9749,7 @@ pub unsafe fn vaddlvq_u32(a: uint32x4_t) -> u64 {
 #[cfg_attr(test, assert_instr(ssubw))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
-    let c: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     simd_sub(a, simd_cast(c))
 }
 
@@ -9761,7 +9761,7 @@ pub unsafe fn vsubw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(ssubw))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
-    let c: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let c: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     simd_sub(a, simd_cast(c))
 }
 
@@ -9773,7 +9773,7 @@ pub unsafe fn vsubw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(ssubw))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
-    let c: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let c: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     simd_sub(a, simd_cast(c))
 }
 
@@ -9785,7 +9785,7 @@ pub unsafe fn vsubw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(usubw))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
-    let c: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     simd_sub(a, simd_cast(c))
 }
 
@@ -9797,7 +9797,7 @@ pub unsafe fn vsubw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(usubw))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
-    let c: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let c: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     simd_sub(a, simd_cast(c))
 }
 
@@ -9809,7 +9809,7 @@ pub unsafe fn vsubw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(usubw))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubw_high_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
-    let c: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let c: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
     simd_sub(a, simd_cast(c))
 }
 
@@ -9821,9 +9821,9 @@ pub unsafe fn vsubw_high_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(ssubl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
-    let c: int8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
     let d: int16x8_t = simd_cast(c);
-    let e: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let e: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let f: int16x8_t = simd_cast(e);
     simd_sub(d, f)
 }
@@ -9836,9 +9836,9 @@ pub unsafe fn vsubl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(ssubl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
-    let c: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let c: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     let d: int32x4_t = simd_cast(c);
-    let e: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let e: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let f: int32x4_t = simd_cast(e);
     simd_sub(d, f)
 }
@@ -9851,9 +9851,9 @@ pub unsafe fn vsubl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(ssubl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
-    let c: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let c: int32x2_t = simd_shuffle!(a, a, [2, 3]);
     let d: int64x2_t = simd_cast(c);
-    let e: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let e: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     let f: int64x2_t = simd_cast(e);
     simd_sub(d, f)
 }
@@ -9866,9 +9866,9 @@ pub unsafe fn vsubl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(usubl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
-    let c: uint8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let c: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
     let d: uint16x8_t = simd_cast(c);
-    let e: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let e: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let f: uint16x8_t = simd_cast(e);
     simd_sub(d, f)
 }
@@ -9881,9 +9881,9 @@ pub unsafe fn vsubl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(usubl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
-    let c: uint16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let c: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     let d: uint32x4_t = simd_cast(c);
-    let e: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let e: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let f: uint32x4_t = simd_cast(e);
     simd_sub(d, f)
 }
@@ -9896,9 +9896,9 @@ pub unsafe fn vsubl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(usubl))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vsubl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
-    let c: uint32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let c: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
     let d: uint64x2_t = simd_cast(c);
-    let e: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let e: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
     let f: uint64x2_t = simd_cast(e);
     simd_sub(d, f)
 }
@@ -10302,7 +10302,7 @@ pub unsafe fn vcmlaq_rot270_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) 
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_f32(a, b, c)
 }
 
@@ -10315,7 +10315,7 @@ pub unsafe fn vcmla_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c:
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x4_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_f32(a, b, c)
 }
 
@@ -10328,7 +10328,7 @@ pub unsafe fn vcmla_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x2_t) -> float32x4_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_f32(a, b, c)
 }
 
@@ -10341,7 +10341,7 @@ pub unsafe fn vcmlaq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_f32(a, b, c)
 }
 
@@ -10354,7 +10354,7 @@ pub unsafe fn vcmlaq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, 
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_rot90_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_rot90_f32(a, b, c)
 }
 
@@ -10367,7 +10367,7 @@ pub unsafe fn vcmla_rot90_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_rot90_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x4_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_rot90_f32(a, b, c)
 }
 
@@ -10380,7 +10380,7 @@ pub unsafe fn vcmla_rot90_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_rot90_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x2_t) -> float32x4_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_rot90_f32(a, b, c)
 }
 
@@ -10393,7 +10393,7 @@ pub unsafe fn vcmlaq_rot90_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_rot90_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_rot90_f32(a, b, c)
 }
 
@@ -10406,7 +10406,7 @@ pub unsafe fn vcmlaq_rot90_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_rot180_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_rot180_f32(a, b, c)
 }
 
@@ -10419,7 +10419,7 @@ pub unsafe fn vcmla_rot180_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_rot180_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x4_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_rot180_f32(a, b, c)
 }
 
@@ -10432,7 +10432,7 @@ pub unsafe fn vcmla_rot180_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_rot180_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x2_t) -> float32x4_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_rot180_f32(a, b, c)
 }
 
@@ -10445,7 +10445,7 @@ pub unsafe fn vcmlaq_rot180_lane_f32<const LANE: i32>(a: float32x4_t, b: float32
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_rot180_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_rot180_f32(a, b, c)
 }
 
@@ -10458,7 +10458,7 @@ pub unsafe fn vcmlaq_rot180_laneq_f32<const LANE: i32>(a: float32x4_t, b: float3
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_rot270_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_rot270_f32(a, b, c)
 }
 
@@ -10471,7 +10471,7 @@ pub unsafe fn vcmla_rot270_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmla_rot270_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x4_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    let c: float32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x2_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmla_rot270_f32(a, b, c)
 }
 
@@ -10484,7 +10484,7 @@ pub unsafe fn vcmla_rot270_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_rot270_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x2_t) -> float32x4_t {
     static_assert!(LANE : i32 where LANE == 0);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_rot270_f32(a, b, c)
 }
 
@@ -10497,7 +10497,7 @@ pub unsafe fn vcmlaq_rot270_lane_f32<const LANE: i32>(a: float32x4_t, b: float32
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vcmlaq_rot270_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    let c: float32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
+    let c: float32x4_t = simd_shuffle!(c, c, [2 * LANE as u32, 2 * LANE as u32 + 1, 2 * LANE as u32, 2 * LANE as u32 + 1]);
     vcmlaq_rot270_f32(a, b, c)
 }
 
@@ -10570,7 +10570,7 @@ pub unsafe fn vdotq_u32(a: uint32x4_t, b: uint8x16_t, c: uint8x16_t) -> uint32x4
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdot_lane_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8x8_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    let c: int8x8_t = simd_shuffle8!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: int8x8_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdot_s32(a, b, c)
 }
 
@@ -10583,7 +10583,7 @@ pub unsafe fn vdot_lane_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8x
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdot_laneq_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8x16_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    let c: int8x8_t = simd_shuffle8!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: int8x8_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdot_s32(a, b, c)
 }
 
@@ -10596,7 +10596,7 @@ pub unsafe fn vdot_laneq_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdotq_lane_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: int8x8_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    let c: int8x16_t = simd_shuffle16!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: int8x16_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdotq_s32(a, b, c)
 }
 
@@ -10609,7 +10609,7 @@ pub unsafe fn vdotq_lane_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: int
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdotq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: int8x16_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    let c: int8x16_t = simd_shuffle16!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: int8x16_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdotq_s32(a, b, c)
 }
 
@@ -10622,7 +10622,7 @@ pub unsafe fn vdotq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: in
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdot_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: uint8x8_t) -> uint32x2_t {
     static_assert_imm1!(LANE);
-    let c: uint8x8_t = simd_shuffle8!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: uint8x8_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdot_u32(a, b, c)
 }
 
@@ -10635,7 +10635,7 @@ pub unsafe fn vdot_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: uin
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdot_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: uint8x16_t) -> uint32x2_t {
     static_assert_imm2!(LANE);
-    let c: uint8x8_t = simd_shuffle8!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: uint8x8_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdot_u32(a, b, c)
 }
 
@@ -10648,7 +10648,7 @@ pub unsafe fn vdot_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: ui
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdotq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint8x16_t, c: uint8x8_t) -> uint32x4_t {
     static_assert_imm1!(LANE);
-    let c: uint8x16_t = simd_shuffle16!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: uint8x16_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdotq_u32(a, b, c)
 }
 
@@ -10661,7 +10661,7 @@ pub unsafe fn vdotq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint8x16_t, c: u
 #[rustc_legacy_const_generics(3)]
 pub unsafe fn vdotq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint8x16_t, c: uint8x16_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    let c: uint8x16_t = simd_shuffle16!(c, c, <const LANE: i32> [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
+    let c: uint8x16_t = simd_shuffle!(c, c, [4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3, 4 * LANE as u32, 4 * LANE as u32 + 1, 4 * LANE as u32 + 2, 4 * LANE as u32 + 3]);
     vdotq_u32(a, b, c)
 }
 
@@ -11009,7 +11009,7 @@ pub unsafe fn vminnmvq_f32(a: float32x4_t) -> f32 {
 #[cfg_attr(test, assert_instr(sxtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovl_high_s8(a: int8x16_t) -> int16x8_t {
-    let a: int8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmovl_s8(a)
 }
 
@@ -11021,7 +11021,7 @@ pub unsafe fn vmovl_high_s8(a: int8x16_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(sxtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovl_high_s16(a: int16x8_t) -> int32x4_t {
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     vmovl_s16(a)
 }
 
@@ -11033,7 +11033,7 @@ pub unsafe fn vmovl_high_s16(a: int16x8_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(sxtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovl_high_s32(a: int32x4_t) -> int64x2_t {
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
     vmovl_s32(a)
 }
 
@@ -11045,7 +11045,7 @@ pub unsafe fn vmovl_high_s32(a: int32x4_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(uxtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovl_high_u8(a: uint8x16_t) -> uint16x8_t {
-    let a: uint8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
     vmovl_u8(a)
 }
 
@@ -11057,7 +11057,7 @@ pub unsafe fn vmovl_high_u8(a: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(uxtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovl_high_u16(a: uint16x8_t) -> uint32x4_t {
-    let a: uint16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let a: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     vmovl_u16(a)
 }
 
@@ -11069,7 +11069,7 @@ pub unsafe fn vmovl_high_u16(a: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(uxtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vmovl_high_u32(a: uint32x4_t) -> uint64x2_t {
-    let a: uint32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let a: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
     vmovl_u32(a)
 }
 
@@ -11280,8 +11280,8 @@ pub unsafe fn vqdmulls_s32(a: i32, b: i32) -> i64 {
 #[cfg_attr(test, assert_instr(sqdmull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     vqdmull_s16(a, b)
 }
 
@@ -11293,8 +11293,8 @@ pub unsafe fn vqdmull_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(sqdmull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     vqdmull_s32(a, b)
 }
 
@@ -11306,7 +11306,7 @@ pub unsafe fn vqdmull_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(sqdmull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_n_s16(a: int16x8_t, b: i16) -> int32x4_t {
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     let b: int16x4_t = vdup_n_s16(b);
     vqdmull_s16(a, b)
 }
@@ -11319,7 +11319,7 @@ pub unsafe fn vqdmull_high_n_s16(a: int16x8_t, b: i16) -> int32x4_t {
 #[cfg_attr(test, assert_instr(sqdmull2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_n_s32(a: int32x4_t, b: i32) -> int64x2_t {
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
     let b: int32x2_t = vdup_n_s32(b);
     vqdmull_s32(a, b)
 }
@@ -11334,7 +11334,7 @@ pub unsafe fn vqdmull_high_n_s32(a: int32x4_t, b: i32) -> int64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_laneq_s16<const N: i32>(a: int16x4_t, b: int16x8_t) -> int32x4_t {
     static_assert_imm3!(N);
-    let b: int16x4_t = simd_shuffle4!(b, b, <const N: i32> [N as u32, N as u32, N as u32, N as u32]);
+    let b: int16x4_t = simd_shuffle!(b, b, [N as u32, N as u32, N as u32, N as u32]);
     vqdmull_s16(a, b)
 }
 
@@ -11348,7 +11348,7 @@ pub unsafe fn vqdmull_laneq_s16<const N: i32>(a: int16x4_t, b: int16x8_t) -> int
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_laneq_s32<const N: i32>(a: int32x2_t, b: int32x4_t) -> int64x2_t {
     static_assert_imm2!(N);
-    let b: int32x2_t = simd_shuffle2!(b, b, <const N: i32> [N as u32, N as u32]);
+    let b: int32x2_t = simd_shuffle!(b, b, [N as u32, N as u32]);
     vqdmull_s32(a, b)
 }
 
@@ -11418,8 +11418,8 @@ pub unsafe fn vqdmulls_laneq_s32<const N: i32>(a: i32, b: int32x4_t) -> i64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_lane_s16<const N: i32>(a: int16x8_t, b: int16x4_t) -> int32x4_t {
     static_assert_imm2!(N);
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: int16x4_t = simd_shuffle4!(b, b, <const N: i32> [N as u32, N as u32, N as u32, N as u32]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [N as u32, N as u32, N as u32, N as u32]);
     vqdmull_s16(a, b)
 }
 
@@ -11433,8 +11433,8 @@ pub unsafe fn vqdmull_high_lane_s16<const N: i32>(a: int16x8_t, b: int16x4_t) ->
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_lane_s32<const N: i32>(a: int32x4_t, b: int32x2_t) -> int64x2_t {
     static_assert_imm1!(N);
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: int32x2_t = simd_shuffle2!(b, b, <const N: i32> [N as u32, N as u32]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [N as u32, N as u32]);
     vqdmull_s32(a, b)
 }
 
@@ -11448,8 +11448,8 @@ pub unsafe fn vqdmull_high_lane_s32<const N: i32>(a: int32x4_t, b: int32x2_t) ->
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_laneq_s16<const N: i32>(a: int16x8_t, b: int16x8_t) -> int32x4_t {
     static_assert_imm3!(N);
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: int16x4_t = simd_shuffle4!(b, b, <const N: i32> [N as u32, N as u32, N as u32, N as u32]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [N as u32, N as u32, N as u32, N as u32]);
     vqdmull_s16(a, b)
 }
 
@@ -11463,8 +11463,8 @@ pub unsafe fn vqdmull_high_laneq_s16<const N: i32>(a: int16x8_t, b: int16x8_t) -
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqdmull_high_laneq_s32<const N: i32>(a: int32x4_t, b: int32x4_t) -> int64x2_t {
     static_assert_imm2!(N);
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: int32x2_t = simd_shuffle2!(b, b, <const N: i32> [N as u32, N as u32]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [N as u32, N as u32]);
     vqdmull_s32(a, b)
 }
 
@@ -12082,7 +12082,7 @@ pub unsafe fn vqmovnd_u64(a: u64) -> u32 {
 #[cfg_attr(test, assert_instr(sqxtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovn_high_s16(a: int8x8_t, b: int16x8_t) -> int8x16_t {
-    simd_shuffle16!(a, vqmovn_s16(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqmovn_s16(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating extract narrow
@@ -12093,7 +12093,7 @@ pub unsafe fn vqmovn_high_s16(a: int8x8_t, b: int16x8_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(sqxtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovn_high_s32(a: int16x4_t, b: int32x4_t) -> int16x8_t {
-    simd_shuffle8!(a, vqmovn_s32(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqmovn_s32(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating extract narrow
@@ -12104,7 +12104,7 @@ pub unsafe fn vqmovn_high_s32(a: int16x4_t, b: int32x4_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(sqxtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovn_high_s64(a: int32x2_t, b: int64x2_t) -> int32x4_t {
-    simd_shuffle4!(a, vqmovn_s64(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqmovn_s64(b), [0, 1, 2, 3])
 }
 
 /// Signed saturating extract narrow
@@ -12115,7 +12115,7 @@ pub unsafe fn vqmovn_high_s64(a: int32x2_t, b: int64x2_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(uqxtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovn_high_u16(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
-    simd_shuffle16!(a, vqmovn_u16(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqmovn_u16(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating extract narrow
@@ -12126,7 +12126,7 @@ pub unsafe fn vqmovn_high_u16(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(uqxtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovn_high_u32(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
-    simd_shuffle8!(a, vqmovn_u32(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqmovn_u32(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating extract narrow
@@ -12137,7 +12137,7 @@ pub unsafe fn vqmovn_high_u32(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(uqxtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovn_high_u64(a: uint32x2_t, b: uint64x2_t) -> uint32x4_t {
-    simd_shuffle4!(a, vqmovn_u64(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqmovn_u64(b), [0, 1, 2, 3])
 }
 
 /// Signed saturating extract unsigned narrow
@@ -12181,7 +12181,7 @@ pub unsafe fn vqmovund_s64(a: i64) -> u32 {
 #[cfg_attr(test, assert_instr(sqxtun2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovun_high_s16(a: uint8x8_t, b: int16x8_t) -> uint8x16_t {
-    simd_shuffle16!(a, vqmovun_s16(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqmovun_s16(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating extract unsigned narrow
@@ -12192,7 +12192,7 @@ pub unsafe fn vqmovun_high_s16(a: uint8x8_t, b: int16x8_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(sqxtun2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovun_high_s32(a: uint16x4_t, b: int32x4_t) -> uint16x8_t {
-    simd_shuffle8!(a, vqmovun_s32(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqmovun_s32(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating extract unsigned narrow
@@ -12203,7 +12203,7 @@ pub unsafe fn vqmovun_high_s32(a: uint16x4_t, b: int32x4_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(sqxtun2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqmovun_high_s64(a: uint32x2_t, b: int64x2_t) -> uint32x4_t {
-    simd_shuffle4!(a, vqmovun_s64(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqmovun_s64(b), [0, 1, 2, 3])
 }
 
 /// Signed saturating rounding doubling multiply returning high half
@@ -12382,7 +12382,7 @@ pub unsafe fn vqrdmlahs_s32(a: i32, b: i32, c: i32) -> i32 {
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlah_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
     static_assert_imm2!(LANE);
-    let c: int16x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlah_s16(a, b, c)
 }
 
@@ -12396,7 +12396,7 @@ pub unsafe fn vqrdmlah_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: 
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlah_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x8_t) -> int16x4_t {
     static_assert_imm3!(LANE);
-    let c: int16x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlah_s16(a, b, c)
 }
 
@@ -12410,7 +12410,7 @@ pub unsafe fn vqrdmlah_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlahq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x4_t) -> int16x8_t {
     static_assert_imm2!(LANE);
-    let c: int16x8_t = simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x8_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlahq_s16(a, b, c)
 }
 
@@ -12424,7 +12424,7 @@ pub unsafe fn vqrdmlahq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlahq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
     static_assert_imm3!(LANE);
-    let c: int16x8_t = simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x8_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlahq_s16(a, b, c)
 }
 
@@ -12438,7 +12438,7 @@ pub unsafe fn vqrdmlahq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlah_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    let c: int32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]);
+    let c: int32x2_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32]);
     vqrdmlah_s32(a, b, c)
 }
 
@@ -12452,7 +12452,7 @@ pub unsafe fn vqrdmlah_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: 
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlah_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x4_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    let c: int32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]);
+    let c: int32x2_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32]);
     vqrdmlah_s32(a, b, c)
 }
 
@@ -12466,7 +12466,7 @@ pub unsafe fn vqrdmlah_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlahq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x2_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    let c: int32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int32x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlahq_s32(a, b, c)
 }
 
@@ -12480,7 +12480,7 @@ pub unsafe fn vqrdmlahq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlahq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    let c: int32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int32x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlahq_s32(a, b, c)
 }
 
@@ -12638,7 +12638,7 @@ pub unsafe fn vqrdmlshs_s32(a: i32, b: i32, c: i32) -> i32 {
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlsh_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
     static_assert_imm2!(LANE);
-    let c: int16x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlsh_s16(a, b, c)
 }
 
@@ -12652,7 +12652,7 @@ pub unsafe fn vqrdmlsh_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: 
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlsh_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x8_t) -> int16x4_t {
     static_assert_imm3!(LANE);
-    let c: int16x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlsh_s16(a, b, c)
 }
 
@@ -12666,7 +12666,7 @@ pub unsafe fn vqrdmlsh_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlshq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x4_t) -> int16x8_t {
     static_assert_imm2!(LANE);
-    let c: int16x8_t = simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x8_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlshq_s16(a, b, c)
 }
 
@@ -12680,7 +12680,7 @@ pub unsafe fn vqrdmlshq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlshq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
     static_assert_imm3!(LANE);
-    let c: int16x8_t = simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int16x8_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlshq_s16(a, b, c)
 }
 
@@ -12694,7 +12694,7 @@ pub unsafe fn vqrdmlshq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlsh_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    let c: int32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]);
+    let c: int32x2_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32]);
     vqrdmlsh_s32(a, b, c)
 }
 
@@ -12708,7 +12708,7 @@ pub unsafe fn vqrdmlsh_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: 
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlsh_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x4_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    let c: int32x2_t = simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]);
+    let c: int32x2_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32]);
     vqrdmlsh_s32(a, b, c)
 }
 
@@ -12722,7 +12722,7 @@ pub unsafe fn vqrdmlsh_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlshq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x2_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    let c: int32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int32x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlshq_s32(a, b, c)
 }
 
@@ -12736,7 +12736,7 @@ pub unsafe fn vqrdmlshq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c:
 #[stable(feature = "rdm_intrinsics", since = "1.62.0")]
 pub unsafe fn vqrdmlshq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    let c: int32x4_t = simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let c: int32x4_t = simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmlshq_s32(a, b, c)
 }
 
@@ -12960,7 +12960,7 @@ pub unsafe fn vqrshrnd_n_s64<const N: i32>(a: i64) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vqrshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqrshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating rounded shift right narrow
@@ -12973,7 +12973,7 @@ pub unsafe fn vqrshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vqrshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqrshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating rounded shift right narrow
@@ -12986,7 +12986,7 @@ pub unsafe fn vqrshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> in
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrn_high_n_s64<const N: i32>(a: int32x2_t, b: int64x2_t) -> int32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vqrshrn_n_s64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqrshrn_n_s64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Unsigned saturating rounded shift right narrow
@@ -13041,7 +13041,7 @@ pub unsafe fn vqrshrnd_n_u64<const N: i32>(a: u64) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vqrshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqrshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Unsigned saturating rounded shift right narrow
@@ -13054,7 +13054,7 @@ pub unsafe fn vqrshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> u
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vqrshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqrshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Unsigned saturating rounded shift right narrow
@@ -13067,7 +13067,7 @@ pub unsafe fn vqrshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrn_high_n_u64<const N: i32>(a: uint32x2_t, b: uint64x2_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vqrshrn_n_u64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqrshrn_n_u64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Signed saturating rounded shift right unsigned narrow
@@ -13122,7 +13122,7 @@ pub unsafe fn vqrshrund_n_s64<const N: i32>(a: i64) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrun_high_n_s16<const N: i32>(a: uint8x8_t, b: int16x8_t) -> uint8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vqrshrun_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqrshrun_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating rounded shift right unsigned narrow
@@ -13135,7 +13135,7 @@ pub unsafe fn vqrshrun_high_n_s16<const N: i32>(a: uint8x8_t, b: int16x8_t) -> u
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrun_high_n_s32<const N: i32>(a: uint16x4_t, b: int32x4_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vqrshrun_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqrshrun_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating rounded shift right unsigned narrow
@@ -13148,7 +13148,7 @@ pub unsafe fn vqrshrun_high_n_s32<const N: i32>(a: uint16x4_t, b: int32x4_t) -> 
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqrshrun_high_n_s64<const N: i32>(a: uint32x2_t, b: int64x2_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vqrshrun_n_s64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqrshrun_n_s64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Signed saturating shift left
@@ -13465,7 +13465,7 @@ pub unsafe fn vqshrns_n_s32<const N: i32>(a: i32) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vqshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating shift right narrow
@@ -13478,7 +13478,7 @@ pub unsafe fn vqshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vqshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating shift right narrow
@@ -13491,7 +13491,7 @@ pub unsafe fn vqshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrn_high_n_s64<const N: i32>(a: int32x2_t, b: int64x2_t) -> int32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vqshrn_n_s64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqshrn_n_s64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Unsigned saturating shift right narrow
@@ -13548,7 +13548,7 @@ pub unsafe fn vqshrns_n_u32<const N: i32>(a: u32) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vqshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Unsigned saturating shift right narrow
@@ -13561,7 +13561,7 @@ pub unsafe fn vqshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> ui
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vqshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Unsigned saturating shift right narrow
@@ -13574,7 +13574,7 @@ pub unsafe fn vqshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> u
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrn_high_n_u64<const N: i32>(a: uint32x2_t, b: uint64x2_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vqshrn_n_u64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqshrn_n_u64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Signed saturating shift right unsigned narrow
@@ -13626,7 +13626,7 @@ pub unsafe fn vqshrund_n_s64<const N: i32>(a: i64) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrun_high_n_s16<const N: i32>(a: uint8x8_t, b: int16x8_t) -> uint8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vqshrun_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vqshrun_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Signed saturating shift right unsigned narrow
@@ -13639,7 +13639,7 @@ pub unsafe fn vqshrun_high_n_s16<const N: i32>(a: uint8x8_t, b: int16x8_t) -> ui
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrun_high_n_s32<const N: i32>(a: uint16x4_t, b: int32x4_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vqshrun_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vqshrun_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Signed saturating shift right unsigned narrow
@@ -13652,7 +13652,7 @@ pub unsafe fn vqshrun_high_n_s32<const N: i32>(a: uint16x4_t, b: int32x4_t) -> u
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vqshrun_high_n_s64<const N: i32>(a: uint32x2_t, b: int64x2_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vqshrun_n_s64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vqshrun_n_s64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Unsigned saturating accumulate of signed value
@@ -14791,7 +14791,7 @@ pub unsafe fn vrshrd_n_u64<const N: i32>(a: u64) -> u64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vrshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vrshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Rounding shift right narrow
@@ -14804,7 +14804,7 @@ pub unsafe fn vrshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vrshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vrshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Rounding shift right narrow
@@ -14817,7 +14817,7 @@ pub unsafe fn vrshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrshrn_high_n_s64<const N: i32>(a: int32x2_t, b: int64x2_t) -> int32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vrshrn_n_s64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vrshrn_n_s64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Rounding shift right narrow
@@ -14830,7 +14830,7 @@ pub unsafe fn vrshrn_high_n_s64<const N: i32>(a: int32x2_t, b: int64x2_t) -> int
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vrshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vrshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Rounding shift right narrow
@@ -14843,7 +14843,7 @@ pub unsafe fn vrshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> ui
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vrshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vrshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Rounding shift right narrow
@@ -14856,7 +14856,7 @@ pub unsafe fn vrshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> u
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrshrn_high_n_u64<const N: i32>(a: uint32x2_t, b: uint64x2_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vrshrn_n_u64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vrshrn_n_u64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Signed rounding shift right and accumulate.
@@ -14896,7 +14896,7 @@ pub unsafe fn vrsrad_n_u64<const N: i32>(a: u64, b: u64) -> u64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrsubhn_high_s16(a: int8x8_t, b: int16x8_t, c: int16x8_t) -> int8x16_t {
     let x: int8x8_t = vrsubhn_s16(b, c);
-    simd_shuffle16!(a, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Rounding subtract returning high narrow
@@ -14908,7 +14908,7 @@ pub unsafe fn vrsubhn_high_s16(a: int8x8_t, b: int16x8_t, c: int16x8_t) -> int8x
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrsubhn_high_s32(a: int16x4_t, b: int32x4_t, c: int32x4_t) -> int16x8_t {
     let x: int16x4_t = vrsubhn_s32(b, c);
-    simd_shuffle8!(a, x, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, x, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Rounding subtract returning high narrow
@@ -14920,7 +14920,7 @@ pub unsafe fn vrsubhn_high_s32(a: int16x4_t, b: int32x4_t, c: int32x4_t) -> int1
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrsubhn_high_s64(a: int32x2_t, b: int64x2_t, c: int64x2_t) -> int32x4_t {
     let x: int32x2_t = vrsubhn_s64(b, c);
-    simd_shuffle4!(a, x, [0, 1, 2, 3])
+    simd_shuffle!(a, x, [0, 1, 2, 3])
 }
 
 /// Rounding subtract returning high narrow
@@ -14932,7 +14932,7 @@ pub unsafe fn vrsubhn_high_s64(a: int32x2_t, b: int64x2_t, c: int64x2_t) -> int3
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrsubhn_high_u16(a: uint8x8_t, b: uint16x8_t, c: uint16x8_t) -> uint8x16_t {
     let x: uint8x8_t = vrsubhn_u16(b, c);
-    simd_shuffle16!(a, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Rounding subtract returning high narrow
@@ -14944,7 +14944,7 @@ pub unsafe fn vrsubhn_high_u16(a: uint8x8_t, b: uint16x8_t, c: uint16x8_t) -> ui
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrsubhn_high_u32(a: uint16x4_t, b: uint32x4_t, c: uint32x4_t) -> uint16x8_t {
     let x: uint16x4_t = vrsubhn_u32(b, c);
-    simd_shuffle8!(a, x, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, x, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Rounding subtract returning high narrow
@@ -14956,7 +14956,7 @@ pub unsafe fn vrsubhn_high_u32(a: uint16x4_t, b: uint32x4_t, c: uint32x4_t) -> u
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vrsubhn_high_u64(a: uint32x2_t, b: uint64x2_t, c: uint64x2_t) -> uint32x4_t {
     let x: uint32x2_t = vrsubhn_u64(b, c);
-    simd_shuffle4!(a, x, [0, 1, 2, 3])
+    simd_shuffle!(a, x, [0, 1, 2, 3])
 }
 
 /// Insert vector element from another vector element
@@ -15017,7 +15017,7 @@ pub unsafe fn vshld_u64(a: u64, b: i64) -> u64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshll_high_n_s8<const N: i32>(a: int8x16_t) -> int16x8_t {
     static_assert!(N : i32 where N >= 0 && N <= 8);
-    let b: int8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
     vshll_n_s8::<N>(b)
 }
 
@@ -15031,7 +15031,7 @@ pub unsafe fn vshll_high_n_s8<const N: i32>(a: int8x16_t) -> int16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshll_high_n_s16<const N: i32>(a: int16x8_t) -> int32x4_t {
     static_assert!(N : i32 where N >= 0 && N <= 16);
-    let b: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     vshll_n_s16::<N>(b)
 }
 
@@ -15045,7 +15045,7 @@ pub unsafe fn vshll_high_n_s16<const N: i32>(a: int16x8_t) -> int32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshll_high_n_s32<const N: i32>(a: int32x4_t) -> int64x2_t {
     static_assert!(N : i32 where N >= 0 && N <= 32);
-    let b: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(a, a, [2, 3]);
     vshll_n_s32::<N>(b)
 }
 
@@ -15059,7 +15059,7 @@ pub unsafe fn vshll_high_n_s32<const N: i32>(a: int32x4_t) -> int64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshll_high_n_u8<const N: i32>(a: uint8x16_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 0 && N <= 8);
-    let b: uint8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
     vshll_n_u8::<N>(b)
 }
 
@@ -15073,7 +15073,7 @@ pub unsafe fn vshll_high_n_u8<const N: i32>(a: uint8x16_t) -> uint16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshll_high_n_u16<const N: i32>(a: uint16x8_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 0 && N <= 16);
-    let b: uint16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
+    let b: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
     vshll_n_u16::<N>(b)
 }
 
@@ -15087,7 +15087,7 @@ pub unsafe fn vshll_high_n_u16<const N: i32>(a: uint16x8_t) -> uint32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshll_high_n_u32<const N: i32>(a: uint32x4_t) -> uint64x2_t {
     static_assert!(N : i32 where N >= 0 && N <= 32);
-    let b: uint32x2_t = simd_shuffle2!(a, a, [2, 3]);
+    let b: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
     vshll_n_u32::<N>(b)
 }
 
@@ -15101,7 +15101,7 @@ pub unsafe fn vshll_high_n_u32<const N: i32>(a: uint32x4_t) -> uint64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vshrn_n_s16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Shift right narrow
@@ -15114,7 +15114,7 @@ pub unsafe fn vshrn_high_n_s16<const N: i32>(a: int8x8_t, b: int16x8_t) -> int8x
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vshrn_n_s32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Shift right narrow
@@ -15127,7 +15127,7 @@ pub unsafe fn vshrn_high_n_s32<const N: i32>(a: int16x4_t, b: int32x4_t) -> int1
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshrn_high_n_s64<const N: i32>(a: int32x2_t, b: int64x2_t) -> int32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vshrn_n_s64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vshrn_n_s64::<N>(b), [0, 1, 2, 3])
 }
 
 /// Shift right narrow
@@ -15140,7 +15140,7 @@ pub unsafe fn vshrn_high_n_s64<const N: i32>(a: int32x2_t, b: int64x2_t) -> int3
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> uint8x16_t {
     static_assert!(N : i32 where N >= 1 && N <= 8);
-    simd_shuffle16!(a, vshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, vshrn_n_u16::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Shift right narrow
@@ -15153,7 +15153,7 @@ pub unsafe fn vshrn_high_n_u16<const N: i32>(a: uint8x8_t, b: uint16x8_t) -> uin
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> uint16x8_t {
     static_assert!(N : i32 where N >= 1 && N <= 16);
-    simd_shuffle8!(a, vshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, vshrn_n_u32::<N>(b), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Shift right narrow
@@ -15166,7 +15166,7 @@ pub unsafe fn vshrn_high_n_u32<const N: i32>(a: uint16x4_t, b: uint32x4_t) -> ui
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vshrn_high_n_u64<const N: i32>(a: uint32x2_t, b: uint64x2_t) -> uint32x4_t {
     static_assert!(N : i32 where N >= 1 && N <= 32);
-    simd_shuffle4!(a, vshrn_n_u64::<N>(b), [0, 1, 2, 3])
+    simd_shuffle!(a, vshrn_n_u64::<N>(b), [0, 1, 2, 3])
 }
 
 /// SM3PARTW1
@@ -15447,7 +15447,7 @@ pub unsafe fn vrnd64zq_f32(a: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
+    simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 /// Transpose vectors
@@ -15458,7 +15458,7 @@ pub unsafe fn vtrn1_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
+    simd_shuffle!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
 }
 
 /// Transpose vectors
@@ -15469,7 +15469,7 @@ pub unsafe fn vtrn1q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Transpose vectors
@@ -15480,7 +15480,7 @@ pub unsafe fn vtrn1_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
+    simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 /// Transpose vectors
@@ -15491,7 +15491,7 @@ pub unsafe fn vtrn1q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Transpose vectors
@@ -15502,7 +15502,7 @@ pub unsafe fn vtrn1q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
+    simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 /// Transpose vectors
@@ -15513,7 +15513,7 @@ pub unsafe fn vtrn1_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
+    simd_shuffle!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
 }
 
 /// Transpose vectors
@@ -15524,7 +15524,7 @@ pub unsafe fn vtrn1q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Transpose vectors
@@ -15535,7 +15535,7 @@ pub unsafe fn vtrn1_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
+    simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 /// Transpose vectors
@@ -15546,7 +15546,7 @@ pub unsafe fn vtrn1q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Transpose vectors
@@ -15557,7 +15557,7 @@ pub unsafe fn vtrn1q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
+    simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 /// Transpose vectors
@@ -15568,7 +15568,7 @@ pub unsafe fn vtrn1_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
+    simd_shuffle!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
 }
 
 /// Transpose vectors
@@ -15579,7 +15579,7 @@ pub unsafe fn vtrn1q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Transpose vectors
@@ -15590,7 +15590,7 @@ pub unsafe fn vtrn1_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
+    simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 /// Transpose vectors
@@ -15601,7 +15601,7 @@ pub unsafe fn vtrn1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15612,7 +15612,7 @@ pub unsafe fn vtrn1_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15623,7 +15623,7 @@ pub unsafe fn vtrn1q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15634,7 +15634,7 @@ pub unsafe fn vtrn1_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15645,7 +15645,7 @@ pub unsafe fn vtrn1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15656,7 +15656,7 @@ pub unsafe fn vtrn1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[cfg_attr(test, assert_instr(trn1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Transpose vectors
@@ -15667,7 +15667,7 @@ pub unsafe fn vtrn1q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15678,7 +15678,7 @@ pub unsafe fn vtrn1_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn1q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Transpose vectors
@@ -15689,7 +15689,7 @@ pub unsafe fn vtrn1q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
+    simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 /// Transpose vectors
@@ -15700,7 +15700,7 @@ pub unsafe fn vtrn2_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
+    simd_shuffle!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
 }
 
 /// Transpose vectors
@@ -15711,7 +15711,7 @@ pub unsafe fn vtrn2q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Transpose vectors
@@ -15722,7 +15722,7 @@ pub unsafe fn vtrn2_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
+    simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 /// Transpose vectors
@@ -15733,7 +15733,7 @@ pub unsafe fn vtrn2q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Transpose vectors
@@ -15744,7 +15744,7 @@ pub unsafe fn vtrn2q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
+    simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 /// Transpose vectors
@@ -15755,7 +15755,7 @@ pub unsafe fn vtrn2_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
+    simd_shuffle!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
 }
 
 /// Transpose vectors
@@ -15766,7 +15766,7 @@ pub unsafe fn vtrn2q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Transpose vectors
@@ -15777,7 +15777,7 @@ pub unsafe fn vtrn2_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
+    simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 /// Transpose vectors
@@ -15788,7 +15788,7 @@ pub unsafe fn vtrn2q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Transpose vectors
@@ -15799,7 +15799,7 @@ pub unsafe fn vtrn2q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
+    simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 /// Transpose vectors
@@ -15810,7 +15810,7 @@ pub unsafe fn vtrn2_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
+    simd_shuffle!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
 }
 
 /// Transpose vectors
@@ -15821,7 +15821,7 @@ pub unsafe fn vtrn2q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Transpose vectors
@@ -15832,7 +15832,7 @@ pub unsafe fn vtrn2_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
+    simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 /// Transpose vectors
@@ -15843,7 +15843,7 @@ pub unsafe fn vtrn2q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Transpose vectors
@@ -15854,7 +15854,7 @@ pub unsafe fn vtrn2_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Transpose vectors
@@ -15865,7 +15865,7 @@ pub unsafe fn vtrn2q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Transpose vectors
@@ -15876,7 +15876,7 @@ pub unsafe fn vtrn2_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Transpose vectors
@@ -15887,7 +15887,7 @@ pub unsafe fn vtrn2q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Transpose vectors
@@ -15898,7 +15898,7 @@ pub unsafe fn vtrn2q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[cfg_attr(test, assert_instr(trn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Transpose vectors
@@ -15909,7 +15909,7 @@ pub unsafe fn vtrn2q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Transpose vectors
@@ -15920,7 +15920,7 @@ pub unsafe fn vtrn2_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vtrn2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -15931,7 +15931,7 @@ pub unsafe fn vtrn2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 /// Zip vectors
@@ -15942,7 +15942,7 @@ pub unsafe fn vzip1_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
+    simd_shuffle!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
 }
 
 /// Zip vectors
@@ -15953,7 +15953,7 @@ pub unsafe fn vzip1q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Zip vectors
@@ -15964,7 +15964,7 @@ pub unsafe fn vzip1_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 /// Zip vectors
@@ -15975,7 +15975,7 @@ pub unsafe fn vzip1q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -15986,7 +15986,7 @@ pub unsafe fn vzip1_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Zip vectors
@@ -15997,7 +15997,7 @@ pub unsafe fn vzip1q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -16008,7 +16008,7 @@ pub unsafe fn vzip1q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 /// Zip vectors
@@ -16019,7 +16019,7 @@ pub unsafe fn vzip1_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
+    simd_shuffle!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
 }
 
 /// Zip vectors
@@ -16030,7 +16030,7 @@ pub unsafe fn vzip1q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Zip vectors
@@ -16041,7 +16041,7 @@ pub unsafe fn vzip1_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 /// Zip vectors
@@ -16052,7 +16052,7 @@ pub unsafe fn vzip1q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -16063,7 +16063,7 @@ pub unsafe fn vzip1_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Zip vectors
@@ -16074,7 +16074,7 @@ pub unsafe fn vzip1q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -16085,7 +16085,7 @@ pub unsafe fn vzip1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 /// Zip vectors
@@ -16096,7 +16096,7 @@ pub unsafe fn vzip1_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
+    simd_shuffle!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
 }
 
 /// Zip vectors
@@ -16107,7 +16107,7 @@ pub unsafe fn vzip1q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Zip vectors
@@ -16118,7 +16118,7 @@ pub unsafe fn vzip1_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 /// Zip vectors
@@ -16129,7 +16129,7 @@ pub unsafe fn vzip1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -16140,7 +16140,7 @@ pub unsafe fn vzip1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -16151,7 +16151,7 @@ pub unsafe fn vzip1_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Zip vectors
@@ -16162,7 +16162,7 @@ pub unsafe fn vzip1q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip1q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Zip vectors
@@ -16173,7 +16173,7 @@ pub unsafe fn vzip1q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 /// Zip vectors
@@ -16184,7 +16184,7 @@ pub unsafe fn vzip2_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
+    simd_shuffle!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
 }
 
 /// Zip vectors
@@ -16195,7 +16195,7 @@ pub unsafe fn vzip2q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Zip vectors
@@ -16206,7 +16206,7 @@ pub unsafe fn vzip2_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 /// Zip vectors
@@ -16217,7 +16217,7 @@ pub unsafe fn vzip2q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -16228,7 +16228,7 @@ pub unsafe fn vzip2_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Zip vectors
@@ -16239,7 +16239,7 @@ pub unsafe fn vzip2q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -16250,7 +16250,7 @@ pub unsafe fn vzip2q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 /// Zip vectors
@@ -16261,7 +16261,7 @@ pub unsafe fn vzip2_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
+    simd_shuffle!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
 }
 
 /// Zip vectors
@@ -16272,7 +16272,7 @@ pub unsafe fn vzip2q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Zip vectors
@@ -16283,7 +16283,7 @@ pub unsafe fn vzip2_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 /// Zip vectors
@@ -16294,7 +16294,7 @@ pub unsafe fn vzip2q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -16305,7 +16305,7 @@ pub unsafe fn vzip2_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Zip vectors
@@ -16316,7 +16316,7 @@ pub unsafe fn vzip2q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -16327,7 +16327,7 @@ pub unsafe fn vzip2q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 /// Zip vectors
@@ -16338,7 +16338,7 @@ pub unsafe fn vzip2_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
+    simd_shuffle!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
 }
 
 /// Zip vectors
@@ -16349,7 +16349,7 @@ pub unsafe fn vzip2q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Zip vectors
@@ -16360,7 +16360,7 @@ pub unsafe fn vzip2_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 /// Zip vectors
@@ -16371,7 +16371,7 @@ pub unsafe fn vzip2q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -16382,7 +16382,7 @@ pub unsafe fn vzip2q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Zip vectors
@@ -16393,7 +16393,7 @@ pub unsafe fn vzip2_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Zip vectors
@@ -16404,7 +16404,7 @@ pub unsafe fn vzip2q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vzip2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16415,7 +16415,7 @@ pub unsafe fn vzip2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 /// Unzip vectors
@@ -16426,7 +16426,7 @@ pub unsafe fn vuzp1_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
 }
 
 /// Unzip vectors
@@ -16437,7 +16437,7 @@ pub unsafe fn vuzp1q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, b, [0, 2, 4, 6])
+    simd_shuffle!(a, b, [0, 2, 4, 6])
 }
 
 /// Unzip vectors
@@ -16448,7 +16448,7 @@ pub unsafe fn vuzp1_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 /// Unzip vectors
@@ -16459,7 +16459,7 @@ pub unsafe fn vuzp1q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, b, [0, 2, 4, 6])
+    simd_shuffle!(a, b, [0, 2, 4, 6])
 }
 
 /// Unzip vectors
@@ -16470,7 +16470,7 @@ pub unsafe fn vuzp1q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 /// Unzip vectors
@@ -16481,7 +16481,7 @@ pub unsafe fn vuzp1_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
 }
 
 /// Unzip vectors
@@ -16492,7 +16492,7 @@ pub unsafe fn vuzp1q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, b, [0, 2, 4, 6])
+    simd_shuffle!(a, b, [0, 2, 4, 6])
 }
 
 /// Unzip vectors
@@ -16503,7 +16503,7 @@ pub unsafe fn vuzp1_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 /// Unzip vectors
@@ -16514,7 +16514,7 @@ pub unsafe fn vuzp1q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, b, [0, 2, 4, 6])
+    simd_shuffle!(a, b, [0, 2, 4, 6])
 }
 
 /// Unzip vectors
@@ -16525,7 +16525,7 @@ pub unsafe fn vuzp1q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 /// Unzip vectors
@@ -16536,7 +16536,7 @@ pub unsafe fn vuzp1_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
 }
 
 /// Unzip vectors
@@ -16547,7 +16547,7 @@ pub unsafe fn vuzp1q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, b, [0, 2, 4, 6])
+    simd_shuffle!(a, b, [0, 2, 4, 6])
 }
 
 /// Unzip vectors
@@ -16558,7 +16558,7 @@ pub unsafe fn vuzp1_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
+    simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 /// Unzip vectors
@@ -16569,7 +16569,7 @@ pub unsafe fn vuzp1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16580,7 +16580,7 @@ pub unsafe fn vuzp1_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16591,7 +16591,7 @@ pub unsafe fn vuzp1q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16602,7 +16602,7 @@ pub unsafe fn vuzp1_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16613,7 +16613,7 @@ pub unsafe fn vuzp1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16624,7 +16624,7 @@ pub unsafe fn vuzp1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, b, [0, 2, 4, 6])
+    simd_shuffle!(a, b, [0, 2, 4, 6])
 }
 
 /// Unzip vectors
@@ -16635,7 +16635,7 @@ pub unsafe fn vuzp1q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16646,7 +16646,7 @@ pub unsafe fn vuzp1_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(zip1))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp1q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 /// Unzip vectors
@@ -16657,7 +16657,7 @@ pub unsafe fn vuzp1q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 /// Unzip vectors
@@ -16668,7 +16668,7 @@ pub unsafe fn vuzp2_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
 }
 
 /// Unzip vectors
@@ -16679,7 +16679,7 @@ pub unsafe fn vuzp2q_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, b, [1, 3, 5, 7])
+    simd_shuffle!(a, b, [1, 3, 5, 7])
 }
 
 /// Unzip vectors
@@ -16690,7 +16690,7 @@ pub unsafe fn vuzp2_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 /// Unzip vectors
@@ -16701,7 +16701,7 @@ pub unsafe fn vuzp2q_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, b, [1, 3, 5, 7])
+    simd_shuffle!(a, b, [1, 3, 5, 7])
 }
 
 /// Unzip vectors
@@ -16712,7 +16712,7 @@ pub unsafe fn vuzp2q_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 /// Unzip vectors
@@ -16723,7 +16723,7 @@ pub unsafe fn vuzp2_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
 }
 
 /// Unzip vectors
@@ -16734,7 +16734,7 @@ pub unsafe fn vuzp2q_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, b, [1, 3, 5, 7])
+    simd_shuffle!(a, b, [1, 3, 5, 7])
 }
 
 /// Unzip vectors
@@ -16745,7 +16745,7 @@ pub unsafe fn vuzp2_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 /// Unzip vectors
@@ -16756,7 +16756,7 @@ pub unsafe fn vuzp2q_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, b, [1, 3, 5, 7])
+    simd_shuffle!(a, b, [1, 3, 5, 7])
 }
 
 /// Unzip vectors
@@ -16767,7 +16767,7 @@ pub unsafe fn vuzp2q_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 /// Unzip vectors
@@ -16778,7 +16778,7 @@ pub unsafe fn vuzp2_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
 }
 
 /// Unzip vectors
@@ -16789,7 +16789,7 @@ pub unsafe fn vuzp2q_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, b, [1, 3, 5, 7])
+    simd_shuffle!(a, b, [1, 3, 5, 7])
 }
 
 /// Unzip vectors
@@ -16800,7 +16800,7 @@ pub unsafe fn vuzp2_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
+    simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 /// Unzip vectors
@@ -16811,7 +16811,7 @@ pub unsafe fn vuzp2q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16822,7 +16822,7 @@ pub unsafe fn vuzp2_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16833,7 +16833,7 @@ pub unsafe fn vuzp2q_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16844,7 +16844,7 @@ pub unsafe fn vuzp2_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16855,7 +16855,7 @@ pub unsafe fn vuzp2q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16866,7 +16866,7 @@ pub unsafe fn vuzp2q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, b, [1, 3, 5, 7])
+    simd_shuffle!(a, b, [1, 3, 5, 7])
 }
 
 /// Unzip vectors
@@ -16877,7 +16877,7 @@ pub unsafe fn vuzp2q_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unzip vectors
@@ -16888,7 +16888,7 @@ pub unsafe fn vuzp2_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(test, assert_instr(zip2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vuzp2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// Unsigned Absolute difference and Accumulate Long
@@ -16899,8 +16899,8 @@ pub unsafe fn vuzp2q_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(uabal))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
-    let d: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let e: uint8x8_t = simd_shuffle8!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let d: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let e: uint8x8_t = simd_shuffle!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
     let f: uint8x8_t = vabd_u8(d, e);
     simd_add(a, simd_cast(f))
 }
@@ -16913,8 +16913,8 @@ pub unsafe fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint
 #[cfg_attr(test, assert_instr(uabal))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
-    let d: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
-    let e: uint16x4_t = simd_shuffle4!(c, c, [4, 5, 6, 7]);
+    let d: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
+    let e: uint16x4_t = simd_shuffle!(c, c, [4, 5, 6, 7]);
     let f: uint16x4_t = vabd_u16(d, e);
     simd_add(a, simd_cast(f))
 }
@@ -16927,8 +16927,8 @@ pub unsafe fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uin
 #[cfg_attr(test, assert_instr(uabal))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
-    let d: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
-    let e: uint32x2_t = simd_shuffle2!(c, c, [2, 3]);
+    let d: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
+    let e: uint32x2_t = simd_shuffle!(c, c, [2, 3]);
     let f: uint32x2_t = vabd_u32(d, e);
     simd_add(a, simd_cast(f))
 }
@@ -16941,8 +16941,8 @@ pub unsafe fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uin
 #[cfg_attr(test, assert_instr(sabal))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
-    let d: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let e: int8x8_t = simd_shuffle8!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let d: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let e: int8x8_t = simd_shuffle!(c, c, [8, 9, 10, 11, 12, 13, 14, 15]);
     let f: int8x8_t = vabd_s8(d, e);
     let f: uint8x8_t = simd_cast(f);
     simd_add(a, simd_cast(f))
@@ -16956,8 +16956,8 @@ pub unsafe fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8
 #[cfg_attr(test, assert_instr(sabal))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
-    let d: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
-    let e: int16x4_t = simd_shuffle4!(c, c, [4, 5, 6, 7]);
+    let d: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
+    let e: int16x4_t = simd_shuffle!(c, c, [4, 5, 6, 7]);
     let f: int16x4_t = vabd_s16(d, e);
     let f: uint16x4_t = simd_cast(f);
     simd_add(a, simd_cast(f))
@@ -16971,8 +16971,8 @@ pub unsafe fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x
 #[cfg_attr(test, assert_instr(sabal))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
-    let d: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
-    let e: int32x2_t = simd_shuffle2!(c, c, [2, 3]);
+    let d: int32x2_t = simd_shuffle!(b, b, [2, 3]);
+    let e: int32x2_t = simd_shuffle!(c, c, [2, 3]);
     let f: int32x2_t = vabd_s32(d, e);
     let f: uint32x2_t = simd_cast(f);
     simd_add(a, simd_cast(f))

--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -737,7 +737,7 @@ pub unsafe fn vld1_dup_f64(ptr: *const f64) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vld1q_dup_f64(ptr: *const f64) -> float64x2_t {
     let x = vld1q_lane_f64::<0>(ptr, transmute(f64x2::splat(0.)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure to one lane of one register.
@@ -2101,7 +2101,7 @@ pub unsafe fn vgetq_lane_f64<const IMM5: i32>(v: float64x2_t) -> f64 {
 #[cfg_attr(test, assert_instr(mov))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcombine_f64(low: float64x1_t, high: float64x1_t) -> float64x2_t {
-    simd_shuffle2!(low, high, [0, 1])
+    simd_shuffle!(low, high, [0, 1])
 }
 
 /// Table look-up

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -3250,7 +3250,7 @@ vcvtq_u32_f32_(a)
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_s8<const N: i32>(a: int8x8_t) -> int8x8_t {
     static_assert_imm3!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3265,7 +3265,7 @@ pub unsafe fn vdup_lane_s8<const N: i32>(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_s8<const N: i32>(a: int8x16_t) -> int8x16_t {
     static_assert_imm4!(N);
-    simd_shuffle16!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3280,7 +3280,7 @@ pub unsafe fn vdupq_laneq_s8<const N: i32>(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_s16<const N: i32>(a: int16x4_t) -> int16x4_t {
     static_assert_imm2!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3295,7 +3295,7 @@ pub unsafe fn vdup_lane_s16<const N: i32>(a: int16x4_t) -> int16x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_s16<const N: i32>(a: int16x8_t) -> int16x8_t {
     static_assert_imm3!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3310,7 +3310,7 @@ pub unsafe fn vdupq_laneq_s16<const N: i32>(a: int16x8_t) -> int16x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_s32<const N: i32>(a: int32x2_t) -> int32x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3325,7 +3325,7 @@ pub unsafe fn vdup_lane_s32<const N: i32>(a: int32x2_t) -> int32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_s32<const N: i32>(a: int32x4_t) -> int32x4_t {
     static_assert_imm2!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3340,7 +3340,7 @@ pub unsafe fn vdupq_laneq_s32<const N: i32>(a: int32x4_t) -> int32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_s8<const N: i32>(a: int8x16_t) -> int8x8_t {
     static_assert_imm4!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3355,7 +3355,7 @@ pub unsafe fn vdup_laneq_s8<const N: i32>(a: int8x16_t) -> int8x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_s16<const N: i32>(a: int16x8_t) -> int16x4_t {
     static_assert_imm3!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3370,7 +3370,7 @@ pub unsafe fn vdup_laneq_s16<const N: i32>(a: int16x8_t) -> int16x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_s32<const N: i32>(a: int32x4_t) -> int32x2_t {
     static_assert_imm2!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3385,7 +3385,7 @@ pub unsafe fn vdup_laneq_s32<const N: i32>(a: int32x4_t) -> int32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_s8<const N: i32>(a: int8x8_t) -> int8x16_t {
     static_assert_imm3!(N);
-    simd_shuffle16!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3400,7 +3400,7 @@ pub unsafe fn vdupq_lane_s8<const N: i32>(a: int8x8_t) -> int8x16_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_s16<const N: i32>(a: int16x4_t) -> int16x8_t {
     static_assert_imm2!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3415,7 +3415,7 @@ pub unsafe fn vdupq_lane_s16<const N: i32>(a: int16x4_t) -> int16x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_s32<const N: i32>(a: int32x2_t) -> int32x4_t {
     static_assert_imm1!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3430,7 +3430,7 @@ pub unsafe fn vdupq_lane_s32<const N: i32>(a: int32x2_t) -> int32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_u8<const N: i32>(a: uint8x8_t) -> uint8x8_t {
     static_assert_imm3!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3445,7 +3445,7 @@ pub unsafe fn vdup_lane_u8<const N: i32>(a: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_u8<const N: i32>(a: uint8x16_t) -> uint8x16_t {
     static_assert_imm4!(N);
-    simd_shuffle16!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3460,7 +3460,7 @@ pub unsafe fn vdupq_laneq_u8<const N: i32>(a: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_u16<const N: i32>(a: uint16x4_t) -> uint16x4_t {
     static_assert_imm2!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3475,7 +3475,7 @@ pub unsafe fn vdup_lane_u16<const N: i32>(a: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_u16<const N: i32>(a: uint16x8_t) -> uint16x8_t {
     static_assert_imm3!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3490,7 +3490,7 @@ pub unsafe fn vdupq_laneq_u16<const N: i32>(a: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_u32<const N: i32>(a: uint32x2_t) -> uint32x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3505,7 +3505,7 @@ pub unsafe fn vdup_lane_u32<const N: i32>(a: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_u32<const N: i32>(a: uint32x4_t) -> uint32x4_t {
     static_assert_imm2!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3520,7 +3520,7 @@ pub unsafe fn vdupq_laneq_u32<const N: i32>(a: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_u8<const N: i32>(a: uint8x16_t) -> uint8x8_t {
     static_assert_imm4!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3535,7 +3535,7 @@ pub unsafe fn vdup_laneq_u8<const N: i32>(a: uint8x16_t) -> uint8x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_u16<const N: i32>(a: uint16x8_t) -> uint16x4_t {
     static_assert_imm3!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3550,7 +3550,7 @@ pub unsafe fn vdup_laneq_u16<const N: i32>(a: uint16x8_t) -> uint16x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_u32<const N: i32>(a: uint32x4_t) -> uint32x2_t {
     static_assert_imm2!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3565,7 +3565,7 @@ pub unsafe fn vdup_laneq_u32<const N: i32>(a: uint32x4_t) -> uint32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_u8<const N: i32>(a: uint8x8_t) -> uint8x16_t {
     static_assert_imm3!(N);
-    simd_shuffle16!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3580,7 +3580,7 @@ pub unsafe fn vdupq_lane_u8<const N: i32>(a: uint8x8_t) -> uint8x16_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_u16<const N: i32>(a: uint16x4_t) -> uint16x8_t {
     static_assert_imm2!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3595,7 +3595,7 @@ pub unsafe fn vdupq_lane_u16<const N: i32>(a: uint16x4_t) -> uint16x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_u32<const N: i32>(a: uint32x2_t) -> uint32x4_t {
     static_assert_imm1!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3610,7 +3610,7 @@ pub unsafe fn vdupq_lane_u32<const N: i32>(a: uint32x2_t) -> uint32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_p8<const N: i32>(a: poly8x8_t) -> poly8x8_t {
     static_assert_imm3!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3625,7 +3625,7 @@ pub unsafe fn vdup_lane_p8<const N: i32>(a: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_p8<const N: i32>(a: poly8x16_t) -> poly8x16_t {
     static_assert_imm4!(N);
-    simd_shuffle16!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3640,7 +3640,7 @@ pub unsafe fn vdupq_laneq_p8<const N: i32>(a: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_p16<const N: i32>(a: poly16x4_t) -> poly16x4_t {
     static_assert_imm2!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3655,7 +3655,7 @@ pub unsafe fn vdup_lane_p16<const N: i32>(a: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_p16<const N: i32>(a: poly16x8_t) -> poly16x8_t {
     static_assert_imm3!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3670,7 +3670,7 @@ pub unsafe fn vdupq_laneq_p16<const N: i32>(a: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_p8<const N: i32>(a: poly8x16_t) -> poly8x8_t {
     static_assert_imm4!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3685,7 +3685,7 @@ pub unsafe fn vdup_laneq_p8<const N: i32>(a: poly8x16_t) -> poly8x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_p16<const N: i32>(a: poly16x8_t) -> poly16x4_t {
     static_assert_imm3!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3700,7 +3700,7 @@ pub unsafe fn vdup_laneq_p16<const N: i32>(a: poly16x8_t) -> poly16x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_p8<const N: i32>(a: poly8x8_t) -> poly8x16_t {
     static_assert_imm3!(N);
-    simd_shuffle16!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3715,7 +3715,7 @@ pub unsafe fn vdupq_lane_p8<const N: i32>(a: poly8x8_t) -> poly8x16_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_p16<const N: i32>(a: poly16x4_t) -> poly16x8_t {
     static_assert_imm2!(N);
-    simd_shuffle8!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3730,7 +3730,7 @@ pub unsafe fn vdupq_lane_p16<const N: i32>(a: poly16x4_t) -> poly16x8_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_s64<const N: i32>(a: int64x2_t) -> int64x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3745,7 +3745,7 @@ pub unsafe fn vdupq_laneq_s64<const N: i32>(a: int64x2_t) -> int64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_s64<const N: i32>(a: int64x1_t) -> int64x2_t {
     static_assert!(N : i32 where N == 0);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3760,7 +3760,7 @@ pub unsafe fn vdupq_lane_s64<const N: i32>(a: int64x1_t) -> int64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_u64<const N: i32>(a: uint64x2_t) -> uint64x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3775,7 +3775,7 @@ pub unsafe fn vdupq_laneq_u64<const N: i32>(a: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_u64<const N: i32>(a: uint64x1_t) -> uint64x2_t {
     static_assert!(N : i32 where N == 0);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3790,7 +3790,7 @@ pub unsafe fn vdupq_lane_u64<const N: i32>(a: uint64x1_t) -> uint64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_lane_f32<const N: i32>(a: float32x2_t) -> float32x2_t {
     static_assert_imm1!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3805,7 +3805,7 @@ pub unsafe fn vdup_lane_f32<const N: i32>(a: float32x2_t) -> float32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_laneq_f32<const N: i32>(a: float32x4_t) -> float32x4_t {
     static_assert_imm2!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3820,7 +3820,7 @@ pub unsafe fn vdupq_laneq_f32<const N: i32>(a: float32x4_t) -> float32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdup_laneq_f32<const N: i32>(a: float32x4_t) -> float32x2_t {
     static_assert_imm2!(N);
-    simd_shuffle2!(a, a, <const N: i32> [N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3835,7 +3835,7 @@ pub unsafe fn vdup_laneq_f32<const N: i32>(a: float32x4_t) -> float32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vdupq_lane_f32<const N: i32>(a: float32x2_t) -> float32x4_t {
     static_assert_imm1!(N);
-    simd_shuffle4!(a, a, <const N: i32> [N as u32, N as u32, N as u32, N as u32])
+    simd_shuffle!(a, a, [N as u32, N as u32, N as u32, N as u32])
 }
 
 /// Set all vector lanes to the same value
@@ -3911,14 +3911,14 @@ pub unsafe fn vdup_laneq_u64<const N: i32>(a: uint64x2_t) -> uint64x1_t {
 pub unsafe fn vext_s8<const N: i32>(a: int8x8_t, b: int8x8_t) -> int8x8_t {
     static_assert_imm3!(N);
     match N & 0b111 {
-        0 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        2 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        3 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        4 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        5 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        6 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        7 => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3936,22 +3936,22 @@ pub unsafe fn vext_s8<const N: i32>(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 pub unsafe fn vextq_s8<const N: i32>(a: int8x16_t, b: int8x16_t) -> int8x16_t {
     static_assert_imm4!(N);
     match N & 0b1111 {
-        0 => simd_shuffle16!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-        2 => simd_shuffle16!(a, b, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
-        3 => simd_shuffle16!(a, b, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]),
-        4 => simd_shuffle16!(a, b, [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
-        5 => simd_shuffle16!(a, b, [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
-        6 => simd_shuffle16!(a, b, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
-        7 => simd_shuffle16!(a, b, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]),
-        8 => simd_shuffle16!(a, b, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]),
-        9 => simd_shuffle16!(a, b, [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
-        10 => simd_shuffle16!(a, b, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]),
-        11 => simd_shuffle16!(a, b, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]),
-        12 => simd_shuffle16!(a, b, [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]),
-        13 => simd_shuffle16!(a, b, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]),
-        14 => simd_shuffle16!(a, b, [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]),
-        15 => simd_shuffle16!(a, b, [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]),
+        8 => simd_shuffle!(a, b, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]),
+        9 => simd_shuffle!(a, b, [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
+        10 => simd_shuffle!(a, b, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]),
+        11 => simd_shuffle!(a, b, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]),
+        12 => simd_shuffle!(a, b, [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]),
+        13 => simd_shuffle!(a, b, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]),
+        14 => simd_shuffle!(a, b, [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]),
+        15 => simd_shuffle!(a, b, [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3969,10 +3969,10 @@ pub unsafe fn vextq_s8<const N: i32>(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 pub unsafe fn vext_s16<const N: i32>(a: int16x4_t, b: int16x4_t) -> int16x4_t {
     static_assert_imm2!(N);
     match N & 0b11 {
-        0 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        2 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        3 => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6]),
         _ => unreachable_unchecked(),
     }
 }
@@ -3990,14 +3990,14 @@ pub unsafe fn vext_s16<const N: i32>(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 pub unsafe fn vextq_s16<const N: i32>(a: int16x8_t, b: int16x8_t) -> int16x8_t {
     static_assert_imm3!(N);
     match N & 0b111 {
-        0 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        2 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        3 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        4 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        5 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        6 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        7 => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4015,8 +4015,8 @@ pub unsafe fn vextq_s16<const N: i32>(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 pub unsafe fn vext_s32<const N: i32>(a: int32x2_t, b: int32x2_t) -> int32x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4034,10 +4034,10 @@ pub unsafe fn vext_s32<const N: i32>(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 pub unsafe fn vextq_s32<const N: i32>(a: int32x4_t, b: int32x4_t) -> int32x4_t {
     static_assert_imm2!(N);
     match N & 0b11 {
-        0 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        2 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        3 => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4055,14 +4055,14 @@ pub unsafe fn vextq_s32<const N: i32>(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 pub unsafe fn vext_u8<const N: i32>(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
     static_assert_imm3!(N);
     match N & 0b111 {
-        0 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        2 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        3 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        4 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        5 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        6 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        7 => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4080,22 +4080,22 @@ pub unsafe fn vext_u8<const N: i32>(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 pub unsafe fn vextq_u8<const N: i32>(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     static_assert_imm4!(N);
     match N & 0b1111 {
-        0 => simd_shuffle16!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-        2 => simd_shuffle16!(a, b, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
-        3 => simd_shuffle16!(a, b, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]),
-        4 => simd_shuffle16!(a, b, [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
-        5 => simd_shuffle16!(a, b, [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
-        6 => simd_shuffle16!(a, b, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
-        7 => simd_shuffle16!(a, b, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]),
-        8 => simd_shuffle16!(a, b, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]),
-        9 => simd_shuffle16!(a, b, [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
-        10 => simd_shuffle16!(a, b, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]),
-        11 => simd_shuffle16!(a, b, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]),
-        12 => simd_shuffle16!(a, b, [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]),
-        13 => simd_shuffle16!(a, b, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]),
-        14 => simd_shuffle16!(a, b, [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]),
-        15 => simd_shuffle16!(a, b, [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]),
+        8 => simd_shuffle!(a, b, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]),
+        9 => simd_shuffle!(a, b, [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
+        10 => simd_shuffle!(a, b, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]),
+        11 => simd_shuffle!(a, b, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]),
+        12 => simd_shuffle!(a, b, [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]),
+        13 => simd_shuffle!(a, b, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]),
+        14 => simd_shuffle!(a, b, [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]),
+        15 => simd_shuffle!(a, b, [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4113,10 +4113,10 @@ pub unsafe fn vextq_u8<const N: i32>(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t
 pub unsafe fn vext_u16<const N: i32>(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
     static_assert_imm2!(N);
     match N & 0b11 {
-        0 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        2 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        3 => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4134,14 +4134,14 @@ pub unsafe fn vext_u16<const N: i32>(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t
 pub unsafe fn vextq_u16<const N: i32>(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
     static_assert_imm3!(N);
     match N & 0b111 {
-        0 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        2 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        3 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        4 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        5 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        6 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        7 => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4159,8 +4159,8 @@ pub unsafe fn vextq_u16<const N: i32>(a: uint16x8_t, b: uint16x8_t) -> uint16x8_
 pub unsafe fn vext_u32<const N: i32>(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4178,10 +4178,10 @@ pub unsafe fn vext_u32<const N: i32>(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t
 pub unsafe fn vextq_u32<const N: i32>(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     static_assert_imm2!(N);
     match N & 0b11 {
-        0 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        2 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        3 => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4199,14 +4199,14 @@ pub unsafe fn vextq_u32<const N: i32>(a: uint32x4_t, b: uint32x4_t) -> uint32x4_
 pub unsafe fn vext_p8<const N: i32>(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
     static_assert_imm3!(N);
     match N & 0b111 {
-        0 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        2 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        3 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        4 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        5 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        6 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        7 => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4224,22 +4224,22 @@ pub unsafe fn vext_p8<const N: i32>(a: poly8x8_t, b: poly8x8_t) -> poly8x8_t {
 pub unsafe fn vextq_p8<const N: i32>(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
     static_assert_imm4!(N);
     match N & 0b1111 {
-        0 => simd_shuffle16!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle16!(a, b, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-        2 => simd_shuffle16!(a, b, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
-        3 => simd_shuffle16!(a, b, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]),
-        4 => simd_shuffle16!(a, b, [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
-        5 => simd_shuffle16!(a, b, [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
-        6 => simd_shuffle16!(a, b, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
-        7 => simd_shuffle16!(a, b, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]),
-        8 => simd_shuffle16!(a, b, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]),
-        9 => simd_shuffle16!(a, b, [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
-        10 => simd_shuffle16!(a, b, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]),
-        11 => simd_shuffle16!(a, b, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]),
-        12 => simd_shuffle16!(a, b, [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]),
-        13 => simd_shuffle16!(a, b, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]),
-        14 => simd_shuffle16!(a, b, [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]),
-        15 => simd_shuffle16!(a, b, [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]),
+        8 => simd_shuffle!(a, b, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]),
+        9 => simd_shuffle!(a, b, [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
+        10 => simd_shuffle!(a, b, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]),
+        11 => simd_shuffle!(a, b, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]),
+        12 => simd_shuffle!(a, b, [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]),
+        13 => simd_shuffle!(a, b, [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]),
+        14 => simd_shuffle!(a, b, [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]),
+        15 => simd_shuffle!(a, b, [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4257,10 +4257,10 @@ pub unsafe fn vextq_p8<const N: i32>(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t
 pub unsafe fn vext_p16<const N: i32>(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t {
     static_assert_imm2!(N);
     match N & 0b11 {
-        0 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        2 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        3 => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4278,14 +4278,14 @@ pub unsafe fn vext_p16<const N: i32>(a: poly16x4_t, b: poly16x4_t) -> poly16x4_t
 pub unsafe fn vextq_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
     static_assert_imm3!(N);
     match N & 0b111 {
-        0 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        1 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        2 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        3 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        4 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        5 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        6 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        7 => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        4 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        5 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        6 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        7 => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4303,8 +4303,8 @@ pub unsafe fn vextq_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x8_
 pub unsafe fn vextq_s64<const N: i32>(a: int64x2_t, b: int64x2_t) -> int64x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4322,8 +4322,8 @@ pub unsafe fn vextq_s64<const N: i32>(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 pub unsafe fn vextq_u64<const N: i32>(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4341,8 +4341,8 @@ pub unsafe fn vextq_u64<const N: i32>(a: uint64x2_t, b: uint64x2_t) -> uint64x2_
 pub unsafe fn vext_f32<const N: i32>(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     static_assert_imm1!(N);
     match N & 0b1 {
-        0 => simd_shuffle2!(a, b, [0, 1]),
-        1 => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [0, 1]),
+        1 => simd_shuffle!(a, b, [1, 2]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4360,10 +4360,10 @@ pub unsafe fn vext_f32<const N: i32>(a: float32x2_t, b: float32x2_t) -> float32x
 pub unsafe fn vextq_f32<const N: i32>(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     static_assert_imm2!(N);
     match N & 0b11 {
-        0 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        2 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        3 => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        2 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        3 => simd_shuffle!(a, b, [3, 4, 5, 6]),
         _ => unreachable_unchecked(),
     }
 }
@@ -4692,7 +4692,7 @@ pub unsafe fn vmlaq_n_f32(a: float32x4_t, b: float32x4_t, c: f32) -> float32x4_t
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
     static_assert_imm2!(LANE);
-    vmla_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmla_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4707,7 +4707,7 @@ pub unsafe fn vmla_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int1
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x8_t) -> int16x4_t {
     static_assert_imm3!(LANE);
-    vmla_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmla_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4722,7 +4722,7 @@ pub unsafe fn vmla_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x4_t) -> int16x8_t {
     static_assert_imm2!(LANE);
-    vmlaq_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4737,7 +4737,7 @@ pub unsafe fn vmlaq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
     static_assert_imm3!(LANE);
-    vmlaq_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4752,7 +4752,7 @@ pub unsafe fn vmlaq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    vmla_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmla_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4767,7 +4767,7 @@ pub unsafe fn vmla_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int3
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x4_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    vmla_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmla_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4782,7 +4782,7 @@ pub unsafe fn vmla_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x2_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    vmlaq_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4797,7 +4797,7 @@ pub unsafe fn vmlaq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmlaq_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4812,7 +4812,7 @@ pub unsafe fn vmlaq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: uint16x4_t) -> uint16x4_t {
     static_assert_imm2!(LANE);
-    vmla_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmla_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4827,7 +4827,7 @@ pub unsafe fn vmla_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: uint16x8_t) -> uint16x4_t {
     static_assert_imm3!(LANE);
-    vmla_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmla_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4842,7 +4842,7 @@ pub unsafe fn vmla_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: uint16x4_t) -> uint16x8_t {
     static_assert_imm2!(LANE);
-    vmlaq_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4857,7 +4857,7 @@ pub unsafe fn vmlaq_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: uint16x8_t) -> uint16x8_t {
     static_assert_imm3!(LANE);
-    vmlaq_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4872,7 +4872,7 @@ pub unsafe fn vmlaq_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: uint32x2_t) -> uint32x2_t {
     static_assert_imm1!(LANE);
-    vmla_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmla_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4887,7 +4887,7 @@ pub unsafe fn vmla_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: uint32x4_t) -> uint32x2_t {
     static_assert_imm2!(LANE);
-    vmla_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmla_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4902,7 +4902,7 @@ pub unsafe fn vmla_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: uint32x2_t) -> uint32x4_t {
     static_assert_imm1!(LANE);
-    vmlaq_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4917,7 +4917,7 @@ pub unsafe fn vmlaq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmlaq_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4932,7 +4932,7 @@ pub unsafe fn vmlaq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    vmla_f32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmla_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4947,7 +4947,7 @@ pub unsafe fn vmla_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmla_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x4_t) -> float32x2_t {
     static_assert_imm2!(LANE);
-    vmla_f32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmla_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4962,7 +4962,7 @@ pub unsafe fn vmla_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c:
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x2_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    vmlaq_f32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply accumulate with scalar
@@ -4977,7 +4977,7 @@ pub unsafe fn vmlaq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c:
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlaq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
     static_assert_imm2!(LANE);
-    vmlaq_f32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlaq_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Signed multiply-add long
@@ -5122,7 +5122,7 @@ pub unsafe fn vmlal_n_u32(a: uint64x2_t, b: uint32x2_t, c: u32) -> uint64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmlal_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5137,7 +5137,7 @@ pub unsafe fn vmlal_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: int16x8_t) -> int32x4_t {
     static_assert_imm3!(LANE);
-    vmlal_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5152,7 +5152,7 @@ pub unsafe fn vmlal_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: int32x2_t) -> int64x2_t {
     static_assert_imm1!(LANE);
-    vmlal_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlal_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5167,7 +5167,7 @@ pub unsafe fn vmlal_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: int32x4_t) -> int64x2_t {
     static_assert_imm2!(LANE);
-    vmlal_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlal_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5182,7 +5182,7 @@ pub unsafe fn vmlal_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmlal_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5197,7 +5197,7 @@ pub unsafe fn vmlal_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: uint16x8_t) -> uint32x4_t {
     static_assert_imm3!(LANE);
-    vmlal_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlal_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5212,7 +5212,7 @@ pub unsafe fn vmlal_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
     static_assert_imm1!(LANE);
-    vmlal_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlal_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply accumulate with scalar
@@ -5227,7 +5227,7 @@ pub unsafe fn vmlal_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x2_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlal_laneq_u32<const LANE: i32>(a: uint64x2_t, b: uint32x2_t, c: uint32x4_t) -> uint64x2_t {
     static_assert_imm2!(LANE);
-    vmlal_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlal_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Multiply-subtract from accumulator
@@ -5554,7 +5554,7 @@ pub unsafe fn vmlsq_n_f32(a: float32x4_t, b: float32x4_t, c: f32) -> float32x4_t
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
     static_assert_imm2!(LANE);
-    vmls_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmls_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5569,7 +5569,7 @@ pub unsafe fn vmls_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int1
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int16x8_t) -> int16x4_t {
     static_assert_imm3!(LANE);
-    vmls_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmls_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5584,7 +5584,7 @@ pub unsafe fn vmls_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x4_t) -> int16x8_t {
     static_assert_imm2!(LANE);
-    vmlsq_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5599,7 +5599,7 @@ pub unsafe fn vmlsq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
     static_assert_imm3!(LANE);
-    vmlsq_s16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5614,7 +5614,7 @@ pub unsafe fn vmlsq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    vmls_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmls_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5629,7 +5629,7 @@ pub unsafe fn vmls_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int3
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int32x4_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    vmls_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmls_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5644,7 +5644,7 @@ pub unsafe fn vmls_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x2_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    vmlsq_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5659,7 +5659,7 @@ pub unsafe fn vmlsq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmlsq_s32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5674,7 +5674,7 @@ pub unsafe fn vmlsq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: uint16x4_t) -> uint16x4_t {
     static_assert_imm2!(LANE);
-    vmls_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmls_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5689,7 +5689,7 @@ pub unsafe fn vmls_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: uint16x8_t) -> uint16x4_t {
     static_assert_imm3!(LANE);
-    vmls_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmls_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5704,7 +5704,7 @@ pub unsafe fn vmls_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: uint16x4_t) -> uint16x8_t {
     static_assert_imm2!(LANE);
-    vmlsq_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5719,7 +5719,7 @@ pub unsafe fn vmlsq_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: uint16x8_t) -> uint16x8_t {
     static_assert_imm3!(LANE);
-    vmlsq_u16(a, b, simd_shuffle8!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5734,7 +5734,7 @@ pub unsafe fn vmlsq_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: uint32x2_t) -> uint32x2_t {
     static_assert_imm1!(LANE);
-    vmls_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmls_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5749,7 +5749,7 @@ pub unsafe fn vmls_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: uint32x4_t) -> uint32x2_t {
     static_assert_imm2!(LANE);
-    vmls_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmls_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5764,7 +5764,7 @@ pub unsafe fn vmls_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: uint32x2_t) -> uint32x4_t {
     static_assert_imm1!(LANE);
-    vmlsq_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5779,7 +5779,7 @@ pub unsafe fn vmlsq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmlsq_u32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5794,7 +5794,7 @@ pub unsafe fn vmlsq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    vmls_f32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmls_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5809,7 +5809,7 @@ pub unsafe fn vmls_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmls_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c: float32x4_t) -> float32x2_t {
     static_assert_imm2!(LANE);
-    vmls_f32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmls_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5824,7 +5824,7 @@ pub unsafe fn vmls_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t, c:
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x2_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    vmlsq_f32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector multiply subtract with scalar
@@ -5839,7 +5839,7 @@ pub unsafe fn vmlsq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c:
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
     static_assert_imm2!(LANE);
-    vmlsq_f32(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsq_f32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Signed multiply-subtract long
@@ -5984,7 +5984,7 @@ pub unsafe fn vmlsl_n_u32(a: uint64x2_t, b: uint32x2_t, c: u32) -> uint64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: int16x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmlsl_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -5999,7 +5999,7 @@ pub unsafe fn vmlsl_lane_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: int16x8_t) -> int32x4_t {
     static_assert_imm3!(LANE);
-    vmlsl_s16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_s16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -6014,7 +6014,7 @@ pub unsafe fn vmlsl_laneq_s16<const LANE: i32>(a: int32x4_t, b: int16x4_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: int32x2_t) -> int64x2_t {
     static_assert_imm1!(LANE);
-    vmlsl_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlsl_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -6029,7 +6029,7 @@ pub unsafe fn vmlsl_lane_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: int32x4_t) -> int64x2_t {
     static_assert_imm2!(LANE);
-    vmlsl_s32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlsl_s32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -6044,7 +6044,7 @@ pub unsafe fn vmlsl_laneq_s32<const LANE: i32>(a: int64x2_t, b: int32x2_t, c: in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: uint16x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmlsl_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -6059,7 +6059,7 @@ pub unsafe fn vmlsl_lane_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: uint16x8_t) -> uint32x4_t {
     static_assert_imm3!(LANE);
-    vmlsl_u16(a, b, simd_shuffle4!(c, c, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmlsl_u16(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -6074,7 +6074,7 @@ pub unsafe fn vmlsl_laneq_u16<const LANE: i32>(a: uint32x4_t, b: uint16x4_t, c: 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x2_t, c: uint32x2_t) -> uint64x2_t {
     static_assert_imm1!(LANE);
-    vmlsl_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlsl_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Vector widening multiply subtract with scalar
@@ -6089,7 +6089,7 @@ pub unsafe fn vmlsl_lane_u32<const LANE: i32>(a: uint64x2_t, b: uint32x2_t, c: u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmlsl_laneq_u32<const LANE: i32>(a: uint64x2_t, b: uint32x2_t, c: uint32x4_t) -> uint64x2_t {
     static_assert_imm2!(LANE);
-    vmlsl_u32(a, b, simd_shuffle2!(c, c, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmlsl_u32(a, b, simd_shuffle!(c, c, [LANE as u32, LANE as u32]))
 }
 
 /// Negate
@@ -17137,7 +17137,7 @@ pub unsafe fn vmulq_n_f32(a: float32x4_t, b: f32) -> float32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t) -> int16x4_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17152,7 +17152,7 @@ pub unsafe fn vmul_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t) -> int1
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x8_t) -> int16x4_t {
     static_assert_imm3!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17167,7 +17167,7 @@ pub unsafe fn vmul_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x8_t) -> int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x4_t) -> int16x8_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17182,7 +17182,7 @@ pub unsafe fn vmulq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x4_t) -> int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t) -> int16x8_t {
     static_assert_imm3!(LANE);
-    simd_mul(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17197,7 +17197,7 @@ pub unsafe fn vmulq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t) -> in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17212,7 +17212,7 @@ pub unsafe fn vmul_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t) -> int3
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x4_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17227,7 +17227,7 @@ pub unsafe fn vmul_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x4_t) -> int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x2_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17242,7 +17242,7 @@ pub unsafe fn vmulq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x2_t) -> int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17257,7 +17257,7 @@ pub unsafe fn vmulq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t) -> in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17272,7 +17272,7 @@ pub unsafe fn vmul_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t) -> ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x8_t) -> uint16x4_t {
     static_assert_imm3!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17287,7 +17287,7 @@ pub unsafe fn vmul_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x8_t) -> u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x4_t) -> uint16x8_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17302,7 +17302,7 @@ pub unsafe fn vmulq_lane_u16<const LANE: i32>(a: uint16x8_t, b: uint16x4_t) -> u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
     static_assert_imm3!(LANE);
-    simd_mul(a, simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17317,7 +17317,7 @@ pub unsafe fn vmulq_laneq_u16<const LANE: i32>(a: uint16x8_t, b: uint16x8_t) -> 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17332,7 +17332,7 @@ pub unsafe fn vmul_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t) -> ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x4_t) -> uint32x2_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17347,7 +17347,7 @@ pub unsafe fn vmul_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x4_t) -> u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x2_t) -> uint32x4_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Multiply
@@ -17362,7 +17362,7 @@ pub unsafe fn vmulq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint32x2_t) -> u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply
@@ -17377,7 +17377,7 @@ pub unsafe fn vmulq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint32x4_t) -> 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply
@@ -17392,7 +17392,7 @@ pub unsafe fn vmul_lane_f32<const LANE: i32>(a: float32x2_t, b: float32x2_t) -> 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmul_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x4_t) -> float32x2_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply
@@ -17407,7 +17407,7 @@ pub unsafe fn vmul_laneq_f32<const LANE: i32>(a: float32x2_t, b: float32x4_t) ->
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x2_t) -> float32x4_t {
     static_assert_imm1!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Floating-point multiply
@@ -17422,7 +17422,7 @@ pub unsafe fn vmulq_lane_f32<const LANE: i32>(a: float32x4_t, b: float32x2_t) ->
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmulq_laneq_f32<const LANE: i32>(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     static_assert_imm2!(LANE);
-    simd_mul(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    simd_mul(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Signed multiply long
@@ -17622,7 +17622,7 @@ pub unsafe fn vmull_n_u32(a: uint32x2_t, b: u32) -> uint64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    vmull_s16(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_s16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17637,7 +17637,7 @@ pub unsafe fn vmull_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t) -> int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x8_t) -> int32x4_t {
     static_assert_imm3!(LANE);
-    vmull_s16(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_s16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17652,7 +17652,7 @@ pub unsafe fn vmull_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x8_t) -> in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t) -> int64x2_t {
     static_assert_imm1!(LANE);
-    vmull_s32(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmull_s32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17667,7 +17667,7 @@ pub unsafe fn vmull_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t) -> int
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x4_t) -> int64x2_t {
     static_assert_imm2!(LANE);
-    vmull_s32(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmull_s32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17682,7 +17682,7 @@ pub unsafe fn vmull_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x4_t) -> in
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t) -> uint32x4_t {
     static_assert_imm2!(LANE);
-    vmull_u16(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_u16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17697,7 +17697,7 @@ pub unsafe fn vmull_lane_u16<const LANE: i32>(a: uint16x4_t, b: uint16x4_t) -> u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x8_t) -> uint32x4_t {
     static_assert_imm3!(LANE);
-    vmull_u16(a, simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
+    vmull_u16(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17712,7 +17712,7 @@ pub unsafe fn vmull_laneq_u16<const LANE: i32>(a: uint16x4_t, b: uint16x8_t) -> 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     static_assert_imm1!(LANE);
-    vmull_u32(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmull_u32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Vector long multiply by scalar
@@ -17727,7 +17727,7 @@ pub unsafe fn vmull_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint32x2_t) -> u
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vmull_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint32x4_t) -> uint64x2_t {
     static_assert_imm2!(LANE);
-    vmull_u32(a, simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]))
+    vmull_u32(a, simd_shuffle!(b, b, [LANE as u32, LANE as u32]))
 }
 
 /// Floating-point fused Multiply-Add to accumulator(vector)
@@ -18268,7 +18268,7 @@ pub unsafe fn vsubhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vsubhn_high_s16(a: int8x8_t, b: int16x8_t, c: int16x8_t) -> int8x16_t {
     let d: int8x8_t = vsubhn_s16(b, c);
-    simd_shuffle16!(a, d, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, d, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Subtract returning high narrow
@@ -18282,7 +18282,7 @@ pub unsafe fn vsubhn_high_s16(a: int8x8_t, b: int16x8_t, c: int16x8_t) -> int8x1
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vsubhn_high_s32(a: int16x4_t, b: int32x4_t, c: int32x4_t) -> int16x8_t {
     let d: int16x4_t = vsubhn_s32(b, c);
-    simd_shuffle8!(a, d, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, d, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Subtract returning high narrow
@@ -18296,7 +18296,7 @@ pub unsafe fn vsubhn_high_s32(a: int16x4_t, b: int32x4_t, c: int32x4_t) -> int16
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vsubhn_high_s64(a: int32x2_t, b: int64x2_t, c: int64x2_t) -> int32x4_t {
     let d: int32x2_t = vsubhn_s64(b, c);
-    simd_shuffle4!(a, d, [0, 1, 2, 3])
+    simd_shuffle!(a, d, [0, 1, 2, 3])
 }
 
 /// Subtract returning high narrow
@@ -18310,7 +18310,7 @@ pub unsafe fn vsubhn_high_s64(a: int32x2_t, b: int64x2_t, c: int64x2_t) -> int32
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vsubhn_high_u16(a: uint8x8_t, b: uint16x8_t, c: uint16x8_t) -> uint8x16_t {
     let d: uint8x8_t = vsubhn_u16(b, c);
-    simd_shuffle16!(a, d, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, d, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Subtract returning high narrow
@@ -18324,7 +18324,7 @@ pub unsafe fn vsubhn_high_u16(a: uint8x8_t, b: uint16x8_t, c: uint16x8_t) -> uin
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vsubhn_high_u32(a: uint16x4_t, b: uint32x4_t, c: uint32x4_t) -> uint16x8_t {
     let d: uint16x4_t = vsubhn_u32(b, c);
-    simd_shuffle8!(a, d, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, d, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Subtract returning high narrow
@@ -18338,7 +18338,7 @@ pub unsafe fn vsubhn_high_u32(a: uint16x4_t, b: uint32x4_t, c: uint32x4_t) -> ui
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vsubhn_high_u64(a: uint32x2_t, b: uint64x2_t, c: uint64x2_t) -> uint32x4_t {
     let d: uint32x2_t = vsubhn_u64(b, c);
-    simd_shuffle4!(a, d, [0, 1, 2, 3])
+    simd_shuffle!(a, d, [0, 1, 2, 3])
 }
 
 /// Signed halving subtract
@@ -19440,7 +19440,7 @@ pub unsafe fn vqdmull_n_s32(a: int32x2_t, b: i32) -> int64x2_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqdmull_lane_s16<const N: i32>(a: int16x4_t, b: int16x4_t) -> int32x4_t {
     static_assert_imm2!(N);
-    let b: int16x4_t = simd_shuffle4!(b, b, <const N: i32> [N as u32, N as u32, N as u32, N as u32]);
+    let b: int16x4_t = simd_shuffle!(b, b, [N as u32, N as u32, N as u32, N as u32]);
     vqdmull_s16(a, b)
 }
 
@@ -19456,7 +19456,7 @@ pub unsafe fn vqdmull_lane_s16<const N: i32>(a: int16x4_t, b: int16x4_t) -> int3
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqdmull_lane_s32<const N: i32>(a: int32x2_t, b: int32x2_t) -> int64x2_t {
     static_assert_imm1!(N);
-    let b: int32x2_t = simd_shuffle2!(b, b, <const N: i32> [N as u32, N as u32]);
+    let b: int32x2_t = simd_shuffle!(b, b, [N as u32, N as u32]);
     vqdmull_s32(a, b)
 }
 
@@ -20127,7 +20127,7 @@ pub unsafe fn vqrdmulhq_n_s32(a: int32x4_t, b: i32) -> int32x4_t {
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulh_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t) -> int16x4_t {
     static_assert_imm2!(LANE);
-    let b: int16x4_t = simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let b: int16x4_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmulh_s16(a, b)
 }
 
@@ -20143,7 +20143,7 @@ pub unsafe fn vqrdmulh_lane_s16<const LANE: i32>(a: int16x4_t, b: int16x4_t) -> 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulh_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x8_t) -> int16x4_t {
     static_assert_imm3!(LANE);
-    let b: int16x4_t = simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let b: int16x4_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmulh_s16(a, b)
 }
 
@@ -20159,7 +20159,7 @@ pub unsafe fn vqrdmulh_laneq_s16<const LANE: i32>(a: int16x4_t, b: int16x8_t) ->
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulhq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x4_t) -> int16x8_t {
     static_assert_imm2!(LANE);
-    let b: int16x8_t = simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let b: int16x8_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmulhq_s16(a, b)
 }
 
@@ -20175,7 +20175,7 @@ pub unsafe fn vqrdmulhq_lane_s16<const LANE: i32>(a: int16x8_t, b: int16x4_t) ->
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulhq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t) -> int16x8_t {
     static_assert_imm3!(LANE);
-    let b: int16x8_t = simd_shuffle8!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let b: int16x8_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmulhq_s16(a, b)
 }
 
@@ -20191,7 +20191,7 @@ pub unsafe fn vqrdmulhq_laneq_s16<const LANE: i32>(a: int16x8_t, b: int16x8_t) -
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulh_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t) -> int32x2_t {
     static_assert_imm1!(LANE);
-    let b: int32x2_t = simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]);
+    let b: int32x2_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32]);
     vqrdmulh_s32(a, b)
 }
 
@@ -20207,7 +20207,7 @@ pub unsafe fn vqrdmulh_lane_s32<const LANE: i32>(a: int32x2_t, b: int32x2_t) -> 
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulh_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x4_t) -> int32x2_t {
     static_assert_imm2!(LANE);
-    let b: int32x2_t = simd_shuffle2!(b, b, <const LANE: i32> [LANE as u32, LANE as u32]);
+    let b: int32x2_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32]);
     vqrdmulh_s32(a, b)
 }
 
@@ -20223,7 +20223,7 @@ pub unsafe fn vqrdmulh_laneq_s32<const LANE: i32>(a: int32x2_t, b: int32x4_t) ->
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulhq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x2_t) -> int32x4_t {
     static_assert_imm1!(LANE);
-    let b: int32x4_t = simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let b: int32x4_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmulhq_s32(a, b)
 }
 
@@ -20239,7 +20239,7 @@ pub unsafe fn vqrdmulhq_lane_s32<const LANE: i32>(a: int32x4_t, b: int32x2_t) ->
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vqrdmulhq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int32x4_t) -> int32x4_t {
     static_assert_imm2!(LANE);
-    let b: int32x4_t = simd_shuffle4!(b, b, <const LANE: i32> [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
+    let b: int32x4_t = simd_shuffle!(b, b, [LANE as u32, LANE as u32, LANE as u32, LANE as u32]);
     vqrdmulhq_s32(a, b)
 }
 
@@ -28495,8 +28495,8 @@ pub unsafe fn vsraq_n_u64<const N: i32>(a: uint64x2_t, b: uint64x2_t) -> uint64x
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
-    let a1: int8x8_t = simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
-    let b1: int8x8_t = simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
+    let a1: int8x8_t = simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
+    let b1: int8x8_t = simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
     transmute((a1, b1))
 }
 
@@ -28510,8 +28510,8 @@ pub unsafe fn vtrn_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
-    let a1: int16x4_t = simd_shuffle4!(a, b, [0, 4, 2, 6]);
-    let b1: int16x4_t = simd_shuffle4!(a, b, [1, 5, 3, 7]);
+    let a1: int16x4_t = simd_shuffle!(a, b, [0, 4, 2, 6]);
+    let b1: int16x4_t = simd_shuffle!(a, b, [1, 5, 3, 7]);
     transmute((a1, b1))
 }
 
@@ -28525,8 +28525,8 @@ pub unsafe fn vtrn_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
-    let a1: int8x16_t = simd_shuffle16!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]);
-    let b1: int8x16_t = simd_shuffle16!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]);
+    let a1: int8x16_t = simd_shuffle!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]);
+    let b1: int8x16_t = simd_shuffle!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]);
     transmute((a1, b1))
 }
 
@@ -28540,8 +28540,8 @@ pub unsafe fn vtrnq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
-    let a1: int16x8_t = simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
-    let b1: int16x8_t = simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
+    let a1: int16x8_t = simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
+    let b1: int16x8_t = simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
     transmute((a1, b1))
 }
 
@@ -28555,8 +28555,8 @@ pub unsafe fn vtrnq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
-    let a1: int32x4_t = simd_shuffle4!(a, b, [0, 4, 2, 6]);
-    let b1: int32x4_t = simd_shuffle4!(a, b, [1, 5, 3, 7]);
+    let a1: int32x4_t = simd_shuffle!(a, b, [0, 4, 2, 6]);
+    let b1: int32x4_t = simd_shuffle!(a, b, [1, 5, 3, 7]);
     transmute((a1, b1))
 }
 
@@ -28570,8 +28570,8 @@ pub unsafe fn vtrnq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
-    let a1: uint8x8_t = simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
-    let b1: uint8x8_t = simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
+    let a1: uint8x8_t = simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
+    let b1: uint8x8_t = simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
     transmute((a1, b1))
 }
 
@@ -28585,8 +28585,8 @@ pub unsafe fn vtrn_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
-    let a1: uint16x4_t = simd_shuffle4!(a, b, [0, 4, 2, 6]);
-    let b1: uint16x4_t = simd_shuffle4!(a, b, [1, 5, 3, 7]);
+    let a1: uint16x4_t = simd_shuffle!(a, b, [0, 4, 2, 6]);
+    let b1: uint16x4_t = simd_shuffle!(a, b, [1, 5, 3, 7]);
     transmute((a1, b1))
 }
 
@@ -28600,8 +28600,8 @@ pub unsafe fn vtrn_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
-    let a1: uint8x16_t = simd_shuffle16!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]);
-    let b1: uint8x16_t = simd_shuffle16!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]);
+    let a1: uint8x16_t = simd_shuffle!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]);
+    let b1: uint8x16_t = simd_shuffle!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]);
     transmute((a1, b1))
 }
 
@@ -28615,8 +28615,8 @@ pub unsafe fn vtrnq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
-    let a1: uint16x8_t = simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
-    let b1: uint16x8_t = simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
+    let a1: uint16x8_t = simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
+    let b1: uint16x8_t = simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
     transmute((a1, b1))
 }
 
@@ -28630,8 +28630,8 @@ pub unsafe fn vtrnq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
-    let a1: uint32x4_t = simd_shuffle4!(a, b, [0, 4, 2, 6]);
-    let b1: uint32x4_t = simd_shuffle4!(a, b, [1, 5, 3, 7]);
+    let a1: uint32x4_t = simd_shuffle!(a, b, [0, 4, 2, 6]);
+    let b1: uint32x4_t = simd_shuffle!(a, b, [1, 5, 3, 7]);
     transmute((a1, b1))
 }
 
@@ -28645,8 +28645,8 @@ pub unsafe fn vtrnq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
-    let a1: poly8x8_t = simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
-    let b1: poly8x8_t = simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
+    let a1: poly8x8_t = simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
+    let b1: poly8x8_t = simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
     transmute((a1, b1))
 }
 
@@ -28660,8 +28660,8 @@ pub unsafe fn vtrn_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
-    let a1: poly16x4_t = simd_shuffle4!(a, b, [0, 4, 2, 6]);
-    let b1: poly16x4_t = simd_shuffle4!(a, b, [1, 5, 3, 7]);
+    let a1: poly16x4_t = simd_shuffle!(a, b, [0, 4, 2, 6]);
+    let b1: poly16x4_t = simd_shuffle!(a, b, [1, 5, 3, 7]);
     transmute((a1, b1))
 }
 
@@ -28675,8 +28675,8 @@ pub unsafe fn vtrn_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
-    let a1: poly8x16_t = simd_shuffle16!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]);
-    let b1: poly8x16_t = simd_shuffle16!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]);
+    let a1: poly8x16_t = simd_shuffle!(a, b, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]);
+    let b1: poly8x16_t = simd_shuffle!(a, b, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31]);
     transmute((a1, b1))
 }
 
@@ -28690,8 +28690,8 @@ pub unsafe fn vtrnq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
-    let a1: poly16x8_t = simd_shuffle8!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
-    let b1: poly16x8_t = simd_shuffle8!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
+    let a1: poly16x8_t = simd_shuffle!(a, b, [0, 8, 2, 10, 4, 12, 6, 14]);
+    let b1: poly16x8_t = simd_shuffle!(a, b, [1, 9, 3, 11, 5, 13, 7, 15]);
     transmute((a1, b1))
 }
 
@@ -28705,8 +28705,8 @@ pub unsafe fn vtrnq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
-    let a1: int32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b1: int32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a1: int32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b1: int32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a1, b1))
 }
 
@@ -28720,8 +28720,8 @@ pub unsafe fn vtrn_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
-    let a1: uint32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b1: uint32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a1: uint32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b1: uint32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a1, b1))
 }
 
@@ -28735,8 +28735,8 @@ pub unsafe fn vtrn_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrn_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
-    let a1: float32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b1: float32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a1: float32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b1: float32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a1, b1))
 }
 
@@ -28750,8 +28750,8 @@ pub unsafe fn vtrn_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(trn))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vtrnq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
-    let a1: float32x4_t = simd_shuffle4!(a, b, [0, 4, 2, 6]);
-    let b1: float32x4_t = simd_shuffle4!(a, b, [1, 5, 3, 7]);
+    let a1: float32x4_t = simd_shuffle!(a, b, [0, 4, 2, 6]);
+    let b1: float32x4_t = simd_shuffle!(a, b, [1, 5, 3, 7]);
     transmute((a1, b1))
 }
 
@@ -28765,8 +28765,8 @@ pub unsafe fn vtrnq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
-    let a0: int8x8_t = simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
-    let b0: int8x8_t = simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
+    let a0: int8x8_t = simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
+    let b0: int8x8_t = simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute((a0, b0))
 }
 
@@ -28780,8 +28780,8 @@ pub unsafe fn vzip_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
-    let a0: int16x4_t = simd_shuffle4!(a, b, [0, 4, 1, 5]);
-    let b0: int16x4_t = simd_shuffle4!(a, b, [2, 6, 3, 7]);
+    let a0: int16x4_t = simd_shuffle!(a, b, [0, 4, 1, 5]);
+    let b0: int16x4_t = simd_shuffle!(a, b, [2, 6, 3, 7]);
     transmute((a0, b0))
 }
 
@@ -28795,8 +28795,8 @@ pub unsafe fn vzip_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
-    let a0: uint8x8_t = simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
-    let b0: uint8x8_t = simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
+    let a0: uint8x8_t = simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
+    let b0: uint8x8_t = simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute((a0, b0))
 }
 
@@ -28810,8 +28810,8 @@ pub unsafe fn vzip_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
-    let a0: uint16x4_t = simd_shuffle4!(a, b, [0, 4, 1, 5]);
-    let b0: uint16x4_t = simd_shuffle4!(a, b, [2, 6, 3, 7]);
+    let a0: uint16x4_t = simd_shuffle!(a, b, [0, 4, 1, 5]);
+    let b0: uint16x4_t = simd_shuffle!(a, b, [2, 6, 3, 7]);
     transmute((a0, b0))
 }
 
@@ -28825,8 +28825,8 @@ pub unsafe fn vzip_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
-    let a0: poly8x8_t = simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
-    let b0: poly8x8_t = simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
+    let a0: poly8x8_t = simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
+    let b0: poly8x8_t = simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute((a0, b0))
 }
 
@@ -28840,8 +28840,8 @@ pub unsafe fn vzip_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
-    let a0: poly16x4_t = simd_shuffle4!(a, b, [0, 4, 1, 5]);
-    let b0: poly16x4_t = simd_shuffle4!(a, b, [2, 6, 3, 7]);
+    let a0: poly16x4_t = simd_shuffle!(a, b, [0, 4, 1, 5]);
+    let b0: poly16x4_t = simd_shuffle!(a, b, [2, 6, 3, 7]);
     transmute((a0, b0))
 }
 
@@ -28855,8 +28855,8 @@ pub unsafe fn vzip_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
-    let a0: int32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b0: int32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a0: int32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b0: int32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a0, b0))
 }
 
@@ -28870,8 +28870,8 @@ pub unsafe fn vzip_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
-    let a0: uint32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b0: uint32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a0: uint32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b0: uint32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a0, b0))
 }
 
@@ -28885,8 +28885,8 @@ pub unsafe fn vzip_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
-    let a0: int8x16_t = simd_shuffle16!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]);
-    let b0: int8x16_t = simd_shuffle16!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]);
+    let a0: int8x16_t = simd_shuffle!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]);
+    let b0: int8x16_t = simd_shuffle!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]);
     transmute((a0, b0))
 }
 
@@ -28900,8 +28900,8 @@ pub unsafe fn vzipq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
-    let a0: int16x8_t = simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
-    let b0: int16x8_t = simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
+    let a0: int16x8_t = simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
+    let b0: int16x8_t = simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute((a0, b0))
 }
 
@@ -28915,8 +28915,8 @@ pub unsafe fn vzipq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
-    let a0: int32x4_t = simd_shuffle4!(a, b, [0, 4, 1, 5]);
-    let b0: int32x4_t = simd_shuffle4!(a, b, [2, 6, 3, 7]);
+    let a0: int32x4_t = simd_shuffle!(a, b, [0, 4, 1, 5]);
+    let b0: int32x4_t = simd_shuffle!(a, b, [2, 6, 3, 7]);
     transmute((a0, b0))
 }
 
@@ -28930,8 +28930,8 @@ pub unsafe fn vzipq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
-    let a0: uint8x16_t = simd_shuffle16!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]);
-    let b0: uint8x16_t = simd_shuffle16!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]);
+    let a0: uint8x16_t = simd_shuffle!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]);
+    let b0: uint8x16_t = simd_shuffle!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]);
     transmute((a0, b0))
 }
 
@@ -28945,8 +28945,8 @@ pub unsafe fn vzipq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
-    let a0: uint16x8_t = simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
-    let b0: uint16x8_t = simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
+    let a0: uint16x8_t = simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
+    let b0: uint16x8_t = simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute((a0, b0))
 }
 
@@ -28960,8 +28960,8 @@ pub unsafe fn vzipq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
-    let a0: uint32x4_t = simd_shuffle4!(a, b, [0, 4, 1, 5]);
-    let b0: uint32x4_t = simd_shuffle4!(a, b, [2, 6, 3, 7]);
+    let a0: uint32x4_t = simd_shuffle!(a, b, [0, 4, 1, 5]);
+    let b0: uint32x4_t = simd_shuffle!(a, b, [2, 6, 3, 7]);
     transmute((a0, b0))
 }
 
@@ -28975,8 +28975,8 @@ pub unsafe fn vzipq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
-    let a0: poly8x16_t = simd_shuffle16!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]);
-    let b0: poly8x16_t = simd_shuffle16!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]);
+    let a0: poly8x16_t = simd_shuffle!(a, b, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23]);
+    let b0: poly8x16_t = simd_shuffle!(a, b, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31]);
     transmute((a0, b0))
 }
 
@@ -28990,8 +28990,8 @@ pub unsafe fn vzipq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
-    let a0: poly16x8_t = simd_shuffle8!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
-    let b0: poly16x8_t = simd_shuffle8!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
+    let a0: poly16x8_t = simd_shuffle!(a, b, [0, 8, 1, 9, 2, 10, 3, 11]);
+    let b0: poly16x8_t = simd_shuffle!(a, b, [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute((a0, b0))
 }
 
@@ -29005,8 +29005,8 @@ pub unsafe fn vzipq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzip_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
-    let a0: float32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b0: float32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a0: float32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b0: float32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a0, b0))
 }
 
@@ -29020,8 +29020,8 @@ pub unsafe fn vzip_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vzipq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
-    let a0: float32x4_t = simd_shuffle4!(a, b, [0, 4, 1, 5]);
-    let b0: float32x4_t = simd_shuffle4!(a, b, [2, 6, 3, 7]);
+    let a0: float32x4_t = simd_shuffle!(a, b, [0, 4, 1, 5]);
+    let b0: float32x4_t = simd_shuffle!(a, b, [2, 6, 3, 7]);
     transmute((a0, b0))
 }
 
@@ -29035,8 +29035,8 @@ pub unsafe fn vzipq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
-    let a0: int8x8_t = simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
-    let b0: int8x8_t = simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
+    let a0: int8x8_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
+    let b0: int8x8_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
     transmute((a0, b0))
 }
 
@@ -29050,8 +29050,8 @@ pub unsafe fn vuzp_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
-    let a0: int16x4_t = simd_shuffle4!(a, b, [0, 2, 4, 6]);
-    let b0: int16x4_t = simd_shuffle4!(a, b, [1, 3, 5, 7]);
+    let a0: int16x4_t = simd_shuffle!(a, b, [0, 2, 4, 6]);
+    let b0: int16x4_t = simd_shuffle!(a, b, [1, 3, 5, 7]);
     transmute((a0, b0))
 }
 
@@ -29065,8 +29065,8 @@ pub unsafe fn vuzp_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
-    let a0: int8x16_t = simd_shuffle16!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
-    let b0: int8x16_t = simd_shuffle16!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]);
+    let a0: int8x16_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
+    let b0: int8x16_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]);
     transmute((a0, b0))
 }
 
@@ -29080,8 +29080,8 @@ pub unsafe fn vuzpq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
-    let a0: int16x8_t = simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
-    let b0: int16x8_t = simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
+    let a0: int16x8_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
+    let b0: int16x8_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
     transmute((a0, b0))
 }
 
@@ -29095,8 +29095,8 @@ pub unsafe fn vuzpq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
-    let a0: int32x4_t = simd_shuffle4!(a, b, [0, 2, 4, 6]);
-    let b0: int32x4_t = simd_shuffle4!(a, b, [1, 3, 5, 7]);
+    let a0: int32x4_t = simd_shuffle!(a, b, [0, 2, 4, 6]);
+    let b0: int32x4_t = simd_shuffle!(a, b, [1, 3, 5, 7]);
     transmute((a0, b0))
 }
 
@@ -29110,8 +29110,8 @@ pub unsafe fn vuzpq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
-    let a0: uint8x8_t = simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
-    let b0: uint8x8_t = simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
+    let a0: uint8x8_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
+    let b0: uint8x8_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
     transmute((a0, b0))
 }
 
@@ -29125,8 +29125,8 @@ pub unsafe fn vuzp_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
-    let a0: uint16x4_t = simd_shuffle4!(a, b, [0, 2, 4, 6]);
-    let b0: uint16x4_t = simd_shuffle4!(a, b, [1, 3, 5, 7]);
+    let a0: uint16x4_t = simd_shuffle!(a, b, [0, 2, 4, 6]);
+    let b0: uint16x4_t = simd_shuffle!(a, b, [1, 3, 5, 7]);
     transmute((a0, b0))
 }
 
@@ -29140,8 +29140,8 @@ pub unsafe fn vuzp_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
-    let a0: uint8x16_t = simd_shuffle16!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
-    let b0: uint8x16_t = simd_shuffle16!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]);
+    let a0: uint8x16_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
+    let b0: uint8x16_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]);
     transmute((a0, b0))
 }
 
@@ -29155,8 +29155,8 @@ pub unsafe fn vuzpq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
-    let a0: uint16x8_t = simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
-    let b0: uint16x8_t = simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
+    let a0: uint16x8_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
+    let b0: uint16x8_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
     transmute((a0, b0))
 }
 
@@ -29170,8 +29170,8 @@ pub unsafe fn vuzpq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
-    let a0: uint32x4_t = simd_shuffle4!(a, b, [0, 2, 4, 6]);
-    let b0: uint32x4_t = simd_shuffle4!(a, b, [1, 3, 5, 7]);
+    let a0: uint32x4_t = simd_shuffle!(a, b, [0, 2, 4, 6]);
+    let b0: uint32x4_t = simd_shuffle!(a, b, [1, 3, 5, 7]);
     transmute((a0, b0))
 }
 
@@ -29185,8 +29185,8 @@ pub unsafe fn vuzpq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
-    let a0: poly8x8_t = simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
-    let b0: poly8x8_t = simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
+    let a0: poly8x8_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
+    let b0: poly8x8_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
     transmute((a0, b0))
 }
 
@@ -29200,8 +29200,8 @@ pub unsafe fn vuzp_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
-    let a0: poly16x4_t = simd_shuffle4!(a, b, [0, 2, 4, 6]);
-    let b0: poly16x4_t = simd_shuffle4!(a, b, [1, 3, 5, 7]);
+    let a0: poly16x4_t = simd_shuffle!(a, b, [0, 2, 4, 6]);
+    let b0: poly16x4_t = simd_shuffle!(a, b, [1, 3, 5, 7]);
     transmute((a0, b0))
 }
 
@@ -29215,8 +29215,8 @@ pub unsafe fn vuzp_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
-    let a0: poly8x16_t = simd_shuffle16!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
-    let b0: poly8x16_t = simd_shuffle16!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]);
+    let a0: poly8x16_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]);
+    let b0: poly8x16_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]);
     transmute((a0, b0))
 }
 
@@ -29230,8 +29230,8 @@ pub unsafe fn vuzpq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
-    let a0: poly16x8_t = simd_shuffle8!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
-    let b0: poly16x8_t = simd_shuffle8!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
+    let a0: poly16x8_t = simd_shuffle!(a, b, [0, 2, 4, 6, 8, 10, 12, 14]);
+    let b0: poly16x8_t = simd_shuffle!(a, b, [1, 3, 5, 7, 9, 11, 13, 15]);
     transmute((a0, b0))
 }
 
@@ -29245,8 +29245,8 @@ pub unsafe fn vuzpq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
-    let a0: int32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b0: int32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a0: int32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b0: int32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a0, b0))
 }
 
@@ -29260,8 +29260,8 @@ pub unsafe fn vuzp_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
-    let a0: uint32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b0: uint32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a0: uint32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b0: uint32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a0, b0))
 }
 
@@ -29275,8 +29275,8 @@ pub unsafe fn vuzp_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(zip))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzp_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
-    let a0: float32x2_t = simd_shuffle2!(a, b, [0, 2]);
-    let b0: float32x2_t = simd_shuffle2!(a, b, [1, 3]);
+    let a0: float32x2_t = simd_shuffle!(a, b, [0, 2]);
+    let b0: float32x2_t = simd_shuffle!(a, b, [1, 3]);
     transmute((a0, b0))
 }
 
@@ -29290,8 +29290,8 @@ pub unsafe fn vuzp_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uzp))]
 #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 pub unsafe fn vuzpq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
-    let a0: float32x4_t = simd_shuffle4!(a, b, [0, 2, 4, 6]);
-    let b0: float32x4_t = simd_shuffle4!(a, b, [1, 3, 5, 7]);
+    let a0: float32x4_t = simd_shuffle!(a, b, [0, 2, 4, 6]);
+    let b0: float32x4_t = simd_shuffle!(a, b, [1, 3, 5, 7]);
     transmute((a0, b0))
 }
 

--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -1363,7 +1363,7 @@ pub unsafe fn vld1q_lane_f32<const LANE: i32>(ptr: *const f32, src: float32x4_t)
 )]
 pub unsafe fn vld1_dup_s8(ptr: *const i8) -> int8x8_t {
     let x = vld1_lane_s8::<0>(ptr, transmute(i8x8::splat(0)));
-    simd_shuffle8!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1378,7 +1378,7 @@ pub unsafe fn vld1_dup_s8(ptr: *const i8) -> int8x8_t {
 )]
 pub unsafe fn vld1q_dup_s8(ptr: *const i8) -> int8x16_t {
     let x = vld1q_lane_s8::<0>(ptr, transmute(i8x16::splat(0)));
-    simd_shuffle16!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1393,7 +1393,7 @@ pub unsafe fn vld1q_dup_s8(ptr: *const i8) -> int8x16_t {
 )]
 pub unsafe fn vld1_dup_s16(ptr: *const i16) -> int16x4_t {
     let x = vld1_lane_s16::<0>(ptr, transmute(i16x4::splat(0)));
-    simd_shuffle4!(x, x, [0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1408,7 +1408,7 @@ pub unsafe fn vld1_dup_s16(ptr: *const i16) -> int16x4_t {
 )]
 pub unsafe fn vld1q_dup_s16(ptr: *const i16) -> int16x8_t {
     let x = vld1q_lane_s16::<0>(ptr, transmute(i16x8::splat(0)));
-    simd_shuffle8!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1423,7 +1423,7 @@ pub unsafe fn vld1q_dup_s16(ptr: *const i16) -> int16x8_t {
 )]
 pub unsafe fn vld1_dup_s32(ptr: *const i32) -> int32x2_t {
     let x = vld1_lane_s32::<0>(ptr, transmute(i32x2::splat(0)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1438,7 +1438,7 @@ pub unsafe fn vld1_dup_s32(ptr: *const i32) -> int32x2_t {
 )]
 pub unsafe fn vld1q_dup_s32(ptr: *const i32) -> int32x4_t {
     let x = vld1q_lane_s32::<0>(ptr, transmute(i32x4::splat(0)));
-    simd_shuffle4!(x, x, [0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1474,7 +1474,7 @@ pub unsafe fn vld1_dup_s64(ptr: *const i64) -> int64x1_t {
 )]
 pub unsafe fn vld1q_dup_s64(ptr: *const i64) -> int64x2_t {
     let x = vld1q_lane_s64::<0>(ptr, transmute(i64x2::splat(0)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1489,7 +1489,7 @@ pub unsafe fn vld1q_dup_s64(ptr: *const i64) -> int64x2_t {
 )]
 pub unsafe fn vld1_dup_u8(ptr: *const u8) -> uint8x8_t {
     let x = vld1_lane_u8::<0>(ptr, transmute(u8x8::splat(0)));
-    simd_shuffle8!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1504,7 +1504,7 @@ pub unsafe fn vld1_dup_u8(ptr: *const u8) -> uint8x8_t {
 )]
 pub unsafe fn vld1q_dup_u8(ptr: *const u8) -> uint8x16_t {
     let x = vld1q_lane_u8::<0>(ptr, transmute(u8x16::splat(0)));
-    simd_shuffle16!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1519,7 +1519,7 @@ pub unsafe fn vld1q_dup_u8(ptr: *const u8) -> uint8x16_t {
 )]
 pub unsafe fn vld1_dup_u16(ptr: *const u16) -> uint16x4_t {
     let x = vld1_lane_u16::<0>(ptr, transmute(u16x4::splat(0)));
-    simd_shuffle4!(x, x, [0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1534,7 +1534,7 @@ pub unsafe fn vld1_dup_u16(ptr: *const u16) -> uint16x4_t {
 )]
 pub unsafe fn vld1q_dup_u16(ptr: *const u16) -> uint16x8_t {
     let x = vld1q_lane_u16::<0>(ptr, transmute(u16x8::splat(0)));
-    simd_shuffle8!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1549,7 +1549,7 @@ pub unsafe fn vld1q_dup_u16(ptr: *const u16) -> uint16x8_t {
 )]
 pub unsafe fn vld1_dup_u32(ptr: *const u32) -> uint32x2_t {
     let x = vld1_lane_u32::<0>(ptr, transmute(u32x2::splat(0)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1564,7 +1564,7 @@ pub unsafe fn vld1_dup_u32(ptr: *const u32) -> uint32x2_t {
 )]
 pub unsafe fn vld1q_dup_u32(ptr: *const u32) -> uint32x4_t {
     let x = vld1q_lane_u32::<0>(ptr, transmute(u32x4::splat(0)));
-    simd_shuffle4!(x, x, [0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1600,7 +1600,7 @@ pub unsafe fn vld1_dup_u64(ptr: *const u64) -> uint64x1_t {
 )]
 pub unsafe fn vld1q_dup_u64(ptr: *const u64) -> uint64x2_t {
     let x = vld1q_lane_u64::<0>(ptr, transmute(u64x2::splat(0)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1615,7 +1615,7 @@ pub unsafe fn vld1q_dup_u64(ptr: *const u64) -> uint64x2_t {
 )]
 pub unsafe fn vld1_dup_p8(ptr: *const p8) -> poly8x8_t {
     let x = vld1_lane_p8::<0>(ptr, transmute(u8x8::splat(0)));
-    simd_shuffle8!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1630,7 +1630,7 @@ pub unsafe fn vld1_dup_p8(ptr: *const p8) -> poly8x8_t {
 )]
 pub unsafe fn vld1q_dup_p8(ptr: *const p8) -> poly8x16_t {
     let x = vld1q_lane_p8::<0>(ptr, transmute(u8x16::splat(0)));
-    simd_shuffle16!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1645,7 +1645,7 @@ pub unsafe fn vld1q_dup_p8(ptr: *const p8) -> poly8x16_t {
 )]
 pub unsafe fn vld1_dup_p16(ptr: *const p16) -> poly16x4_t {
     let x = vld1_lane_p16::<0>(ptr, transmute(u16x4::splat(0)));
-    simd_shuffle4!(x, x, [0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1660,7 +1660,7 @@ pub unsafe fn vld1_dup_p16(ptr: *const p16) -> poly16x4_t {
 )]
 pub unsafe fn vld1q_dup_p16(ptr: *const p16) -> poly16x8_t {
     let x = vld1q_lane_p16::<0>(ptr, transmute(u16x8::splat(0)));
-    simd_shuffle8!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1675,7 +1675,7 @@ pub unsafe fn vld1q_dup_p16(ptr: *const p16) -> poly16x8_t {
 )]
 pub unsafe fn vld1_dup_f32(ptr: *const f32) -> float32x2_t {
     let x = vld1_lane_f32::<0>(ptr, transmute(f32x2::splat(0.)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1715,7 +1715,7 @@ pub unsafe fn vld1_dup_p64(ptr: *const p64) -> poly64x1_t {
 )]
 pub unsafe fn vld1q_dup_p64(ptr: *const p64) -> poly64x2_t {
     let x = vld1q_lane_p64::<0>(ptr, transmute(u64x2::splat(0)));
-    simd_shuffle2!(x, x, [0, 0])
+    simd_shuffle!(x, x, [0, 0])
 }
 
 /// Load one single-element structure and Replicate to all lanes (of one register).
@@ -1730,7 +1730,7 @@ pub unsafe fn vld1q_dup_p64(ptr: *const p64) -> poly64x2_t {
 )]
 pub unsafe fn vld1q_dup_f32(ptr: *const f32) -> float32x4_t {
     let x = vld1q_lane_f32::<0>(ptr, transmute(f32x4::splat(0.)));
-    simd_shuffle4!(x, x, [0, 0, 0, 0])
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 
 // signed absolute difference and accumulate (64-bit)
@@ -2369,8 +2369,8 @@ pub unsafe fn vaddl_u32(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
-    let a: int8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let b: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let a: int16x8_t = simd_cast(a);
     let b: int16x8_t = simd_cast(b);
     simd_add(a, b)
@@ -2387,8 +2387,8 @@ pub unsafe fn vaddl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
-    let a: int16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let a: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let a: int32x4_t = simd_cast(a);
     let b: int32x4_t = simd_cast(b);
     simd_add(a, b)
@@ -2405,8 +2405,8 @@ pub unsafe fn vaddl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
-    let a: int32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let a: int32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     let a: int64x2_t = simd_cast(a);
     let b: int64x2_t = simd_cast(b);
     simd_add(a, b)
@@ -2423,8 +2423,8 @@ pub unsafe fn vaddl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
-    let a: uint8x8_t = simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
-    let b: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let a: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let a: uint16x8_t = simd_cast(a);
     let b: uint16x8_t = simd_cast(b);
     simd_add(a, b)
@@ -2441,8 +2441,8 @@ pub unsafe fn vaddl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
-    let a: uint16x4_t = simd_shuffle4!(a, a, [4, 5, 6, 7]);
-    let b: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let a: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
+    let b: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let a: uint32x4_t = simd_cast(a);
     let b: uint32x4_t = simd_cast(b);
     simd_add(a, b)
@@ -2459,8 +2459,8 @@ pub unsafe fn vaddl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
-    let a: uint32x2_t = simd_shuffle2!(a, a, [2, 3]);
-    let b: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let a: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
+    let b: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
     let a: uint64x2_t = simd_cast(a);
     let b: uint64x2_t = simd_cast(b);
     simd_add(a, b)
@@ -2567,7 +2567,7 @@ pub unsafe fn vaddw_u32(a: uint64x2_t, b: uint32x2_t) -> uint64x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
-    let b: int8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let b: int16x8_t = simd_cast(b);
     simd_add(a, b)
 }
@@ -2583,7 +2583,7 @@ pub unsafe fn vaddw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
-    let b: int16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let b: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let b: int32x4_t = simd_cast(b);
     simd_add(a, b)
 }
@@ -2599,7 +2599,7 @@ pub unsafe fn vaddw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
-    let b: int32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let b: int32x2_t = simd_shuffle!(b, b, [2, 3]);
     let b: int64x2_t = simd_cast(b);
     simd_add(a, b)
 }
@@ -2615,7 +2615,7 @@ pub unsafe fn vaddw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
-    let b: uint8x8_t = simd_shuffle8!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
+    let b: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
     let b: uint16x8_t = simd_cast(b);
     simd_add(a, b)
 }
@@ -2631,7 +2631,7 @@ pub unsafe fn vaddw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
-    let b: uint16x4_t = simd_shuffle4!(b, b, [4, 5, 6, 7]);
+    let b: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
     let b: uint32x4_t = simd_cast(b);
     simd_add(a, b)
 }
@@ -2647,7 +2647,7 @@ pub unsafe fn vaddw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
-    let b: uint32x2_t = simd_shuffle2!(b, b, [2, 3]);
+    let b: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
     let b: uint64x2_t = simd_cast(b);
     simd_add(a, b)
 }
@@ -2748,7 +2748,7 @@ pub unsafe fn vaddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
 )]
 pub unsafe fn vaddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x16_t {
     let x = simd_cast(simd_shr(simd_add(a, b), int16x8_t(8, 8, 8, 8, 8, 8, 8, 8)));
-    simd_shuffle16!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Add returning High Narrow (high half).
@@ -2763,7 +2763,7 @@ pub unsafe fn vaddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x1
 )]
 pub unsafe fn vaddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int16x8_t {
     let x = simd_cast(simd_shr(simd_add(a, b), int32x4_t(16, 16, 16, 16)));
-    simd_shuffle8!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Add returning High Narrow (high half).
@@ -2778,7 +2778,7 @@ pub unsafe fn vaddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int16
 )]
 pub unsafe fn vaddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int32x4_t {
     let x = simd_cast(simd_shr(simd_add(a, b), int64x2_t(32, 32)));
-    simd_shuffle4!(r, x, [0, 1, 2, 3])
+    simd_shuffle!(r, x, [0, 1, 2, 3])
 }
 
 /// Add returning High Narrow (high half).
@@ -2793,7 +2793,7 @@ pub unsafe fn vaddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int32
 )]
 pub unsafe fn vaddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> uint8x16_t {
     let x = simd_cast(simd_shr(simd_add(a, b), uint16x8_t(8, 8, 8, 8, 8, 8, 8, 8)));
-    simd_shuffle16!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Add returning High Narrow (high half).
@@ -2808,7 +2808,7 @@ pub unsafe fn vaddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> uin
 )]
 pub unsafe fn vaddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> uint16x8_t {
     let x = simd_cast(simd_shr(simd_add(a, b), uint32x4_t(16, 16, 16, 16)));
-    simd_shuffle8!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Add returning High Narrow (high half).
@@ -2823,7 +2823,7 @@ pub unsafe fn vaddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> ui
 )]
 pub unsafe fn vaddhn_high_u64(r: uint32x2_t, a: uint64x2_t, b: uint64x2_t) -> uint32x4_t {
     let x = simd_cast(simd_shr(simd_add(a, b), uint64x2_t(32, 32)));
-    simd_shuffle4!(r, x, [0, 1, 2, 3])
+    simd_shuffle!(r, x, [0, 1, 2, 3])
 }
 
 /// Rounding Add returning High Narrow.
@@ -2922,7 +2922,7 @@ pub unsafe fn vraddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
 )]
 pub unsafe fn vraddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x16_t {
     let x = vraddhn_s16_(a, b);
-    simd_shuffle16!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Rounding Add returning High Narrow (high half).
@@ -2937,7 +2937,7 @@ pub unsafe fn vraddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x
 )]
 pub unsafe fn vraddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int16x8_t {
     let x = vraddhn_s32_(a, b);
-    simd_shuffle8!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Rounding Add returning High Narrow (high half).
@@ -2952,7 +2952,7 @@ pub unsafe fn vraddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int1
 )]
 pub unsafe fn vraddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int32x4_t {
     let x = vraddhn_s64_(a, b);
-    simd_shuffle4!(r, x, [0, 1, 2, 3])
+    simd_shuffle!(r, x, [0, 1, 2, 3])
 }
 
 /// Rounding Add returning High Narrow (high half).
@@ -2967,7 +2967,7 @@ pub unsafe fn vraddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int3
 )]
 pub unsafe fn vraddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> uint8x16_t {
     let x: uint8x8_t = transmute(vraddhn_s16_(transmute(a), transmute(b)));
-    simd_shuffle16!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Rounding Add returning High Narrow (high half).
@@ -2982,7 +2982,7 @@ pub unsafe fn vraddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> ui
 )]
 pub unsafe fn vraddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> uint16x8_t {
     let x: uint16x4_t = transmute(vraddhn_s32_(transmute(a), transmute(b)));
-    simd_shuffle8!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(r, x, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Rounding Add returning High Narrow (high half).
@@ -2997,7 +2997,7 @@ pub unsafe fn vraddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> u
 )]
 pub unsafe fn vraddhn_high_u64(r: uint32x2_t, a: uint64x2_t, b: uint64x2_t) -> uint32x4_t {
     let x: uint32x2_t = transmute(vraddhn_s64_(transmute(a), transmute(b)));
-    simd_shuffle4!(r, x, [0, 1, 2, 3])
+    simd_shuffle!(r, x, [0, 1, 2, 3])
 }
 
 /// Signed Add Long Pairwise.
@@ -5015,7 +5015,7 @@ pub unsafe fn vgetq_lane_p8<const IMM5: i32>(v: poly8x16_t) -> p8 {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s8(a: int8x16_t) -> int8x8_t {
-    simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5029,7 +5029,7 @@ pub unsafe fn vget_high_s8(a: int8x16_t) -> int8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s16(a: int16x8_t) -> int16x4_t {
-    simd_shuffle4!(a, a, [4, 5, 6, 7])
+    simd_shuffle!(a, a, [4, 5, 6, 7])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5043,7 +5043,7 @@ pub unsafe fn vget_high_s16(a: int16x8_t) -> int16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s32(a: int32x4_t) -> int32x2_t {
-    simd_shuffle2!(a, a, [2, 3])
+    simd_shuffle!(a, a, [2, 3])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5071,7 +5071,7 @@ pub unsafe fn vget_high_s64(a: int64x2_t) -> int64x1_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u8(a: uint8x16_t) -> uint8x8_t {
-    simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5085,7 +5085,7 @@ pub unsafe fn vget_high_u8(a: uint8x16_t) -> uint8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u16(a: uint16x8_t) -> uint16x4_t {
-    simd_shuffle4!(a, a, [4, 5, 6, 7])
+    simd_shuffle!(a, a, [4, 5, 6, 7])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5099,7 +5099,7 @@ pub unsafe fn vget_high_u16(a: uint16x8_t) -> uint16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u32(a: uint32x4_t) -> uint32x2_t {
-    simd_shuffle2!(a, a, [2, 3])
+    simd_shuffle!(a, a, [2, 3])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5127,7 +5127,7 @@ pub unsafe fn vget_high_u64(a: uint64x2_t) -> uint64x1_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_p8(a: poly8x16_t) -> poly8x8_t {
-    simd_shuffle8!(a, a, [8, 9, 10, 11, 12, 13, 14, 15])
+    simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5141,7 +5141,7 @@ pub unsafe fn vget_high_p8(a: poly8x16_t) -> poly8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_p16(a: poly16x8_t) -> poly16x4_t {
-    simd_shuffle4!(a, a, [4, 5, 6, 7])
+    simd_shuffle!(a, a, [4, 5, 6, 7])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5155,7 +5155,7 @@ pub unsafe fn vget_high_p16(a: poly16x8_t) -> poly16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_f32(a: float32x4_t) -> float32x2_t {
-    simd_shuffle2!(a, a, [2, 3])
+    simd_shuffle!(a, a, [2, 3])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5168,7 +5168,7 @@ pub unsafe fn vget_high_f32(a: float32x4_t) -> float32x2_t {
     stable(feature = "vget_low_s8", since = "1.60.0")
 )]
 pub unsafe fn vget_low_s8(a: int8x16_t) -> int8x8_t {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5181,7 +5181,7 @@ pub unsafe fn vget_low_s8(a: int8x16_t) -> int8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_s16(a: int16x8_t) -> int16x4_t {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5194,7 +5194,7 @@ pub unsafe fn vget_low_s16(a: int16x8_t) -> int16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_s32(a: int32x4_t) -> int32x2_t {
-    simd_shuffle2!(a, a, [0, 1])
+    simd_shuffle!(a, a, [0, 1])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5220,7 +5220,7 @@ pub unsafe fn vget_low_s64(a: int64x2_t) -> int64x1_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u8(a: uint8x16_t) -> uint8x8_t {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5233,7 +5233,7 @@ pub unsafe fn vget_low_u8(a: uint8x16_t) -> uint8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u16(a: uint16x8_t) -> uint16x4_t {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5246,7 +5246,7 @@ pub unsafe fn vget_low_u16(a: uint16x8_t) -> uint16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u32(a: uint32x4_t) -> uint32x2_t {
-    simd_shuffle2!(a, a, [0, 1])
+    simd_shuffle!(a, a, [0, 1])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5272,7 +5272,7 @@ pub unsafe fn vget_low_u64(a: uint64x2_t) -> uint64x1_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_p8(a: poly8x16_t) -> poly8x8_t {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5285,7 +5285,7 @@ pub unsafe fn vget_low_p8(a: poly8x16_t) -> poly8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_p16(a: poly16x8_t) -> poly16x4_t {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -5298,7 +5298,7 @@ pub unsafe fn vget_low_p16(a: poly16x8_t) -> poly16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_f32(a: float32x4_t) -> float32x2_t {
-    simd_shuffle2!(a, a, [0, 1])
+    simd_shuffle!(a, a, [0, 1])
 }
 
 /// Duplicate vector element to vector or scalar
@@ -6110,7 +6110,7 @@ pub unsafe fn vcntq_p8(a: poly8x16_t) -> poly8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16_s8(a: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6124,7 +6124,7 @@ pub unsafe fn vrev16_s8(a: int8x8_t) -> int8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16q_s8(a: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, a, [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6138,7 +6138,7 @@ pub unsafe fn vrev16q_s8(a: int8x16_t) -> int8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16_u8(a: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6152,7 +6152,7 @@ pub unsafe fn vrev16_u8(a: uint8x8_t) -> uint8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16q_u8(a: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, a, [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6166,7 +6166,7 @@ pub unsafe fn vrev16q_u8(a: uint8x16_t) -> uint8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16_p8(a: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6180,7 +6180,7 @@ pub unsafe fn vrev16_p8(a: poly8x8_t) -> poly8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16q_p8(a: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, a, [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6194,7 +6194,7 @@ pub unsafe fn vrev16q_p8(a: poly8x16_t) -> poly8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_s8(a: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6208,7 +6208,7 @@ pub unsafe fn vrev32_s8(a: int8x8_t) -> int8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_s8(a: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, a, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6222,7 +6222,7 @@ pub unsafe fn vrev32q_s8(a: int8x16_t) -> int8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_u8(a: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6236,7 +6236,7 @@ pub unsafe fn vrev32_u8(a: uint8x8_t) -> uint8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_u8(a: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, a, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6250,7 +6250,7 @@ pub unsafe fn vrev32q_u8(a: uint8x16_t) -> uint8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_s16(a: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, a, [1, 0, 3, 2])
+    simd_shuffle!(a, a, [1, 0, 3, 2])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6264,7 +6264,7 @@ pub unsafe fn vrev32_s16(a: int16x4_t) -> int16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_s16(a: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6278,7 +6278,7 @@ pub unsafe fn vrev32q_s16(a: int16x8_t) -> int16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_p16(a: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, a, [1, 0, 3, 2])
+    simd_shuffle!(a, a, [1, 0, 3, 2])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6292,7 +6292,7 @@ pub unsafe fn vrev32_p16(a: poly16x4_t) -> poly16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_p16(a: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6306,7 +6306,7 @@ pub unsafe fn vrev32q_p16(a: poly16x8_t) -> poly16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_u16(a: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, a, [1, 0, 3, 2])
+    simd_shuffle!(a, a, [1, 0, 3, 2])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6320,7 +6320,7 @@ pub unsafe fn vrev32_u16(a: uint16x4_t) -> uint16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_u16(a: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
+    simd_shuffle!(a, a, [1, 0, 3, 2, 5, 4, 7, 6])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6334,7 +6334,7 @@ pub unsafe fn vrev32q_u16(a: uint16x8_t) -> uint16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_p8(a: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6348,7 +6348,7 @@ pub unsafe fn vrev32_p8(a: poly8x8_t) -> poly8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_p8(a: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, a, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6362,7 +6362,7 @@ pub unsafe fn vrev32q_p8(a: poly8x16_t) -> poly8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_s8(a: int8x8_t) -> int8x8_t {
-    simd_shuffle8!(a, a, [7, 6, 5, 4, 3, 2, 1, 0])
+    simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6376,7 +6376,7 @@ pub unsafe fn vrev64_s8(a: int8x8_t) -> int8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_s8(a: int8x16_t) -> int8x16_t {
-    simd_shuffle16!(a, a, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8])
+    simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6390,7 +6390,7 @@ pub unsafe fn vrev64q_s8(a: int8x16_t) -> int8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_s16(a: int16x4_t) -> int16x4_t {
-    simd_shuffle4!(a, a, [3, 2, 1, 0])
+    simd_shuffle!(a, a, [3, 2, 1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6404,7 +6404,7 @@ pub unsafe fn vrev64_s16(a: int16x4_t) -> int16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_s16(a: int16x8_t) -> int16x8_t {
-    simd_shuffle8!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6418,7 +6418,7 @@ pub unsafe fn vrev64q_s16(a: int16x8_t) -> int16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_s32(a: int32x2_t) -> int32x2_t {
-    simd_shuffle2!(a, a, [1, 0])
+    simd_shuffle!(a, a, [1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6432,7 +6432,7 @@ pub unsafe fn vrev64_s32(a: int32x2_t) -> int32x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_s32(a: int32x4_t) -> int32x4_t {
-    simd_shuffle4!(a, a, [1, 0, 3, 2])
+    simd_shuffle!(a, a, [1, 0, 3, 2])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6446,7 +6446,7 @@ pub unsafe fn vrev64q_s32(a: int32x4_t) -> int32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_u8(a: uint8x8_t) -> uint8x8_t {
-    simd_shuffle8!(a, a, [7, 6, 5, 4, 3, 2, 1, 0])
+    simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6460,7 +6460,7 @@ pub unsafe fn vrev64_u8(a: uint8x8_t) -> uint8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_u8(a: uint8x16_t) -> uint8x16_t {
-    simd_shuffle16!(a, a, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8])
+    simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6474,7 +6474,7 @@ pub unsafe fn vrev64q_u8(a: uint8x16_t) -> uint8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_u16(a: uint16x4_t) -> uint16x4_t {
-    simd_shuffle4!(a, a, [3, 2, 1, 0])
+    simd_shuffle!(a, a, [3, 2, 1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6488,7 +6488,7 @@ pub unsafe fn vrev64_u16(a: uint16x4_t) -> uint16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_u16(a: uint16x8_t) -> uint16x8_t {
-    simd_shuffle8!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6502,7 +6502,7 @@ pub unsafe fn vrev64q_u16(a: uint16x8_t) -> uint16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_u32(a: uint32x2_t) -> uint32x2_t {
-    simd_shuffle2!(a, a, [1, 0])
+    simd_shuffle!(a, a, [1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6516,7 +6516,7 @@ pub unsafe fn vrev64_u32(a: uint32x2_t) -> uint32x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_u32(a: uint32x4_t) -> uint32x4_t {
-    simd_shuffle4!(a, a, [1, 0, 3, 2])
+    simd_shuffle!(a, a, [1, 0, 3, 2])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6530,7 +6530,7 @@ pub unsafe fn vrev64q_u32(a: uint32x4_t) -> uint32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_f32(a: float32x2_t) -> float32x2_t {
-    simd_shuffle2!(a, a, [1, 0])
+    simd_shuffle!(a, a, [1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6544,7 +6544,7 @@ pub unsafe fn vrev64_f32(a: float32x2_t) -> float32x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_f32(a: float32x4_t) -> float32x4_t {
-    simd_shuffle4!(a, a, [1, 0, 3, 2])
+    simd_shuffle!(a, a, [1, 0, 3, 2])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6558,7 +6558,7 @@ pub unsafe fn vrev64q_f32(a: float32x4_t) -> float32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_p8(a: poly8x8_t) -> poly8x8_t {
-    simd_shuffle8!(a, a, [7, 6, 5, 4, 3, 2, 1, 0])
+    simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6572,7 +6572,7 @@ pub unsafe fn vrev64_p8(a: poly8x8_t) -> poly8x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_p8(a: poly8x16_t) -> poly8x16_t {
-    simd_shuffle16!(a, a, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8])
+    simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6586,7 +6586,7 @@ pub unsafe fn vrev64q_p8(a: poly8x16_t) -> poly8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_p16(a: poly16x4_t) -> poly16x4_t {
-    simd_shuffle4!(a, a, [3, 2, 1, 0])
+    simd_shuffle!(a, a, [3, 2, 1, 0])
 }
 
 /// Reversing vector elements (swap endianness)
@@ -6600,7 +6600,7 @@ pub unsafe fn vrev64_p16(a: poly16x4_t) -> poly16x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_p16(a: poly16x8_t) -> poly16x8_t {
-    simd_shuffle8!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
+    simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4])
 }
 
 /// Signed Add and Accumulate Long Pairwise.
@@ -6922,7 +6922,7 @@ pub unsafe fn vusmmlaq_s32(a: int32x4_t, b: uint8x16_t, c: int8x16_t) -> int32x4
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub unsafe fn vcombine_f16 ( low: float16x4_t,  high: float16x4_t) -> float16x8_t {
-    simd_shuffle8!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 */
 
@@ -6933,7 +6933,7 @@ pub unsafe fn vcombine_f16 ( low: float16x4_t,  high: float16x4_t) -> float16x8_
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcombine_f32(low: float32x2_t, high: float32x2_t) -> float32x4_t {
-    simd_shuffle4!(low, high, [0, 1, 2, 3])
+    simd_shuffle!(low, high, [0, 1, 2, 3])
 }
 
 /// Vector combine
@@ -6943,7 +6943,7 @@ pub unsafe fn vcombine_f32(low: float32x2_t, high: float32x2_t) -> float32x4_t {
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcombine_p8(low: poly8x8_t, high: poly8x8_t) -> poly8x16_t {
-    simd_shuffle16!(
+    simd_shuffle!(
         low,
         high,
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -6957,7 +6957,7 @@ pub unsafe fn vcombine_p8(low: poly8x8_t, high: poly8x8_t) -> poly8x16_t {
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vcombine_p16(low: poly16x4_t, high: poly16x4_t) -> poly16x8_t {
-    simd_shuffle8!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Vector combine
@@ -6970,7 +6970,7 @@ pub unsafe fn vcombine_p16(low: poly16x4_t, high: poly16x4_t) -> poly16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_s8(low: int8x8_t, high: int8x8_t) -> int8x16_t {
-    simd_shuffle16!(
+    simd_shuffle!(
         low,
         high,
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -6987,7 +6987,7 @@ pub unsafe fn vcombine_s8(low: int8x8_t, high: int8x8_t) -> int8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_s16(low: int16x4_t, high: int16x4_t) -> int16x8_t {
-    simd_shuffle8!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Vector combine
@@ -7000,7 +7000,7 @@ pub unsafe fn vcombine_s16(low: int16x4_t, high: int16x4_t) -> int16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_s32(low: int32x2_t, high: int32x2_t) -> int32x4_t {
-    simd_shuffle4!(low, high, [0, 1, 2, 3])
+    simd_shuffle!(low, high, [0, 1, 2, 3])
 }
 
 /// Vector combine
@@ -7013,7 +7013,7 @@ pub unsafe fn vcombine_s32(low: int32x2_t, high: int32x2_t) -> int32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_s64(low: int64x1_t, high: int64x1_t) -> int64x2_t {
-    simd_shuffle2!(low, high, [0, 1])
+    simd_shuffle!(low, high, [0, 1])
 }
 
 /// Vector combine
@@ -7026,7 +7026,7 @@ pub unsafe fn vcombine_s64(low: int64x1_t, high: int64x1_t) -> int64x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_u8(low: uint8x8_t, high: uint8x8_t) -> uint8x16_t {
-    simd_shuffle16!(
+    simd_shuffle!(
         low,
         high,
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -7043,7 +7043,7 @@ pub unsafe fn vcombine_u8(low: uint8x8_t, high: uint8x8_t) -> uint8x16_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_u16(low: uint16x4_t, high: uint16x4_t) -> uint16x8_t {
-    simd_shuffle8!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(low, high, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Vector combine
@@ -7057,7 +7057,7 @@ pub unsafe fn vcombine_u16(low: uint16x4_t, high: uint16x4_t) -> uint16x8_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_u32(low: uint32x2_t, high: uint32x2_t) -> uint32x4_t {
-    simd_shuffle4!(low, high, [0, 1, 2, 3])
+    simd_shuffle!(low, high, [0, 1, 2, 3])
 }
 
 /// Vector combine
@@ -7070,7 +7070,7 @@ pub unsafe fn vcombine_u32(low: uint32x2_t, high: uint32x2_t) -> uint32x4_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_u64(low: uint64x1_t, high: uint64x1_t) -> uint64x2_t {
-    simd_shuffle2!(low, high, [0, 1])
+    simd_shuffle!(low, high, [0, 1])
 }
 
 /// Vector combine
@@ -7083,7 +7083,7 @@ pub unsafe fn vcombine_u64(low: uint64x1_t, high: uint64x1_t) -> uint64x2_t {
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcombine_p64(low: poly64x1_t, high: poly64x1_t) -> poly64x2_t {
-    simd_shuffle2!(low, high, [0, 1])
+    simd_shuffle!(low, high, [0, 1])
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -32,7 +32,9 @@
     allow_internal_unstable,
     decl_macro,
     asm_const,
-    target_feature_11
+    target_feature_11,
+    inline_const,
+    generic_arg_infer
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall))]
 #![deny(clippy::missing_inline_in_public_items)]

--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -94,97 +94,15 @@ macro_rules! types {
 }
 
 #[allow(unused)]
-macro_rules! simd_shuffle2 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
-        struct ConstParam<$(const $imm: $ty),+>;
-        impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
-            const IDX: [u32; 2] = $idx;
-        }
-
-        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
-    }};
+macro_rules! simd_shuffle {
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        const IDX: [u32; 2] = $idx;
-        simd_shuffle($x, $y, IDX)
-    }};
-}
-
-#[allow(unused_macros)]
-macro_rules! simd_shuffle4 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
-        struct ConstParam<$(const $imm: $ty),+>;
-        impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
-            const IDX: [u32; 4] = $idx;
-        }
-
-        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
-    }};
-    ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        const IDX: [u32; 4] = $idx;
-        simd_shuffle($x, $y, IDX)
-    }};
-}
-
-#[allow(unused_macros)]
-macro_rules! simd_shuffle8 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
-        struct ConstParam<$(const $imm: $ty),+>;
-        impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
-            const IDX: [u32; 8] = $idx;
-        }
-
-        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
-    }};
-    ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        const IDX: [u32; 8] = $idx;
-        simd_shuffle($x, $y, IDX)
-    }};
-}
-
-#[allow(unused)]
-macro_rules! simd_shuffle16 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
-        struct ConstParam<$(const $imm: $ty),+>;
-        impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
-            const IDX: [u32; 16] = $idx;
-        }
-
-        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
-    }};
-    ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        const IDX: [u32; 16] = $idx;
-        simd_shuffle($x, $y, IDX)
-    }};
-}
-
-#[allow(unused_macros)]
-macro_rules! simd_shuffle32 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+> $(,)? $idx:expr $(,)?) => {{
-        struct ConstParam<$(const $imm: $ty),+>;
-        impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
-            const IDX: [u32; 32] = $idx;
-        }
-
-        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
-    }};
-    ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        const IDX: [u32; 32] = $idx;
-        simd_shuffle($x, $y, IDX)
-    }};
-}
-
-#[allow(unused_macros)]
-macro_rules! simd_shuffle64 {
-    ($x:expr, $y:expr, <$(const $imm:ident : $ty:ty),+ $(,)?> $idx:expr $(,)?) => {{
-        struct ConstParam<$(const $imm: $ty),+>;
-        impl<$(const $imm: $ty),+> ConstParam<$($imm),+> {
-            const IDX: [u32; 64] = $idx;
-        }
-
-        simd_shuffle($x, $y, ConstParam::<$($imm),+>::IDX)
-    }};
-    ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        const IDX: [u32; 64] = $idx;
-        simd_shuffle($x, $y, IDX)
+        simd_shuffle(
+            $x,
+            $y,
+            const {
+                let v: [u32; _] = $idx;
+                v
+            },
+        )
     }};
 }

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -47,10 +47,10 @@ mod sealed {
     #[cfg_attr(all(test, target_endian = "big"), assert_instr(xxspltd, dm = 0x0))]
     unsafe fn xxpermdi(a: i64x2, b: i64x2, dm: u8) -> i64x2 {
         match dm & 0b11 {
-            0 => simd_shuffle2!(a, b, [0b00, 0b10]),
-            1 => simd_shuffle2!(a, b, [0b01, 0b10]),
-            2 => simd_shuffle2!(a, b, [0b00, 0b11]),
-            _ => simd_shuffle2!(a, b, [0b01, 0b11]),
+            0 => simd_shuffle!(a, b, [0b00, 0b10]),
+            1 => simd_shuffle!(a, b, [0b01, 0b10]),
+            2 => simd_shuffle!(a, b, [0b00, 0b11]),
+            _ => simd_shuffle!(a, b, [0b01, 0b11]),
         }
     }
 

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -954,30 +954,13 @@ pub fn i8x16_shuffle<
     static_assert!(I14: usize where I14 < 32);
     static_assert!(I15: usize where I15 < 32);
     let shuf: simd::u8x16 = unsafe {
-        simd_shuffle16!(
+        simd_shuffle!(
             a.as_u8x16(),
             b.as_u8x16(),
-            <
-                const I0: usize,
-                const I1: usize,
-                const I2: usize,
-                const I3: usize,
-                const I4: usize,
-                const I5: usize,
-                const I6: usize,
-                const I7: usize,
-                const I8: usize,
-                const I9: usize,
-                const I10: usize,
-                const I11: usize,
-                const I12: usize,
-                const I13: usize,
-                const I14: usize,
-                const I15: usize,
-            > [
-                I0 as u32, I1 as u32, I2 as u32, I3 as u32, I4 as u32, I5 as u32, I6 as u32, I7 as u32,
-                I8 as u32, I9 as u32, I10 as u32, I11 as u32, I12 as u32, I13 as u32, I14 as u32,
-                I15 as u32,
+            [
+                I0 as u32, I1 as u32, I2 as u32, I3 as u32, I4 as u32, I5 as u32, I6 as u32,
+                I7 as u32, I8 as u32, I9 as u32, I10 as u32, I11 as u32, I12 as u32, I13 as u32,
+                I14 as u32, I15 as u32,
             ],
         )
     };
@@ -1033,20 +1016,12 @@ pub fn i16x8_shuffle<
     static_assert!(I6: usize where I6 < 16);
     static_assert!(I7: usize where I7 < 16);
     let shuf: simd::u16x8 = unsafe {
-        simd_shuffle8!(
+        simd_shuffle!(
             a.as_u16x8(),
             b.as_u16x8(),
-            <
-                const I0: usize,
-                const I1: usize,
-                const I2: usize,
-                const I3: usize,
-                const I4: usize,
-                const I5: usize,
-                const I6: usize,
-                const I7: usize,
-            > [
-                I0 as u32, I1 as u32, I2 as u32, I3 as u32, I4 as u32, I5 as u32, I6 as u32, I7 as u32,
+            [
+                I0 as u32, I1 as u32, I2 as u32, I3 as u32, I4 as u32, I5 as u32, I6 as u32,
+                I7 as u32,
             ],
         )
     };
@@ -1077,10 +1052,10 @@ pub fn i32x4_shuffle<const I0: usize, const I1: usize, const I2: usize, const I3
     static_assert!(I2: usize where I2 < 8);
     static_assert!(I3: usize where I3 < 8);
     let shuf: simd::u32x4 = unsafe {
-        simd_shuffle4!(
+        simd_shuffle!(
             a.as_u32x4(),
             b.as_u32x4(),
-            <const I0: usize, const I1: usize, const I2: usize, const I3: usize> [I0 as u32, I1 as u32, I2 as u32, I3 as u32],
+            [I0 as u32, I1 as u32, I2 as u32, I3 as u32],
         )
     };
     shuf.v128()
@@ -1104,13 +1079,8 @@ pub use i32x4_shuffle as u32x4_shuffle;
 pub fn i64x2_shuffle<const I0: usize, const I1: usize>(a: v128, b: v128) -> v128 {
     static_assert!(I0: usize where I0 < 4);
     static_assert!(I1: usize where I1 < 4);
-    let shuf: simd::u64x2 = unsafe {
-        simd_shuffle2!(
-            a.as_u64x2(),
-            b.as_u64x2(),
-            <const I0: usize, const I1: usize> [I0 as u32, I1 as u32],
-        )
-    };
+    let shuf: simd::u64x2 =
+        unsafe { simd_shuffle!(a.as_u64x2(), b.as_u64x2(), [I0 as u32, I1 as u32]) };
     shuf.v128()
 }
 
@@ -2682,7 +2652,7 @@ pub fn u16x8_narrow_i32x4(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extend_low_i8x16(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
+        simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle!(
             a.as_i8x16(),
             a.as_i8x16(),
             [0, 1, 2, 3, 4, 5, 6, 7],
@@ -2700,7 +2670,7 @@ pub fn i16x8_extend_low_i8x16(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extend_high_i8x16(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
+        simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle!(
             a.as_i8x16(),
             a.as_i8x16(),
             [8, 9, 10, 11, 12, 13, 14, 15],
@@ -2718,7 +2688,7 @@ pub fn i16x8_extend_high_i8x16(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extend_low_u8x16(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
+        simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle!(
             a.as_u8x16(),
             a.as_u8x16(),
             [0, 1, 2, 3, 4, 5, 6, 7],
@@ -2739,7 +2709,7 @@ pub use i16x8_extend_low_u8x16 as u16x8_extend_low_u8x16;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extend_high_u8x16(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
+        simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle!(
             a.as_u8x16(),
             a.as_u8x16(),
             [8, 9, 10, 11, 12, 13, 14, 15],
@@ -2952,12 +2922,12 @@ pub fn u16x8_avgr(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extmul_low_i8x16(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
+        let lhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle!(
             a.as_i8x16(),
             a.as_i8x16(),
             [0, 1, 2, 3, 4, 5, 6, 7],
         ));
-        let rhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
+        let rhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle!(
             b.as_i8x16(),
             b.as_i8x16(),
             [0, 1, 2, 3, 4, 5, 6, 7],
@@ -2977,12 +2947,12 @@ pub fn i16x8_extmul_low_i8x16(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extmul_high_i8x16(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
+        let lhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle!(
             a.as_i8x16(),
             a.as_i8x16(),
             [8, 9, 10, 11, 12, 13, 14, 15],
         ));
-        let rhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle8!(
+        let rhs = simd_cast::<simd::i8x8, simd::i16x8>(simd_shuffle!(
             b.as_i8x16(),
             b.as_i8x16(),
             [8, 9, 10, 11, 12, 13, 14, 15],
@@ -3002,12 +2972,12 @@ pub fn i16x8_extmul_high_i8x16(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extmul_low_u8x16(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
+        let lhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle!(
             a.as_u8x16(),
             a.as_u8x16(),
             [0, 1, 2, 3, 4, 5, 6, 7],
         ));
-        let rhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
+        let rhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle!(
             b.as_u8x16(),
             b.as_u8x16(),
             [0, 1, 2, 3, 4, 5, 6, 7],
@@ -3030,12 +3000,12 @@ pub use i16x8_extmul_low_u8x16 as u16x8_extmul_low_u8x16;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i16x8_extmul_high_u8x16(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
+        let lhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle!(
             a.as_u8x16(),
             a.as_u8x16(),
             [8, 9, 10, 11, 12, 13, 14, 15],
         ));
-        let rhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle8!(
+        let rhs = simd_cast::<simd::u8x8, simd::u16x8>(simd_shuffle!(
             b.as_u8x16(),
             b.as_u8x16(),
             [8, 9, 10, 11, 12, 13, 14, 15],
@@ -3132,7 +3102,7 @@ pub use i32x4_bitmask as u32x4_bitmask;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extend_low_i16x8(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle!(
             a.as_i16x8(),
             a.as_i16x8(),
             [0, 1, 2, 3]
@@ -3150,7 +3120,7 @@ pub fn i32x4_extend_low_i16x8(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extend_high_i16x8(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle!(
             a.as_i16x8(),
             a.as_i16x8(),
             [4, 5, 6, 7]
@@ -3168,7 +3138,7 @@ pub fn i32x4_extend_high_i16x8(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extend_low_u16x8(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle!(
             a.as_u16x8(),
             a.as_u16x8(),
             [0, 1, 2, 3]
@@ -3189,7 +3159,7 @@ pub use i32x4_extend_low_u16x8 as u32x4_extend_low_u16x8;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extend_high_u16x8(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle!(
             a.as_u16x8(),
             a.as_u16x8(),
             [4, 5, 6, 7]
@@ -3359,12 +3329,12 @@ pub fn i32x4_dot_i16x8(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extmul_low_i16x8(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        let lhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle!(
             a.as_i16x8(),
             a.as_i16x8(),
             [0, 1, 2, 3]
         ));
-        let rhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        let rhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle!(
             b.as_i16x8(),
             b.as_i16x8(),
             [0, 1, 2, 3]
@@ -3384,12 +3354,12 @@ pub fn i32x4_extmul_low_i16x8(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extmul_high_i16x8(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        let lhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle!(
             a.as_i16x8(),
             a.as_i16x8(),
             [4, 5, 6, 7]
         ));
-        let rhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle4!(
+        let rhs = simd_cast::<simd::i16x4, simd::i32x4>(simd_shuffle!(
             b.as_i16x8(),
             b.as_i16x8(),
             [4, 5, 6, 7]
@@ -3409,12 +3379,12 @@ pub fn i32x4_extmul_high_i16x8(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extmul_low_u16x8(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        let lhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle!(
             a.as_u16x8(),
             a.as_u16x8(),
             [0, 1, 2, 3]
         ));
-        let rhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        let rhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle!(
             b.as_u16x8(),
             b.as_u16x8(),
             [0, 1, 2, 3]
@@ -3437,12 +3407,12 @@ pub use i32x4_extmul_low_u16x8 as u32x4_extmul_low_u16x8;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_extmul_high_u16x8(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        let lhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle!(
             a.as_u16x8(),
             a.as_u16x8(),
             [4, 5, 6, 7]
         ));
-        let rhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle4!(
+        let rhs = simd_cast::<simd::u16x4, simd::u32x4>(simd_shuffle!(
             b.as_u16x8(),
             b.as_u16x8(),
             [4, 5, 6, 7]
@@ -3514,7 +3484,7 @@ pub use i64x2_bitmask as u64x2_bitmask;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extend_low_i32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(a.as_i32x4(), a.as_i32x4(), [0, 1]))
+        simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle!(a.as_i32x4(), a.as_i32x4(), [0, 1]))
             .v128()
     }
 }
@@ -3528,7 +3498,7 @@ pub fn i64x2_extend_low_i32x4(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extend_high_i32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(a.as_i32x4(), a.as_i32x4(), [2, 3]))
+        simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle!(a.as_i32x4(), a.as_i32x4(), [2, 3]))
             .v128()
     }
 }
@@ -3542,7 +3512,7 @@ pub fn i64x2_extend_high_i32x4(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extend_low_u32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u32x2, simd::i64x2>(simd_shuffle2!(a.as_u32x4(), a.as_u32x4(), [0, 1]))
+        simd_cast::<simd::u32x2, simd::i64x2>(simd_shuffle!(a.as_u32x4(), a.as_u32x4(), [0, 1]))
             .v128()
     }
 }
@@ -3559,7 +3529,7 @@ pub use i64x2_extend_low_u32x4 as u64x2_extend_low_u32x4;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extend_high_u32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u32x2, simd::i64x2>(simd_shuffle2!(a.as_u32x4(), a.as_u32x4(), [2, 3]))
+        simd_cast::<simd::u32x2, simd::i64x2>(simd_shuffle!(a.as_u32x4(), a.as_u32x4(), [2, 3]))
             .v128()
     }
 }
@@ -3661,12 +3631,12 @@ pub use i64x2_mul as u64x2_mul;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extmul_low_i32x4(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(
+        let lhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle!(
             a.as_i32x4(),
             a.as_i32x4(),
             [0, 1]
         ));
-        let rhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(
+        let rhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle!(
             b.as_i32x4(),
             b.as_i32x4(),
             [0, 1]
@@ -3686,12 +3656,12 @@ pub fn i64x2_extmul_low_i32x4(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extmul_high_i32x4(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(
+        let lhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle!(
             a.as_i32x4(),
             a.as_i32x4(),
             [2, 3]
         ));
-        let rhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle2!(
+        let rhs = simd_cast::<simd::i32x2, simd::i64x2>(simd_shuffle!(
             b.as_i32x4(),
             b.as_i32x4(),
             [2, 3]
@@ -3711,12 +3681,12 @@ pub fn i64x2_extmul_high_i32x4(a: v128, b: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extmul_low_u32x4(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle2!(
+        let lhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle!(
             a.as_u32x4(),
             a.as_u32x4(),
             [0, 1]
         ));
-        let rhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle2!(
+        let rhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle!(
             b.as_u32x4(),
             b.as_u32x4(),
             [0, 1]
@@ -3739,12 +3709,12 @@ pub use i64x2_extmul_low_u32x4 as u64x2_extmul_low_u32x4;
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i64x2_extmul_high_u32x4(a: v128, b: v128) -> v128 {
     unsafe {
-        let lhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle2!(
+        let lhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle!(
             a.as_u32x4(),
             a.as_u32x4(),
             [2, 3]
         ));
-        let rhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle2!(
+        let rhs = simd_cast::<simd::u32x2, simd::u64x2>(simd_shuffle!(
             b.as_u32x4(),
             b.as_u32x4(),
             [2, 3]
@@ -4171,7 +4141,7 @@ pub fn f32x4_convert_u32x4(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn i32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
     let ret: simd::i32x4 = unsafe {
-        simd_shuffle4!(
+        simd_shuffle!(
             llvm_i32x2_trunc_sat_f64x2_s(a.as_f64x2()),
             simd::i32x2::splat(0),
             [0, 1, 2, 3],
@@ -4195,7 +4165,7 @@ pub fn i32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn u32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
     let ret: simd::i32x4 = unsafe {
-        simd_shuffle4!(
+        simd_shuffle!(
             llvm_i32x2_trunc_sat_f64x2_u(a.as_f64x2()),
             simd::i32x2::splat(0),
             [0, 1, 2, 3],
@@ -4212,7 +4182,7 @@ pub fn u32x4_trunc_sat_f64x2_zero(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn f64x2_convert_low_i32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::i32x2, simd::f64x2>(simd_shuffle2!(a.as_i32x4(), a.as_i32x4(), [0, 1],))
+        simd_cast::<simd::i32x2, simd::f64x2>(simd_shuffle!(a.as_i32x4(), a.as_i32x4(), [0, 1],))
             .v128()
     }
 }
@@ -4225,7 +4195,7 @@ pub fn f64x2_convert_low_i32x4(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn f64x2_convert_low_u32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::u32x2, simd::f64x2>(simd_shuffle2!(a.as_u32x4(), a.as_u32x4(), [0, 1],))
+        simd_cast::<simd::u32x2, simd::f64x2>(simd_shuffle!(a.as_u32x4(), a.as_u32x4(), [0, 1],))
             .v128()
     }
 }
@@ -4242,7 +4212,7 @@ pub fn f64x2_convert_low_u32x4(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn f32x4_demote_f64x2_zero(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::f64x4, simd::f32x4>(simd_shuffle4!(
+        simd_cast::<simd::f64x4, simd::f32x4>(simd_shuffle!(
             a.as_f64x2(),
             simd::f64x2::splat(0.0),
             [0, 1, 2, 3]
@@ -4260,7 +4230,7 @@ pub fn f32x4_demote_f64x2_zero(a: v128) -> v128 {
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 pub fn f64x2_promote_low_f32x4(a: v128) -> v128 {
     unsafe {
-        simd_cast::<simd::f32x2, simd::f64x2>(simd_shuffle2!(a.as_f32x4(), a.as_f32x4(), [0, 1]))
+        simd_cast::<simd::f32x2, simd::f64x2>(simd_shuffle!(a.as_f32x4(), a.as_f32x4(), [0, 1]))
             .v128()
     }
 }

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -118,10 +118,10 @@ pub unsafe fn _mm256_or_ps(a: __m256, b: __m256) -> __m256 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_shuffle_pd<const MASK: i32>(a: __m256d, b: __m256d) -> __m256d {
     static_assert_imm8!(MASK);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b1,
             ((MASK as u32 >> 1) & 0b1) + 4,
             ((MASK as u32 >> 2) & 0b1) + 2,
@@ -141,10 +141,10 @@ pub unsafe fn _mm256_shuffle_pd<const MASK: i32>(a: __m256d, b: __m256d) -> __m2
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_shuffle_ps<const MASK: i32>(a: __m256, b: __m256) -> __m256 {
     static_assert_imm8!(MASK);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11) + 8,
@@ -463,10 +463,10 @@ pub unsafe fn _mm256_sqrt_pd(a: __m256d) -> __m256d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_blend_pd<const IMM4: i32>(a: __m256d, b: __m256d) -> __m256d {
     static_assert_imm4!(IMM4);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         b,
-        <const IMM4: i32> [
+        [
             ((IMM4 as u32 >> 0) & 1) * 4 + 0,
             ((IMM4 as u32 >> 1) & 1) * 4 + 1,
             ((IMM4 as u32 >> 2) & 1) * 4 + 2,
@@ -486,10 +486,10 @@ pub unsafe fn _mm256_blend_pd<const IMM4: i32>(a: __m256d, b: __m256d) -> __m256
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_blend_ps<const IMM8: i32>(a: __m256, b: __m256) -> __m256 {
     static_assert_imm8!(IMM8);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         b,
-        <const IMM8: i32> [
+        [
             ((IMM8 as u32 >> 0) & 1) * 8 + 0,
             ((IMM8 as u32 >> 1) & 1) * 8 + 1,
             ((IMM8 as u32 >> 2) & 1) * 8 + 2,
@@ -930,10 +930,10 @@ pub unsafe fn _mm256_cvttps_epi32(a: __m256) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extractf128_ps<const IMM1: i32>(a: __m256) -> __m128 {
     static_assert_imm1!(IMM1);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         _mm256_undefined_ps(),
-        <const IMM1: i32> [[0, 1, 2, 3], [4, 5, 6, 7]][IMM1 as usize],
+        [[0, 1, 2, 3], [4, 5, 6, 7]][IMM1 as usize],
     )
 }
 
@@ -951,7 +951,7 @@ pub unsafe fn _mm256_extractf128_ps<const IMM1: i32>(a: __m256) -> __m128 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extractf128_pd<const IMM1: i32>(a: __m256d) -> __m128d {
     static_assert_imm1!(IMM1);
-    simd_shuffle2!(a, _mm256_undefined_pd(), <const IMM1: i32> [[0, 1], [2, 3]][IMM1 as usize])
+    simd_shuffle!(a, _mm256_undefined_pd(), [[0, 1], [2, 3]][IMM1 as usize])
 }
 
 /// Extracts 128 bits (composed of integer data) from `a`, selected with `imm8`.
@@ -967,10 +967,10 @@ pub unsafe fn _mm256_extractf128_pd<const IMM1: i32>(a: __m256d) -> __m128d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_extractf128_si256<const IMM1: i32>(a: __m256i) -> __m128i {
     static_assert_imm1!(IMM1);
-    let dst: i64x2 = simd_shuffle2!(
+    let dst: i64x2 = simd_shuffle!(
         a.as_i64x4(),
         _mm256_undefined_si256().as_i64x4(),
-        <const IMM1: i32> [[0, 1], [2, 3]][IMM1 as usize],
+        [[0, 1], [2, 3]][IMM1 as usize],
     );
     transmute(dst)
 }
@@ -1033,10 +1033,10 @@ pub unsafe fn _mm_permutevar_ps(a: __m128, b: __m128i) -> __m128 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_permute_ps<const IMM8: i32>(a: __m256) -> __m256 {
     static_assert_imm8!(IMM8);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         _mm256_undefined_ps(),
-        <const IMM8: i32> [
+        [
             (IMM8 as u32 >> 0) & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -1060,10 +1060,10 @@ pub unsafe fn _mm256_permute_ps<const IMM8: i32>(a: __m256) -> __m256 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_permute_ps<const IMM8: i32>(a: __m128) -> __m128 {
     static_assert_imm8!(IMM8);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         _mm_undefined_ps(),
-        <const IMM8: i32> [
+        [
             (IMM8 as u32 >> 0) & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -1107,10 +1107,10 @@ pub unsafe fn _mm_permutevar_pd(a: __m128d, b: __m128i) -> __m128d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_permute_pd<const IMM4: i32>(a: __m256d) -> __m256d {
     static_assert_imm4!(IMM4);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         _mm256_undefined_pd(),
-        <const IMM4: i32> [
+        [
             ((IMM4 as u32 >> 0) & 1),
             ((IMM4 as u32 >> 1) & 1),
             ((IMM4 as u32 >> 2) & 1) + 2,
@@ -1130,10 +1130,10 @@ pub unsafe fn _mm256_permute_pd<const IMM4: i32>(a: __m256d) -> __m256d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_permute_pd<const IMM2: i32>(a: __m128d) -> __m128d {
     static_assert_imm2!(IMM2);
-    simd_shuffle2!(
+    simd_shuffle!(
         a,
         _mm_undefined_pd(),
-        <const IMM2: i32> [(IMM2 as u32) & 1, (IMM2 as u32 >> 1) & 1],
+        [(IMM2 as u32) & 1, (IMM2 as u32 >> 1) & 1],
     )
 }
 
@@ -1257,10 +1257,10 @@ pub unsafe fn _mm256_broadcast_pd(a: &__m128d) -> __m256d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insertf128_ps<const IMM1: i32>(a: __m256, b: __m128) -> __m256 {
     static_assert_imm1!(IMM1);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         _mm256_castps128_ps256(b),
-        <const IMM1: i32> [[8, 9, 10, 11, 4, 5, 6, 7], [0, 1, 2, 3, 8, 9, 10, 11]][IMM1 as usize],
+        [[8, 9, 10, 11, 4, 5, 6, 7], [0, 1, 2, 3, 8, 9, 10, 11]][IMM1 as usize],
     )
 }
 
@@ -1279,10 +1279,10 @@ pub unsafe fn _mm256_insertf128_ps<const IMM1: i32>(a: __m256, b: __m128) -> __m
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insertf128_pd<const IMM1: i32>(a: __m256d, b: __m128d) -> __m256d {
     static_assert_imm1!(IMM1);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         _mm256_castpd128_pd256(b),
-        <const IMM1: i32> [[4, 5, 2, 3], [0, 1, 4, 5]][IMM1 as usize],
+        [[4, 5, 2, 3], [0, 1, 4, 5]][IMM1 as usize],
     )
 }
 
@@ -1300,10 +1300,10 @@ pub unsafe fn _mm256_insertf128_pd<const IMM1: i32>(a: __m256d, b: __m128d) -> _
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_insertf128_si256<const IMM1: i32>(a: __m256i, b: __m128i) -> __m256i {
     static_assert_imm1!(IMM1);
-    let dst: i64x4 = simd_shuffle4!(
+    let dst: i64x4 = simd_shuffle!(
         a.as_i64x4(),
         _mm256_castsi128_si256(b).as_i64x4(),
-        <const IMM1: i32> [[4, 5, 2, 3], [0, 1, 4, 5]][IMM1 as usize],
+        [[4, 5, 2, 3], [0, 1, 4, 5]][IMM1 as usize],
     );
     transmute(dst)
 }
@@ -1639,7 +1639,7 @@ pub unsafe fn _mm_maskstore_ps(mem_addr: *mut f32, mask: __m128i, a: __m128) {
 #[cfg_attr(test, assert_instr(vmovshdup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_movehdup_ps(a: __m256) -> __m256 {
-    simd_shuffle8!(a, a, [1, 1, 3, 3, 5, 5, 7, 7])
+    simd_shuffle!(a, a, [1, 1, 3, 3, 5, 5, 7, 7])
 }
 
 /// Duplicate even-indexed single-precision (32-bit) floating-point elements
@@ -1651,7 +1651,7 @@ pub unsafe fn _mm256_movehdup_ps(a: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vmovsldup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_moveldup_ps(a: __m256) -> __m256 {
-    simd_shuffle8!(a, a, [0, 0, 2, 2, 4, 4, 6, 6])
+    simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6])
 }
 
 /// Duplicate even-indexed double-precision (64-bit) floating-point elements
@@ -1663,7 +1663,7 @@ pub unsafe fn _mm256_moveldup_ps(a: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vmovddup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_movedup_pd(a: __m256d) -> __m256d {
-    simd_shuffle4!(a, a, [0, 0, 2, 2])
+    simd_shuffle!(a, a, [0, 0, 2, 2])
 }
 
 /// Loads 256-bits of integer data from unaligned memory into result.
@@ -1756,7 +1756,7 @@ pub unsafe fn _mm256_rsqrt_ps(a: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vunpckhpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_pd(a: __m256d, b: __m256d) -> __m256d {
-    simd_shuffle4!(a, b, [1, 5, 3, 7])
+    simd_shuffle!(a, b, [1, 5, 3, 7])
 }
 
 /// Unpacks and interleave single-precision (32-bit) floating-point elements
@@ -1768,7 +1768,7 @@ pub unsafe fn _mm256_unpackhi_pd(a: __m256d, b: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vunpckhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_ps(a: __m256, b: __m256) -> __m256 {
-    simd_shuffle8!(a, b, [2, 10, 3, 11, 6, 14, 7, 15])
+    simd_shuffle!(a, b, [2, 10, 3, 11, 6, 14, 7, 15])
 }
 
 /// Unpacks and interleave double-precision (64-bit) floating-point elements
@@ -1780,7 +1780,7 @@ pub unsafe fn _mm256_unpackhi_ps(a: __m256, b: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vunpcklpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_pd(a: __m256d, b: __m256d) -> __m256d {
-    simd_shuffle4!(a, b, [0, 4, 2, 6])
+    simd_shuffle!(a, b, [0, 4, 2, 6])
 }
 
 /// Unpacks and interleave single-precision (32-bit) floating-point elements
@@ -1792,7 +1792,7 @@ pub unsafe fn _mm256_unpacklo_pd(a: __m256d, b: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vunpcklps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_ps(a: __m256, b: __m256) -> __m256 {
-    simd_shuffle8!(a, b, [0, 8, 1, 9, 4, 12, 5, 13])
+    simd_shuffle!(a, b, [0, 8, 1, 9, 4, 12, 5, 13])
 }
 
 /// Computes the bitwise AND of 256 bits (representing integer data) in `a` and
@@ -2571,7 +2571,7 @@ pub unsafe fn _mm256_castsi256_pd(a: __m256i) -> __m256d {
 // instructions, thus it has zero latency.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_castps256_ps128(a: __m256) -> __m128 {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Casts vector of type __m256d to type __m128d.
@@ -2583,7 +2583,7 @@ pub unsafe fn _mm256_castps256_ps128(a: __m256) -> __m128 {
 // instructions, thus it has zero latency.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_castpd256_pd128(a: __m256d) -> __m128d {
-    simd_shuffle2!(a, a, [0, 1])
+    simd_shuffle!(a, a, [0, 1])
 }
 
 /// Casts vector of type __m256i to type __m128i.
@@ -2596,7 +2596,7 @@ pub unsafe fn _mm256_castpd256_pd128(a: __m256d) -> __m128d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_castsi256_si128(a: __m256i) -> __m128i {
     let a = a.as_i64x4();
-    let dst: i64x2 = simd_shuffle2!(a, a, [0, 1]);
+    let dst: i64x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(dst)
 }
 
@@ -2610,8 +2610,8 @@ pub unsafe fn _mm256_castsi256_si128(a: __m256i) -> __m128i {
 // instructions, thus it has zero latency.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_castps128_ps256(a: __m128) -> __m256 {
-    // FIXME simd_shuffle8!(a, a, [0, 1, 2, 3, -1, -1, -1, -1])
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 0, 0, 0, 0])
+    // FIXME simd_shuffle!(a, a, [0, 1, 2, 3, -1, -1, -1, -1])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 0, 0, 0, 0])
 }
 
 /// Casts vector of type __m128d to type __m256d;
@@ -2624,8 +2624,8 @@ pub unsafe fn _mm256_castps128_ps256(a: __m128) -> __m256 {
 // instructions, thus it has zero latency.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_castpd128_pd256(a: __m128d) -> __m256d {
-    // FIXME simd_shuffle4!(a, a, [0, 1, -1, -1])
-    simd_shuffle4!(a, a, [0, 1, 0, 0])
+    // FIXME simd_shuffle!(a, a, [0, 1, -1, -1])
+    simd_shuffle!(a, a, [0, 1, 0, 0])
 }
 
 /// Casts vector of type __m128i to type __m256i;
@@ -2639,8 +2639,8 @@ pub unsafe fn _mm256_castpd128_pd256(a: __m128d) -> __m256d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_castsi128_si256(a: __m128i) -> __m256i {
     let a = a.as_i64x2();
-    // FIXME simd_shuffle4!(a, a, [0, 1, -1, -1])
-    let dst: i64x4 = simd_shuffle4!(a, a, [0, 1, 0, 0]);
+    // FIXME simd_shuffle!(a, a, [0, 1, -1, -1])
+    let dst: i64x4 = simd_shuffle!(a, a, [0, 1, 0, 0]);
     transmute(dst)
 }
 
@@ -2655,7 +2655,7 @@ pub unsafe fn _mm256_castsi128_si256(a: __m128i) -> __m256i {
 // instructions, thus it has zero latency.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_zextps128_ps256(a: __m128) -> __m256 {
-    simd_shuffle8!(a, _mm_setzero_ps(), [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, _mm_setzero_ps(), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Constructs a 256-bit integer vector from a 128-bit integer vector.
@@ -2670,7 +2670,7 @@ pub unsafe fn _mm256_zextps128_ps256(a: __m128) -> __m256 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_zextsi128_si256(a: __m128i) -> __m256i {
     let b = _mm_setzero_si128().as_i64x2();
-    let dst: i64x4 = simd_shuffle4!(a.as_i64x2(), b, [0, 1, 2, 3]);
+    let dst: i64x4 = simd_shuffle!(a.as_i64x2(), b, [0, 1, 2, 3]);
     transmute(dst)
 }
 
@@ -2686,7 +2686,7 @@ pub unsafe fn _mm256_zextsi128_si256(a: __m128i) -> __m256i {
 // instructions, thus it has zero latency.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_zextpd128_pd256(a: __m128d) -> __m256d {
-    simd_shuffle4!(a, _mm_setzero_pd(), [0, 1, 2, 3])
+    simd_shuffle!(a, _mm_setzero_pd(), [0, 1, 2, 3])
 }
 
 /// Returns vector of type `__m256` with undefined elements.
@@ -2730,7 +2730,7 @@ pub unsafe fn _mm256_undefined_si256() -> __m256i {
 #[cfg_attr(test, assert_instr(vinsertf128))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_set_m128(hi: __m128, lo: __m128) -> __m256 {
-    simd_shuffle8!(lo, hi, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(lo, hi, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Sets packed __m256d returned vector with the supplied values.

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -175,7 +175,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
     let b = b.as_i8x32();
 
     let r: i8x32 = match IMM8 % 16 {
-        0 => simd_shuffle32!(
+        0 => simd_shuffle!(
             b,
             a,
             [
@@ -183,7 +183,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 23, 24, 25, 26, 27, 28, 29, 30, 31,
             ],
         ),
-        1 => simd_shuffle32!(
+        1 => simd_shuffle!(
             b,
             a,
             [
@@ -191,7 +191,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 24, 25, 26, 27, 28, 29, 30, 31, 48,
             ],
         ),
-        2 => simd_shuffle32!(
+        2 => simd_shuffle!(
             b,
             a,
             [
@@ -199,7 +199,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 25, 26, 27, 28, 29, 30, 31, 48, 49,
             ],
         ),
-        3 => simd_shuffle32!(
+        3 => simd_shuffle!(
             b,
             a,
             [
@@ -207,7 +207,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 25, 26, 27, 28, 29, 30, 31, 48, 49, 50,
             ],
         ),
-        4 => simd_shuffle32!(
+        4 => simd_shuffle!(
             b,
             a,
             [
@@ -215,7 +215,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 26, 27, 28, 29, 30, 31, 48, 49, 50, 51,
             ],
         ),
-        5 => simd_shuffle32!(
+        5 => simd_shuffle!(
             b,
             a,
             [
@@ -223,7 +223,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 27, 28, 29, 30, 31, 48, 49, 50, 51, 52,
             ],
         ),
-        6 => simd_shuffle32!(
+        6 => simd_shuffle!(
             b,
             a,
             [
@@ -231,7 +231,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 28, 29, 30, 31, 48, 49, 50, 51, 52, 53,
             ],
         ),
-        7 => simd_shuffle32!(
+        7 => simd_shuffle!(
             b,
             a,
             [
@@ -239,7 +239,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54,
             ],
         ),
-        8 => simd_shuffle32!(
+        8 => simd_shuffle!(
             b,
             a,
             [
@@ -247,7 +247,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55,
             ],
         ),
-        9 => simd_shuffle32!(
+        9 => simd_shuffle!(
             b,
             a,
             [
@@ -255,7 +255,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 30, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56,
             ],
         ),
-        10 => simd_shuffle32!(
+        10 => simd_shuffle!(
             b,
             a,
             [
@@ -263,7 +263,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 31, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
             ],
         ),
-        11 => simd_shuffle32!(
+        11 => simd_shuffle!(
             b,
             a,
             [
@@ -271,7 +271,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
             ],
         ),
-        12 => simd_shuffle32!(
+        12 => simd_shuffle!(
             b,
             a,
             [
@@ -279,7 +279,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
             ],
         ),
-        13 => simd_shuffle32!(
+        13 => simd_shuffle!(
             b,
             a,
             [
@@ -287,7 +287,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
             ],
         ),
-        14 => simd_shuffle32!(
+        14 => simd_shuffle!(
             b,
             a,
             [
@@ -295,7 +295,7 @@ pub unsafe fn _mm256_alignr_epi8<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
                 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
             ],
         ),
-        15 => simd_shuffle32!(
+        15 => simd_shuffle!(
             b,
             a,
             [
@@ -370,10 +370,10 @@ pub unsafe fn _mm_blend_epi32<const IMM4: i32>(a: __m128i, b: __m128i) -> __m128
     static_assert_imm4!(IMM4);
     let a = a.as_i32x4();
     let b = b.as_i32x4();
-    let r: i32x4 = simd_shuffle4!(
+    let r: i32x4 = simd_shuffle!(
         a,
         b,
-        <const IMM4: i32> [
+        [
             [0, 4, 0, 4][IMM4 as usize & 0b11],
             [1, 1, 5, 5][IMM4 as usize & 0b11],
             [2, 6, 2, 6][(IMM4 as usize >> 2) & 0b11],
@@ -395,10 +395,10 @@ pub unsafe fn _mm256_blend_epi32<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
     static_assert_imm8!(IMM8);
     let a = a.as_i32x8();
     let b = b.as_i32x8();
-    let r: i32x8 = simd_shuffle8!(
+    let r: i32x8 = simd_shuffle!(
         a,
         b,
-        <const IMM8: i32> [
+        [
             [0, 8, 0, 8][IMM8 as usize & 0b11],
             [1, 1, 9, 9][IMM8 as usize & 0b11],
             [2, 10, 2, 10][(IMM8 as usize >> 2) & 0b11],
@@ -425,10 +425,10 @@ pub unsafe fn _mm256_blend_epi16<const IMM8: i32>(a: __m256i, b: __m256i) -> __m
     let a = a.as_i16x16();
     let b = b.as_i16x16();
 
-    let r: i16x16 = simd_shuffle16!(
+    let r: i16x16 = simd_shuffle!(
         a,
         b,
-        <const IMM8: i32> [
+        [
             [0, 16, 0, 16][IMM8 as usize & 0b11],
             [1, 1, 17, 17][IMM8 as usize & 0b11],
             [2, 18, 2, 18][(IMM8 as usize >> 2) & 0b11],
@@ -471,7 +471,7 @@ pub unsafe fn _mm256_blendv_epi8(a: __m256i, b: __m256i, mask: __m256i) -> __m25
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_broadcastb_epi8(a: __m128i) -> __m128i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle16!(a.as_i8x16(), zero.as_i8x16(), [0_u32; 16]);
+    let ret = simd_shuffle!(a.as_i8x16(), zero.as_i8x16(), [0_u32; 16]);
     transmute::<i8x16, _>(ret)
 }
 
@@ -485,7 +485,7 @@ pub unsafe fn _mm_broadcastb_epi8(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastb_epi8(a: __m128i) -> __m256i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle32!(a.as_i8x16(), zero.as_i8x16(), [0_u32; 32]);
+    let ret = simd_shuffle!(a.as_i8x16(), zero.as_i8x16(), [0_u32; 32]);
     transmute::<i8x32, _>(ret)
 }
 
@@ -501,7 +501,7 @@ pub unsafe fn _mm256_broadcastb_epi8(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_broadcastd_epi32(a: __m128i) -> __m128i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle4!(a.as_i32x4(), zero.as_i32x4(), [0_u32; 4]);
+    let ret = simd_shuffle!(a.as_i32x4(), zero.as_i32x4(), [0_u32; 4]);
     transmute::<i32x4, _>(ret)
 }
 
@@ -517,7 +517,7 @@ pub unsafe fn _mm_broadcastd_epi32(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastd_epi32(a: __m128i) -> __m256i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle8!(a.as_i32x4(), zero.as_i32x4(), [0_u32; 8]);
+    let ret = simd_shuffle!(a.as_i32x4(), zero.as_i32x4(), [0_u32; 8]);
     transmute::<i32x8, _>(ret)
 }
 
@@ -532,7 +532,7 @@ pub unsafe fn _mm256_broadcastd_epi32(a: __m128i) -> __m256i {
 #[cfg_attr(test, assert_instr(vmovddup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_broadcastq_epi64(a: __m128i) -> __m128i {
-    let ret = simd_shuffle2!(a.as_i64x2(), a.as_i64x2(), [0_u32; 2]);
+    let ret = simd_shuffle!(a.as_i64x2(), a.as_i64x2(), [0_u32; 2]);
     transmute::<i64x2, _>(ret)
 }
 
@@ -545,7 +545,7 @@ pub unsafe fn _mm_broadcastq_epi64(a: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastq_epi64(a: __m128i) -> __m256i {
-    let ret = simd_shuffle4!(a.as_i64x2(), a.as_i64x2(), [0_u32; 4]);
+    let ret = simd_shuffle!(a.as_i64x2(), a.as_i64x2(), [0_u32; 4]);
     transmute::<i64x4, _>(ret)
 }
 
@@ -558,7 +558,7 @@ pub unsafe fn _mm256_broadcastq_epi64(a: __m128i) -> __m256i {
 #[cfg_attr(test, assert_instr(vmovddup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_broadcastsd_pd(a: __m128d) -> __m128d {
-    simd_shuffle2!(a, _mm_setzero_pd(), [0_u32; 2])
+    simd_shuffle!(a, _mm_setzero_pd(), [0_u32; 2])
 }
 
 /// Broadcasts the low double-precision (64-bit) floating-point element
@@ -570,7 +570,7 @@ pub unsafe fn _mm_broadcastsd_pd(a: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastsd_pd(a: __m128d) -> __m256d {
-    simd_shuffle4!(a, _mm_setzero_pd(), [0_u32; 4])
+    simd_shuffle!(a, _mm_setzero_pd(), [0_u32; 4])
 }
 
 // N.B., `broadcastsi128_si256` is often compiled to `vinsertf128` or
@@ -584,7 +584,7 @@ pub unsafe fn _mm256_broadcastsd_pd(a: __m128d) -> __m256d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastsi128_si256(a: __m128i) -> __m256i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle4!(a.as_i64x2(), zero.as_i64x2(), [0, 1, 0, 1]);
+    let ret = simd_shuffle!(a.as_i64x2(), zero.as_i64x2(), [0, 1, 0, 1]);
     transmute::<i64x4, _>(ret)
 }
 
@@ -597,7 +597,7 @@ pub unsafe fn _mm256_broadcastsi128_si256(a: __m128i) -> __m256i {
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_broadcastss_ps(a: __m128) -> __m128 {
-    simd_shuffle4!(a, _mm_setzero_ps(), [0_u32; 4])
+    simd_shuffle!(a, _mm_setzero_ps(), [0_u32; 4])
 }
 
 /// Broadcasts the low single-precision (32-bit) floating-point element
@@ -609,7 +609,7 @@ pub unsafe fn _mm_broadcastss_ps(a: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastss_ps(a: __m128) -> __m256 {
-    simd_shuffle8!(a, _mm_setzero_ps(), [0_u32; 8])
+    simd_shuffle!(a, _mm_setzero_ps(), [0_u32; 8])
 }
 
 /// Broadcasts the low packed 16-bit integer from a to all elements of
@@ -622,7 +622,7 @@ pub unsafe fn _mm256_broadcastss_ps(a: __m128) -> __m256 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_broadcastw_epi16(a: __m128i) -> __m128i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle8!(a.as_i16x8(), zero.as_i16x8(), [0_u32; 8]);
+    let ret = simd_shuffle!(a.as_i16x8(), zero.as_i16x8(), [0_u32; 8]);
     transmute::<i16x8, _>(ret)
 }
 
@@ -636,7 +636,7 @@ pub unsafe fn _mm_broadcastw_epi16(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_broadcastw_epi16(a: __m128i) -> __m256i {
     let zero = _mm_setzero_si128();
-    let ret = simd_shuffle16!(a.as_i16x8(), zero.as_i16x8(), [0_u32; 16]);
+    let ret = simd_shuffle!(a.as_i16x8(), zero.as_i16x8(), [0_u32; 16]);
     transmute::<i16x16, _>(ret)
 }
 
@@ -748,7 +748,7 @@ pub unsafe fn _mm256_cvtepi16_epi32(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtepi16_epi64(a: __m128i) -> __m256i {
     let a = a.as_i16x8();
-    let v64: i16x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let v64: i16x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute::<i64x4, _>(simd_cast(v64))
 }
 
@@ -783,7 +783,7 @@ pub unsafe fn _mm256_cvtepi8_epi16(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtepi8_epi32(a: __m128i) -> __m256i {
     let a = a.as_i8x16();
-    let v64: i8x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let v64: i8x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute::<i32x8, _>(simd_cast(v64))
 }
 
@@ -796,7 +796,7 @@ pub unsafe fn _mm256_cvtepi8_epi32(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtepi8_epi64(a: __m128i) -> __m256i {
     let a = a.as_i8x16();
-    let v32: i8x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let v32: i8x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute::<i64x4, _>(simd_cast(v32))
 }
 
@@ -822,7 +822,7 @@ pub unsafe fn _mm256_cvtepu16_epi32(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtepu16_epi64(a: __m128i) -> __m256i {
     let a = a.as_u16x8();
-    let v64: u16x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let v64: u16x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute::<i64x4, _>(simd_cast(v64))
 }
 
@@ -858,7 +858,7 @@ pub unsafe fn _mm256_cvtepu8_epi16(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtepu8_epi32(a: __m128i) -> __m256i {
     let a = a.as_u8x16();
-    let v64: u8x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let v64: u8x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute::<i32x8, _>(simd_cast(v64))
 }
 
@@ -872,7 +872,7 @@ pub unsafe fn _mm256_cvtepu8_epi32(a: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtepu8_epi64(a: __m128i) -> __m256i {
     let a = a.as_u8x16();
-    let v32: u8x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let v32: u8x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute::<i64x4, _>(simd_cast(v32))
 }
 
@@ -891,7 +891,7 @@ pub unsafe fn _mm256_extracti128_si256<const IMM1: i32>(a: __m256i) -> __m128i {
     static_assert_imm1!(IMM1);
     let a = a.as_i64x4();
     let b = _mm256_undefined_si256().as_i64x4();
-    let dst: i64x2 = simd_shuffle2!(a, b, <const IMM1: i32> [[0, 1], [2, 3]][IMM1 as usize]);
+    let dst: i64x2 = simd_shuffle!(a, b, [[0, 1], [2, 3]][IMM1 as usize]);
     transmute(dst)
 }
 
@@ -1713,8 +1713,7 @@ pub unsafe fn _mm256_inserti128_si256<const IMM1: i32>(a: __m256i, b: __m128i) -
     static_assert_imm1!(IMM1);
     let a = a.as_i64x4();
     let b = _mm256_castsi128_si256(b).as_i64x4();
-    let dst: i64x4 =
-        simd_shuffle4!(a, b, <const IMM1: i32> [[4, 5, 2, 3], [0, 1, 4, 5]][IMM1 as usize]);
+    let dst: i64x4 = simd_shuffle!(a, b, [[4, 5, 2, 3], [0, 1, 4, 5]][IMM1 as usize]);
     transmute(dst)
 }
 
@@ -2229,10 +2228,10 @@ pub unsafe fn _mm256_permutevar8x32_epi32(a: __m256i, b: __m256i) -> __m256i {
 pub unsafe fn _mm256_permute4x64_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_imm8!(IMM8);
     let zero = _mm256_setzero_si256().as_i64x4();
-    let r: i64x4 = simd_shuffle4!(
+    let r: i64x4 = simd_shuffle!(
         a.as_i64x4(),
         zero,
-        <const IMM8: i32> [
+        [
             IMM8 as u32 & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -2266,10 +2265,10 @@ pub unsafe fn _mm256_permute2x128_si256<const IMM8: i32>(a: __m256i, b: __m256i)
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_permute4x64_pd<const IMM8: i32>(a: __m256d) -> __m256d {
     static_assert_imm8!(IMM8);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         _mm256_undefined_pd(),
-        <const IMM8: i32> [
+        [
             IMM8 as u32 & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -2379,10 +2378,10 @@ pub unsafe fn _mm256_shuffle_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_shuffle_epi32<const MASK: i32>(a: __m256i) -> __m256i {
     static_assert_imm8!(MASK);
-    let r: i32x8 = simd_shuffle8!(
+    let r: i32x8 = simd_shuffle!(
         a.as_i32x8(),
         a.as_i32x8(),
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             (MASK as u32 >> 4) & 0b11,
@@ -2409,10 +2408,10 @@ pub unsafe fn _mm256_shuffle_epi32<const MASK: i32>(a: __m256i) -> __m256i {
 pub unsafe fn _mm256_shufflehi_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_imm8!(IMM8);
     let a = a.as_i16x16();
-    let r: i16x16 = simd_shuffle16!(
+    let r: i16x16 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             0,
             1,
             2,
@@ -2447,10 +2446,10 @@ pub unsafe fn _mm256_shufflehi_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
 pub unsafe fn _mm256_shufflelo_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_imm8!(IMM8);
     let a = a.as_i16x16();
-    let r: i16x16 = simd_shuffle16!(
+    let r: i16x16 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             0 + (IMM8 as u32 & 0b11),
             0 + ((IMM8 as u32 >> 2) & 0b11),
             0 + ((IMM8 as u32 >> 4) & 0b11),
@@ -2622,10 +2621,10 @@ pub unsafe fn _mm256_bslli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
     }
     let a = a.as_i8x32();
     let zero = _mm256_setzero_si256().as_i8x32();
-    let r: i8x32 = simd_shuffle32!(
+    let r: i8x32 = simd_shuffle!(
         zero,
         a,
-        <const IMM8: i32> [
+        [
             mask(IMM8, 0),
             mask(IMM8, 1),
             mask(IMM8, 2),
@@ -2817,7 +2816,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
     let a = a.as_i8x32();
     let zero = _mm256_setzero_si256().as_i8x32();
     let r: i8x32 = match IMM8 % 16 {
-        0 => simd_shuffle32!(
+        0 => simd_shuffle!(
             a,
             zero,
             [
@@ -2825,7 +2824,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 23, 24, 25, 26, 27, 28, 29, 30, 31,
             ],
         ),
-        1 => simd_shuffle32!(
+        1 => simd_shuffle!(
             a,
             zero,
             [
@@ -2833,7 +2832,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 24, 25, 26, 27, 28, 29, 30, 31, 32,
             ],
         ),
-        2 => simd_shuffle32!(
+        2 => simd_shuffle!(
             a,
             zero,
             [
@@ -2841,7 +2840,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 25, 26, 27, 28, 29, 30, 31, 32, 32,
             ],
         ),
-        3 => simd_shuffle32!(
+        3 => simd_shuffle!(
             a,
             zero,
             [
@@ -2849,7 +2848,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 25, 26, 27, 28, 29, 30, 31, 32, 32, 32,
             ],
         ),
-        4 => simd_shuffle32!(
+        4 => simd_shuffle!(
             a,
             zero,
             [
@@ -2857,7 +2856,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 26, 27, 28, 29, 30, 31, 32, 32, 32, 32,
             ],
         ),
-        5 => simd_shuffle32!(
+        5 => simd_shuffle!(
             a,
             zero,
             [
@@ -2865,7 +2864,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 27, 28, 29, 30, 31, 32, 32, 32, 32, 32,
             ],
         ),
-        6 => simd_shuffle32!(
+        6 => simd_shuffle!(
             a,
             zero,
             [
@@ -2873,7 +2872,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 28, 29, 30, 31, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        7 => simd_shuffle32!(
+        7 => simd_shuffle!(
             a,
             zero,
             [
@@ -2881,7 +2880,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 28, 29, 30, 31, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        8 => simd_shuffle32!(
+        8 => simd_shuffle!(
             a,
             zero,
             [
@@ -2889,7 +2888,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 29, 30, 31, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        9 => simd_shuffle32!(
+        9 => simd_shuffle!(
             a,
             zero,
             [
@@ -2897,7 +2896,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 30, 31, 32, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        10 => simd_shuffle32!(
+        10 => simd_shuffle!(
             a,
             zero,
             [
@@ -2905,7 +2904,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 31, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        11 => simd_shuffle32!(
+        11 => simd_shuffle!(
             a,
             zero,
             [
@@ -2913,7 +2912,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        12 => simd_shuffle32!(
+        12 => simd_shuffle!(
             a,
             zero,
             [
@@ -2921,7 +2920,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        13 => simd_shuffle32!(
+        13 => simd_shuffle!(
             a,
             zero,
             [
@@ -2929,7 +2928,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        14 => simd_shuffle32!(
+        14 => simd_shuffle!(
             a,
             zero,
             [
@@ -2937,7 +2936,7 @@ pub unsafe fn _mm256_bsrli_epi128<const IMM8: i32>(a: __m256i) -> __m256i {
                 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
             ],
         ),
-        15 => simd_shuffle32!(
+        15 => simd_shuffle!(
             a,
             zero,
             [
@@ -3215,7 +3214,7 @@ pub unsafe fn _mm256_subs_epu8(a: __m256i, b: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_epi8(a: __m256i, b: __m256i) -> __m256i {
     #[rustfmt::skip]
-    let r: i8x32 = simd_shuffle32!(a.as_i8x32(), b.as_i8x32(), [
+    let r: i8x32 = simd_shuffle!(a.as_i8x32(), b.as_i8x32(), [
             8, 40, 9, 41, 10, 42, 11, 43,
             12, 44, 13, 45, 14, 46, 15, 47,
             24, 56, 25, 57, 26, 58, 27, 59,
@@ -3268,7 +3267,7 @@ pub unsafe fn _mm256_unpackhi_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_epi8(a: __m256i, b: __m256i) -> __m256i {
     #[rustfmt::skip]
-    let r: i8x32 = simd_shuffle32!(a.as_i8x32(), b.as_i8x32(), [
+    let r: i8x32 = simd_shuffle!(a.as_i8x32(), b.as_i8x32(), [
         0, 32, 1, 33, 2, 34, 3, 35,
         4, 36, 5, 37, 6, 38, 7, 39,
         16, 48, 17, 49, 18, 50, 19, 51,
@@ -3316,7 +3315,7 @@ pub unsafe fn _mm256_unpacklo_epi8(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpunpckhwd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_epi16(a: __m256i, b: __m256i) -> __m256i {
-    let r: i16x16 = simd_shuffle16!(
+    let r: i16x16 = simd_shuffle!(
         a.as_i16x16(),
         b.as_i16x16(),
         [4, 20, 5, 21, 6, 22, 7, 23, 12, 28, 13, 29, 14, 30, 15, 31],
@@ -3364,7 +3363,7 @@ pub unsafe fn _mm256_unpackhi_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpunpcklwd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
-    let r: i16x16 = simd_shuffle16!(
+    let r: i16x16 = simd_shuffle!(
         a.as_i16x16(),
         b.as_i16x16(),
         [0, 16, 1, 17, 2, 18, 3, 19, 8, 24, 9, 25, 10, 26, 11, 27],
@@ -3405,7 +3404,7 @@ pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vunpckhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
-    let r: i32x8 = simd_shuffle8!(a.as_i32x8(), b.as_i32x8(), [2, 10, 3, 11, 6, 14, 7, 15]);
+    let r: i32x8 = simd_shuffle!(a.as_i32x8(), b.as_i32x8(), [2, 10, 3, 11, 6, 14, 7, 15]);
     transmute(r)
 }
 
@@ -3442,7 +3441,7 @@ pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vunpcklps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
-    let r: i32x8 = simd_shuffle8!(a.as_i32x8(), b.as_i32x8(), [0, 8, 1, 9, 4, 12, 5, 13]);
+    let r: i32x8 = simd_shuffle!(a.as_i32x8(), b.as_i32x8(), [0, 8, 1, 9, 4, 12, 5, 13]);
     transmute(r)
 }
 
@@ -3479,7 +3478,7 @@ pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vunpckhpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_epi64(a: __m256i, b: __m256i) -> __m256i {
-    let r: i64x4 = simd_shuffle4!(a.as_i64x4(), b.as_i64x4(), [1, 5, 3, 7]);
+    let r: i64x4 = simd_shuffle!(a.as_i64x4(), b.as_i64x4(), [1, 5, 3, 7]);
     transmute(r)
 }
 
@@ -3516,7 +3515,7 @@ pub unsafe fn _mm256_unpackhi_epi64(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vunpcklpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_epi64(a: __m256i, b: __m256i) -> __m256i {
-    let r: i64x4 = simd_shuffle4!(a.as_i64x4(), b.as_i64x4(), [0, 4, 2, 6]);
+    let r: i64x4 = simd_shuffle!(a.as_i64x4(), b.as_i64x4(), [0, 4, 2, 6]);
     transmute(r)
 }
 

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -6545,7 +6545,7 @@ pub unsafe fn _mm_mask_blend_epi8(k: __mmask16, a: __m128i, b: __m128i) -> __m12
 #[cfg_attr(test, assert_instr(vpbroadcastw))]
 pub unsafe fn _mm512_broadcastw_epi16(a: __m128i) -> __m512i {
     let a = _mm512_castsi128_si512(a).as_i16x32();
-    let ret: i16x32 = simd_shuffle32!(
+    let ret: i16x32 = simd_shuffle!(
         a,
         a,
         [
@@ -6633,7 +6633,7 @@ pub unsafe fn _mm_maskz_broadcastw_epi16(k: __mmask8, a: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(vpbroadcastb))]
 pub unsafe fn _mm512_broadcastb_epi8(a: __m128i) -> __m512i {
     let a = _mm512_castsi128_si512(a).as_i8x64();
-    let ret: i8x64 = simd_shuffle64!(
+    let ret: i8x64 = simd_shuffle!(
         a,
         a,
         [
@@ -6724,7 +6724,7 @@ pub unsafe fn _mm512_unpackhi_epi16(a: __m512i, b: __m512i) -> __m512i {
     let a = a.as_i16x32();
     let b = b.as_i16x32();
     #[rustfmt::skip]
-    let r: i16x32 = simd_shuffle32!(
+    let r: i16x32 = simd_shuffle!(
         a,
         b,
         [
@@ -6835,7 +6835,7 @@ pub unsafe fn _mm512_unpackhi_epi8(a: __m512i, b: __m512i) -> __m512i {
     let a = a.as_i8x64();
     let b = b.as_i8x64();
     #[rustfmt::skip]
-    let r: i8x64 = simd_shuffle64!(
+    let r: i8x64 = simd_shuffle!(
         a,
         b,
         [
@@ -6954,7 +6954,7 @@ pub unsafe fn _mm512_unpacklo_epi16(a: __m512i, b: __m512i) -> __m512i {
     let a = a.as_i16x32();
     let b = b.as_i16x32();
     #[rustfmt::skip]
-    let r: i16x32 = simd_shuffle32!(
+    let r: i16x32 = simd_shuffle!(
         a,
         b,
         [
@@ -7065,7 +7065,7 @@ pub unsafe fn _mm512_unpacklo_epi8(a: __m512i, b: __m512i) -> __m512i {
     let a = a.as_i8x64();
     let b = b.as_i8x64();
     #[rustfmt::skip]
-    let r: i8x64 = simd_shuffle64!(
+    let r: i8x64 = simd_shuffle!(
         a,
         b,
         [
@@ -7460,10 +7460,10 @@ pub unsafe fn _mm_maskz_set1_epi8(k: __mmask16, a: i8) -> __m128i {
 pub unsafe fn _mm512_shufflelo_epi16<const IMM8: i32>(a: __m512i) -> __m512i {
     static_assert_imm8!(IMM8);
     let a = a.as_i16x32();
-    let r: i16x32 = simd_shuffle32!(
+    let r: i16x32 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             IMM8 as u32 & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -7604,10 +7604,10 @@ pub unsafe fn _mm_maskz_shufflelo_epi16<const IMM8: i32>(k: __mmask8, a: __m128i
 pub unsafe fn _mm512_shufflehi_epi16<const IMM8: i32>(a: __m512i) -> __m512i {
     static_assert_imm8!(IMM8);
     let a = a.as_i16x32();
-    let r: i16x32 = simd_shuffle32!(
+    let r: i16x32 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             0,
             1,
             2,
@@ -8749,7 +8749,7 @@ pub unsafe fn _mm256_maskz_cvtepi16_epi8(k: __mmask16, a: __m256i) -> __m128i {
 pub unsafe fn _mm_cvtepi16_epi8(a: __m128i) -> __m128i {
     let a = a.as_i16x8();
     let zero = _mm_setzero_si128().as_i16x8();
-    let v256: i16x16 = simd_shuffle16!(a, zero, [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8, 8]);
+    let v256: i16x16 = simd_shuffle!(a, zero, [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8, 8]);
     transmute::<i8x16, _>(simd_cast(v256))
 }
 
@@ -9199,10 +9199,10 @@ pub unsafe fn _mm512_bslli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
     }
     let a = a.as_i8x64();
     let zero = _mm512_setzero_si512().as_i8x64();
-    let r: i8x64 = simd_shuffle64!(
+    let r: i8x64 = simd_shuffle!(
         zero,
         a,
-        <const IMM8: i32> [
+        [
             mask(IMM8, 0),
             mask(IMM8, 1),
             mask(IMM8, 2),
@@ -9284,7 +9284,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
     let a = a.as_i8x64();
     let zero = _mm512_setzero_si512().as_i8x64();
     let r: i8x64 = match IMM8 % 16 {
-        0 => simd_shuffle64!(
+        0 => simd_shuffle!(
             a,
             zero,
             [
@@ -9293,7 +9293,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
             ],
         ),
-        1 => simd_shuffle64!(
+        1 => simd_shuffle!(
             a,
             zero,
             [
@@ -9302,7 +9302,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 45, 46, 47, 96, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 112,
             ],
         ),
-        2 => simd_shuffle64!(
+        2 => simd_shuffle!(
             a,
             zero,
             [
@@ -9311,7 +9311,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 46, 47, 96, 97, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 112, 113,
             ],
         ),
-        3 => simd_shuffle64!(
+        3 => simd_shuffle!(
             a,
             zero,
             [
@@ -9321,7 +9321,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 114,
             ],
         ),
-        4 => simd_shuffle64!(
+        4 => simd_shuffle!(
             a,
             zero,
             [
@@ -9331,7 +9331,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 115,
             ],
         ),
-        5 => simd_shuffle64!(
+        5 => simd_shuffle!(
             a,
             zero,
             [
@@ -9341,7 +9341,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 115, 116,
             ],
         ),
-        6 => simd_shuffle64!(
+        6 => simd_shuffle!(
             a,
             zero,
             [
@@ -9351,7 +9351,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 116, 117,
             ],
         ),
-        7 => simd_shuffle64!(
+        7 => simd_shuffle!(
             a,
             zero,
             [
@@ -9361,7 +9361,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 116, 117, 118,
             ],
         ),
-        8 => simd_shuffle64!(
+        8 => simd_shuffle!(
             a,
             zero,
             [
@@ -9371,7 +9371,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 116, 117, 118, 119,
             ],
         ),
-        9 => simd_shuffle64!(
+        9 => simd_shuffle!(
             a,
             zero,
             [
@@ -9381,7 +9381,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 117, 118, 119, 120,
             ],
         ),
-        10 => simd_shuffle64!(
+        10 => simd_shuffle!(
             a,
             zero,
             [
@@ -9391,7 +9391,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 118, 119, 120, 121,
             ],
         ),
-        11 => simd_shuffle64!(
+        11 => simd_shuffle!(
             a,
             zero,
             [
@@ -9401,7 +9401,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 117, 118, 119, 120, 121, 122,
             ],
         ),
-        12 => simd_shuffle64!(
+        12 => simd_shuffle!(
             a,
             zero,
             [
@@ -9411,7 +9411,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 118, 119, 120, 121, 122, 123,
             ],
         ),
-        13 => simd_shuffle64!(
+        13 => simd_shuffle!(
             a,
             zero,
             [
@@ -9421,7 +9421,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 119, 120, 121, 122, 123, 124,
             ],
         ),
-        14 => simd_shuffle64!(
+        14 => simd_shuffle!(
             a,
             zero,
             [
@@ -9431,7 +9431,7 @@ pub unsafe fn _mm512_bsrli_epi128<const IMM8: i32>(a: __m512i) -> __m512i {
                 120, 121, 122, 123, 124, 125,
             ],
         ),
-        15 => simd_shuffle64!(
+        15 => simd_shuffle!(
             a,
             zero,
             [
@@ -9470,7 +9470,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
     let b = b.as_i8x64();
 
     let r: i8x64 = match IMM8 % 16 {
-        0 => simd_shuffle64!(
+        0 => simd_shuffle!(
             b,
             a,
             [
@@ -9479,7 +9479,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
             ],
         ),
-        1 => simd_shuffle64!(
+        1 => simd_shuffle!(
             b,
             a,
             [
@@ -9488,7 +9488,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 45, 46, 47, 96, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 112,
             ],
         ),
-        2 => simd_shuffle64!(
+        2 => simd_shuffle!(
             b,
             a,
             [
@@ -9497,7 +9497,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 46, 47, 96, 97, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 112, 113,
             ],
         ),
-        3 => simd_shuffle64!(
+        3 => simd_shuffle!(
             b,
             a,
             [
@@ -9507,7 +9507,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 114,
             ],
         ),
-        4 => simd_shuffle64!(
+        4 => simd_shuffle!(
             b,
             a,
             [
@@ -9517,7 +9517,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 115,
             ],
         ),
-        5 => simd_shuffle64!(
+        5 => simd_shuffle!(
             b,
             a,
             [
@@ -9527,7 +9527,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 115, 116,
             ],
         ),
-        6 => simd_shuffle64!(
+        6 => simd_shuffle!(
             b,
             a,
             [
@@ -9537,7 +9537,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 116, 117,
             ],
         ),
-        7 => simd_shuffle64!(
+        7 => simd_shuffle!(
             b,
             a,
             [
@@ -9547,7 +9547,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 116, 117, 118,
             ],
         ),
-        8 => simd_shuffle64!(
+        8 => simd_shuffle!(
             b,
             a,
             [
@@ -9557,7 +9557,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 116, 117, 118, 119,
             ],
         ),
-        9 => simd_shuffle64!(
+        9 => simd_shuffle!(
             b,
             a,
             [
@@ -9567,7 +9567,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 117, 118, 119, 120,
             ],
         ),
-        10 => simd_shuffle64!(
+        10 => simd_shuffle!(
             b,
             a,
             [
@@ -9577,7 +9577,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 118, 119, 120, 121,
             ],
         ),
-        11 => simd_shuffle64!(
+        11 => simd_shuffle!(
             b,
             a,
             [
@@ -9587,7 +9587,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 117, 118, 119, 120, 121, 122,
             ],
         ),
-        12 => simd_shuffle64!(
+        12 => simd_shuffle!(
             b,
             a,
             [
@@ -9597,7 +9597,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 118, 119, 120, 121, 122, 123,
             ],
         ),
-        13 => simd_shuffle64!(
+        13 => simd_shuffle!(
             b,
             a,
             [
@@ -9607,7 +9607,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 119, 120, 121, 122, 123, 124,
             ],
         ),
-        14 => simd_shuffle64!(
+        14 => simd_shuffle!(
             b,
             a,
             [
@@ -9617,7 +9617,7 @@ pub unsafe fn _mm512_alignr_epi8<const IMM8: i32>(a: __m512i, b: __m512i) -> __m
                 120, 121, 122, 123, 124, 125,
             ],
         ),
-        15 => simd_shuffle64!(
+        15 => simd_shuffle!(
             b,
             a,
             [

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -10561,7 +10561,7 @@ pub unsafe fn _mm512_cvtpd_pslo(v2: __m512d) -> __m512 {
         0b11111111,
         _MM_FROUND_CUR_DIRECTION,
     );
-    simd_shuffle16!(
+    simd_shuffle!(
         r,
         _mm256_setzero_ps().as_f32x8(),
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8, 8],
@@ -10581,7 +10581,7 @@ pub unsafe fn _mm512_mask_cvtpd_pslo(src: __m512, k: __mmask8, v2: __m512d) -> _
         k,
         _MM_FROUND_CUR_DIRECTION,
     );
-    simd_shuffle16!(
+    simd_shuffle!(
         r,
         _mm256_setzero_ps().as_f32x8(),
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8, 8],
@@ -10676,7 +10676,7 @@ pub unsafe fn _mm_maskz_cvtepi8_epi32(k: __mmask8, a: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(vpmovsxbq))]
 pub unsafe fn _mm512_cvtepi8_epi64(a: __m128i) -> __m512i {
     let a = a.as_i8x16();
-    let v64: i8x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let v64: i8x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute::<i64x8, _>(simd_cast(v64))
 }
 
@@ -10837,7 +10837,7 @@ pub unsafe fn _mm_maskz_cvtepu8_epi32(k: __mmask8, a: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(vpmovzxbq))]
 pub unsafe fn _mm512_cvtepu8_epi64(a: __m128i) -> __m512i {
     let a = a.as_u8x16();
-    let v64: u8x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let v64: u8x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute::<i64x8, _>(simd_cast(v64))
 }
 
@@ -11660,7 +11660,7 @@ pub unsafe fn _mm256_maskz_cvtepu32_pd(k: __mmask8, a: __m128i) -> __m256d {
 #[cfg_attr(test, assert_instr(vcvtudq2pd))]
 pub unsafe fn _mm_cvtepu32_pd(a: __m128i) -> __m128d {
     let a = a.as_u32x4();
-    let u64: u32x2 = simd_shuffle2!(a, a, [0, 1]);
+    let u64: u32x2 = simd_shuffle!(a, a, [0, 1]);
     transmute::<f64x2, _>(simd_cast(u64))
 }
 
@@ -11695,7 +11695,7 @@ pub unsafe fn _mm_maskz_cvtepu32_pd(k: __mmask8, a: __m128i) -> __m128d {
 #[cfg_attr(test, assert_instr(vcvtdq2pd))]
 pub unsafe fn _mm512_cvtepi32lo_pd(v2: __m512i) -> __m512d {
     let v2 = v2.as_i32x16();
-    let v256: i32x8 = simd_shuffle8!(v2, v2, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let v256: i32x8 = simd_shuffle!(v2, v2, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute::<f64x8, _>(simd_cast(v256))
 }
 
@@ -11718,7 +11718,7 @@ pub unsafe fn _mm512_mask_cvtepi32lo_pd(src: __m512d, k: __mmask8, v2: __m512i) 
 #[cfg_attr(test, assert_instr(vcvtudq2pd))]
 pub unsafe fn _mm512_cvtepu32lo_pd(v2: __m512i) -> __m512d {
     let v2 = v2.as_u32x16();
-    let v256: u32x8 = simd_shuffle8!(v2, v2, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let v256: u32x8 = simd_shuffle!(v2, v2, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute::<f64x8, _>(simd_cast(v256))
 }
 
@@ -19367,10 +19367,10 @@ pub unsafe fn _mm_maskz_srlv_epi64(k: __mmask8, a: __m128i, count: __m128i) -> _
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_permute_ps<const MASK: i32>(a: __m512) -> __m512 {
     static_assert_imm8!(MASK);
-    simd_shuffle16!(
+    simd_shuffle!(
         a,
         a,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11),
@@ -19485,10 +19485,10 @@ pub unsafe fn _mm_maskz_permute_ps<const MASK: i32>(k: __mmask8, a: __m128) -> _
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_permute_pd<const MASK: i32>(a: __m512d) -> __m512d {
     static_assert_imm8!(MASK);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         a,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b1,
             ((MASK as u32 >> 1) & 0b1),
             ((MASK as u32 >> 2) & 0b1) + 2,
@@ -19603,10 +19603,10 @@ pub unsafe fn _mm_maskz_permute_pd<const IMM2: i32>(k: __mmask8, a: __m128d) -> 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_permutex_epi64<const MASK: i32>(a: __m512i) -> __m512i {
     static_assert_imm8!(MASK);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         a,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11),
@@ -19659,10 +19659,10 @@ pub unsafe fn _mm512_maskz_permutex_epi64<const MASK: i32>(k: __mmask8, a: __m51
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_permutex_epi64<const MASK: i32>(a: __m256i) -> __m256i {
     static_assert_imm8!(MASK);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         a,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11),
@@ -19711,10 +19711,10 @@ pub unsafe fn _mm256_maskz_permutex_epi64<const MASK: i32>(k: __mmask8, a: __m25
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_permutex_pd<const MASK: i32>(a: __m512d) -> __m512d {
     static_assert_imm8!(MASK);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         a,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11),
@@ -19765,10 +19765,10 @@ pub unsafe fn _mm512_maskz_permutex_pd<const MASK: i32>(k: __mmask8, a: __m512d)
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_permutex_pd<const MASK: i32>(a: __m256d) -> __m256d {
     static_assert_imm8!(MASK);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         a,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11),
@@ -21019,10 +21019,10 @@ pub unsafe fn _mm_mask2_permutex2var_pd(
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_shuffle_epi32<const MASK: _MM_PERM_ENUM>(a: __m512i) -> __m512i {
     static_assert_imm8!(MASK);
-    let r: i32x16 = simd_shuffle16!(
+    let r: i32x16 = simd_shuffle!(
         a.as_i32x16(),
         a.as_i32x16(),
-        <const MASK: _MM_PERM_ENUM> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             (MASK as u32 >> 4) & 0b11,
@@ -21155,10 +21155,10 @@ pub unsafe fn _mm_maskz_shuffle_epi32<const MASK: _MM_PERM_ENUM>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_shuffle_ps<const MASK: i32>(a: __m512, b: __m512) -> __m512 {
     static_assert_imm8!(MASK);
-    simd_shuffle16!(
+    simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11) + 16,
@@ -21292,10 +21292,10 @@ pub unsafe fn _mm_maskz_shuffle_ps<const MASK: i32>(k: __mmask8, a: __m128, b: _
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_shuffle_pd<const MASK: i32>(a: __m512d, b: __m512d) -> __m512d {
     static_assert_imm8!(MASK);
-    simd_shuffle8!(
+    simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b1,
             ((MASK as u32 >> 1) & 0b1) + 8,
             ((MASK as u32 >> 2) & 0b1) + 2,
@@ -21427,10 +21427,10 @@ pub unsafe fn _mm512_shuffle_i32x4<const MASK: i32>(a: __m512i, b: __m512i) -> _
     static_assert_imm8!(MASK);
     let a = a.as_i32x16();
     let b = b.as_i32x16();
-    let r: i32x16 = simd_shuffle16!(
+    let r: i32x16 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b11) * 4 + 0,
             (MASK as u32 & 0b11) * 4 + 1,
             (MASK as u32 & 0b11) * 4 + 2,
@@ -21499,10 +21499,10 @@ pub unsafe fn _mm256_shuffle_i32x4<const MASK: i32>(a: __m256i, b: __m256i) -> _
     static_assert_imm8!(MASK);
     let a = a.as_i32x8();
     let b = b.as_i32x8();
-    let r: i32x8 = simd_shuffle8!(
+    let r: i32x8 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b1) * 4 + 0,
             (MASK as u32 & 0b1) * 4 + 1,
             (MASK as u32 & 0b1) * 4 + 2,
@@ -21563,10 +21563,10 @@ pub unsafe fn _mm512_shuffle_i64x2<const MASK: i32>(a: __m512i, b: __m512i) -> _
     static_assert_imm8!(MASK);
     let a = a.as_i64x8();
     let b = b.as_i64x8();
-    let r: i64x8 = simd_shuffle8!(
+    let r: i64x8 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b11) * 2 + 0,
             (MASK as u32 & 0b11) * 2 + 1,
             ((MASK as u32 >> 2) & 0b11) * 2 + 0,
@@ -21627,10 +21627,10 @@ pub unsafe fn _mm256_shuffle_i64x2<const MASK: i32>(a: __m256i, b: __m256i) -> _
     static_assert_imm8!(MASK);
     let a = a.as_i64x4();
     let b = b.as_i64x4();
-    let r: i64x4 = simd_shuffle4!(
+    let r: i64x4 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b1) * 2 + 0,
             (MASK as u32 & 0b1) * 2 + 1,
             ((MASK as u32 >> 1) & 0b1) * 2 + 0 + 4,
@@ -21687,10 +21687,10 @@ pub unsafe fn _mm512_shuffle_f32x4<const MASK: i32>(a: __m512, b: __m512) -> __m
     static_assert_imm8!(MASK);
     let a = a.as_f32x16();
     let b = b.as_f32x16();
-    let r: f32x16 = simd_shuffle16!(
+    let r: f32x16 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b11) * 4 + 0,
             (MASK as u32 & 0b11) * 4 + 1,
             (MASK as u32 & 0b11) * 4 + 2,
@@ -21759,10 +21759,10 @@ pub unsafe fn _mm256_shuffle_f32x4<const MASK: i32>(a: __m256, b: __m256) -> __m
     static_assert_imm8!(MASK);
     let a = a.as_f32x8();
     let b = b.as_f32x8();
-    let r: f32x8 = simd_shuffle8!(
+    let r: f32x8 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b1) * 4 + 0,
             (MASK as u32 & 0b1) * 4 + 1,
             (MASK as u32 & 0b1) * 4 + 2,
@@ -21823,10 +21823,10 @@ pub unsafe fn _mm512_shuffle_f64x2<const MASK: i32>(a: __m512d, b: __m512d) -> _
     static_assert_imm8!(MASK);
     let a = a.as_f64x8();
     let b = b.as_f64x8();
-    let r: f64x8 = simd_shuffle8!(
+    let r: f64x8 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b11) * 2 + 0,
             (MASK as u32 & 0b11) * 2 + 1,
             ((MASK as u32 >> 2) & 0b11) * 2 + 0,
@@ -21887,10 +21887,10 @@ pub unsafe fn _mm256_shuffle_f64x2<const MASK: i32>(a: __m256d, b: __m256d) -> _
     static_assert_imm8!(MASK);
     let a = a.as_f64x4();
     let b = b.as_f64x4();
-    let r: f64x4 = simd_shuffle4!(
+    let r: f64x4 = simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             (MASK as u32 & 0b1) * 2 + 0,
             (MASK as u32 & 0b1) * 2 + 1,
             ((MASK as u32 >> 1) & 0b1) * 2 + 0 + 4,
@@ -21949,10 +21949,10 @@ pub unsafe fn _mm256_maskz_shuffle_f64x2<const MASK: i32>(
 pub unsafe fn _mm512_extractf32x4_ps<const IMM8: i32>(a: __m512) -> __m128 {
     static_assert_imm2!(IMM8);
     match IMM8 & 0x3 {
-        0 => simd_shuffle4!(a, _mm512_undefined_ps(), [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, _mm512_undefined_ps(), [4, 5, 6, 7]),
-        2 => simd_shuffle4!(a, _mm512_undefined_ps(), [8, 9, 10, 11]),
-        _ => simd_shuffle4!(a, _mm512_undefined_ps(), [12, 13, 14, 15]),
+        0 => simd_shuffle!(a, _mm512_undefined_ps(), [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, _mm512_undefined_ps(), [4, 5, 6, 7]),
+        2 => simd_shuffle!(a, _mm512_undefined_ps(), [8, 9, 10, 11]),
+        _ => simd_shuffle!(a, _mm512_undefined_ps(), [12, 13, 14, 15]),
     }
 }
 
@@ -22006,8 +22006,8 @@ pub unsafe fn _mm512_maskz_extractf32x4_ps<const IMM8: i32>(k: __mmask8, a: __m5
 pub unsafe fn _mm256_extractf32x4_ps<const IMM8: i32>(a: __m256) -> __m128 {
     static_assert_imm1!(IMM8);
     match IMM8 & 0x1 {
-        0 => simd_shuffle4!(a, _mm256_undefined_ps(), [0, 1, 2, 3]),
-        _ => simd_shuffle4!(a, _mm256_undefined_ps(), [4, 5, 6, 7]),
+        0 => simd_shuffle!(a, _mm256_undefined_ps(), [0, 1, 2, 3]),
+        _ => simd_shuffle!(a, _mm256_undefined_ps(), [4, 5, 6, 7]),
     }
 }
 
@@ -22061,8 +22061,8 @@ pub unsafe fn _mm256_maskz_extractf32x4_ps<const IMM8: i32>(k: __mmask8, a: __m2
 pub unsafe fn _mm512_extracti64x4_epi64<const IMM1: i32>(a: __m512i) -> __m256i {
     static_assert_imm1!(IMM1);
     match IMM1 {
-        0 => simd_shuffle4!(a, _mm512_set1_epi64(0), [0, 1, 2, 3]),
-        _ => simd_shuffle4!(a, _mm512_set1_epi64(0), [4, 5, 6, 7]),
+        0 => simd_shuffle!(a, _mm512_set1_epi64(0), [0, 1, 2, 3]),
+        _ => simd_shuffle!(a, _mm512_set1_epi64(0), [4, 5, 6, 7]),
     }
 }
 
@@ -22116,8 +22116,8 @@ pub unsafe fn _mm512_maskz_extracti64x4_epi64<const IMM1: i32>(k: __mmask8, a: _
 pub unsafe fn _mm512_extractf64x4_pd<const IMM8: i32>(a: __m512d) -> __m256d {
     static_assert_imm1!(IMM8);
     match IMM8 & 0x1 {
-        0 => simd_shuffle4!(a, _mm512_undefined_pd(), [0, 1, 2, 3]),
-        _ => simd_shuffle4!(a, _mm512_undefined_pd(), [4, 5, 6, 7]),
+        0 => simd_shuffle!(a, _mm512_undefined_pd(), [0, 1, 2, 3]),
+        _ => simd_shuffle!(a, _mm512_undefined_pd(), [4, 5, 6, 7]),
     }
 }
 
@@ -22173,10 +22173,10 @@ pub unsafe fn _mm512_extracti32x4_epi32<const IMM2: i32>(a: __m512i) -> __m128i 
     let a = a.as_i32x16();
     let undefined = _mm512_undefined_epi32().as_i32x16();
     let extract: i32x4 = match IMM2 {
-        0 => simd_shuffle4!(a, undefined, [0, 1, 2, 3]),
-        1 => simd_shuffle4!(a, undefined, [4, 5, 6, 7]),
-        2 => simd_shuffle4!(a, undefined, [8, 9, 10, 11]),
-        _ => simd_shuffle4!(a, undefined, [12, 13, 14, 15]),
+        0 => simd_shuffle!(a, undefined, [0, 1, 2, 3]),
+        1 => simd_shuffle!(a, undefined, [4, 5, 6, 7]),
+        2 => simd_shuffle!(a, undefined, [8, 9, 10, 11]),
+        _ => simd_shuffle!(a, undefined, [12, 13, 14, 15]),
     };
     transmute(extract)
 }
@@ -22233,8 +22233,8 @@ pub unsafe fn _mm256_extracti32x4_epi32<const IMM1: i32>(a: __m256i) -> __m128i 
     let a = a.as_i32x8();
     let undefined = _mm256_undefined_si256().as_i32x8();
     let extract: i32x4 = match IMM1 {
-        0 => simd_shuffle4!(a, undefined, [0, 1, 2, 3]),
-        _ => simd_shuffle4!(a, undefined, [4, 5, 6, 7]),
+        0 => simd_shuffle!(a, undefined, [0, 1, 2, 3]),
+        _ => simd_shuffle!(a, undefined, [4, 5, 6, 7]),
     };
     transmute(extract)
 }
@@ -22283,7 +22283,7 @@ pub unsafe fn _mm256_maskz_extracti32x4_epi32<const IMM1: i32>(k: __mmask8, a: _
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovsldup))]
 pub unsafe fn _mm512_moveldup_ps(a: __m512) -> __m512 {
-    let r: f32x16 = simd_shuffle16!(a, a, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14]);
+    let r: f32x16 = simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14]);
     transmute(r)
 }
 
@@ -22294,7 +22294,7 @@ pub unsafe fn _mm512_moveldup_ps(a: __m512) -> __m512 {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovsldup))]
 pub unsafe fn _mm512_mask_moveldup_ps(src: __m512, k: __mmask16, a: __m512) -> __m512 {
-    let mov: f32x16 = simd_shuffle16!(a, a, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14]);
+    let mov: f32x16 = simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14]);
     transmute(simd_select_bitmask(k, mov, src.as_f32x16()))
 }
 
@@ -22305,7 +22305,7 @@ pub unsafe fn _mm512_mask_moveldup_ps(src: __m512, k: __mmask16, a: __m512) -> _
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovsldup))]
 pub unsafe fn _mm512_maskz_moveldup_ps(k: __mmask16, a: __m512) -> __m512 {
-    let mov: f32x16 = simd_shuffle16!(a, a, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14]);
+    let mov: f32x16 = simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14]);
     let zero = _mm512_setzero_ps().as_f32x16();
     transmute(simd_select_bitmask(k, mov, zero))
 }
@@ -22363,7 +22363,7 @@ pub unsafe fn _mm_maskz_moveldup_ps(k: __mmask8, a: __m128) -> __m128 {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovshdup))]
 pub unsafe fn _mm512_movehdup_ps(a: __m512) -> __m512 {
-    let r: f32x16 = simd_shuffle16!(a, a, [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15]);
+    let r: f32x16 = simd_shuffle!(a, a, [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15]);
     transmute(r)
 }
 
@@ -22374,7 +22374,7 @@ pub unsafe fn _mm512_movehdup_ps(a: __m512) -> __m512 {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovshdup))]
 pub unsafe fn _mm512_mask_movehdup_ps(src: __m512, k: __mmask16, a: __m512) -> __m512 {
-    let mov: f32x16 = simd_shuffle16!(a, a, [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15]);
+    let mov: f32x16 = simd_shuffle!(a, a, [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15]);
     transmute(simd_select_bitmask(k, mov, src.as_f32x16()))
 }
 
@@ -22385,7 +22385,7 @@ pub unsafe fn _mm512_mask_movehdup_ps(src: __m512, k: __mmask16, a: __m512) -> _
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovshdup))]
 pub unsafe fn _mm512_maskz_movehdup_ps(k: __mmask16, a: __m512) -> __m512 {
-    let mov: f32x16 = simd_shuffle16!(a, a, [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15]);
+    let mov: f32x16 = simd_shuffle!(a, a, [1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15]);
     let zero = _mm512_setzero_ps().as_f32x16();
     transmute(simd_select_bitmask(k, mov, zero))
 }
@@ -22443,7 +22443,7 @@ pub unsafe fn _mm_maskz_movehdup_ps(k: __mmask8, a: __m128) -> __m128 {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovddup))]
 pub unsafe fn _mm512_movedup_pd(a: __m512d) -> __m512d {
-    let r: f64x8 = simd_shuffle8!(a, a, [0, 0, 2, 2, 4, 4, 6, 6]);
+    let r: f64x8 = simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6]);
     transmute(r)
 }
 
@@ -22454,7 +22454,7 @@ pub unsafe fn _mm512_movedup_pd(a: __m512d) -> __m512d {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovddup))]
 pub unsafe fn _mm512_mask_movedup_pd(src: __m512d, k: __mmask8, a: __m512d) -> __m512d {
-    let mov: f64x8 = simd_shuffle8!(a, a, [0, 0, 2, 2, 4, 4, 6, 6]);
+    let mov: f64x8 = simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6]);
     transmute(simd_select_bitmask(k, mov, src.as_f64x8()))
 }
 
@@ -22465,7 +22465,7 @@ pub unsafe fn _mm512_mask_movedup_pd(src: __m512d, k: __mmask8, a: __m512d) -> _
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vmovddup))]
 pub unsafe fn _mm512_maskz_movedup_pd(k: __mmask8, a: __m512d) -> __m512d {
-    let mov: f64x8 = simd_shuffle8!(a, a, [0, 0, 2, 2, 4, 4, 6, 6]);
+    let mov: f64x8 = simd_shuffle!(a, a, [0, 0, 2, 2, 4, 4, 6, 6]);
     let zero = _mm512_setzero_pd().as_f64x8();
     transmute(simd_select_bitmask(k, mov, zero))
 }
@@ -22528,22 +22528,22 @@ pub unsafe fn _mm512_inserti32x4<const IMM8: i32>(a: __m512i, b: __m128i) -> __m
     let a = a.as_i32x16();
     let b = _mm512_castsi128_si512(b).as_i32x16();
     let ret: i32x16 = match IMM8 & 0b11 {
-        0 => simd_shuffle16!(
+        0 => simd_shuffle!(
             a,
             b,
             [16, 17, 18, 19, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         ),
-        1 => simd_shuffle16!(
+        1 => simd_shuffle!(
             a,
             b,
             [0, 1, 2, 3, 16, 17, 18, 19, 8, 9, 10, 11, 12, 13, 14, 15],
         ),
-        2 => simd_shuffle16!(
+        2 => simd_shuffle!(
             a,
             b,
             [0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 12, 13, 14, 15],
         ),
-        _ => simd_shuffle16!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19]),
+        _ => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19]),
     };
     transmute(ret)
 }
@@ -22599,8 +22599,8 @@ pub unsafe fn _mm256_inserti32x4<const IMM8: i32>(a: __m256i, b: __m128i) -> __m
     let a = a.as_i32x8();
     let b = _mm256_castsi128_si256(b).as_i32x8();
     let ret: i32x8 = match IMM8 & 0b1 {
-        0 => simd_shuffle8!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
-        _ => simd_shuffle8!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
+        0 => simd_shuffle!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
+        _ => simd_shuffle!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
     };
     transmute(ret)
 }
@@ -22658,8 +22658,8 @@ pub unsafe fn _mm512_inserti64x4<const IMM8: i32>(a: __m512i, b: __m256i) -> __m
     static_assert_imm1!(IMM8);
     let b = _mm512_castsi256_si512(b);
     match IMM8 & 0b1 {
-        0 => simd_shuffle8!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
-        _ => simd_shuffle8!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
+        0 => simd_shuffle!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
+        _ => simd_shuffle!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
     }
 }
 
@@ -22710,22 +22710,22 @@ pub unsafe fn _mm512_insertf32x4<const IMM8: i32>(a: __m512, b: __m128) -> __m51
     static_assert_imm2!(IMM8);
     let b = _mm512_castps128_ps512(b);
     match IMM8 & 0b11 {
-        0 => simd_shuffle16!(
+        0 => simd_shuffle!(
             a,
             b,
             [16, 17, 18, 19, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         ),
-        1 => simd_shuffle16!(
+        1 => simd_shuffle!(
             a,
             b,
             [0, 1, 2, 3, 16, 17, 18, 19, 8, 9, 10, 11, 12, 13, 14, 15],
         ),
-        2 => simd_shuffle16!(
+        2 => simd_shuffle!(
             a,
             b,
             [0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 12, 13, 14, 15],
         ),
-        _ => simd_shuffle16!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19]),
+        _ => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 17, 18, 19]),
     }
 }
 
@@ -22779,8 +22779,8 @@ pub unsafe fn _mm256_insertf32x4<const IMM8: i32>(a: __m256, b: __m128) -> __m25
     static_assert_imm1!(IMM8);
     let b = _mm256_castps128_ps256(b);
     match IMM8 & 0b1 {
-        0 => simd_shuffle8!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
-        _ => simd_shuffle8!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
+        0 => simd_shuffle!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
+        _ => simd_shuffle!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
     }
 }
 
@@ -22837,8 +22837,8 @@ pub unsafe fn _mm512_insertf64x4<const IMM8: i32>(a: __m512d, b: __m256d) -> __m
     static_assert_imm1!(IMM8);
     let b = _mm512_castpd256_pd512(b);
     match IMM8 & 0b1 {
-        0 => simd_shuffle8!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
-        _ => simd_shuffle8!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
+        0 => simd_shuffle!(a, b, [8, 9, 10, 11, 4, 5, 6, 7]),
+        _ => simd_shuffle!(a, b, [0, 1, 2, 3, 8, 9, 10, 11]),
     }
 }
 
@@ -22888,7 +22888,7 @@ pub unsafe fn _mm512_unpackhi_epi32(a: __m512i, b: __m512i) -> __m512i {
     let a = a.as_i32x16();
     let b = b.as_i32x16();
     #[rustfmt::skip]
-    let r: i32x16 = simd_shuffle16!(
+    let r: i32x16 = simd_shuffle!(
         a, b,
         [ 2, 18, 3, 19,
           2 + 4, 18 + 4, 3 + 4, 19 + 4,
@@ -22989,7 +22989,7 @@ pub unsafe fn _mm_maskz_unpackhi_epi32(k: __mmask8, a: __m128i, b: __m128i) -> _
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vunpckhpd))] //should be vpunpckhqdq
 pub unsafe fn _mm512_unpackhi_epi64(a: __m512i, b: __m512i) -> __m512i {
-    simd_shuffle8!(a, b, [1, 9, 1 + 2, 9 + 2, 1 + 4, 9 + 4, 1 + 6, 9 + 6])
+    simd_shuffle!(a, b, [1, 9, 1 + 2, 9 + 2, 1 + 4, 9 + 4, 1 + 6, 9 + 6])
 }
 
 /// Unpack and interleave 64-bit integers from the high half of each 128-bit lane in a and b, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -23084,7 +23084,7 @@ pub unsafe fn _mm_maskz_unpackhi_epi64(k: __mmask8, a: __m128i, b: __m128i) -> _
 #[cfg_attr(test, assert_instr(vunpckhps))]
 pub unsafe fn _mm512_unpackhi_ps(a: __m512, b: __m512) -> __m512 {
     #[rustfmt::skip]
-    simd_shuffle16!(
+    simd_shuffle!(
         a, b,
         [ 2, 18, 3, 19,
           2 + 4, 18 + 4, 3 + 4, 19 + 4,
@@ -23169,7 +23169,7 @@ pub unsafe fn _mm_maskz_unpackhi_ps(k: __mmask8, a: __m128, b: __m128) -> __m128
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vunpckhpd))]
 pub unsafe fn _mm512_unpackhi_pd(a: __m512d, b: __m512d) -> __m512d {
-    simd_shuffle8!(a, b, [1, 9, 1 + 2, 9 + 2, 1 + 4, 9 + 4, 1 + 6, 9 + 6])
+    simd_shuffle!(a, b, [1, 9, 1 + 2, 9 + 2, 1 + 4, 9 + 4, 1 + 6, 9 + 6])
 }
 
 /// Unpack and interleave double-precision (64-bit) floating-point elements from the high half of each 128-bit lane in a and b, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -23261,7 +23261,7 @@ pub unsafe fn _mm512_unpacklo_epi32(a: __m512i, b: __m512i) -> __m512i {
     let a = a.as_i32x16();
     let b = b.as_i32x16();
     #[rustfmt::skip]
-    let r: i32x16 = simd_shuffle16!(
+    let r: i32x16 = simd_shuffle!(
         a, b,
         [ 0, 16, 1, 17,
           0 + 4, 16 + 4, 1 + 4, 17 + 4,
@@ -23362,7 +23362,7 @@ pub unsafe fn _mm_maskz_unpacklo_epi32(k: __mmask8, a: __m128i, b: __m128i) -> _
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vunpcklpd))] //should be vpunpcklqdq
 pub unsafe fn _mm512_unpacklo_epi64(a: __m512i, b: __m512i) -> __m512i {
-    simd_shuffle8!(a, b, [0, 8, 0 + 2, 8 + 2, 0 + 4, 8 + 4, 0 + 6, 8 + 6])
+    simd_shuffle!(a, b, [0, 8, 0 + 2, 8 + 2, 0 + 4, 8 + 4, 0 + 6, 8 + 6])
 }
 
 /// Unpack and interleave 64-bit integers from the low half of each 128-bit lane in a and b, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -23457,7 +23457,7 @@ pub unsafe fn _mm_maskz_unpacklo_epi64(k: __mmask8, a: __m128i, b: __m128i) -> _
 #[cfg_attr(test, assert_instr(vunpcklps))]
 pub unsafe fn _mm512_unpacklo_ps(a: __m512, b: __m512) -> __m512 {
     #[rustfmt::skip]
-    simd_shuffle16!(a, b,
+    simd_shuffle!(a, b,
                    [ 0, 16, 1, 17,
                      0 + 4, 16 + 4, 1 + 4, 17 + 4,
                      0 + 8, 16 + 8, 1 + 8, 17 + 8,
@@ -23541,7 +23541,7 @@ pub unsafe fn _mm_maskz_unpacklo_ps(k: __mmask8, a: __m128, b: __m128) -> __m128
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vunpcklpd))]
 pub unsafe fn _mm512_unpacklo_pd(a: __m512d, b: __m512d) -> __m512d {
-    simd_shuffle8!(a, b, [0, 8, 0 + 2, 8 + 2, 0 + 4, 8 + 4, 0 + 6, 8 + 6])
+    simd_shuffle!(a, b, [0, 8, 0 + 2, 8 + 2, 0 + 4, 8 + 4, 0 + 6, 8 + 6])
 }
 
 /// Unpack and interleave double-precision (64-bit) floating-point elements from the low half of each 128-bit lane in a and b, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -23629,7 +23629,7 @@ pub unsafe fn _mm_maskz_unpacklo_pd(k: __mmask8, a: __m128d, b: __m128d) -> __m1
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castps128_ps512(a: __m128) -> __m512 {
-    simd_shuffle16!(
+    simd_shuffle!(
         a,
         _mm_set1_ps(-1.),
         [0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
@@ -23642,7 +23642,7 @@ pub unsafe fn _mm512_castps128_ps512(a: __m128) -> __m512 {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castps256_ps512(a: __m256) -> __m512 {
-    simd_shuffle16!(
+    simd_shuffle!(
         a,
         _mm256_set1_ps(-1.),
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8, 8],
@@ -23655,7 +23655,7 @@ pub unsafe fn _mm512_castps256_ps512(a: __m256) -> __m512 {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_zextps128_ps512(a: __m128) -> __m512 {
-    simd_shuffle16!(
+    simd_shuffle!(
         a,
         _mm_set1_ps(0.),
         [0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
@@ -23668,7 +23668,7 @@ pub unsafe fn _mm512_zextps128_ps512(a: __m128) -> __m512 {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_zextps256_ps512(a: __m256) -> __m512 {
-    simd_shuffle16!(
+    simd_shuffle!(
         a,
         _mm256_set1_ps(0.),
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8, 8],
@@ -23681,7 +23681,7 @@ pub unsafe fn _mm512_zextps256_ps512(a: __m256) -> __m512 {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castps512_ps128(a: __m512) -> __m128 {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Cast vector of type __m512 to type __m256. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23690,7 +23690,7 @@ pub unsafe fn _mm512_castps512_ps128(a: __m512) -> __m128 {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castps512_ps256(a: __m512) -> __m256 {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
 /// Cast vector of type __m512 to type __m512d. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23717,7 +23717,7 @@ pub unsafe fn _mm512_castps_si512(a: __m512) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castpd128_pd512(a: __m128d) -> __m512d {
-    simd_shuffle8!(a, _mm_set1_pd(-1.), [0, 1, 2, 2, 2, 2, 2, 2])
+    simd_shuffle!(a, _mm_set1_pd(-1.), [0, 1, 2, 2, 2, 2, 2, 2])
 }
 
 /// Cast vector of type __m256d to type __m512d; the upper 256 bits of the result are undefined. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23726,7 +23726,7 @@ pub unsafe fn _mm512_castpd128_pd512(a: __m128d) -> __m512d {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castpd256_pd512(a: __m256d) -> __m512d {
-    simd_shuffle8!(a, _mm256_set1_pd(-1.), [0, 1, 2, 3, 4, 4, 4, 4])
+    simd_shuffle!(a, _mm256_set1_pd(-1.), [0, 1, 2, 3, 4, 4, 4, 4])
 }
 
 /// Cast vector of type __m128d to type __m512d; the upper 384 bits of the result are zeroed. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23735,7 +23735,7 @@ pub unsafe fn _mm512_castpd256_pd512(a: __m256d) -> __m512d {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_zextpd128_pd512(a: __m128d) -> __m512d {
-    simd_shuffle8!(a, _mm_set1_pd(0.), [0, 1, 2, 2, 2, 2, 2, 2])
+    simd_shuffle!(a, _mm_set1_pd(0.), [0, 1, 2, 2, 2, 2, 2, 2])
 }
 
 /// Cast vector of type __m256d to type __m512d; the upper 256 bits of the result are zeroed. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23744,7 +23744,7 @@ pub unsafe fn _mm512_zextpd128_pd512(a: __m128d) -> __m512d {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_zextpd256_pd512(a: __m256d) -> __m512d {
-    simd_shuffle8!(a, _mm256_set1_pd(0.), [0, 1, 2, 3, 4, 4, 4, 4])
+    simd_shuffle!(a, _mm256_set1_pd(0.), [0, 1, 2, 3, 4, 4, 4, 4])
 }
 
 /// Cast vector of type __m512d to type __m128d. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23753,7 +23753,7 @@ pub unsafe fn _mm512_zextpd256_pd512(a: __m256d) -> __m512d {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castpd512_pd128(a: __m512d) -> __m128d {
-    simd_shuffle2!(a, a, [0, 1])
+    simd_shuffle!(a, a, [0, 1])
 }
 
 /// Cast vector of type __m512d to type __m256d. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23762,7 +23762,7 @@ pub unsafe fn _mm512_castpd512_pd128(a: __m512d) -> __m128d {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castpd512_pd256(a: __m512d) -> __m256d {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Cast vector of type __m512d to type __m512. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23789,7 +23789,7 @@ pub unsafe fn _mm512_castpd_si512(a: __m512d) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castsi128_si512(a: __m128i) -> __m512i {
-    simd_shuffle8!(a, _mm_set1_epi64x(-1), [0, 1, 2, 2, 2, 2, 2, 2])
+    simd_shuffle!(a, _mm_set1_epi64x(-1), [0, 1, 2, 2, 2, 2, 2, 2])
 }
 
 /// Cast vector of type __m256i to type __m512i; the upper 256 bits of the result are undefined. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23798,7 +23798,7 @@ pub unsafe fn _mm512_castsi128_si512(a: __m128i) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castsi256_si512(a: __m256i) -> __m512i {
-    simd_shuffle8!(a, _mm256_set1_epi64x(-1), [0, 1, 2, 3, 4, 4, 4, 4])
+    simd_shuffle!(a, _mm256_set1_epi64x(-1), [0, 1, 2, 3, 4, 4, 4, 4])
 }
 
 /// Cast vector of type __m128i to type __m512i; the upper 384 bits of the result are zeroed. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23807,7 +23807,7 @@ pub unsafe fn _mm512_castsi256_si512(a: __m256i) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_zextsi128_si512(a: __m128i) -> __m512i {
-    simd_shuffle8!(a, _mm_set1_epi64x(0), [0, 1, 2, 2, 2, 2, 2, 2])
+    simd_shuffle!(a, _mm_set1_epi64x(0), [0, 1, 2, 2, 2, 2, 2, 2])
 }
 
 /// Cast vector of type __m256i to type __m512i; the upper 256 bits of the result are zeroed. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23816,7 +23816,7 @@ pub unsafe fn _mm512_zextsi128_si512(a: __m128i) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_zextsi256_si512(a: __m256i) -> __m512i {
-    simd_shuffle8!(a, _mm256_set1_epi64x(0), [0, 1, 2, 3, 4, 4, 4, 4])
+    simd_shuffle!(a, _mm256_set1_epi64x(0), [0, 1, 2, 3, 4, 4, 4, 4])
 }
 
 /// Cast vector of type __m512i to type __m128i. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23825,7 +23825,7 @@ pub unsafe fn _mm512_zextsi256_si512(a: __m256i) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castsi512_si128(a: __m512i) -> __m128i {
-    simd_shuffle2!(a, a, [0, 1])
+    simd_shuffle!(a, a, [0, 1])
 }
 
 /// Cast vector of type __m512i to type __m256i. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23834,7 +23834,7 @@ pub unsafe fn _mm512_castsi512_si128(a: __m512i) -> __m128i {
 #[inline]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn _mm512_castsi512_si256(a: __m512i) -> __m256i {
-    simd_shuffle4!(a, a, [0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3])
 }
 
 /// Cast vector of type __m512i to type __m512. This intrinsic is only used for compilation and does not generate any instructions, thus it has zero latency.
@@ -23874,7 +23874,7 @@ pub unsafe fn _mm512_cvtsi512_si32(a: __m512i) -> i32 {
 #[cfg_attr(test, assert_instr(vbroadcast))] //should be vpbroadcastd
 pub unsafe fn _mm512_broadcastd_epi32(a: __m128i) -> __m512i {
     let a = _mm512_castsi128_si512(a).as_i32x16();
-    let ret: i32x16 = simd_shuffle16!(a, a, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let ret: i32x16 = simd_shuffle!(a, a, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     transmute(ret)
 }
 
@@ -23954,7 +23954,7 @@ pub unsafe fn _mm_maskz_broadcastd_epi32(k: __mmask8, a: __m128i) -> __m128i {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vbroadcas))] //should be vpbroadcastq
 pub unsafe fn _mm512_broadcastq_epi64(a: __m128i) -> __m512i {
-    simd_shuffle8!(a, a, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(a, a, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Broadcast the low packed 64-bit integer from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24033,7 +24033,7 @@ pub unsafe fn _mm_maskz_broadcastq_epi64(k: __mmask8, a: __m128i) -> __m128i {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm512_broadcastss_ps(a: __m128) -> __m512 {
-    simd_shuffle16!(a, a, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(a, a, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Broadcast the low single-precision (32-bit) floating-point element from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24112,7 +24112,7 @@ pub unsafe fn _mm_maskz_broadcastss_ps(k: __mmask8, a: __m128) -> __m128 {
 #[target_feature(enable = "avx512f")]
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 pub unsafe fn _mm512_broadcastsd_pd(a: __m128d) -> __m512d {
-    simd_shuffle8!(a, a, [0, 0, 0, 0, 0, 0, 0, 0])
+    simd_shuffle!(a, a, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 /// Broadcast the low double-precision (64-bit) floating-point element from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24168,7 +24168,7 @@ pub unsafe fn _mm256_maskz_broadcastsd_pd(k: __mmask8, a: __m128d) -> __m256d {
 #[target_feature(enable = "avx512f")] //msvc: vbroadcasti32x4, linux: vshuf
 pub unsafe fn _mm512_broadcast_i32x4(a: __m128i) -> __m512i {
     let a = a.as_i32x4();
-    let ret: i32x16 = simd_shuffle16!(a, a, [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]);
+    let ret: i32x16 = simd_shuffle!(a, a, [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]);
     transmute(ret)
 }
 
@@ -24200,7 +24200,7 @@ pub unsafe fn _mm512_maskz_broadcast_i32x4(k: __mmask16, a: __m128i) -> __m512i 
 #[target_feature(enable = "avx512f,avx512vl")] //msvc: vbroadcasti32x4, linux: vshuf
 pub unsafe fn _mm256_broadcast_i32x4(a: __m128i) -> __m256i {
     let a = a.as_i32x4();
-    let ret: i32x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 0, 1, 2, 3]);
+    let ret: i32x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 0, 1, 2, 3]);
     transmute(ret)
 }
 
@@ -24231,7 +24231,7 @@ pub unsafe fn _mm256_maskz_broadcast_i32x4(k: __mmask8, a: __m128i) -> __m256i {
 #[inline]
 #[target_feature(enable = "avx512f")] //msvc: vbroadcasti64x4, linux: vperm
 pub unsafe fn _mm512_broadcast_i64x4(a: __m256i) -> __m512i {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 0, 1, 2, 3])
 }
 
 /// Broadcast the 4 packed 64-bit integers from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24261,7 +24261,7 @@ pub unsafe fn _mm512_maskz_broadcast_i64x4(k: __mmask8, a: __m256i) -> __m512i {
 #[inline]
 #[target_feature(enable = "avx512f")] //msvc: vbroadcastf32x4, linux: vshuf
 pub unsafe fn _mm512_broadcast_f32x4(a: __m128) -> __m512 {
-    simd_shuffle16!(a, a, [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3])
 }
 
 /// Broadcast the 4 packed single-precision (32-bit) floating-point elements from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24291,7 +24291,7 @@ pub unsafe fn _mm512_maskz_broadcast_f32x4(k: __mmask16, a: __m128) -> __m512 {
 #[inline]
 #[target_feature(enable = "avx512f,avx512vl")] //msvc: vbroadcastf32x4, linux: vshuf
 pub unsafe fn _mm256_broadcast_f32x4(a: __m128) -> __m256 {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 0, 1, 2, 3])
 }
 
 /// Broadcast the 4 packed single-precision (32-bit) floating-point elements from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24321,7 +24321,7 @@ pub unsafe fn _mm256_maskz_broadcast_f32x4(k: __mmask8, a: __m128) -> __m256 {
 #[inline]
 #[target_feature(enable = "avx512f")] //msvc: vbroadcastf64x4, linux: vperm
 pub unsafe fn _mm512_broadcast_f64x4(a: __m256d) -> __m512d {
-    simd_shuffle8!(a, a, [0, 1, 2, 3, 0, 1, 2, 3])
+    simd_shuffle!(a, a, [0, 1, 2, 3, 0, 1, 2, 3])
 }
 
 /// Broadcast the 4 packed double-precision (64-bit) floating-point elements from a to all elements of dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -24478,62 +24478,62 @@ pub unsafe fn _mm512_alignr_epi32<const IMM8: i32>(a: __m512i, b: __m512i) -> __
     let b = b.as_i32x16();
     let imm8: i32 = IMM8 % 16;
     let r: i32x16 = match imm8 {
-        0 => simd_shuffle16!(
+        0 => simd_shuffle!(
             a,
             b,
             [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,],
         ),
-        1 => simd_shuffle16!(
+        1 => simd_shuffle!(
             a,
             b,
             [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0,],
         ),
-        2 => simd_shuffle16!(
+        2 => simd_shuffle!(
             a,
             b,
             [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1],
         ),
-        3 => simd_shuffle16!(
+        3 => simd_shuffle!(
             a,
             b,
             [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2],
         ),
-        4 => simd_shuffle16!(
+        4 => simd_shuffle!(
             a,
             b,
             [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3],
         ),
-        5 => simd_shuffle16!(
+        5 => simd_shuffle!(
             a,
             b,
             [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4],
         ),
-        6 => simd_shuffle16!(
+        6 => simd_shuffle!(
             a,
             b,
             [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5],
         ),
-        7 => simd_shuffle16!(
+        7 => simd_shuffle!(
             a,
             b,
             [23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6],
         ),
-        8 => simd_shuffle16!(
+        8 => simd_shuffle!(
             a,
             b,
             [24, 25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7],
         ),
-        9 => simd_shuffle16!(
+        9 => simd_shuffle!(
             a,
             b,
             [25, 26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8],
         ),
-        10 => simd_shuffle16!(a, b, [26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-        11 => simd_shuffle16!(a, b, [27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
-        12 => simd_shuffle16!(a, b, [28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-        13 => simd_shuffle16!(a, b, [29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-        14 => simd_shuffle16!(a, b, [30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
-        _ => simd_shuffle16!(a, b, [31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]),
+        10 => simd_shuffle!(a, b, [26, 27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        11 => simd_shuffle!(a, b, [27, 28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        12 => simd_shuffle!(a, b, [28, 29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+        13 => simd_shuffle!(a, b, [29, 30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        14 => simd_shuffle!(a, b, [30, 31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+        _ => simd_shuffle!(a, b, [31, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]),
     };
     transmute(r)
 }
@@ -24587,22 +24587,22 @@ pub unsafe fn _mm256_alignr_epi32<const IMM8: i32>(a: __m256i, b: __m256i) -> __
     let b = b.as_i32x8();
     let imm8: i32 = IMM8 % 16;
     let r: i32x8 = match imm8 {
-        0 => simd_shuffle8!(a, b, [8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle8!(a, b, [9, 10, 11, 12, 13, 14, 15, 0]),
-        2 => simd_shuffle8!(a, b, [10, 11, 12, 13, 14, 15, 0, 1]),
-        3 => simd_shuffle8!(a, b, [11, 12, 13, 14, 15, 0, 1, 2]),
-        4 => simd_shuffle8!(a, b, [12, 13, 14, 15, 0, 1, 2, 3]),
-        5 => simd_shuffle8!(a, b, [13, 14, 15, 0, 1, 2, 3, 4]),
-        6 => simd_shuffle8!(a, b, [14, 15, 0, 1, 2, 3, 4, 5]),
-        7 => simd_shuffle8!(a, b, [15, 0, 1, 2, 3, 4, 5, 6]),
-        8 => simd_shuffle8!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
-        9 => simd_shuffle8!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
-        10 => simd_shuffle8!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
-        11 => simd_shuffle8!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
-        12 => simd_shuffle8!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
-        13 => simd_shuffle8!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
-        14 => simd_shuffle8!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
-        _ => simd_shuffle8!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
+        0 => simd_shuffle!(a, b, [8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [9, 10, 11, 12, 13, 14, 15, 0]),
+        2 => simd_shuffle!(a, b, [10, 11, 12, 13, 14, 15, 0, 1]),
+        3 => simd_shuffle!(a, b, [11, 12, 13, 14, 15, 0, 1, 2]),
+        4 => simd_shuffle!(a, b, [12, 13, 14, 15, 0, 1, 2, 3]),
+        5 => simd_shuffle!(a, b, [13, 14, 15, 0, 1, 2, 3, 4]),
+        6 => simd_shuffle!(a, b, [14, 15, 0, 1, 2, 3, 4, 5]),
+        7 => simd_shuffle!(a, b, [15, 0, 1, 2, 3, 4, 5, 6]),
+        8 => simd_shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7]),
+        9 => simd_shuffle!(a, b, [1, 2, 3, 4, 5, 6, 7, 8]),
+        10 => simd_shuffle!(a, b, [2, 3, 4, 5, 6, 7, 8, 9]),
+        11 => simd_shuffle!(a, b, [3, 4, 5, 6, 7, 8, 9, 10]),
+        12 => simd_shuffle!(a, b, [4, 5, 6, 7, 8, 9, 10, 11]),
+        13 => simd_shuffle!(a, b, [5, 6, 7, 8, 9, 10, 11, 12]),
+        14 => simd_shuffle!(a, b, [6, 7, 8, 9, 10, 11, 12, 13]),
+        _ => simd_shuffle!(a, b, [7, 8, 9, 10, 11, 12, 13, 14]),
     };
     transmute(r)
 }
@@ -24656,14 +24656,14 @@ pub unsafe fn _mm_alignr_epi32<const IMM8: i32>(a: __m128i, b: __m128i) -> __m12
     let b = b.as_i32x4();
     let imm8: i32 = IMM8 % 8;
     let r: i32x4 = match imm8 {
-        0 => simd_shuffle4!(a, b, [4, 5, 6, 7]),
-        1 => simd_shuffle4!(a, b, [5, 6, 7, 0]),
-        2 => simd_shuffle4!(a, b, [6, 7, 0, 1]),
-        3 => simd_shuffle4!(a, b, [7, 0, 1, 2]),
-        4 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        5 => simd_shuffle4!(a, b, [1, 2, 3, 0]),
-        6 => simd_shuffle4!(a, b, [2, 3, 0, 1]),
-        _ => simd_shuffle4!(a, b, [3, 0, 1, 2]),
+        0 => simd_shuffle!(a, b, [4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [5, 6, 7, 0]),
+        2 => simd_shuffle!(a, b, [6, 7, 0, 1]),
+        3 => simd_shuffle!(a, b, [7, 0, 1, 2]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        5 => simd_shuffle!(a, b, [1, 2, 3, 0]),
+        6 => simd_shuffle!(a, b, [2, 3, 0, 1]),
+        _ => simd_shuffle!(a, b, [3, 0, 1, 2]),
     };
     transmute(r)
 }
@@ -24715,14 +24715,14 @@ pub unsafe fn _mm512_alignr_epi64<const IMM8: i32>(a: __m512i, b: __m512i) -> __
     static_assert_imm8!(IMM8);
     let imm8: i32 = IMM8 % 8;
     let r: i64x8 = match imm8 {
-        0 => simd_shuffle8!(a, b, [8, 9, 10, 11, 12, 13, 14, 15]),
-        1 => simd_shuffle8!(a, b, [9, 10, 11, 12, 13, 14, 15, 0]),
-        2 => simd_shuffle8!(a, b, [10, 11, 12, 13, 14, 15, 0, 1]),
-        3 => simd_shuffle8!(a, b, [11, 12, 13, 14, 15, 0, 1, 2]),
-        4 => simd_shuffle8!(a, b, [12, 13, 14, 15, 0, 1, 2, 3]),
-        5 => simd_shuffle8!(a, b, [13, 14, 15, 0, 1, 2, 3, 4]),
-        6 => simd_shuffle8!(a, b, [14, 15, 0, 1, 2, 3, 4, 5]),
-        _ => simd_shuffle8!(a, b, [15, 0, 1, 2, 3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [8, 9, 10, 11, 12, 13, 14, 15]),
+        1 => simd_shuffle!(a, b, [9, 10, 11, 12, 13, 14, 15, 0]),
+        2 => simd_shuffle!(a, b, [10, 11, 12, 13, 14, 15, 0, 1]),
+        3 => simd_shuffle!(a, b, [11, 12, 13, 14, 15, 0, 1, 2]),
+        4 => simd_shuffle!(a, b, [12, 13, 14, 15, 0, 1, 2, 3]),
+        5 => simd_shuffle!(a, b, [13, 14, 15, 0, 1, 2, 3, 4]),
+        6 => simd_shuffle!(a, b, [14, 15, 0, 1, 2, 3, 4, 5]),
+        _ => simd_shuffle!(a, b, [15, 0, 1, 2, 3, 4, 5, 6]),
     };
     transmute(r)
 }
@@ -24774,14 +24774,14 @@ pub unsafe fn _mm256_alignr_epi64<const IMM8: i32>(a: __m256i, b: __m256i) -> __
     static_assert_imm8!(IMM8);
     let imm8: i32 = IMM8 % 8;
     let r: i64x4 = match imm8 {
-        0 => simd_shuffle4!(a, b, [4, 5, 6, 7]),
-        1 => simd_shuffle4!(a, b, [5, 6, 7, 0]),
-        2 => simd_shuffle4!(a, b, [6, 7, 0, 1]),
-        3 => simd_shuffle4!(a, b, [7, 0, 1, 2]),
-        4 => simd_shuffle4!(a, b, [0, 1, 2, 3]),
-        5 => simd_shuffle4!(a, b, [1, 2, 3, 4]),
-        6 => simd_shuffle4!(a, b, [2, 3, 4, 5]),
-        _ => simd_shuffle4!(a, b, [3, 4, 5, 6]),
+        0 => simd_shuffle!(a, b, [4, 5, 6, 7]),
+        1 => simd_shuffle!(a, b, [5, 6, 7, 0]),
+        2 => simd_shuffle!(a, b, [6, 7, 0, 1]),
+        3 => simd_shuffle!(a, b, [7, 0, 1, 2]),
+        4 => simd_shuffle!(a, b, [0, 1, 2, 3]),
+        5 => simd_shuffle!(a, b, [1, 2, 3, 4]),
+        6 => simd_shuffle!(a, b, [2, 3, 4, 5]),
+        _ => simd_shuffle!(a, b, [3, 4, 5, 6]),
     };
     transmute(r)
 }
@@ -24833,10 +24833,10 @@ pub unsafe fn _mm_alignr_epi64<const IMM8: i32>(a: __m128i, b: __m128i) -> __m12
     static_assert_imm8!(IMM8);
     let imm8: i32 = IMM8 % 4;
     let r: i64x2 = match imm8 {
-        0 => simd_shuffle2!(a, b, [2, 3]),
-        1 => simd_shuffle2!(a, b, [3, 0]),
-        2 => simd_shuffle2!(a, b, [0, 1]),
-        _ => simd_shuffle2!(a, b, [1, 2]),
+        0 => simd_shuffle!(a, b, [2, 3]),
+        1 => simd_shuffle!(a, b, [3, 0]),
+        2 => simd_shuffle!(a, b, [0, 1]),
+        _ => simd_shuffle!(a, b, [1, 2]),
     };
     transmute(r)
 }

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -350,7 +350,7 @@ pub unsafe fn _mm_cmple_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(cmpltss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cmpgt_ss(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, cmpss(b, a, 1), [4, 1, 2, 3])
+    simd_shuffle!(a, cmpss(b, a, 1), [4, 1, 2, 3])
 }
 
 /// Compares the lowest `f32` of both inputs for greater than or equal. The
@@ -364,7 +364,7 @@ pub unsafe fn _mm_cmpgt_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(cmpless))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cmpge_ss(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, cmpss(b, a, 2), [4, 1, 2, 3])
+    simd_shuffle!(a, cmpss(b, a, 2), [4, 1, 2, 3])
 }
 
 /// Compares the lowest `f32` of both inputs for inequality. The lowest 32 bits
@@ -420,7 +420,7 @@ pub unsafe fn _mm_cmpnle_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(cmpnltss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cmpngt_ss(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, cmpss(b, a, 5), [4, 1, 2, 3])
+    simd_shuffle!(a, cmpss(b, a, 5), [4, 1, 2, 3])
 }
 
 /// Compares the lowest `f32` of both inputs for not-greater-than-or-equal. The
@@ -434,7 +434,7 @@ pub unsafe fn _mm_cmpngt_ss(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(cmpnless))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cmpnge_ss(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, cmpss(b, a, 6), [4, 1, 2, 3])
+    simd_shuffle!(a, cmpss(b, a, 6), [4, 1, 2, 3])
 }
 
 /// Checks if the lowest `f32` of both inputs are ordered. The lowest 32 bits of
@@ -1011,10 +1011,10 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_shuffle_ps<const MASK: i32>(a: __m128, b: __m128) -> __m128 {
     static_assert_imm8!(MASK);
-    simd_shuffle4!(
+    simd_shuffle!(
         a,
         b,
-        <const MASK: i32> [
+        [
             MASK as u32 & 0b11,
             (MASK as u32 >> 2) & 0b11,
             ((MASK as u32 >> 4) & 0b11) + 4,
@@ -1032,7 +1032,7 @@ pub unsafe fn _mm_shuffle_ps<const MASK: i32>(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(unpckhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_ps(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, b, [2, 6, 3, 7])
+    simd_shuffle!(a, b, [2, 6, 3, 7])
 }
 
 /// Unpacks and interleave single-precision (32-bit) floating-point elements
@@ -1044,7 +1044,7 @@ pub unsafe fn _mm_unpackhi_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(unpcklps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_ps(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, b, [0, 4, 1, 5])
+    simd_shuffle!(a, b, [0, 4, 1, 5])
 }
 
 /// Combine higher half of `a` and `b`. The highwe half of `b` occupies the
@@ -1057,7 +1057,7 @@ pub unsafe fn _mm_unpacklo_ps(a: __m128, b: __m128) -> __m128 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_movehl_ps(a: __m128, b: __m128) -> __m128 {
     // TODO; figure why this is a different instruction on Windows?
-    simd_shuffle4!(a, b, [6, 7, 2, 3])
+    simd_shuffle!(a, b, [6, 7, 2, 3])
 }
 
 /// Combine lower half of `a` and `b`. The lower half of `b` occupies the
@@ -1069,7 +1069,7 @@ pub unsafe fn _mm_movehl_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(all(test, not(target_os = "windows")), assert_instr(movlhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_movelh_ps(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, b, [0, 1, 4, 5])
+    simd_shuffle!(a, b, [0, 1, 4, 5])
 }
 
 /// Returns a mask of the most significant bit of each element in `a`.
@@ -1198,7 +1198,7 @@ pub unsafe fn _mm_loadu_ps(p: *const f32) -> __m128 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_loadr_ps(p: *const f32) -> __m128 {
     let a = _mm_load_ps(p);
-    simd_shuffle4!(a, a, [3, 2, 1, 0])
+    simd_shuffle!(a, a, [3, 2, 1, 0])
 }
 
 /// Loads unaligned 64-bits of integer data from memory into new vector.
@@ -1250,7 +1250,7 @@ pub unsafe fn _mm_store_ss(p: *mut f32, a: __m128) {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe fn _mm_store1_ps(p: *mut f32, a: __m128) {
-    let b: __m128 = simd_shuffle4!(a, a, [0, 0, 0, 0]);
+    let b: __m128 = simd_shuffle!(a, a, [0, 0, 0, 0]);
     *(p as *mut __m128) = b;
 }
 
@@ -1326,7 +1326,7 @@ pub unsafe fn _mm_storeu_ps(p: *mut f32, a: __m128) {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe fn _mm_storer_ps(p: *mut f32, a: __m128) {
-    let b: __m128 = simd_shuffle4!(a, a, [3, 2, 1, 0]);
+    let b: __m128 = simd_shuffle!(a, a, [3, 2, 1, 0]);
     *(p as *mut __m128) = b;
 }
 
@@ -1344,7 +1344,7 @@ pub unsafe fn _mm_storer_ps(p: *mut f32, a: __m128) {
 #[cfg_attr(test, assert_instr(movss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_move_ss(a: __m128, b: __m128) -> __m128 {
-    simd_shuffle4!(a, b, [4, 1, 2, 3])
+    simd_shuffle!(a, b, [4, 1, 2, 3])
 }
 
 /// Performs a serializing operation on all store-to-memory instructions that

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -441,10 +441,10 @@ unsafe fn _mm_slli_si128_impl<const IMM8: i32>(a: __m128i) -> __m128i {
         }
     }
     let zero = _mm_set1_epi8(0).as_i8x16();
-    transmute::<i8x16, _>(simd_shuffle16!(
+    transmute::<i8x16, _>(simd_shuffle!(
         zero,
         a.as_i8x16(),
-        <const IMM8: i32> [
+        [
             mask(IMM8, 0),
             mask(IMM8, 1),
             mask(IMM8, 2),
@@ -644,10 +644,10 @@ unsafe fn _mm_srli_si128_impl<const IMM8: i32>(a: __m128i) -> __m128i {
         }
     }
     let zero = _mm_set1_epi8(0).as_i8x16();
-    let x: i8x16 = simd_shuffle16!(
+    let x: i8x16 = simd_shuffle!(
         a.as_i8x16(),
         zero,
-        <const IMM8: i32> [
+        [
             mask(IMM8, 0),
             mask(IMM8, 1),
             mask(IMM8, 2),
@@ -904,7 +904,7 @@ pub unsafe fn _mm_cmplt_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi32_pd(a: __m128i) -> __m128d {
     let a = a.as_i32x4();
-    simd_cast::<i32x2, __m128d>(simd_shuffle2!(a, a, [0, 1]))
+    simd_cast::<i32x2, __m128d>(simd_shuffle!(a, a, [0, 1]))
 }
 
 /// Returns `a` with its lower element replaced by `b` after converting it to
@@ -1312,7 +1312,7 @@ pub unsafe fn _mm_stream_si32(mem_addr: *mut i32, a: i32) {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_move_epi64(a: __m128i) -> __m128i {
     let zero = _mm_setzero_si128();
-    let r: i64x2 = simd_shuffle2!(a.as_i64x2(), zero.as_i64x2(), [0, 2]);
+    let r: i64x2 = simd_shuffle!(a.as_i64x2(), zero.as_i64x2(), [0, 2]);
     transmute(r)
 }
 
@@ -1402,10 +1402,10 @@ pub unsafe fn _mm_movemask_epi8(a: __m128i) -> i32 {
 pub unsafe fn _mm_shuffle_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
     static_assert_imm8!(IMM8);
     let a = a.as_i32x4();
-    let x: i32x4 = simd_shuffle4!(
+    let x: i32x4 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             IMM8 as u32 & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -1430,10 +1430,10 @@ pub unsafe fn _mm_shuffle_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
 pub unsafe fn _mm_shufflehi_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
     static_assert_imm8!(IMM8);
     let a = a.as_i16x8();
-    let x: i16x8 = simd_shuffle8!(
+    let x: i16x8 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             0,
             1,
             2,
@@ -1462,10 +1462,10 @@ pub unsafe fn _mm_shufflehi_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
 pub unsafe fn _mm_shufflelo_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
     static_assert_imm8!(IMM8);
     let a = a.as_i16x8();
-    let x: i16x8 = simd_shuffle8!(
+    let x: i16x8 = simd_shuffle!(
         a,
         a,
-        <const IMM8: i32> [
+        [
             IMM8 as u32 & 0b11,
             (IMM8 as u32 >> 2) & 0b11,
             (IMM8 as u32 >> 4) & 0b11,
@@ -1487,7 +1487,7 @@ pub unsafe fn _mm_shufflelo_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(punpckhbw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi8(a: __m128i, b: __m128i) -> __m128i {
-    transmute::<i8x16, _>(simd_shuffle16!(
+    transmute::<i8x16, _>(simd_shuffle!(
         a.as_i8x16(),
         b.as_i8x16(),
         [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31],
@@ -1502,7 +1502,7 @@ pub unsafe fn _mm_unpackhi_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(punpckhwd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi16(a: __m128i, b: __m128i) -> __m128i {
-    let x = simd_shuffle8!(a.as_i16x8(), b.as_i16x8(), [4, 12, 5, 13, 6, 14, 7, 15]);
+    let x = simd_shuffle!(a.as_i16x8(), b.as_i16x8(), [4, 12, 5, 13, 6, 14, 7, 15]);
     transmute::<i16x8, _>(x)
 }
 
@@ -1514,7 +1514,7 @@ pub unsafe fn _mm_unpackhi_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(unpckhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi32(a: __m128i, b: __m128i) -> __m128i {
-    transmute::<i32x4, _>(simd_shuffle4!(a.as_i32x4(), b.as_i32x4(), [2, 6, 3, 7]))
+    transmute::<i32x4, _>(simd_shuffle!(a.as_i32x4(), b.as_i32x4(), [2, 6, 3, 7]))
 }
 
 /// Unpacks and interleave 64-bit integers from the high half of `a` and `b`.
@@ -1525,7 +1525,7 @@ pub unsafe fn _mm_unpackhi_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(unpckhpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi64(a: __m128i, b: __m128i) -> __m128i {
-    transmute::<i64x2, _>(simd_shuffle2!(a.as_i64x2(), b.as_i64x2(), [1, 3]))
+    transmute::<i64x2, _>(simd_shuffle!(a.as_i64x2(), b.as_i64x2(), [1, 3]))
 }
 
 /// Unpacks and interleave 8-bit integers from the low half of `a` and `b`.
@@ -1536,7 +1536,7 @@ pub unsafe fn _mm_unpackhi_epi64(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(punpcklbw))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi8(a: __m128i, b: __m128i) -> __m128i {
-    transmute::<i8x16, _>(simd_shuffle16!(
+    transmute::<i8x16, _>(simd_shuffle!(
         a.as_i8x16(),
         b.as_i8x16(),
         [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23],
@@ -1551,7 +1551,7 @@ pub unsafe fn _mm_unpacklo_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(punpcklwd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi16(a: __m128i, b: __m128i) -> __m128i {
-    let x = simd_shuffle8!(a.as_i16x8(), b.as_i16x8(), [0, 8, 1, 9, 2, 10, 3, 11]);
+    let x = simd_shuffle!(a.as_i16x8(), b.as_i16x8(), [0, 8, 1, 9, 2, 10, 3, 11]);
     transmute::<i16x8, _>(x)
 }
 
@@ -1563,7 +1563,7 @@ pub unsafe fn _mm_unpacklo_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(unpcklps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi32(a: __m128i, b: __m128i) -> __m128i {
-    transmute::<i32x4, _>(simd_shuffle4!(a.as_i32x4(), b.as_i32x4(), [0, 4, 1, 5]))
+    transmute::<i32x4, _>(simd_shuffle!(a.as_i32x4(), b.as_i32x4(), [0, 4, 1, 5]))
 }
 
 /// Unpacks and interleave 64-bit integers from the low half of `a` and `b`.
@@ -1574,7 +1574,7 @@ pub unsafe fn _mm_unpacklo_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(all(test, not(target_os = "windows")), assert_instr(movlhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi64(a: __m128i, b: __m128i) -> __m128i {
-    transmute::<i64x2, _>(simd_shuffle2!(a.as_i64x2(), b.as_i64x2(), [0, 2]))
+    transmute::<i64x2, _>(simd_shuffle!(a.as_i64x2(), b.as_i64x2(), [0, 2]))
 }
 
 /// Returns a new vector with the low element of `a` replaced by the sum of the
@@ -2530,7 +2530,7 @@ pub unsafe fn _mm_storeu_pd(mem_addr: *mut f64, a: __m128d) {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe fn _mm_store1_pd(mem_addr: *mut f64, a: __m128d) {
-    let b: __m128d = simd_shuffle2!(a, a, [0, 0]);
+    let b: __m128d = simd_shuffle!(a, a, [0, 0]);
     *(mem_addr as *mut __m128d) = b;
 }
 
@@ -2544,7 +2544,7 @@ pub unsafe fn _mm_store1_pd(mem_addr: *mut f64, a: __m128d) {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe fn _mm_store_pd1(mem_addr: *mut f64, a: __m128d) {
-    let b: __m128d = simd_shuffle2!(a, a, [0, 0]);
+    let b: __m128d = simd_shuffle!(a, a, [0, 0]);
     *(mem_addr as *mut __m128d) = b;
 }
 
@@ -2559,7 +2559,7 @@ pub unsafe fn _mm_store_pd1(mem_addr: *mut f64, a: __m128d) {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe fn _mm_storer_pd(mem_addr: *mut f64, a: __m128d) {
-    let b: __m128d = simd_shuffle2!(a, a, [1, 0]);
+    let b: __m128d = simd_shuffle!(a, a, [1, 0]);
     *(mem_addr as *mut __m128d) = b;
 }
 
@@ -2623,7 +2623,7 @@ pub unsafe fn _mm_load_pd1(mem_addr: *const f64) -> __m128d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_loadr_pd(mem_addr: *const f64) -> __m128d {
     let a = _mm_load_pd(mem_addr);
-    simd_shuffle2!(a, a, [1, 0])
+    simd_shuffle!(a, a, [1, 0])
 }
 
 /// Loads 128-bits (composed of 2 packed double-precision (64-bit)
@@ -2657,7 +2657,7 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> __m128d {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_shuffle_pd<const MASK: i32>(a: __m128d, b: __m128d) -> __m128d {
     static_assert_imm8!(MASK);
-    simd_shuffle2!(a, b, <const MASK: i32> [MASK as u32 & 0b1, ((MASK as u32 >> 1) & 0b1) + 2])
+    simd_shuffle!(a, b, [MASK as u32 & 0b1, ((MASK as u32 >> 1) & 0b1) + 2])
 }
 
 /// Constructs a 128-bit floating-point vector of `[2 x double]`. The lower
@@ -2772,7 +2772,7 @@ pub unsafe fn _mm_undefined_si128() -> __m128i {
 #[cfg_attr(test, assert_instr(unpckhpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_pd(a: __m128d, b: __m128d) -> __m128d {
-    simd_shuffle2!(a, b, [1, 3])
+    simd_shuffle!(a, b, [1, 3])
 }
 
 /// The resulting `__m128d` element is composed by the high-order values of
@@ -2787,7 +2787,7 @@ pub unsafe fn _mm_unpackhi_pd(a: __m128d, b: __m128d) -> __m128d {
 #[cfg_attr(all(test, not(target_os = "windows")), assert_instr(movlhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_pd(a: __m128d, b: __m128d) -> __m128d {
-    simd_shuffle2!(a, b, [0, 2])
+    simd_shuffle!(a, b, [0, 2])
 }
 
 #[allow(improper_ctypes)]

--- a/crates/core_arch/src/x86/sse3.rs
+++ b/crates/core_arch/src/x86/sse3.rs
@@ -102,7 +102,7 @@ pub unsafe fn _mm_lddqu_si128(mem_addr: *const __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(movddup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_movedup_pd(a: __m128d) -> __m128d {
-    simd_shuffle2!(a, a, [0, 0])
+    simd_shuffle!(a, a, [0, 0])
 }
 
 /// Loads a double-precision (64-bit) floating-point element from memory
@@ -126,7 +126,7 @@ pub unsafe fn _mm_loaddup_pd(mem_addr: *const f64) -> __m128d {
 #[cfg_attr(test, assert_instr(movshdup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_movehdup_ps(a: __m128) -> __m128 {
-    simd_shuffle4!(a, a, [1, 1, 3, 3])
+    simd_shuffle!(a, a, [1, 1, 3, 3])
 }
 
 /// Duplicate even-indexed single-precision (32-bit) floating-point elements
@@ -138,7 +138,7 @@ pub unsafe fn _mm_movehdup_ps(a: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(movsldup))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_moveldup_ps(a: __m128) -> __m128 {
-    simd_shuffle4!(a, a, [0, 0, 2, 2])
+    simd_shuffle!(a, a, [0, 0, 2, 2])
 }
 
 #[allow(improper_ctypes)]

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -416,7 +416,7 @@ pub unsafe fn _mm_cmpeq_epi64(a: __m128i, b: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi8_epi16(a: __m128i) -> __m128i {
     let a = a.as_i8x16();
-    let a: i8x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let a: i8x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute(simd_cast::<_, i16x8>(a))
 }
 
@@ -429,7 +429,7 @@ pub unsafe fn _mm_cvtepi8_epi16(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi8_epi32(a: __m128i) -> __m128i {
     let a = a.as_i8x16();
-    let a: i8x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: i8x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute(simd_cast::<_, i32x4>(a))
 }
 
@@ -443,7 +443,7 @@ pub unsafe fn _mm_cvtepi8_epi32(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi8_epi64(a: __m128i) -> __m128i {
     let a = a.as_i8x16();
-    let a: i8x2 = simd_shuffle2!(a, a, [0, 1]);
+    let a: i8x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(simd_cast::<_, i64x2>(a))
 }
 
@@ -456,7 +456,7 @@ pub unsafe fn _mm_cvtepi8_epi64(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi16_epi32(a: __m128i) -> __m128i {
     let a = a.as_i16x8();
-    let a: i16x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: i16x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute(simd_cast::<_, i32x4>(a))
 }
 
@@ -469,7 +469,7 @@ pub unsafe fn _mm_cvtepi16_epi32(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi16_epi64(a: __m128i) -> __m128i {
     let a = a.as_i16x8();
-    let a: i16x2 = simd_shuffle2!(a, a, [0, 1]);
+    let a: i16x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(simd_cast::<_, i64x2>(a))
 }
 
@@ -482,7 +482,7 @@ pub unsafe fn _mm_cvtepi16_epi64(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepi32_epi64(a: __m128i) -> __m128i {
     let a = a.as_i32x4();
-    let a: i32x2 = simd_shuffle2!(a, a, [0, 1]);
+    let a: i32x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(simd_cast::<_, i64x2>(a))
 }
 
@@ -495,7 +495,7 @@ pub unsafe fn _mm_cvtepi32_epi64(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepu8_epi16(a: __m128i) -> __m128i {
     let a = a.as_u8x16();
-    let a: u8x8 = simd_shuffle8!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
+    let a: u8x8 = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7]);
     transmute(simd_cast::<_, i16x8>(a))
 }
 
@@ -508,7 +508,7 @@ pub unsafe fn _mm_cvtepu8_epi16(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepu8_epi32(a: __m128i) -> __m128i {
     let a = a.as_u8x16();
-    let a: u8x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: u8x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute(simd_cast::<_, i32x4>(a))
 }
 
@@ -521,7 +521,7 @@ pub unsafe fn _mm_cvtepu8_epi32(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepu8_epi64(a: __m128i) -> __m128i {
     let a = a.as_u8x16();
-    let a: u8x2 = simd_shuffle2!(a, a, [0, 1]);
+    let a: u8x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(simd_cast::<_, i64x2>(a))
 }
 
@@ -535,7 +535,7 @@ pub unsafe fn _mm_cvtepu8_epi64(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepu16_epi32(a: __m128i) -> __m128i {
     let a = a.as_u16x8();
-    let a: u16x4 = simd_shuffle4!(a, a, [0, 1, 2, 3]);
+    let a: u16x4 = simd_shuffle!(a, a, [0, 1, 2, 3]);
     transmute(simd_cast::<_, i32x4>(a))
 }
 
@@ -549,7 +549,7 @@ pub unsafe fn _mm_cvtepu16_epi32(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepu16_epi64(a: __m128i) -> __m128i {
     let a = a.as_u16x8();
-    let a: u16x2 = simd_shuffle2!(a, a, [0, 1]);
+    let a: u16x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(simd_cast::<_, i64x2>(a))
 }
 
@@ -563,7 +563,7 @@ pub unsafe fn _mm_cvtepu16_epi64(a: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_cvtepu32_epi64(a: __m128i) -> __m128i {
     let a = a.as_u32x4();
-    let a: u32x2 = simd_shuffle2!(a, a, [0, 1]);
+    let a: u32x2 = simd_shuffle!(a, a, [0, 1]);
     transmute(simd_cast::<_, i64x2>(a))
 }
 

--- a/crates/core_arch/src/x86/ssse3.rs
+++ b/crates/core_arch/src/x86/ssse3.rs
@@ -113,10 +113,10 @@ pub unsafe fn _mm_alignr_epi8<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128
             shift + i
         }
     }
-    let r: i8x16 = simd_shuffle16!(
+    let r: i8x16 = simd_shuffle!(
         b.as_i8x16(),
         a.as_i8x16(),
-        <const IMM8: i32> [
+        [
             mask(IMM8 as u32, 0),
             mask(IMM8 as u32, 1),
             mask(IMM8 as u32, 2),

--- a/crates/stdarch-gen/neon.spec
+++ b/crates/stdarch-gen/neon.spec
@@ -218,8 +218,8 @@ generate int32x2_t:int32x2_t:int64x2_t
 /// Unsigned Absolute difference Long
 name = vabdl_high
 no-q
-multi_fn = simd_shuffle8!, c:uint8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
-multi_fn = simd_shuffle8!, d:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, c:uint8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, d:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_cast, {vabd_u8, c, d}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10
@@ -231,8 +231,8 @@ generate uint8x16_t:uint8x16_t:uint16x8_t
 /// Unsigned Absolute difference Long
 name = vabdl_high
 no-q
-multi_fn = simd_shuffle4!, c:uint16x4_t, a, a, [4, 5, 6, 7]
-multi_fn = simd_shuffle4!, d:uint16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, c:uint16x4_t, a, a, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, d:uint16x4_t, b, b, [4, 5, 6, 7]
 multi_fn = simd_cast, {vabd_u16, c, d}
 a = 1, 2, 3, 4, 8, 9, 11, 12
 b = 10, 10, 10, 10, 10, 10, 10, 10
@@ -244,8 +244,8 @@ generate uint16x8_t:uint16x8_t:uint32x4_t
 /// Unsigned Absolute difference Long
 name = vabdl_high
 no-q
-multi_fn = simd_shuffle2!, c:uint32x2_t, a, a, [2, 3]
-multi_fn = simd_shuffle2!, d:uint32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, c:uint32x2_t, a, a, [2, 3]
+multi_fn = simd_shuffle!, d:uint32x2_t, b, b, [2, 3]
 multi_fn = simd_cast, {vabd_u32, c, d}
 a = 1, 2, 3, 4
 b = 10, 10, 10, 10
@@ -257,8 +257,8 @@ generate uint32x4_t:uint32x4_t:uint64x2_t
 /// Signed Absolute difference Long
 name = vabdl_high
 no-q
-multi_fn = simd_shuffle8!, c:int8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
-multi_fn = simd_shuffle8!, d:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, c:int8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, d:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_cast, e:uint8x8_t, {vabd_s8, c, d}
 multi_fn = simd_cast, e
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
@@ -271,8 +271,8 @@ generate int8x16_t:int8x16_t:int16x8_t
 /// Signed Absolute difference Long
 name = vabdl_high
 no-q
-multi_fn = simd_shuffle4!, c:int16x4_t, a, a, [4, 5, 6, 7]
-multi_fn = simd_shuffle4!, d:int16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, c:int16x4_t, a, a, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, d:int16x4_t, b, b, [4, 5, 6, 7]
 multi_fn = simd_cast, e:uint16x4_t, {vabd_s16, c, d}
 multi_fn = simd_cast, e
 a = 1, 2, 3, 4, 9, 10, 11, 12
@@ -285,8 +285,8 @@ generate int16x8_t:int16x8_t:int32x4_t
 /// Signed Absolute difference Long
 name = vabdl_high
 no-q
-multi_fn = simd_shuffle2!, c:int32x2_t, a, a, [2, 3]
-multi_fn = simd_shuffle2!, d:int32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, c:int32x2_t, a, a, [2, 3]
+multi_fn = simd_shuffle!, d:int32x2_t, b, b, [2, 3]
 multi_fn = simd_cast, e:uint32x2_t, {vabd_s32, c, d}
 multi_fn = simd_cast, e
 a = 1, 2, 3, 4
@@ -978,7 +978,7 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in0_len-LANE2}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in0_len-LANE2}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 0, MAX, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 0:1
@@ -995,7 +995,7 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in0_len-LANE2}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in0_len-LANE2}
 a = 1., 2., 3., 4.
 b = 0., 0.5, 0., 0.
 n = 0:1
@@ -1010,8 +1010,8 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = simd_shuffle-in_len-!, a:in_t, a, a, {asc-0-in_len}
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in_len-LANE2}
+multi_fn = simd_shuffle!, a:in_t, a, a, {asc-0-in_len}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in_len-LANE2}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 0, MAX, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 0:1
@@ -1028,8 +1028,8 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = simd_shuffle-in_len-!, a:in_t, a, a, {asc-0-in_len}
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in_len-LANE2}
+multi_fn = simd_shuffle!, a:in_t, a, a, {asc-0-in_len}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in_len-LANE2}
 a = 1., 2., 3., 4.
 b = 0., 0.5, 0., 0.
 n = 0:1
@@ -1044,8 +1044,8 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = simd_shuffle-in0_len-!, b:in_t0, b, b, {asc-0-in0_len}
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in0_len-LANE2}
+multi_fn = simd_shuffle!, b:in_t0, b, b, {asc-0-in0_len}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in0_len-LANE2}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 0, MAX, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 0:1
@@ -1062,8 +1062,8 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = simd_shuffle-in0_len-!, b:in_t0, b, b, {asc-0-in0_len}
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in0_len-LANE2}
+multi_fn = simd_shuffle!, b:in_t0, b, b, {asc-0-in0_len}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in0_len-LANE2}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = MAX, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 1:0
@@ -1078,8 +1078,8 @@ lane-suffixes
 constn = LANE1:LANE2
 multi_fn = static_assert_imm-in0_exp_len-LANE1
 multi_fn = static_assert_imm-in_exp_len-LANE2
-multi_fn = simd_shuffle-in0_len-!, b:in_t0, b, b, {asc-0-in0_len}
-multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle-out_len-!, a, b, {ins-in0_len-in0_len-LANE2}
+multi_fn = simd_shuffle!, b:in_t0, b, b, {asc-0-in0_len}
+multi_fn = matchn-in0_exp_len-LANE1, simd_shuffle!, a, b, {ins-in0_len-in0_len-LANE2}
 a = 1., 2., 3., 4.
 b = 0.5, 0., 0., 0.
 n = 1:0
@@ -1148,7 +1148,7 @@ generate float32x2_t:float64x2_t
 /// Floating-point convert to higher precision long
 name = vcvt_high
 noq-double-suffixes
-multi_fn = simd_shuffle2!, b:float32x2_t, a, a, [2, 3]
+multi_fn = simd_shuffle!, b:float32x2_t, a, a, [2, 3]
 multi_fn = simd_cast, b
 a = -1.2, 1.2, 2.3, 3.4
 validate 2.3f32 as f64, 3.4f32 as f64
@@ -1169,7 +1169,7 @@ generate float64x2_t:float32x2_t
 /// Floating-point convert to lower precision narrow
 name = vcvt_high
 noq-double-suffixes
-multi_fn = simd_shuffle4!, a, {simd_cast, b}, [0, 1, 2, 3]
+multi_fn = simd_shuffle!, a, {simd_cast, b}, [0, 1, 2, 3]
 a = -1.2, 1.2
 b = -2.3, 3.4
 validate -1.2, 1.2, -2.3f64 as f32, 3.4f64 as f32
@@ -1200,7 +1200,7 @@ generate f64:f32
 /// Floating-point convert to lower precision narrow, rounding to odd
 name = vcvtx_high
 noq-double-suffixes
-multi_fn = simd_shuffle4!, a, {vcvtx-noq_doubleself-noext, b}, [0, 1, 2, 3]
+multi_fn = simd_shuffle!, a, {vcvtx-noq_doubleself-noext, b}, [0, 1, 2, 3]
 a = -1.0, 2.0
 b = -3.0, 4.0
 validate -1.0, 2.0, -3.0, 4.0
@@ -1428,7 +1428,7 @@ name = vdup
 lane-suffixes
 constn = N
 multi_fn = static_assert_imm-in_exp_len-N
-multi_fn = simd_shuffle-out_len-!, a, a, {dup-out_len-N as u32}
+multi_fn = simd_shuffle!, a, a, {dup-out_len-N as u32}
 a = 1, 1, 1, 4, 1, 6, 7, 8, 1, 10, 11, 12, 13, 14, 15, 16
 n = HFLEN
 validate 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
@@ -1454,7 +1454,7 @@ name = vdup
 lane-suffixes
 constn = N
 multi_fn = static_assert_imm-in_exp_len-N
-multi_fn = simd_shuffle-out_len-!, a, a, {dup-out_len-N as u32}
+multi_fn = simd_shuffle!, a, a, {dup-out_len-N as u32}
 a = 1, 1, 1, 4, 1, 6, 7, 8, 1, 10, 11, 12, 13, 14, 15, 16
 n = HFLEN
 validate 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
@@ -1468,7 +1468,7 @@ name = vdup
 lane-suffixes
 constn = N
 multi_fn = static_assert_imm-in_exp_len-N
-multi_fn = simd_shuffle-out_len-!, a, a, {dup-out_len-N as u32}
+multi_fn = simd_shuffle!, a, a, {dup-out_len-N as u32}
 a = 1., 1., 1., 4.
 n = HFLEN
 validate 1., 1., 1., 1.
@@ -1569,7 +1569,7 @@ generate float32x2_t:f32, float32x4_t:f32, float64x1_t:f64, float64x2_t:f64
 name = vext
 constn = N
 multi_fn = static_assert_imm-out_exp_len-N
-multi_fn = matchn-out_exp_len-N, simd_shuffle-out_len-!, a, b, {asc-n-out_len}
+multi_fn = matchn-out_exp_len-N, simd_shuffle!, a, b, {asc-n-out_len}
 a = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 n = LEN_M1
@@ -1583,7 +1583,7 @@ generate int*_t, uint*_t, poly8x8_t, poly8x16_t, poly16x4_t, poly16x8_t
 name = vext
 constn = N
 multi_fn = static_assert_imm-out_exp_len-N
-multi_fn = matchn-out_exp_len-N, simd_shuffle-out_len-!, a, b, {asc-n-out_len}
+multi_fn = matchn-out_exp_len-N, simd_shuffle!, a, b, {asc-n-out_len}
 a = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 n = LEN_M1
@@ -1599,7 +1599,7 @@ generate int64x2_t, uint64x2_t
 name = vext
 constn = N
 multi_fn = static_assert_imm-out_exp_len-N
-multi_fn = matchn-out_exp_len-N, simd_shuffle-out_len-!, a, b, {asc-n-out_len}
+multi_fn = matchn-out_exp_len-N, simd_shuffle!, a, b, {asc-n-out_len}
 a = 1., 1., 1., 1.
 b = 2., 2., 2., 2.,
 n = LEN_M1
@@ -1669,7 +1669,7 @@ name = vmla
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmla-self-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmla-self-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 c = 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -1688,7 +1688,7 @@ name = vmla
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmla-self-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmla-self-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 0., 1., 2., 3.
 b = 2., 2., 2., 2.
 c = 0., 3., 0., 0.
@@ -1743,7 +1743,7 @@ name = vmlal_lane
 in2-suffix
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmlal-self-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmlal-self-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 c = 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -1761,8 +1761,8 @@ generate uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t, uint64x2_t:uint32x2_t:uint
 /// Signed multiply-add long
 name = vmlal_high
 no-q
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, c:half, c, c, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, c:half, c, c, {fixed-half-right}
 multi_fn = vmlal-noqself-noext, a, b, c
 a = 8, 7, 6, 5, 4, 3, 2, 1
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
@@ -1776,8 +1776,8 @@ generate int16x8_t:int8x16_t:int8x16_t:int16x8_t, int32x4_t:int16x8_t:int16x8_t:
 /// Unsigned multiply-add long
 name = vmlal_high
 no-q
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, c:half, c, c, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, c:half, c, c, {fixed-half-right}
 multi_fn = vmlal-noqself-noext, a, b, c
 a = 8, 7, 6, 5, 4, 3, 2, 1
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
@@ -1807,7 +1807,7 @@ name = vmlal_high_lane
 in2-suffix
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmlal_high-noqself-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmlal_high-noqself-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 8, 7, 6, 5, 4, 3, 2, 1
 b = 3, 3, 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7
 c = 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -1879,7 +1879,7 @@ name = vmls
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmls-self-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmls-self-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 c = 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -1898,7 +1898,7 @@ name = vmls
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmls-self-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmls-self-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 6., 7., 8., 9.
 b = 2., 2., 2., 2.
 c = 0., 3., 0., 0.
@@ -1953,7 +1953,7 @@ name = vmlsl_lane
 in2-suffix
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmlsl-self-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmlsl-self-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
 c = 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -1971,8 +1971,8 @@ generate uint64x2_t:uint32x2_t:uint32x2_t:uint64x2_t, uint64x2_t:uint32x2_t:uint
 /// Signed multiply-subtract long
 name = vmlsl_high
 no-q
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, c:half, c, c, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, c:half, c, c, {fixed-half-right}
 multi_fn = vmlsl-noqself-noext, a, b, c
 a = 14, 15, 16, 17, 18, 19, 20, 21
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
@@ -1986,8 +1986,8 @@ generate int16x8_t:int8x16_t:int8x16_t:int16x8_t, int32x4_t:int16x8_t:int16x8_t:
 /// Unsigned multiply-subtract long
 name = vmlsl_high
 no-q
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, c:half, c, c, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, c:half, c, c, {fixed-half-right}
 multi_fn = vmlsl-noqself-noext, a, b, c
 a = 14, 15, 16, 17, 18, 19, 20, 21
 b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
@@ -2017,7 +2017,7 @@ name = vmlsl_high_lane
 in2-suffix
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = vmlsl_high-noqself-noext, a, b, {simd_shuffle-in_len-!, c, c, {dup-in_len-LANE as u32}}
+multi_fn = vmlsl_high-noqself-noext, a, b, {simd_shuffle!, c, c, {dup-in_len-LANE as u32}}
 a = 14, 15, 16, 17, 18, 19, 20, 21
 b = 3, 3, 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7
 c = 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -2035,7 +2035,7 @@ generate uint64x2_t:uint32x4_t:uint32x2_t:uint64x2_t, uint64x2_t:uint32x4_t:uint
 name = vmovn_high
 no-q
 multi_fn = simd_cast, c:in_t0, b
-multi_fn = simd_shuffle-out_len-!, a, c, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, c, {asc-0-out_len}
 a = 0, 1, 2, 3, 2, 3, 4, 5
 b = 2, 3, 4, 5, 12, 13, 14, 15
 validate 0, 1, 2, 3, 2, 3, 4, 5, 2, 3, 4, 5, 12, 13, 14, 15
@@ -3483,7 +3483,7 @@ name = vsudot
 out-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_dot-LANE
-multi_fn = simd_shuffle-in_len-!, c:unsigned, c, c, {base-4-LANE}
+multi_fn = simd_shuffle!, c:unsigned, c, c, {base-4-LANE}
 multi_fn = vsudot-outlane-_, a, b, c
 a = 1, 2, 1, 2
 b = 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8
@@ -3567,7 +3567,7 @@ name = vmul
 lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in_exp_len-LANE
-multi_fn = simd_mul, a, {simd_shuffle-out_len-!, b, b, {dup-out_len-LANE as u32}}
+multi_fn = simd_mul, a, {simd_shuffle!, b, b, {dup-out_len-LANE as u32}}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 1
@@ -3599,7 +3599,7 @@ name = vmul
 lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in_exp_len-LANE
-multi_fn = simd_mul, a, {simd_shuffle-out_len-!, b, b, {dup-out_len-LANE as u32}}
+multi_fn = simd_mul, a, {simd_shuffle!, b, b, {dup-out_len-LANE as u32}}
 a = 1., 2., 3., 4.
 b = 2., 0., 0., 0.
 n = 0
@@ -3652,8 +3652,8 @@ generate int8x8_t:int8x8_t:int16x8_t, int16x4_t:int16x4_t:int32x4_t, int32x2_t:i
 /// Signed multiply long
 name = vmull_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a:half, a, a, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, a:half, a, a, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
 multi_fn = vmull-noqself-noext, a, b
 a = 1, 2, 9, 10, 9, 10, 11, 12, 9, 10, 11, 12, 13, 14, 15, 16
 b = 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2
@@ -3678,8 +3678,8 @@ generate uint8x8_t:uint8x8_t:uint16x8_t, uint16x4_t:uint16x4_t:uint32x4_t, uint3
 /// Unsigned multiply long
 name = vmull_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a:half, a, a, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, a:half, a, a, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
 multi_fn = vmull-noqself-noext, a, b
 a = 1, 2, 9, 10, 9, 10, 11, 12, 9, 10, 11, 12, 13, 14, 15, 16
 b = 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2
@@ -3720,8 +3720,8 @@ generate p64:p64:p128
 /// Polynomial multiply long
 name = vmull_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a:half, a, a, {fixed-half-right}
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {fixed-half-right}
+multi_fn = simd_shuffle!, a:half, a, a, {fixed-half-right}
+multi_fn = simd_shuffle!, b:half, b, b, {fixed-half-right}
 multi_fn = vmull-noqself-noext, a, b
 a = 1, 2, 9, 10, 9, 10, 11, 12, 9, 10, 11, 12, 13, 14, 15, 16
 b = 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3
@@ -3761,7 +3761,7 @@ generate uint16x4_t:u16:uint32x4_t, uint32x2_t:u32:uint64x2_t
 name = vmull_lane
 constn = LANE
 multi_fn = static_assert_imm-in_exp_len-LANE
-multi_fn = vmull-in0-noext, a, {simd_shuffle-in0_len-!, b, b, {dup-in0_len-LANE as u32}}
+multi_fn = vmull-in0-noext, a, {simd_shuffle!, b, b, {dup-in0_len-LANE as u32}}
 a = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 b = 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 1
@@ -3792,7 +3792,7 @@ generate uint16x8_t:u16:uint32x4_t, uint32x4_t:u32:uint64x2_t
 name = vmull_high_lane
 constn = LANE
 multi_fn = static_assert_imm-in_exp_len-LANE
-multi_fn = vmull_high-noqself-noext, a, {simd_shuffle-in0_len-!, b, b, {dup-in0_len-LANE as u32}}
+multi_fn = vmull_high-noqself-noext, a, {simd_shuffle!, b, b, {dup-in0_len-LANE as u32}}
 a = 1, 2, 9, 10, 9, 10, 11, 12, 9, 10, 11, 12, 13, 14, 15, 16
 b = 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 n = 1
@@ -3834,7 +3834,7 @@ name = vmulx
 lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in_exp_len-LANE
-multi_fn = vmulx-in0-noext, a, {simd_shuffle-in0_len-!, b, b, {dup-in0_len-LANE as u32}}
+multi_fn = vmulx-in0-noext, a, {simd_shuffle!, b, b, {dup-in0_len-LANE as u32}}
 a = 1., 2., 3., 4.
 b = 2., 0., 0., 0.
 n = 0
@@ -4196,7 +4196,7 @@ generate uint16x8_t:uint8x8_t, uint32x4_t:uint16x4_t, uint64x2_t:uint32x2_t
 name = vsubhn_high
 no-q
 multi_fn = vsubhn-noqself-noext, d:in_t0, b, c
-multi_fn = simd_shuffle-out_len-!, a, d, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, d, {asc-0-out_len}
 a = MAX, 0, MAX, 0, MAX, 0, MAX, 0
 b = MAX, 1, MAX, 1, MAX, 1, MAX, 1
 c = 1, 0, 1, 0, 1, 0, 1, 0
@@ -4252,7 +4252,7 @@ generate uint16x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint32x4_t, uint
 /// Signed Subtract Wide
 name = vsubw_high
 no-q
-multi_fn = simd_shuffle8!, c:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, c:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_sub, a, {simd_cast, c}
 a = 8, 9, 10, 12, 13, 14, 15, 16
 b = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16
@@ -4264,7 +4264,7 @@ generate int16x8_t:int8x16_t:int16x8_t
 /// Signed Subtract Wide
 name = vsubw_high
 no-q
-multi_fn = simd_shuffle4!, c:int16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, c:int16x4_t, b, b, [4, 5, 6, 7]
 multi_fn = simd_sub, a, {simd_cast, c}
 a = 8, 9, 10, 11
 b = 0, 1, 2, 3, 8, 9, 10, 11
@@ -4276,7 +4276,7 @@ generate int32x4_t:int16x8_t:int32x4_t
 /// Signed Subtract Wide
 name = vsubw_high
 no-q
-multi_fn = simd_shuffle2!, c:int32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, c:int32x2_t, b, b, [2, 3]
 multi_fn = simd_sub, a, {simd_cast, c}
 a = 8, 9
 b = 6, 7, 8, 9
@@ -4288,7 +4288,7 @@ generate int64x2_t:int32x4_t:int64x2_t
 /// Unsigned Subtract Wide
 name = vsubw_high
 no-q
-multi_fn = simd_shuffle8!, c:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, c:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_sub, a, {simd_cast, c}
 a = 8, 9, 10, 11, 12, 13, 14, 15
 b = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
@@ -4300,7 +4300,7 @@ generate uint16x8_t:uint8x16_t:uint16x8_t
 /// Unsigned Subtract Wide
 name = vsubw_high
 no-q
-multi_fn = simd_shuffle4!, c:uint16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, c:uint16x4_t, b, b, [4, 5, 6, 7]
 multi_fn = simd_sub, a, {simd_cast, c}
 a = 8, 9, 10, 11
 b = 0, 1, 2, 3, 8, 9, 10, 11
@@ -4312,7 +4312,7 @@ generate uint32x4_t:uint16x8_t:uint32x4_t
 /// Unsigned Subtract Wide
 name = vsubw_high
 no-q
-multi_fn = simd_shuffle2!, c:uint32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, c:uint32x2_t, b, b, [2, 3]
 multi_fn = simd_sub, a, {simd_cast, c}
 a = 8, 9
 b = 6, 7, 8, 9
@@ -4354,9 +4354,9 @@ generate uint8x8_t:uint8x8_t:uint16x8_t, uint16x4_t:uint16x4_t:uint32x4_t, uint3
 /// Signed Subtract Long
 name = vsubl_high
 no-q
-multi_fn = simd_shuffle8!, c:int8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, c:int8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_cast, d:out_t, c
-multi_fn = simd_shuffle8!, e:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, e:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_cast, f:out_t, e
 multi_fn = simd_sub, d, f
 
@@ -4370,9 +4370,9 @@ generate int8x16_t:int8x16_t:int16x8_t
 /// Signed Subtract Long
 name = vsubl_high
 no-q
-multi_fn = simd_shuffle4!, c:int16x4_t, a, a, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, c:int16x4_t, a, a, [4, 5, 6, 7]
 multi_fn = simd_cast, d:out_t, c
-multi_fn = simd_shuffle4!, e:int16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, e:int16x4_t, b, b, [4, 5, 6, 7]
 multi_fn = simd_cast, f:out_t, e
 multi_fn = simd_sub, d, f
 
@@ -4386,9 +4386,9 @@ generate int16x8_t:int16x8_t:int32x4_t
 /// Signed Subtract Long
 name = vsubl_high
 no-q
-multi_fn = simd_shuffle2!, c:int32x2_t, a, a, [2, 3]
+multi_fn = simd_shuffle!, c:int32x2_t, a, a, [2, 3]
 multi_fn = simd_cast, d:out_t, c
-multi_fn = simd_shuffle2!, e:int32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, e:int32x2_t, b, b, [2, 3]
 multi_fn = simd_cast, f:out_t, e
 multi_fn = simd_sub, d, f
 
@@ -4402,9 +4402,9 @@ generate int32x4_t:int32x4_t:int64x2_t
 /// Unsigned Subtract Long
 name = vsubl_high
 no-q
-multi_fn = simd_shuffle8!, c:uint8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, c:uint8x8_t, a, a, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_cast, d:out_t, c
-multi_fn = simd_shuffle8!, e:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, e:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = simd_cast, f:out_t, e
 multi_fn = simd_sub, d, f
 
@@ -4418,9 +4418,9 @@ generate uint8x16_t:uint8x16_t:uint16x8_t
 /// Unsigned Subtract Long
 name = vsubl_high
 no-q
-multi_fn = simd_shuffle4!, c:uint16x4_t, a, a, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, c:uint16x4_t, a, a, [4, 5, 6, 7]
 multi_fn = simd_cast, d:out_t, c
-multi_fn = simd_shuffle4!, e:uint16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, e:uint16x4_t, b, b, [4, 5, 6, 7]
 multi_fn = simd_cast, f:out_t, e
 multi_fn = simd_sub, d, f
 
@@ -4434,9 +4434,9 @@ generate uint16x8_t:uint16x8_t:uint32x4_t
 /// Unsigned Subtract Long
 name = vsubl_high
 no-q
-multi_fn = simd_shuffle2!, c:uint32x2_t, a, a, [2, 3]
+multi_fn = simd_shuffle!, c:uint32x2_t, a, a, [2, 3]
 multi_fn = simd_cast, d:out_t, c
-multi_fn = simd_shuffle2!, e:uint32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, e:uint32x2_t, b, b, [2, 3]
 multi_fn = simd_cast, f:out_t, e
 multi_fn = simd_sub, d, f
 
@@ -4545,7 +4545,7 @@ name = vcmla
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_rot-LANE
-multi_fn = simd_shuffle-out_len-!, c:out_t, c, c, {base-2-LANE}
+multi_fn = simd_shuffle!, c:out_t, c, c, {base-2-LANE}
 multi_fn = vcmla-self-noext, a, b, c
 a = 1., -1., 1., -1.
 b = -1., 1., -1., 1.
@@ -4563,7 +4563,7 @@ name = vcmla_rot90
 rot-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_rot-LANE
-multi_fn = simd_shuffle-out_len-!, c:out_t, c, c, {base-2-LANE}
+multi_fn = simd_shuffle!, c:out_t, c, c, {base-2-LANE}
 multi_fn = vcmla_rot90-rot-noext, a, b, c
 a = 1., -1., 1., -1.
 b = -1., 1., -1., 1.
@@ -4581,7 +4581,7 @@ name = vcmla_rot180
 rot-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_rot-LANE
-multi_fn = simd_shuffle-out_len-!, c:out_t, c, c, {base-2-LANE}
+multi_fn = simd_shuffle!, c:out_t, c, c, {base-2-LANE}
 multi_fn = vcmla_rot180-rot-noext, a, b, c
 a = 1., -1., 1., -1.
 b = -1., 1., -1., 1.
@@ -4599,7 +4599,7 @@ name = vcmla_rot270
 rot-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_rot-LANE
-multi_fn = simd_shuffle-out_len-!, c:out_t, c, c, {base-2-LANE}
+multi_fn = simd_shuffle!, c:out_t, c, c, {base-2-LANE}
 multi_fn = vcmla_rot270-rot-noext, a, b, c
 a = 1., -1., 1., -1.
 b = -1., 1., -1., 1.
@@ -4634,7 +4634,7 @@ name = vdot
 out-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_dot-LANE
-multi_fn = simd_shuffle-in_len-!, c:in_t, c, c, {base-4-LANE}
+multi_fn = simd_shuffle!, c:in_t, c, c, {base-4-LANE}
 multi_fn = vdot-out-noext, a, b, c
 a = 1, 2, 1, 2
 b = 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8
@@ -4820,7 +4820,7 @@ generate float32x4_t:f32
 /// Vector move
 name = vmovl_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a:half, a, a, {asc-halflen-halflen}
+multi_fn = simd_shuffle!, a:half, a, a, {asc-halflen-halflen}
 multi_fn = vmovl-noqself-noext, a
 a = 1, 2, 3, 4, 3, 4, 5, 6, 3, 4, 5, 6, 7, 8, 9, 10
 validate 3, 4, 5, 6, 7, 8, 9, 10
@@ -4949,8 +4949,8 @@ generate int16x4_t:i16:int32x4_t, int32x2_t:i32:int64x2_t
 /// Signed saturating doubling multiply long
 name = vqdmull_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a:half, a, a, {asc-halflen-halflen}
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {asc-halflen-halflen}
+multi_fn = simd_shuffle!, a:half, a, a, {asc-halflen-halflen}
+multi_fn = simd_shuffle!, b:half, b, b, {asc-halflen-halflen}
 multi_fn = vqdmull-noqself-noext, a, b
 a = 0, 1, 4, 5, 4, 5, 6, 7
 b = 1, 2, 5, 6, 5, 6, 7, 8
@@ -4962,7 +4962,7 @@ generate int16x8_t:int16x8_t:int32x4_t, int32x4_t:int32x4_t:int64x2_t
 /// Signed saturating doubling multiply long
 name = vqdmull_high_n
 no-q
-multi_fn = simd_shuffle-out_len-!, a:in_ntt, a, a, {asc-out_len-out_len}
+multi_fn = simd_shuffle!, a:in_ntt, a, a, {asc-out_len-out_len}
 multi_fn = vdup_n-in_ntt-noext, b:in_ntt, b
 multi_fn = vqdmull-in_ntt-noext, a, b
 a = 0, 2, 8, 10, 8, 10, 12, 14
@@ -4976,7 +4976,7 @@ generate int16x8_t:i16:int32x4_t, int32x4_t:i32:int64x2_t
 name = vqdmull_lane
 constn = N
 multi_fn = static_assert_imm-in_exp_len-N
-multi_fn = simd_shuffle-out_len-!, b:in_t0, b, b, {dup-out_len-N as u32}
+multi_fn = simd_shuffle!, b:in_t0, b, b, {dup-out_len-N as u32}
 multi_fn = vqdmull-noqself-noext, a, b
 a = 1, 2, 3, 4
 b = 0, 2, 2, 0, 2, 0, 0, 0
@@ -5021,8 +5021,8 @@ generate i32:int32x2_t:i64, i32:int32x4_t:i64
 name = vqdmull_high_lane
 constn = N
 multi_fn = static_assert_imm-in_exp_len-N
-multi_fn = simd_shuffle-out_len-!, a:in_t, a, a, {asc-out_len-out_len}
-multi_fn = simd_shuffle-out_len-!, b:in_t, b, b, {dup-out_len-N as u32}
+multi_fn = simd_shuffle!, a:in_t, a, a, {asc-out_len-out_len}
+multi_fn = simd_shuffle!, b:in_t, b, b, {dup-out_len-N as u32}
 multi_fn = vqdmull-self-noext, a, b
 a = 0, 1, 4, 5, 4, 5, 6, 7
 b = 0, 2, 2, 0, 2, 0, 0, 0
@@ -5036,8 +5036,8 @@ generate int16x8_t:int16x4_t:int32x4_t, int32x4_t:int32x2_t:int64x2_t
 name = vqdmull_high_lane
 constn = N
 multi_fn = static_assert_imm-in_exp_len-N
-multi_fn = simd_shuffle-out_len-!, a:half, a, a, {asc-out_len-out_len}
-multi_fn = simd_shuffle-out_len-!, b:half, b, b, {dup-out_len-N as u32}
+multi_fn = simd_shuffle!, a:half, a, a, {asc-out_len-out_len}
+multi_fn = simd_shuffle!, b:half, b, b, {dup-out_len-N as u32}
 multi_fn = vqdmull-noqself-noext, a, b
 a = 0, 1, 4, 5, 4, 5, 6, 7
 b = 0, 2, 2, 0, 2, 0, 0, 0
@@ -5418,7 +5418,7 @@ generate u64:u32
 /// Signed saturating extract narrow
 name = vqmovn_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a, {vqmovn-noqself-noext, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqmovn-noqself-noext, b}, {asc-0-out_len}
 a = MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX
 b = MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX
 validate MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX
@@ -5452,7 +5452,7 @@ generate i16:u8, i32:u16, i64:u32
 /// Signed saturating extract unsigned narrow
 name = vqmovun_high
 no-q
-multi_fn = simd_shuffle-out_len-!, a, {vqmovun-noqself-noext, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqmovun-noqself-noext, b}, {asc-0-out_len}
 a = 0, 0, 0, 0, 0, 0, 0, 0
 b = -1, -1, -1, -1, -1, -1, -1, -1
 validate 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -5499,7 +5499,7 @@ name = vqrdmulh
 lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in_exp_len-LANE
-multi_fn = simd_shuffle-out_len-!, b:out_t, b, b, {dup-out_len-LANE as u32}
+multi_fn = simd_shuffle!, b:out_t, b, b, {dup-out_len-LANE as u32}
 multi_fn = vqrdmulh-out-noext, a, b
 a = MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX
 b = 0, 2, 0, 0, 0, 0, 0, 0,
@@ -5557,7 +5557,7 @@ name = vqrdmlah
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = simd_shuffle-out_len-!, c:out_t, c, c, {dup-out_len-LANE as u32}
+multi_fn = simd_shuffle!, c:out_t, c, c, {dup-out_len-LANE as u32}
 multi_fn = vqrdmlah-out-noext, a, b, c
 a = 1, 1, 1, 1, 1, 1, 1, 1
 b = MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX
@@ -5618,7 +5618,7 @@ name = vqrdmlsh
 in2-lane-suffixes
 constn = LANE
 multi_fn = static_assert_imm-in2_exp_len-LANE
-multi_fn = simd_shuffle-out_len-!, c:out_t, c, c, {dup-out_len-LANE as u32}
+multi_fn = simd_shuffle!, c:out_t, c, c, {dup-out_len-LANE as u32}
 multi_fn = vqrdmlsh-out-noext, a, b, c
 a = 1, 1, 1, 1, 1, 1, 1, 1
 b = MAX, MAX, MAX, MAX, MAX, MAX, MAX, MAX
@@ -5740,7 +5740,7 @@ name = vqrshrn_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vqrshrn_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqrshrn_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 2, 3, 2, 3, 6, 7
 b = 8, 12, 24, 28, 48, 52, 56, 60
 n = 2
@@ -5787,7 +5787,7 @@ name = vqrshrn_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vqrshrn_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqrshrn_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 2, 3, 2, 3, 6, 7
 b = 8, 12, 24, 28, 48, 52, 56, 60
 n = 2
@@ -5834,7 +5834,7 @@ name = vqrshrun_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vqrshrun_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqrshrun_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 2, 3, 2, 3, 6, 7
 b = 8, 12, 24, 28, 48, 52, 56, 60
 n = 2
@@ -6020,7 +6020,7 @@ name = vqshrn_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vqshrn_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqshrn_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 8, 9, 8, 9, 10, 11
 b = 32, 36, 40, 44, 48, 52, 56, 60
 n = 2
@@ -6067,7 +6067,7 @@ name = vqshrn_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vqshrn_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqshrn_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 8, 9, 8, 9, 10, 11
 b = 32, 36, 40, 44, 48, 52, 56, 60
 n = 2
@@ -6113,7 +6113,7 @@ name = vqshrun_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vqshrun_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vqshrun_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 8, 9, 8, 9, 10, 11
 b = 32, 36, 40, 44, 48, 52, 56, 60
 n = 2
@@ -6574,7 +6574,7 @@ name = vrshrn_high
 noq-n-suffix
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vrshrn_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vrshrn_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 0, 1, 8, 9, 8, 9, 10, 11
 b = 32, 36, 40, 44, 48, 52, 56, 60
 n = 2
@@ -6673,7 +6673,7 @@ generate uint16x8_t:uint16x8_t:uint8x8_t, uint32x4_t:uint32x4_t:uint16x4_t, uint
 name = vrsubhn_high
 no-q
 multi_fn = vrsubhn-noqself-noext, x:in_t0, b, c
-multi_fn = simd_shuffle-out_len-!, a, x, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, x, {asc-0-out_len}
 a = 1, 2, 0, 0, 0, 0, 0, 0
 b = 1, 2, 3, 4, 5, 6, 7, 8
 c = 1, 2, 3, 4, 5, 6, 7, 8
@@ -6841,7 +6841,7 @@ name = vshll_high_n
 no-q
 constn = N
 multi_fn = static_assert-N-0-bits
-multi_fn = simd_shuffle-out_len-!, b:half, a, a, {asc-halflen-halflen}
+multi_fn = simd_shuffle!, b:half, a, a, {asc-halflen-halflen}
 multi_fn = vshll_n-noqself-::<N>, b
 a = 0, 0, 1, 2, 1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8
 n = 2
@@ -6889,7 +6889,7 @@ name = vshrn_high_n
 no-q
 constn = N
 multi_fn = static_assert-N-1-halfbits
-multi_fn = simd_shuffle-out_len-!, a, {vshrn_n-noqself-::<N>, b}, {asc-0-out_len}
+multi_fn = simd_shuffle!, a, {vshrn_n-noqself-::<N>, b}, {asc-0-out_len}
 a = 1, 2, 5, 6, 5, 6, 7, 8
 b = 20, 24, 28, 32, 52, 56, 60, 64
 n = 2
@@ -7087,8 +7087,8 @@ generate float32x2_t, float32x4_t
 
 /// Transpose elements
 name = vtrn
-multi_fn = simd_shuffle-in_len-!, a1:in_t, a, b, {transpose-1-in_len}
-multi_fn = simd_shuffle-in_len-!, b1:in_t, a, b, {transpose-2-in_len}
+multi_fn = simd_shuffle!, a1:in_t, a, b, {transpose-1-in_len}
+multi_fn = simd_shuffle!, b1:in_t, a, b, {transpose-2-in_len}
 multi_fn = transmute, (a1, b1)
 a = 0, 2, 2, 6, 2, 10, 6, 14, 2, 18, 6, 22, 10, 26, 14, 30
 b = 1, 3, 3, 7, 3, 1, 7, 15, 3, 19, 7, 23, 1, 27, 15, 31
@@ -7104,8 +7104,8 @@ generate int32x2_t:int32x2_t:int32x2x2_t, uint32x2_t:uint32x2_t:uint32x2x2_t
 
 /// Transpose elements
 name = vtrn
-multi_fn = simd_shuffle-in_len-!, a1:in_t, a, b, {transpose-1-in_len}
-multi_fn = simd_shuffle-in_len-!, b1:in_t, a, b, {transpose-2-in_len}
+multi_fn = simd_shuffle!, a1:in_t, a, b, {transpose-1-in_len}
+multi_fn = simd_shuffle!, b1:in_t, a, b, {transpose-2-in_len}
 multi_fn = transmute, (a1, b1)
 a = 0., 2., 2., 6.
 b = 1., 3., 3., 7.
@@ -7119,7 +7119,7 @@ generate float32x4_t:float32x4_t:float32x4x2_t
 
 /// Transpose vectors
 name = vtrn1
-multi_fn = simd_shuffle-in_len-!, a, b, {transpose-1-in_len}
+multi_fn = simd_shuffle!, a, b, {transpose-1-in_len}
 a = 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 b = 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
 validate 0, 1, 4, 5, 8, 9, 12, 13, 16, 17, 20, 21, 24, 25, 28, 29
@@ -7132,7 +7132,7 @@ generate int32x2_t, int64x2_t, uint32x2_t, uint64x2_t, poly64x2_t
 
 /// Transpose vectors
 name = vtrn1
-multi_fn = simd_shuffle-in_len-!, a, b, {transpose-1-in_len}
+multi_fn = simd_shuffle!, a, b, {transpose-1-in_len}
 a = 0., 2., 4., 6., 8., 10., 12., 14.
 b = 1., 3., 5., 7., 9., 11., 13., 15.
 validate 0., 1., 4., 5., 8., 9., 12., 13.
@@ -7145,7 +7145,7 @@ generate float32x2_t, float64x2_t
 
 /// Transpose vectors
 name = vtrn2
-multi_fn = simd_shuffle-in_len-!, a, b, {transpose-2-in_len}
+multi_fn = simd_shuffle!, a, b, {transpose-2-in_len}
 a = 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 b = 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
 validate 2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27, 30, 31
@@ -7158,7 +7158,7 @@ generate int32x2_t, int64x2_t, uint32x2_t, uint64x2_t, poly64x2_t
 
 /// Transpose vectors
 name = vtrn2
-multi_fn = simd_shuffle-in_len-!, a, b, {transpose-2-in_len}
+multi_fn = simd_shuffle!, a, b, {transpose-2-in_len}
 a = 0., 2., 4., 6., 8., 10., 12., 14.
 b = 1., 3., 5., 7., 9., 11., 13., 15.
 validate 2., 3., 6., 7., 10., 11., 14., 15.
@@ -7171,8 +7171,8 @@ generate float32x2_t, float64x2_t
 
 /// Zip vectors
 name = vzip
-multi_fn = simd_shuffle-in_len-!, a0:in_t, a, b, {zip-1-in_len}
-multi_fn = simd_shuffle-in_len-!, b0:in_t, a, b, {zip-2-in_len}
+multi_fn = simd_shuffle!, a0:in_t, a, b, {zip-1-in_len}
+multi_fn = simd_shuffle!, b0:in_t, a, b, {zip-2-in_len}
 multi_fn = transmute, (a0, b0)
 a = 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 b = 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
@@ -7193,8 +7193,8 @@ generate poly8x16_t:poly8x16_t:poly8x16x2_t, poly16x8_t:poly16x8_t:poly16x8x2_t
 
 /// Zip vectors
 name = vzip
-multi_fn = simd_shuffle-in_len-!, a0:in_t, a, b, {zip-1-in_len}
-multi_fn = simd_shuffle-in_len-!, b0:in_t, a, b, {zip-2-in_len}
+multi_fn = simd_shuffle!, a0:in_t, a, b, {zip-1-in_len}
+multi_fn = simd_shuffle!, b0:in_t, a, b, {zip-2-in_len}
 multi_fn = transmute, (a0, b0)
 a = 1., 2., 3., 4.
 b = 5., 6., 7., 8.
@@ -7209,7 +7209,7 @@ generate float32x4_t:float32x4_t:float32x4x2_t
 
 /// Zip vectors
 name = vzip1
-multi_fn = simd_shuffle-in_len-!, a, b, {zip-1-in_len}
+multi_fn = simd_shuffle!, a, b, {zip-1-in_len}
 a = 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30
 b = 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31
 validate 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
@@ -7219,7 +7219,7 @@ generate int*_t, int64x2_t, uint*_t, uint64x2_t, poly8x8_t, poly8x16_t, poly16x4
 
 /// Zip vectors
 name = vzip1
-multi_fn = simd_shuffle-in_len-!, a, b, {zip-1-in_len}
+multi_fn = simd_shuffle!, a, b, {zip-1-in_len}
 a = 0., 2., 4., 6., 8., 10., 12., 14.
 b = 1., 3., 5., 7., 9., 11., 13., 15.
 validate 0., 1., 2., 3., 4., 5., 6., 7.
@@ -7229,7 +7229,7 @@ generate float32x2_t, float32x4_t, float64x2_t
 
 /// Zip vectors
 name = vzip2
-multi_fn = simd_shuffle-in_len-!, a, b, {zip-2-in_len}
+multi_fn = simd_shuffle!, a, b, {zip-2-in_len}
 a = 0, 16, 16, 18, 16, 18, 20, 22, 16, 18, 20, 22, 24, 26, 28, 30
 b = 1, 17, 17, 19, 17, 19, 21, 23, 17, 19, 21, 23, 25, 27, 29, 31
 validate 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
@@ -7239,7 +7239,7 @@ generate int*_t, int64x2_t, uint*_t, uint64x2_t, poly8x8_t, poly8x16_t, poly16x4
 
 /// Zip vectors
 name = vzip2
-multi_fn = simd_shuffle-in_len-!, a, b, {zip-2-in_len}
+multi_fn = simd_shuffle!, a, b, {zip-2-in_len}
 a = 0., 8., 8., 10., 8., 10., 12., 14.
 b = 1., 9., 9., 11., 9., 11., 13., 15.
 validate 8., 9., 10., 11., 12., 13., 14., 15.
@@ -7249,8 +7249,8 @@ generate float32x2_t, float32x4_t, float64x2_t
 
 /// Unzip vectors
 name = vuzp
-multi_fn = simd_shuffle-in_len-!, a0:in_t, a, b, {unzip-1-in_len}
-multi_fn = simd_shuffle-in_len-!, b0:in_t, a, b, {unzip-2-in_len}
+multi_fn = simd_shuffle!, a0:in_t, a, b, {unzip-1-in_len}
+multi_fn = simd_shuffle!, b0:in_t, a, b, {unzip-2-in_len}
 multi_fn = transmute, (a0, b0)
 a = 1, 2, 2, 3, 2, 3, 3, 8, 2, 3, 3, 8, 3, 15, 8, 16
 b = 2, 3, 3, 8, 3, 15, 8, 16, 3, 29, 8, 30, 15, 31, 16, 32
@@ -7267,8 +7267,8 @@ generate int32x2_t:int32x2_t:int32x2x2_t, uint32x2_t:uint32x2_t:uint32x2x2_t
 
 /// Unzip vectors
 name = vuzp
-multi_fn = simd_shuffle-in_len-!, a0:in_t, a, b, {unzip-1-in_len}
-multi_fn = simd_shuffle-in_len-!, b0:in_t, a, b, {unzip-2-in_len}
+multi_fn = simd_shuffle!, a0:in_t, a, b, {unzip-1-in_len}
+multi_fn = simd_shuffle!, b0:in_t, a, b, {unzip-2-in_len}
 multi_fn = transmute, (a0, b0)
 a = 1., 2., 2., 4.
 b = 2., 6., 6., 8.
@@ -7283,7 +7283,7 @@ generate float32x4_t:float32x4_t:float32x4x2_t
 
 /// Unzip vectors
 name = vuzp1
-multi_fn = simd_shuffle-in_len-!, a, b, {unzip-1-in_len}
+multi_fn = simd_shuffle!, a, b, {unzip-1-in_len}
 a = 1, 0, 2, 0, 2, 0, 3, 0, 2, 0, 3, 0, 7, 0, 8, 0
 b = 2, 0, 3, 0, 7, 0, 8, 0, 13, 0, 14, 0, 15, 0, 16, 0
 validate 1, 2, 2, 3, 2, 3, 7, 8, 2, 3, 7, 8, 13, 14, 15, 16
@@ -7296,7 +7296,7 @@ generate int32x2_t, int64x2_t, uint32x2_t, uint64x2_t, poly64x2_t
 
 /// Unzip vectors
 name = vuzp1
-multi_fn = simd_shuffle-in_len-!, a, b, {unzip-1-in_len}
+multi_fn = simd_shuffle!, a, b, {unzip-1-in_len}
 a = 0., 8., 1., 9., 4., 12., 5., 13.
 b = 1., 10., 3., 11., 6., 14., 7., 15.
 validate 0., 1., 1., 3., 4., 5., 6., 7.
@@ -7309,7 +7309,7 @@ generate float32x2_t, float64x2_t
 
 /// Unzip vectors
 name = vuzp2
-multi_fn = simd_shuffle-in_len-!, a, b, {unzip-2-in_len}
+multi_fn = simd_shuffle!, a, b, {unzip-2-in_len}
 a = 0, 17, 0, 18, 0, 18, 0, 19, 0, 18, 0, 19, 0, 23, 0, 24
 b = 0, 18, 0, 19, 0, 23, 0, 24, 0, 29, 0, 30, 0, 31, 0, 32
 validate 17, 18, 18, 19, 18, 19, 23, 24, 18, 19, 23, 24, 29, 30, 31, 32
@@ -7322,7 +7322,7 @@ generate int32x2_t, int64x2_t, uint32x2_t, uint64x2_t, poly64x2_t
 
 /// Unzip vectors
 name = vuzp2
-multi_fn = simd_shuffle-in_len-!, a, b, {unzip-2-in_len}
+multi_fn = simd_shuffle!, a, b, {unzip-2-in_len}
 a = 0., 8., 1., 9., 4., 12., 5., 13.
 b = 2., 9., 3., 11., 6., 14., 7., 15.
 validate 8., 9., 9., 11., 12., 13., 14., 15.
@@ -7353,8 +7353,8 @@ generate uint16x8_t:uint8x8_t:uint8x8_t:uint16x8_t, uint32x4_t:uint16x4_t:uint16
 /// Unsigned Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = simd_shuffle8!, d:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
-multi_fn = simd_shuffle8!, e:uint8x8_t, c, c, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, d:uint8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, e:uint8x8_t, c, c, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = vabd_u8, d, e, f:uint8x8_t
 multi_fn = simd_add, a, {simd_cast, f}
 a = 9, 10, 11, 12, 13, 14, 15, 16
@@ -7368,8 +7368,8 @@ generate uint16x8_t:uint8x16_t:uint8x16_t:uint16x8_t
 /// Unsigned Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = simd_shuffle4!, d:uint16x4_t, b, b, [4, 5, 6, 7]
-multi_fn = simd_shuffle4!, e:uint16x4_t, c, c, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, d:uint16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, e:uint16x4_t, c, c, [4, 5, 6, 7]
 multi_fn = vabd_u16, d, e, f:uint16x4_t
 multi_fn = simd_add, a, {simd_cast, f}
 a = 9, 10, 11, 12
@@ -7383,8 +7383,8 @@ generate uint32x4_t:uint16x8_t:uint16x8_t:uint32x4_t
 /// Unsigned Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = simd_shuffle2!, d:uint32x2_t, b, b, [2, 3]
-multi_fn = simd_shuffle2!, e:uint32x2_t, c, c, [2, 3]
+multi_fn = simd_shuffle!, d:uint32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, e:uint32x2_t, c, c, [2, 3]
 multi_fn = vabd_u32, d, e, f:uint32x2_t
 multi_fn = simd_add, a, {simd_cast, f}
 a = 15, 16
@@ -7444,8 +7444,8 @@ generate int64x2_t:int32x2_t:int32x2_t:int64x2_t
 /// Signed Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = simd_shuffle8!, d:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
-multi_fn = simd_shuffle8!, e:int8x8_t, c, c, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, d:int8x8_t, b, b, [8, 9, 10, 11, 12, 13, 14, 15]
+multi_fn = simd_shuffle!, e:int8x8_t, c, c, [8, 9, 10, 11, 12, 13, 14, 15]
 multi_fn = vabd_s8, d, e, f:int8x8_t
 multi_fn = simd_cast, f:uint8x8_t, f
 multi_fn = simd_add, a, {simd_cast, f}
@@ -7460,8 +7460,8 @@ generate int16x8_t:int8x16_t:int8x16_t:int16x8_t
 /// Signed Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = simd_shuffle4!, d:int16x4_t, b, b, [4, 5, 6, 7]
-multi_fn = simd_shuffle4!, e:int16x4_t, c, c, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, d:int16x4_t, b, b, [4, 5, 6, 7]
+multi_fn = simd_shuffle!, e:int16x4_t, c, c, [4, 5, 6, 7]
 multi_fn = vabd_s16, d, e, f:int16x4_t
 multi_fn = simd_cast, f:uint16x4_t, f
 multi_fn = simd_add, a, {simd_cast, f}
@@ -7476,8 +7476,8 @@ generate int32x4_t:int16x8_t:int16x8_t:int32x4_t
 /// Signed Absolute difference and Accumulate Long
 name = vabal_high
 no-q
-multi_fn = simd_shuffle2!, d:int32x2_t, b, b, [2, 3]
-multi_fn = simd_shuffle2!, e:int32x2_t, c, c, [2, 3]
+multi_fn = simd_shuffle!, d:int32x2_t, b, b, [2, 3]
+multi_fn = simd_shuffle!, e:int32x2_t, c, c, [2, 3]
 multi_fn = vabd_s32, d, e, f:int32x2_t
 multi_fn = simd_cast, f:uint32x2_t, f
 multi_fn = simd_add, a, {simd_cast, f}

--- a/crates/stdarch-gen/src/main.rs
+++ b/crates/stdarch-gen/src/main.rs
@@ -1447,7 +1447,6 @@ fn gen_aarch64(
             calls.push_str(&get_call(
                 &multi_fn[i],
                 current_name,
-                &const_declare,
                 in_t,
                 out_t,
                 fixed,
@@ -2313,7 +2312,6 @@ fn gen_arm(
             calls.push_str(&get_call(
                 &multi_fn[i],
                 current_name,
-                &const_declare,
                 in_t,
                 out_t,
                 fixed,
@@ -2707,7 +2705,6 @@ fn expand_intrinsic(intr: &str, t: &str) -> String {
 fn get_call(
     in_str: &str,
     current_name: &str,
-    const_declare: &str,
     in_t: &[&str; 3],
     out_t: &str,
     fixed: &Vec<String>,
@@ -2747,7 +2744,7 @@ fn get_call(
             "halflen" => type_len(in_t[1]) / 2,
             _ => 0,
         };
-        let mut s = format!("{const_declare} [");
+        let mut s = format!("[");
         for i in 0..len {
             if i != 0 {
                 s.push_str(", ");
@@ -2778,7 +2775,7 @@ fn get_call(
     if fn_name.starts_with("base") {
         let fn_format: Vec<_> = fn_name.split('-').map(|v| v.to_string()).collect();
         assert_eq!(fn_format.len(), 3);
-        let mut s = format!("<const {}: i32> [", &fn_format[2]);
+        let mut s = format!("[");
         let base_len = fn_format[1].parse::<usize>().unwrap();
         for i in 0..type_len(in_t[1]) / base_len {
             for j in 0..base_len {
@@ -2818,7 +2815,7 @@ fn get_call(
             "in0_len" => type_len(in_t[0]),
             _ => 0,
         };
-        let mut s = format!("{const_declare} [");
+        let mut s = format!("[");
         for i in 0..len {
             if i != 0 {
                 s.push_str(", ");
@@ -2928,7 +2925,6 @@ fn get_call(
                 get_call(
                     &sub_call,
                     current_name,
-                    const_declare,
                     in_t,
                     out_t,
                     fixed,
@@ -2977,7 +2973,6 @@ fn get_call(
             let sub_call = get_call(
                 &sub_fn[1..sub_fn.len() - 1],
                 current_name,
-                const_declare,
                 in_t,
                 out_t,
                 fixed,


### PR DESCRIPTION
With inline consts we don't need these associated const hacks any more, and we can use a single macro for all vector widths.