### PR TITLE
std_detect: Support detecting lse/dotprod/jsconv/rcpc on aarch64 Windows

### DIFF
--- a/crates/std_detect/src/detect/os/windows/aarch64.rs
+++ b/crates/std_detect/src/detect/os/windows/aarch64.rs
@@ -14,6 +14,10 @@ pub(crate) fn detect_features() -> cache::Initializer {
     const PF_ARM_NEON_INSTRUCTIONS_AVAILABLE: u32 = 19;
     const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: u32 = 30;
     const PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE: u32 = 31;
+    const PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE: u32 = 34;
+    const PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE: u32 = 43;
+    const PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE: u32 = 44;
+    const PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE: u32 = 45;
 
     extern "system" {
         pub fn IsProcessorFeaturePresent(ProcessorFeature: DWORD) -> BOOL;
@@ -38,6 +42,22 @@ pub(crate) fn detect_features() -> cache::Initializer {
             enable_feature(
                 Feature::crc,
                 IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::lse,
+                IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::dotprod,
+                IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::jsconv,
+                IsProcessorFeaturePresent(PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::rcpc,
+                IsProcessorFeaturePresent(PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE) != FALSE,
             );
             // PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE means aes, sha1, sha2 and
             // pmull support

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -84,6 +84,20 @@ fn aarch64_linux() {
 }
 
 #[test]
+#[cfg(all(target_arch = "aarch64", target_os = "windows"))]
+fn aarch64_windows() {
+    println!("asimd: {:?}", is_aarch64_feature_detected!("asimd"));
+    println!("crc: {:?}", is_aarch64_feature_detected!("crc"));
+    println!("lse: {:?}", is_aarch64_feature_detected!("lse"));
+    println!("dotprod: {:?}", is_aarch64_feature_detected!("dotprod"));
+    println!("jsconv: {:?}", is_aarch64_feature_detected!("jsconv"));
+    println!("rcpc: {:?}", is_aarch64_feature_detected!("rcpc"));
+    println!("aes: {:?}", is_aarch64_feature_detected!("aes"));
+    println!("pmull: {:?}", is_aarch64_feature_detected!("pmull"));
+    println!("sha2: {:?}", is_aarch64_feature_detected!("sha2"));
+}
+
+#[test]
 #[cfg(all(target_arch = "powerpc", target_os = "linux"))]
 fn powerpc_linux() {
     println!("altivec: {}", is_powerpc_feature_detected!("altivec"));


### PR DESCRIPTION
IsProcessorFeaturePresent currently supports the detection of more CPU features.

<img width="532" alt="winnt" src="https://user-images.githubusercontent.com/43724913/214118378-f8ca7aaf-827d-4676-8a24-3dbe3f9bda24.png">

([IsProcessorFeaturePresent docs](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent) currently don't mention most of them but it appears there is [a PR to update it](https://github.com/MicrosoftDocs/sdk-api/pull/1409/files))