### PR TITLE
Fix stable_features warnings

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -21,7 +21,6 @@
     sse4a_target_feature,
     riscv_target_feature,
     arm_target_feature,
-    cmpxchg16b_target_feature,
     avx512_target_feature,
     mips_target_feature,
     powerpc_target_feature,
@@ -31,7 +30,6 @@
     allow_internal_unstable,
     decl_macro,
     asm_const,
-    target_feature_11,
     inline_const,
     generic_arg_infer
 )]


### PR DESCRIPTION
```
warning: the feature `cmpxchg16b_target_feature` has been stable since 1.69.0-nightly and no longer requires an attribute to enable
  --> crates/core_arch/src/lib.rs:24:5
   |
24 |     cmpxchg16b_target_feature,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(stable_features)]` on by default

warning: the feature `target_feature_11` has been stable since 1.69.0-nightly and no longer requires an attribute to enable
  --> crates/core_arch/src/lib.rs:34:5
   |
34 |     target_feature_11,
   |     ^^^^^^^^^^^^^^^^^
```