### PR TITLE
std_detect: Support run-time detection of fp on aarch64 Windows

### DIFF
--- a/crates/std_detect/src/detect/os/windows/aarch64.rs
+++ b/crates/std_detect/src/detect/os/windows/aarch64.rs
@@ -11,6 +11,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // The following Microsoft documents isn't updated for aarch64.
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent
     // These are defined in winnt.h of Windows SDK
+    const PF_ARM_VFP_32_REGISTERS_AVAILABLE: u32 = 18;
     const PF_ARM_NEON_INSTRUCTIONS_AVAILABLE: u32 = 19;
     const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: u32 = 30;
     const PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE: u32 = 31;
@@ -31,10 +32,14 @@ pub(crate) fn detect_features() -> cache::Initializer {
             }
         };
 
-        // Some features such Feature::fp may be supported on current CPU,
+        // Some features may be supported on current CPU,
         // but no way to detect it by OS API.
         // Also, we require unsafe block for the extern "system" calls.
         unsafe {
+            enable_feature(
+                Feature::fp,
+                IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE) != FALSE,
+            );
             enable_feature(
                 Feature::asimd,
                 IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE) != FALSE,
@@ -61,18 +66,11 @@ pub(crate) fn detect_features() -> cache::Initializer {
             );
             // PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE means aes, sha1, sha2 and
             // pmull support
-            enable_feature(
-                Feature::aes,
-                IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != FALSE,
-            );
-            enable_feature(
-                Feature::pmull,
-                IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != FALSE,
-            );
-            enable_feature(
-                Feature::sha2,
-                IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != FALSE,
-            );
+            let crypto =
+                IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != FALSE;
+            enable_feature(Feature::aes, crypto);
+            enable_feature(Feature::pmull, crypto);
+            enable_feature(Feature::sha2, crypto);
         }
     }
     value

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -87,6 +87,7 @@ fn aarch64_linux() {
 #[cfg(all(target_arch = "aarch64", target_os = "windows"))]
 fn aarch64_windows() {
     println!("asimd: {:?}", is_aarch64_feature_detected!("asimd"));
+    println!("fp: {:?}", is_aarch64_feature_detected!("fp"));
     println!("crc: {:?}", is_aarch64_feature_detected!("crc"));
     println!("lse: {:?}", is_aarch64_feature_detected!("lse"));
     println!("dotprod: {:?}", is_aarch64_feature_detected!("dotprod"));


### PR DESCRIPTION
According to google/cpu_features, IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE) returns whether fp is available.
https://github.com/google/cpu_features/blob/a6bf4f9031ec601f905660b8cef82d7478b33d64/src/impl_aarch64_windows.c#L112-L113

~~Also, update to respect feature dependencies based on LLVM's feature definitions:
https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64.td~~

~~I don't know if there is support for [cases where fp or asimd is unavailable](https://developer.arm.com/documentation/den0024/a/AArch64-Floating-point-and-NEON) on Windows, but I think it is reasonable to unify the behavior with [linux](https://github.com/rust-lang/stdarch/blob/15c760e75c58e49f15d32e76022b04d597c308e8/crates/std_detect/src/detect/os/linux/aarch64.rs#L306) and [bsd](https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/src/detect/os/aarch64.rs#L105) in any case.~~

(Tested on aarch64 Windows VM on mac m1)