### PR TITLE
std_detect: Always avoid dlsym on *-linux-gnu* targets

### DIFF
--- a/crates/std_detect/README.md
+++ b/crates/std_detect/README.md
@@ -30,6 +30,8 @@ run-time feature detection. When this feature is disabled, `std_detect` assumes
 that [`getauxval`] is linked to the binary. If that is not the case the behavior
 is undefined.
 
+  Note: This feature is ignored on `*-linux-gnu*` targets, since all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html)) have glibc requirements higher than [glibc 2.16 that `getauxval` added](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html), and we can safely assume [`getauxval`] is linked to the binary.
+
 * `std_detect_file_io` (enabled by default, requires `std`): Enable to perform run-time feature
 detection using file APIs (e.g. `/proc/cpuinfo`, etc.) if other more performant
 methods fail. This feature requires `libstd` as a dependency, preventing the

--- a/crates/std_detect/README.md
+++ b/crates/std_detect/README.md
@@ -30,7 +30,7 @@ run-time feature detection. When this feature is disabled, `std_detect` assumes
 that [`getauxval`] is linked to the binary. If that is not the case the behavior
 is undefined.
 
-  Note: This feature is ignored on `*-linux-gnu*` targets, since all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html)) have glibc requirements higher than [glibc 2.16 that `getauxval` added](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html), and we can safely assume [`getauxval`] is linked to the binary.
+  Note: This feature is ignored on `*-linux-gnu*` targets, since all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html)) have glibc requirements higher than [glibc 2.16 that added `getauxval`](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html), and we can safely assume [`getauxval`] is linked to the binary.
 
 * `std_detect_file_io` (enabled by default, requires `std`): Enable to perform run-time feature
 detection using file APIs (e.g. `/proc/cpuinfo`, etc.) if other more performant

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -56,7 +56,7 @@ pub(crate) struct AuxVec {
 ///
 /// Note: The `std_detect_dlsym_getauxval` cargo feature is ignored on `*-linux-gnu*` targets,
 /// since [all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html))
-/// have glibc requirements higher than [glibc 2.16 that `getauxval` added](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html),
+/// have glibc requirements higher than [glibc 2.16 that added `getauxval`](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html),
 /// and we can safely assume [`getauxval`] is linked to the binary.
 ///
 /// For more information about when `getauxval` is available check the great

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -54,13 +54,21 @@ pub(crate) struct AuxVec {
 /// error, cpuinfo still can (and will) be used to try to perform run-time
 /// feature detecton on some platforms.
 ///
+/// Note: The `std_detect_dlsym_getauxval` cargo feature is ignored on `*-linux-gnu*` targets,
+/// since [all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html))
+/// have glibc requirements higher than [glibc 2.16 that `getauxval` added](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html),
+/// and we can safely assume [`getauxval`] is linked to the binary.
+///
 /// For more information about when `getauxval` is available check the great
 /// [`auxv` crate documentation][auxv_docs].
 ///
 /// [auxvec_h]: https://github.com/torvalds/linux/blob/master/include/uapi/linux/auxvec.h
 /// [auxv_docs]: https://docs.rs/auxv/0.3.3/auxv/
 pub(crate) fn auxv() -> Result<AuxVec, ()> {
-    #[cfg(feature = "std_detect_dlsym_getauxval")]
+    #[cfg(all(
+        feature = "std_detect_dlsym_getauxval",
+        not(all(target_os = "linux", target_env = "gnu"))
+    ))]
     {
         // Try to call a dynamically-linked getauxval function.
         if let Ok(hwcap) = getauxval(AT_HWCAP) {
@@ -101,7 +109,10 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
         }
     }
 
-    #[cfg(not(feature = "std_detect_dlsym_getauxval"))]
+    #[cfg(any(
+        not(feature = "std_detect_dlsym_getauxval"),
+        all(target_os = "linux", target_env = "gnu")
+    ))]
     {
         // Targets with only AT_HWCAP:
         #[cfg(any(
@@ -154,7 +165,10 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
 /// Tries to read the `key` from the auxiliary vector by calling the
 /// dynamically-linked `getauxval` function. If the function is not linked,
 /// this function return `Err`.
-#[cfg(feature = "std_detect_dlsym_getauxval")]
+#[cfg(all(
+    feature = "std_detect_dlsym_getauxval",
+    not(all(target_os = "linux", target_env = "gnu"))
+))]
 fn getauxval(key: usize) -> Result<usize, ()> {
     use libc;
     pub type F = unsafe extern "C" fn(usize) -> usize;


### PR DESCRIPTION
Currently, we use `dlsym` on non-x86[^1] Linux/Android when the `std_detect_dlsym_getauxval` feature (enabled by default) is enabled because `getauxval` may not be available.

However, [since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html), all `*-linux-gnu*` targets have glibc requirements higher than [glibc 2.16 that `getauxval` added](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html), and we can safely assume `getauxval` is linked to the binary.

Related https://github.com/rust-lang/stdarch/issues/655 (fyi @briansmith)

---

IIUC, at this time, we can do this on only `*-linux-gnu*` targets, because:

- On `*-linux-musl*`, it seems that `getauxval` is not always available, independent of version requirements: https://github.com/rust-lang/rust/issues/89626
  - That problem may have been fixed in https://github.com/rust-lang/rust/commit/9a04ae4997493e9260352064163285cddc43de3c, but even in the version containing that patch, [there is report](https://github.com/rust-lang/rust/issues/89626#issuecomment-1242636038) of the same error (perhaps when `getauxval` is used on the C/C++ side).
- On `*-android*`, according to [auxv crate](https://docs.rs/auxv/latest/auxv/#reading-the-auxiliary-vector), `getauxval` is available for android 4.3 or later, but the Android API requirement for Rust is still 4.0 (Ice Cream Sandwich).
  - However, [probably in 1.68 the android API requirements will be updated to 4.4 (KitKat)](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html) so it is likely that in the neer future we can assume that `getauxval` is always available.
- On other `*-linux-*` targets (e.g. `*-linux-uclibc*`), according to [auxv crate](https://docs.rs/auxv/latest/auxv/#reading-the-auxiliary-vector), `getauxval` is not available.

[^1]: On x86, we use cpuid instead of auxv.