### PR TITLE
Re-add #![feature(target_feature_11)]

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -30,6 +30,7 @@
     allow_internal_unstable,
     decl_macro,
     asm_const,
+    target_feature_11,
     inline_const,
     generic_arg_infer
 )]


### PR DESCRIPTION
We removed this in 307c42fbf4bdfdda2c46fdc1d330cc61d96b5182, but the stabilization was reverted in https://github.com/rust-lang/rust/pull/108654.