### PR TITLE
Remove obsolete cfg for nvptx

### DIFF
--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -255,8 +255,8 @@ pub mod arch {
     /// Platform-specific intrinsics for the `NVPTX` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
-    #[cfg(any(target_arch = "nvptx", target_arch = "nvptx64", doc))]
-    #[doc(cfg(any(target_arch = "nvptx", target_arch = "nvptx64")))]
+    #[cfg(any(target_arch = "nvptx64", doc))]
+    #[doc(cfg(target_arch = "nvptx64"))]
     #[unstable(feature = "stdsimd", issue = "27731")]
     pub mod nvptx {
         pub use crate::core_arch::nvptx::*;
@@ -299,6 +299,6 @@ mod powerpc;
 #[doc(cfg(target_arch = "powerpc64"))]
 mod powerpc64;
 
-#[cfg(any(target_arch = "nvptx", target_arch = "nvptx64", doc))]
-#[doc(cfg(any(target_arch = "nvptx", target_arch = "nvptx64")))]
+#[cfg(any(target_arch = "nvptx64", doc))]
+#[doc(cfg(target_arch = "nvptx64"))]
 mod nvptx;


### PR DESCRIPTION
This PR removes the last `target_arch=nvptx` in accordance to the compiler MCP 496 (https://github.com/rust-lang/compiler-team/issues/496). It came up when cleaning up bootstrap extra cfgs (https://github.com/rust-lang/rust/pull/107080).