### PR TITLE
Don't declare f16c_target_feature.

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -28,7 +28,6 @@
     wasm_target_feature,
     abi_unadjusted,
     rtm_target_feature,
-    f16c_target_feature,
     allow_internal_unstable,
     decl_macro,
     asm_const,


### PR DESCRIPTION
f16c_target_feature was recently stabilised.

This fixes a warning that results in a CI failure (due to `-D stable-features`) with current nightly Rust.