### PR TITLE
std_detect: Support run-time detection of FEAT_LSE2 on aarch64 BSD

### DIFF
--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -110,6 +110,7 @@ fn aarch64_bsd() {
     println!("sve: {:?}", is_aarch64_feature_detected!("sve"));
     println!("crc: {:?}", is_aarch64_feature_detected!("crc"));
     println!("lse: {:?}", is_aarch64_feature_detected!("lse"));
+    println!("lse2: {:?}", is_aarch64_feature_detected!("lse2"));
     println!("rdm: {:?}", is_aarch64_feature_detected!("rdm"));
     println!("rcpc: {:?}", is_aarch64_feature_detected!("rcpc"));
     println!("dotprod: {:?}", is_aarch64_feature_detected!("dotprod"));


### PR DESCRIPTION
If FEAT_LSE2 is implemented, AT field of ID_AA64MMFR2_EL1 is 0b0001. https://developer.arm.com/documentation/ddi0601/2022-12/AArch64-Registers/ID-AA64MMFR2-EL1--AArch64-Memory-Model-Feature-Register-2?lang=en#fieldset_0-35_32

Also, if FEAT_LSE is implemented, Atomic field of ID_AA64ISAR0_EL1 is >= 0b0010, not >= 0b0001. (0b0001 is reserved) This patch fixes it too.
https://developer.arm.com/documentation/ddi0601/2022-12/AArch64-Registers/ID-AA64ISAR0-EL1--AArch64-Instruction-Set-Attribute-Register-0?lang=en#fieldset_0-23_20