### PR TITLE
Mark more arm_shared intrinsics and types as stable in docs

### DIFF
--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -109,7 +109,7 @@ types! {
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int8x8x2_t(pub int8x8_t, pub int8x8_t);
@@ -117,7 +117,7 @@ pub struct int8x8x2_t(pub int8x8_t, pub int8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int8x8x3_t(pub int8x8_t, pub int8x8_t, pub int8x8_t);
@@ -125,7 +125,7 @@ pub struct int8x8x3_t(pub int8x8_t, pub int8x8_t, pub int8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int8x8x4_t(pub int8x8_t, pub int8x8_t, pub int8x8_t, pub int8x8_t);
@@ -134,7 +134,7 @@ pub struct int8x8x4_t(pub int8x8_t, pub int8x8_t, pub int8x8_t, pub int8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int8x16x2_t(pub int8x16_t, pub int8x16_t);
@@ -142,7 +142,7 @@ pub struct int8x16x2_t(pub int8x16_t, pub int8x16_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int8x16x3_t(pub int8x16_t, pub int8x16_t, pub int8x16_t);
@@ -150,7 +150,7 @@ pub struct int8x16x3_t(pub int8x16_t, pub int8x16_t, pub int8x16_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int8x16x4_t(pub int8x16_t, pub int8x16_t, pub int8x16_t, pub int8x16_t);
@@ -159,7 +159,7 @@ pub struct int8x16x4_t(pub int8x16_t, pub int8x16_t, pub int8x16_t, pub int8x16_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint8x8x2_t(pub uint8x8_t, pub uint8x8_t);
@@ -167,7 +167,7 @@ pub struct uint8x8x2_t(pub uint8x8_t, pub uint8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint8x8x3_t(pub uint8x8_t, pub uint8x8_t, pub uint8x8_t);
@@ -175,7 +175,7 @@ pub struct uint8x8x3_t(pub uint8x8_t, pub uint8x8_t, pub uint8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint8x8x4_t(pub uint8x8_t, pub uint8x8_t, pub uint8x8_t, pub uint8x8_t);
@@ -184,7 +184,7 @@ pub struct uint8x8x4_t(pub uint8x8_t, pub uint8x8_t, pub uint8x8_t, pub uint8x8_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint8x16x2_t(pub uint8x16_t, pub uint8x16_t);
@@ -192,7 +192,7 @@ pub struct uint8x16x2_t(pub uint8x16_t, pub uint8x16_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint8x16x3_t(pub uint8x16_t, pub uint8x16_t, pub uint8x16_t);
@@ -200,7 +200,7 @@ pub struct uint8x16x3_t(pub uint8x16_t, pub uint8x16_t, pub uint8x16_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint8x16x4_t(
@@ -214,7 +214,7 @@ pub struct uint8x16x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly8x8x2_t(pub poly8x8_t, pub poly8x8_t);
@@ -222,7 +222,7 @@ pub struct poly8x8x2_t(pub poly8x8_t, pub poly8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly8x8x3_t(pub poly8x8_t, pub poly8x8_t, pub poly8x8_t);
@@ -230,7 +230,7 @@ pub struct poly8x8x3_t(pub poly8x8_t, pub poly8x8_t, pub poly8x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly8x8x4_t(pub poly8x8_t, pub poly8x8_t, pub poly8x8_t, pub poly8x8_t);
@@ -239,7 +239,7 @@ pub struct poly8x8x4_t(pub poly8x8_t, pub poly8x8_t, pub poly8x8_t, pub poly8x8_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly8x16x2_t(pub poly8x16_t, pub poly8x16_t);
@@ -247,7 +247,7 @@ pub struct poly8x16x2_t(pub poly8x16_t, pub poly8x16_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly8x16x3_t(pub poly8x16_t, pub poly8x16_t, pub poly8x16_t);
@@ -255,7 +255,7 @@ pub struct poly8x16x3_t(pub poly8x16_t, pub poly8x16_t, pub poly8x16_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly8x16x4_t(
@@ -269,7 +269,7 @@ pub struct poly8x16x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int16x4x2_t(pub int16x4_t, pub int16x4_t);
@@ -277,7 +277,7 @@ pub struct int16x4x2_t(pub int16x4_t, pub int16x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int16x4x3_t(pub int16x4_t, pub int16x4_t, pub int16x4_t);
@@ -285,7 +285,7 @@ pub struct int16x4x3_t(pub int16x4_t, pub int16x4_t, pub int16x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int16x4x4_t(pub int16x4_t, pub int16x4_t, pub int16x4_t, pub int16x4_t);
@@ -294,7 +294,7 @@ pub struct int16x4x4_t(pub int16x4_t, pub int16x4_t, pub int16x4_t, pub int16x4_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int16x8x2_t(pub int16x8_t, pub int16x8_t);
@@ -302,7 +302,7 @@ pub struct int16x8x2_t(pub int16x8_t, pub int16x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int16x8x3_t(pub int16x8_t, pub int16x8_t, pub int16x8_t);
@@ -310,7 +310,7 @@ pub struct int16x8x3_t(pub int16x8_t, pub int16x8_t, pub int16x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int16x8x4_t(pub int16x8_t, pub int16x8_t, pub int16x8_t, pub int16x8_t);
@@ -319,7 +319,7 @@ pub struct int16x8x4_t(pub int16x8_t, pub int16x8_t, pub int16x8_t, pub int16x8_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint16x4x2_t(pub uint16x4_t, pub uint16x4_t);
@@ -327,7 +327,7 @@ pub struct uint16x4x2_t(pub uint16x4_t, pub uint16x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint16x4x3_t(pub uint16x4_t, pub uint16x4_t, pub uint16x4_t);
@@ -335,7 +335,7 @@ pub struct uint16x4x3_t(pub uint16x4_t, pub uint16x4_t, pub uint16x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint16x4x4_t(
@@ -349,7 +349,7 @@ pub struct uint16x4x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint16x8x2_t(pub uint16x8_t, pub uint16x8_t);
@@ -357,7 +357,7 @@ pub struct uint16x8x2_t(pub uint16x8_t, pub uint16x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint16x8x3_t(pub uint16x8_t, pub uint16x8_t, pub uint16x8_t);
@@ -365,7 +365,7 @@ pub struct uint16x8x3_t(pub uint16x8_t, pub uint16x8_t, pub uint16x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint16x8x4_t(
@@ -379,7 +379,7 @@ pub struct uint16x8x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly16x4x2_t(pub poly16x4_t, pub poly16x4_t);
@@ -387,7 +387,7 @@ pub struct poly16x4x2_t(pub poly16x4_t, pub poly16x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly16x4x3_t(pub poly16x4_t, pub poly16x4_t, pub poly16x4_t);
@@ -395,7 +395,7 @@ pub struct poly16x4x3_t(pub poly16x4_t, pub poly16x4_t, pub poly16x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly16x4x4_t(
@@ -409,7 +409,7 @@ pub struct poly16x4x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly16x8x2_t(pub poly16x8_t, pub poly16x8_t);
@@ -417,7 +417,7 @@ pub struct poly16x8x2_t(pub poly16x8_t, pub poly16x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly16x8x3_t(pub poly16x8_t, pub poly16x8_t, pub poly16x8_t);
@@ -425,7 +425,7 @@ pub struct poly16x8x3_t(pub poly16x8_t, pub poly16x8_t, pub poly16x8_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly16x8x4_t(
@@ -439,7 +439,7 @@ pub struct poly16x8x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int32x2x2_t(pub int32x2_t, pub int32x2_t);
@@ -447,7 +447,7 @@ pub struct int32x2x2_t(pub int32x2_t, pub int32x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int32x2x3_t(pub int32x2_t, pub int32x2_t, pub int32x2_t);
@@ -455,7 +455,7 @@ pub struct int32x2x3_t(pub int32x2_t, pub int32x2_t, pub int32x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int32x2x4_t(pub int32x2_t, pub int32x2_t, pub int32x2_t, pub int32x2_t);
@@ -464,7 +464,7 @@ pub struct int32x2x4_t(pub int32x2_t, pub int32x2_t, pub int32x2_t, pub int32x2_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int32x4x2_t(pub int32x4_t, pub int32x4_t);
@@ -472,7 +472,7 @@ pub struct int32x4x2_t(pub int32x4_t, pub int32x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int32x4x3_t(pub int32x4_t, pub int32x4_t, pub int32x4_t);
@@ -480,7 +480,7 @@ pub struct int32x4x3_t(pub int32x4_t, pub int32x4_t, pub int32x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int32x4x4_t(pub int32x4_t, pub int32x4_t, pub int32x4_t, pub int32x4_t);
@@ -489,7 +489,7 @@ pub struct int32x4x4_t(pub int32x4_t, pub int32x4_t, pub int32x4_t, pub int32x4_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint32x2x2_t(pub uint32x2_t, pub uint32x2_t);
@@ -497,7 +497,7 @@ pub struct uint32x2x2_t(pub uint32x2_t, pub uint32x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint32x2x3_t(pub uint32x2_t, pub uint32x2_t, pub uint32x2_t);
@@ -505,7 +505,7 @@ pub struct uint32x2x3_t(pub uint32x2_t, pub uint32x2_t, pub uint32x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint32x2x4_t(
@@ -519,7 +519,7 @@ pub struct uint32x2x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint32x4x2_t(pub uint32x4_t, pub uint32x4_t);
@@ -527,7 +527,7 @@ pub struct uint32x4x2_t(pub uint32x4_t, pub uint32x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint32x4x3_t(pub uint32x4_t, pub uint32x4_t, pub uint32x4_t);
@@ -535,7 +535,7 @@ pub struct uint32x4x3_t(pub uint32x4_t, pub uint32x4_t, pub uint32x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint32x4x4_t(
@@ -549,7 +549,7 @@ pub struct uint32x4x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct float32x2x2_t(pub float32x2_t, pub float32x2_t);
@@ -557,7 +557,7 @@ pub struct float32x2x2_t(pub float32x2_t, pub float32x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct float32x2x3_t(pub float32x2_t, pub float32x2_t, pub float32x2_t);
@@ -565,7 +565,7 @@ pub struct float32x2x3_t(pub float32x2_t, pub float32x2_t, pub float32x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct float32x2x4_t(
@@ -579,7 +579,7 @@ pub struct float32x2x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct float32x4x2_t(pub float32x4_t, pub float32x4_t);
@@ -587,7 +587,7 @@ pub struct float32x4x2_t(pub float32x4_t, pub float32x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct float32x4x3_t(pub float32x4_t, pub float32x4_t, pub float32x4_t);
@@ -595,7 +595,7 @@ pub struct float32x4x3_t(pub float32x4_t, pub float32x4_t, pub float32x4_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct float32x4x4_t(
@@ -609,7 +609,7 @@ pub struct float32x4x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int64x1x2_t(pub int64x1_t, pub int64x1_t);
@@ -617,7 +617,7 @@ pub struct int64x1x2_t(pub int64x1_t, pub int64x1_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int64x1x3_t(pub int64x1_t, pub int64x1_t, pub int64x1_t);
@@ -625,7 +625,7 @@ pub struct int64x1x3_t(pub int64x1_t, pub int64x1_t, pub int64x1_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int64x1x4_t(pub int64x1_t, pub int64x1_t, pub int64x1_t, pub int64x1_t);
@@ -634,7 +634,7 @@ pub struct int64x1x4_t(pub int64x1_t, pub int64x1_t, pub int64x1_t, pub int64x1_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int64x2x2_t(pub int64x2_t, pub int64x2_t);
@@ -642,7 +642,7 @@ pub struct int64x2x2_t(pub int64x2_t, pub int64x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int64x2x3_t(pub int64x2_t, pub int64x2_t, pub int64x2_t);
@@ -650,7 +650,7 @@ pub struct int64x2x3_t(pub int64x2_t, pub int64x2_t, pub int64x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct int64x2x4_t(pub int64x2_t, pub int64x2_t, pub int64x2_t, pub int64x2_t);
@@ -659,7 +659,7 @@ pub struct int64x2x4_t(pub int64x2_t, pub int64x2_t, pub int64x2_t, pub int64x2_
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint64x1x2_t(pub uint64x1_t, pub uint64x1_t);
@@ -667,7 +667,7 @@ pub struct uint64x1x2_t(pub uint64x1_t, pub uint64x1_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint64x1x3_t(pub uint64x1_t, pub uint64x1_t, pub uint64x1_t);
@@ -675,7 +675,7 @@ pub struct uint64x1x3_t(pub uint64x1_t, pub uint64x1_t, pub uint64x1_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint64x1x4_t(
@@ -689,7 +689,7 @@ pub struct uint64x1x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint64x2x2_t(pub uint64x2_t, pub uint64x2_t);
@@ -697,7 +697,7 @@ pub struct uint64x2x2_t(pub uint64x2_t, pub uint64x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint64x2x3_t(pub uint64x2_t, pub uint64x2_t, pub uint64x2_t);
@@ -705,7 +705,7 @@ pub struct uint64x2x3_t(pub uint64x2_t, pub uint64x2_t, pub uint64x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct uint64x2x4_t(
@@ -719,7 +719,7 @@ pub struct uint64x2x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly64x1x2_t(pub poly64x1_t, pub poly64x1_t);
@@ -727,7 +727,7 @@ pub struct poly64x1x2_t(pub poly64x1_t, pub poly64x1_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly64x1x3_t(pub poly64x1_t, pub poly64x1_t, pub poly64x1_t);
@@ -735,7 +735,7 @@ pub struct poly64x1x3_t(pub poly64x1_t, pub poly64x1_t, pub poly64x1_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly64x1x4_t(
@@ -749,7 +749,7 @@ pub struct poly64x1x4_t(
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly64x2x2_t(pub poly64x2_t, pub poly64x2_t);
@@ -757,7 +757,7 @@ pub struct poly64x2x2_t(pub poly64x2_t, pub poly64x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly64x2x3_t(pub poly64x2_t, pub poly64x2_t, pub poly64x2_t);
@@ -765,7 +765,7 @@ pub struct poly64x2x3_t(pub poly64x2_t, pub poly64x2_t, pub poly64x2_t);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub struct poly64x2x4_t(
@@ -971,7 +971,7 @@ extern "unadjusted" {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8", LANE = 7))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 7))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_s8<const LANE: i32>(ptr: *const i8, src: int8x8_t) -> int8x8_t {
@@ -987,7 +987,7 @@ pub unsafe fn vld1_lane_s8<const LANE: i32>(ptr: *const i8, src: int8x8_t) -> in
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8", LANE = 15))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 15))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_s8<const LANE: i32>(ptr: *const i8, src: int8x16_t) -> int8x16_t {
@@ -1003,7 +1003,7 @@ pub unsafe fn vld1q_lane_s8<const LANE: i32>(ptr: *const i8, src: int8x16_t) -> 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16", LANE = 3))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 3))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_s16<const LANE: i32>(ptr: *const i16, src: int16x4_t) -> int16x4_t {
@@ -1019,7 +1019,7 @@ pub unsafe fn vld1_lane_s16<const LANE: i32>(ptr: *const i16, src: int16x4_t) ->
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16", LANE = 7))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 7))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_s16<const LANE: i32>(ptr: *const i16, src: int16x8_t) -> int16x8_t {
@@ -1035,7 +1035,7 @@ pub unsafe fn vld1q_lane_s16<const LANE: i32>(ptr: *const i16, src: int16x8_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32", LANE = 1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_s32<const LANE: i32>(ptr: *const i32, src: int32x2_t) -> int32x2_t {
@@ -1051,7 +1051,7 @@ pub unsafe fn vld1_lane_s32<const LANE: i32>(ptr: *const i32, src: int32x2_t) ->
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32", LANE = 3))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 3))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_s32<const LANE: i32>(ptr: *const i32, src: int32x4_t) -> int32x4_t {
@@ -1067,7 +1067,7 @@ pub unsafe fn vld1q_lane_s32<const LANE: i32>(ptr: *const i32, src: int32x4_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr", LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ldr, LANE = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_s64<const LANE: i32>(ptr: *const i64, src: int64x1_t) -> int64x1_t {
@@ -1083,7 +1083,7 @@ pub unsafe fn vld1_lane_s64<const LANE: i32>(ptr: *const i64, src: int64x1_t) ->
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr", LANE = 1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_s64<const LANE: i32>(ptr: *const i64, src: int64x2_t) -> int64x2_t {
@@ -1099,7 +1099,7 @@ pub unsafe fn vld1q_lane_s64<const LANE: i32>(ptr: *const i64, src: int64x2_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8", LANE = 7))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 7))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_u8<const LANE: i32>(ptr: *const u8, src: uint8x8_t) -> uint8x8_t {
@@ -1115,7 +1115,7 @@ pub unsafe fn vld1_lane_u8<const LANE: i32>(ptr: *const u8, src: uint8x8_t) -> u
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8", LANE = 15))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 15))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_u8<const LANE: i32>(ptr: *const u8, src: uint8x16_t) -> uint8x16_t {
@@ -1131,7 +1131,7 @@ pub unsafe fn vld1q_lane_u8<const LANE: i32>(ptr: *const u8, src: uint8x16_t) ->
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16", LANE = 3))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 3))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_u16<const LANE: i32>(ptr: *const u16, src: uint16x4_t) -> uint16x4_t {
@@ -1147,7 +1147,7 @@ pub unsafe fn vld1_lane_u16<const LANE: i32>(ptr: *const u16, src: uint16x4_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16", LANE = 7))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 7))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_u16<const LANE: i32>(ptr: *const u16, src: uint16x8_t) -> uint16x8_t {
@@ -1163,7 +1163,7 @@ pub unsafe fn vld1q_lane_u16<const LANE: i32>(ptr: *const u16, src: uint16x8_t) 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32", LANE = 1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_u32<const LANE: i32>(ptr: *const u32, src: uint32x2_t) -> uint32x2_t {
@@ -1179,7 +1179,7 @@ pub unsafe fn vld1_lane_u32<const LANE: i32>(ptr: *const u32, src: uint32x2_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32", LANE = 3))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 3))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_u32<const LANE: i32>(ptr: *const u32, src: uint32x4_t) -> uint32x4_t {
@@ -1195,7 +1195,7 @@ pub unsafe fn vld1q_lane_u32<const LANE: i32>(ptr: *const u32, src: uint32x4_t) 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr", LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ldr, LANE = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_u64<const LANE: i32>(ptr: *const u64, src: uint64x1_t) -> uint64x1_t {
@@ -1211,7 +1211,7 @@ pub unsafe fn vld1_lane_u64<const LANE: i32>(ptr: *const u64, src: uint64x1_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr", LANE = 1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_u64<const LANE: i32>(ptr: *const u64, src: uint64x2_t) -> uint64x2_t {
@@ -1227,7 +1227,7 @@ pub unsafe fn vld1q_lane_u64<const LANE: i32>(ptr: *const u64, src: uint64x2_t) 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8", LANE = 7))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 7))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_p8<const LANE: i32>(ptr: *const p8, src: poly8x8_t) -> poly8x8_t {
@@ -1243,7 +1243,7 @@ pub unsafe fn vld1_lane_p8<const LANE: i32>(ptr: *const p8, src: poly8x8_t) -> p
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8", LANE = 15))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 15))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_p8<const LANE: i32>(ptr: *const p8, src: poly8x16_t) -> poly8x16_t {
@@ -1259,7 +1259,7 @@ pub unsafe fn vld1q_lane_p8<const LANE: i32>(ptr: *const p8, src: poly8x16_t) ->
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16", LANE = 3))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 3))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_p16<const LANE: i32>(ptr: *const p16, src: poly16x4_t) -> poly16x4_t {
@@ -1275,7 +1275,7 @@ pub unsafe fn vld1_lane_p16<const LANE: i32>(ptr: *const p16, src: poly16x4_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16", LANE = 7))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 7))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_p16<const LANE: i32>(ptr: *const p16, src: poly16x8_t) -> poly16x8_t {
@@ -1293,7 +1293,7 @@ pub unsafe fn vld1q_lane_p16<const LANE: i32>(ptr: *const p16, src: poly16x8_t) 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr", LANE = 0))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ldr, LANE = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_p64<const LANE: i32>(ptr: *const p64, src: poly64x1_t) -> poly64x1_t {
@@ -1311,7 +1311,7 @@ pub unsafe fn vld1_lane_p64<const LANE: i32>(ptr: *const p64, src: poly64x1_t) -
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr", LANE = 1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_p64<const LANE: i32>(ptr: *const p64, src: poly64x2_t) -> poly64x2_t {
@@ -1327,7 +1327,7 @@ pub unsafe fn vld1q_lane_p64<const LANE: i32>(ptr: *const p64, src: poly64x2_t) 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32", LANE = 1))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_lane_f32<const LANE: i32>(ptr: *const f32, src: float32x2_t) -> float32x2_t {
@@ -1343,7 +1343,7 @@ pub unsafe fn vld1_lane_f32<const LANE: i32>(ptr: *const f32, src: float32x2_t) 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32", LANE = 3))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1, LANE = 3))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_lane_f32<const LANE: i32>(ptr: *const f32, src: float32x4_t) -> float32x4_t {
@@ -1358,7 +1358,7 @@ pub unsafe fn vld1q_lane_f32<const LANE: i32>(ptr: *const f32, src: float32x4_t)
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_s8(ptr: *const i8) -> int8x8_t {
@@ -1373,7 +1373,7 @@ pub unsafe fn vld1_dup_s8(ptr: *const i8) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_s8(ptr: *const i8) -> int8x16_t {
@@ -1388,7 +1388,7 @@ pub unsafe fn vld1q_dup_s8(ptr: *const i8) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_s16(ptr: *const i16) -> int16x4_t {
@@ -1403,7 +1403,7 @@ pub unsafe fn vld1_dup_s16(ptr: *const i16) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_s16(ptr: *const i16) -> int16x8_t {
@@ -1418,7 +1418,7 @@ pub unsafe fn vld1q_dup_s16(ptr: *const i16) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_s32(ptr: *const i32) -> int32x2_t {
@@ -1433,7 +1433,7 @@ pub unsafe fn vld1_dup_s32(ptr: *const i32) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_s32(ptr: *const i32) -> int32x4_t {
@@ -1448,7 +1448,7 @@ pub unsafe fn vld1q_dup_s32(ptr: *const i32) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ldr))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_s64(ptr: *const i64) -> int64x1_t {
@@ -1469,7 +1469,7 @@ pub unsafe fn vld1_dup_s64(ptr: *const i64) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_s64(ptr: *const i64) -> int64x2_t {
@@ -1484,7 +1484,7 @@ pub unsafe fn vld1q_dup_s64(ptr: *const i64) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_u8(ptr: *const u8) -> uint8x8_t {
@@ -1499,7 +1499,7 @@ pub unsafe fn vld1_dup_u8(ptr: *const u8) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_u8(ptr: *const u8) -> uint8x16_t {
@@ -1514,7 +1514,7 @@ pub unsafe fn vld1q_dup_u8(ptr: *const u8) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_u16(ptr: *const u16) -> uint16x4_t {
@@ -1529,7 +1529,7 @@ pub unsafe fn vld1_dup_u16(ptr: *const u16) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_u16(ptr: *const u16) -> uint16x8_t {
@@ -1544,7 +1544,7 @@ pub unsafe fn vld1q_dup_u16(ptr: *const u16) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_u32(ptr: *const u32) -> uint32x2_t {
@@ -1559,7 +1559,7 @@ pub unsafe fn vld1_dup_u32(ptr: *const u32) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_u32(ptr: *const u32) -> uint32x4_t {
@@ -1574,7 +1574,7 @@ pub unsafe fn vld1q_dup_u32(ptr: *const u32) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ldr))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_u64(ptr: *const u64) -> uint64x1_t {
@@ -1595,7 +1595,7 @@ pub unsafe fn vld1_dup_u64(ptr: *const u64) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_u64(ptr: *const u64) -> uint64x2_t {
@@ -1610,7 +1610,7 @@ pub unsafe fn vld1q_dup_u64(ptr: *const u64) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_p8(ptr: *const p8) -> poly8x8_t {
@@ -1625,7 +1625,7 @@ pub unsafe fn vld1_dup_p8(ptr: *const p8) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_p8(ptr: *const p8) -> poly8x16_t {
@@ -1640,7 +1640,7 @@ pub unsafe fn vld1q_dup_p8(ptr: *const p8) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_p16(ptr: *const p16) -> poly16x4_t {
@@ -1655,7 +1655,7 @@ pub unsafe fn vld1_dup_p16(ptr: *const p16) -> poly16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_p16(ptr: *const p16) -> poly16x8_t {
@@ -1670,7 +1670,7 @@ pub unsafe fn vld1q_dup_p16(ptr: *const p16) -> poly16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_f32(ptr: *const f32) -> float32x2_t {
@@ -1687,7 +1687,7 @@ pub unsafe fn vld1_dup_f32(ptr: *const f32) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ldr))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1_dup_p64(ptr: *const p64) -> poly64x1_t {
@@ -1710,7 +1710,7 @@ pub unsafe fn vld1_dup_p64(ptr: *const p64) -> poly64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_p64(ptr: *const p64) -> poly64x2_t {
@@ -1725,7 +1725,7 @@ pub unsafe fn vld1q_dup_p64(ptr: *const p64) -> poly64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vld1.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ld1r))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vld1q_dup_f32(ptr: *const f32) -> float32x4_t {
@@ -1740,7 +1740,7 @@ pub unsafe fn vld1q_dup_f32(ptr: *const f32) -> float32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.s8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("saba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaba_s8(a: int8x8_t, b: int8x8_t, c: int8x8_t) -> int8x8_t {
@@ -1752,7 +1752,7 @@ pub unsafe fn vaba_s8(a: int8x8_t, b: int8x8_t, c: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.s16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("saba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaba_s16(a: int16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
@@ -1764,7 +1764,7 @@ pub unsafe fn vaba_s16(a: int16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.s32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("saba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaba_s32(a: int32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
@@ -1776,7 +1776,7 @@ pub unsafe fn vaba_s32(a: int32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.u8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("uaba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaba_u8(a: uint8x8_t, b: uint8x8_t, c: uint8x8_t) -> uint8x8_t {
@@ -1788,7 +1788,7 @@ pub unsafe fn vaba_u8(a: uint8x8_t, b: uint8x8_t, c: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.u16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("uaba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaba_u16(a: uint16x4_t, b: uint16x4_t, c: uint16x4_t) -> uint16x4_t {
@@ -1800,7 +1800,7 @@ pub unsafe fn vaba_u16(a: uint16x4_t, b: uint16x4_t, c: uint16x4_t) -> uint16x4_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.u32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("uaba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaba_u32(a: uint32x2_t, b: uint32x2_t, c: uint32x2_t) -> uint32x2_t {
@@ -1813,7 +1813,7 @@ pub unsafe fn vaba_u32(a: uint32x2_t, b: uint32x2_t, c: uint32x2_t) -> uint32x2_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.s8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("saba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabaq_s8(a: int8x16_t, b: int8x16_t, c: int8x16_t) -> int8x16_t {
@@ -1825,7 +1825,7 @@ pub unsafe fn vabaq_s8(a: int8x16_t, b: int8x16_t, c: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.s16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("saba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabaq_s16(a: int16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
@@ -1837,7 +1837,7 @@ pub unsafe fn vabaq_s16(a: int16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.s32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("saba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabaq_s32(a: int32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
@@ -1849,7 +1849,7 @@ pub unsafe fn vabaq_s32(a: int32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.u8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("uaba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabaq_u8(a: uint8x16_t, b: uint8x16_t, c: uint8x16_t) -> uint8x16_t {
@@ -1861,7 +1861,7 @@ pub unsafe fn vabaq_u8(a: uint8x16_t, b: uint8x16_t, c: uint8x16_t) -> uint8x16_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.u16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("uaba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabaq_u16(a: uint16x8_t, b: uint16x8_t, c: uint16x8_t) -> uint16x8_t {
@@ -1873,7 +1873,7 @@ pub unsafe fn vabaq_u16(a: uint16x8_t, b: uint16x8_t, c: uint16x8_t) -> uint16x8
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vaba.u32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("uaba"))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabaq_u32(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t) -> uint32x4_t {
@@ -1887,7 +1887,7 @@ pub unsafe fn vabaq_u32(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t) -> uint32x4
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabs))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(abs))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabs_s8(a: int8x8_t) -> int8x8_t {
@@ -1900,7 +1900,7 @@ pub unsafe fn vabs_s8(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabs))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(abs))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabs_s16(a: int16x4_t) -> int16x4_t {
@@ -1913,7 +1913,7 @@ pub unsafe fn vabs_s16(a: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabs))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(abs))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabs_s32(a: int32x2_t) -> int32x2_t {
@@ -1926,7 +1926,7 @@ pub unsafe fn vabs_s32(a: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabs))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(abs))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabsq_s8(a: int8x16_t) -> int8x16_t {
@@ -1939,7 +1939,7 @@ pub unsafe fn vabsq_s8(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabs))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(abs))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabsq_s16(a: int16x8_t) -> int16x8_t {
@@ -1952,7 +1952,7 @@ pub unsafe fn vabsq_s16(a: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vabs))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(abs))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vabsq_s32(a: int32x4_t) -> int32x4_t {
@@ -1966,7 +1966,7 @@ pub unsafe fn vabsq_s32(a: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadd_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
@@ -1979,7 +1979,7 @@ pub unsafe fn vpadd_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadd_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
@@ -1992,7 +1992,7 @@ pub unsafe fn vpadd_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadd_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
@@ -2005,7 +2005,7 @@ pub unsafe fn vpadd_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadd_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
@@ -2018,7 +2018,7 @@ pub unsafe fn vpadd_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadd_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
@@ -2031,7 +2031,7 @@ pub unsafe fn vpadd_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadd_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
@@ -2045,7 +2045,7 @@ pub unsafe fn vpadd_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
@@ -2059,7 +2059,7 @@ pub unsafe fn vadd_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
@@ -2073,7 +2073,7 @@ pub unsafe fn vaddq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
@@ -2087,7 +2087,7 @@ pub unsafe fn vadd_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
@@ -2101,7 +2101,7 @@ pub unsafe fn vaddq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
@@ -2115,7 +2115,7 @@ pub unsafe fn vadd_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
@@ -2129,7 +2129,7 @@ pub unsafe fn vaddq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
@@ -2143,7 +2143,7 @@ pub unsafe fn vaddq_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
@@ -2157,7 +2157,7 @@ pub unsafe fn vadd_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
@@ -2171,7 +2171,7 @@ pub unsafe fn vaddq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
@@ -2185,7 +2185,7 @@ pub unsafe fn vadd_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
@@ -2199,7 +2199,7 @@ pub unsafe fn vaddq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
@@ -2213,7 +2213,7 @@ pub unsafe fn vadd_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
@@ -2227,7 +2227,7 @@ pub unsafe fn vaddq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(add))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
@@ -2241,7 +2241,7 @@ pub unsafe fn vaddq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fadd))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vadd_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
@@ -2255,7 +2255,7 @@ pub unsafe fn vadd_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vadd))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fadd))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
@@ -2269,7 +2269,7 @@ pub unsafe fn vaddq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_s8(a: int8x8_t, b: int8x8_t) -> int16x8_t {
@@ -2285,7 +2285,7 @@ pub unsafe fn vaddl_s8(a: int8x8_t, b: int8x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_s16(a: int16x4_t, b: int16x4_t) -> int32x4_t {
@@ -2301,7 +2301,7 @@ pub unsafe fn vaddl_s16(a: int16x4_t, b: int16x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_s32(a: int32x2_t, b: int32x2_t) -> int64x2_t {
@@ -2317,7 +2317,7 @@ pub unsafe fn vaddl_s32(a: int32x2_t, b: int32x2_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_u8(a: uint8x8_t, b: uint8x8_t) -> uint16x8_t {
@@ -2333,7 +2333,7 @@ pub unsafe fn vaddl_u8(a: uint8x8_t, b: uint8x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_u16(a: uint16x4_t, b: uint16x4_t) -> uint32x4_t {
@@ -2349,7 +2349,7 @@ pub unsafe fn vaddl_u16(a: uint16x4_t, b: uint16x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_u32(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
@@ -2365,7 +2365,7 @@ pub unsafe fn vaddl_u32(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddl2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
@@ -2383,7 +2383,7 @@ pub unsafe fn vaddl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddl2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
@@ -2401,7 +2401,7 @@ pub unsafe fn vaddl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddl2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
@@ -2419,7 +2419,7 @@ pub unsafe fn vaddl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddl2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
@@ -2437,7 +2437,7 @@ pub unsafe fn vaddl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddl2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
@@ -2455,7 +2455,7 @@ pub unsafe fn vaddl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddl2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
@@ -2473,7 +2473,7 @@ pub unsafe fn vaddl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddw))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_s8(a: int16x8_t, b: int8x8_t) -> int16x8_t {
@@ -2488,7 +2488,7 @@ pub unsafe fn vaddw_s8(a: int16x8_t, b: int8x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddw))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_s16(a: int32x4_t, b: int16x4_t) -> int32x4_t {
@@ -2503,7 +2503,7 @@ pub unsafe fn vaddw_s16(a: int32x4_t, b: int16x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddw))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_s32(a: int64x2_t, b: int32x2_t) -> int64x2_t {
@@ -2518,7 +2518,7 @@ pub unsafe fn vaddw_s32(a: int64x2_t, b: int32x2_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddw))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_u8(a: uint16x8_t, b: uint8x8_t) -> uint16x8_t {
@@ -2533,7 +2533,7 @@ pub unsafe fn vaddw_u8(a: uint16x8_t, b: uint8x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddw))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_u16(a: uint32x4_t, b: uint16x4_t) -> uint32x4_t {
@@ -2548,7 +2548,7 @@ pub unsafe fn vaddw_u16(a: uint32x4_t, b: uint16x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddw))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_u32(a: uint64x2_t, b: uint32x2_t) -> uint64x2_t {
@@ -2563,7 +2563,7 @@ pub unsafe fn vaddw_u32(a: uint64x2_t, b: uint32x2_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddw2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
@@ -2579,7 +2579,7 @@ pub unsafe fn vaddw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddw2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
@@ -2595,7 +2595,7 @@ pub unsafe fn vaddw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddw2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
@@ -2611,7 +2611,7 @@ pub unsafe fn vaddw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddw2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
@@ -2627,7 +2627,7 @@ pub unsafe fn vaddw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddw2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
@@ -2643,7 +2643,7 @@ pub unsafe fn vaddw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddw))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddw2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddw_high_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
@@ -2659,7 +2659,7 @@ pub unsafe fn vaddw_high_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_s16(a: int16x8_t, b: int16x8_t) -> int8x8_t {
@@ -2673,7 +2673,7 @@ pub unsafe fn vaddhn_s16(a: int16x8_t, b: int16x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_s32(a: int32x4_t, b: int32x4_t) -> int16x4_t {
@@ -2687,7 +2687,7 @@ pub unsafe fn vaddhn_s32(a: int32x4_t, b: int32x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_s64(a: int64x2_t, b: int64x2_t) -> int32x2_t {
@@ -2701,7 +2701,7 @@ pub unsafe fn vaddhn_s64(a: int64x2_t, b: int64x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_u16(a: uint16x8_t, b: uint16x8_t) -> uint8x8_t {
@@ -2715,7 +2715,7 @@ pub unsafe fn vaddhn_u16(a: uint16x8_t, b: uint16x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_u32(a: uint32x4_t, b: uint32x4_t) -> uint16x4_t {
@@ -2729,7 +2729,7 @@ pub unsafe fn vaddhn_u32(a: uint32x4_t, b: uint32x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
@@ -2743,7 +2743,7 @@ pub unsafe fn vaddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x16_t {
@@ -2758,7 +2758,7 @@ pub unsafe fn vaddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x1
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int16x8_t {
@@ -2773,7 +2773,7 @@ pub unsafe fn vaddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int16
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int32x4_t {
@@ -2788,7 +2788,7 @@ pub unsafe fn vaddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int32
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> uint8x16_t {
@@ -2803,7 +2803,7 @@ pub unsafe fn vaddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> uin
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> uint16x8_t {
@@ -2818,7 +2818,7 @@ pub unsafe fn vaddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> ui
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vaddhn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(addhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vaddhn_high_u64(r: uint32x2_t, a: uint64x2_t, b: uint64x2_t) -> uint32x4_t {
@@ -2833,7 +2833,7 @@ pub unsafe fn vaddhn_high_u64(r: uint32x2_t, a: uint64x2_t, b: uint64x2_t) -> ui
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_s16(a: int16x8_t, b: int16x8_t) -> int8x8_t {
@@ -2847,7 +2847,7 @@ pub unsafe fn vraddhn_s16(a: int16x8_t, b: int16x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_s32(a: int32x4_t, b: int32x4_t) -> int16x4_t {
@@ -2861,7 +2861,7 @@ pub unsafe fn vraddhn_s32(a: int32x4_t, b: int32x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i64))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_s64(a: int64x2_t, b: int64x2_t) -> int32x2_t {
@@ -2875,7 +2875,7 @@ pub unsafe fn vraddhn_s64(a: int64x2_t, b: int64x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_u16(a: uint16x8_t, b: uint16x8_t) -> uint8x8_t {
@@ -2889,7 +2889,7 @@ pub unsafe fn vraddhn_u16(a: uint16x8_t, b: uint16x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_u32(a: uint32x4_t, b: uint32x4_t) -> uint16x4_t {
@@ -2903,7 +2903,7 @@ pub unsafe fn vraddhn_u32(a: uint32x4_t, b: uint32x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i64))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
@@ -2917,7 +2917,7 @@ pub unsafe fn vraddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x16_t {
@@ -2932,7 +2932,7 @@ pub unsafe fn vraddhn_high_s16(r: int8x8_t, a: int16x8_t, b: int16x8_t) -> int8x
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int16x8_t {
@@ -2947,7 +2947,7 @@ pub unsafe fn vraddhn_high_s32(r: int16x4_t, a: int32x4_t, b: int32x4_t) -> int1
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i64))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int32x4_t {
@@ -2962,7 +2962,7 @@ pub unsafe fn vraddhn_high_s64(r: int32x2_t, a: int64x2_t, b: int64x2_t) -> int3
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> uint8x16_t {
@@ -2977,7 +2977,7 @@ pub unsafe fn vraddhn_high_u16(r: uint8x8_t, a: uint16x8_t, b: uint16x8_t) -> ui
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> uint16x8_t {
@@ -2992,7 +2992,7 @@ pub unsafe fn vraddhn_high_u32(r: uint16x4_t, a: uint32x4_t, b: uint32x4_t) -> u
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vraddhn.i64))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(raddhn2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vraddhn_high_u64(r: uint32x2_t, a: uint64x2_t, b: uint64x2_t) -> uint32x4_t {
@@ -3007,7 +3007,7 @@ pub unsafe fn vraddhn_high_u64(r: uint32x2_t, a: uint64x2_t, b: uint64x2_t) -> u
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.s8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddl_s8(a: int8x8_t) -> int16x4_t {
@@ -3021,7 +3021,7 @@ pub unsafe fn vpaddl_s8(a: int8x8_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.s16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddl_s16(a: int16x4_t) -> int32x2_t {
@@ -3035,7 +3035,7 @@ pub unsafe fn vpaddl_s16(a: int16x4_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.s32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddl_s32(a: int32x2_t) -> int64x1_t {
@@ -3049,7 +3049,7 @@ pub unsafe fn vpaddl_s32(a: int32x2_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.s8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddlq_s8(a: int8x16_t) -> int16x8_t {
@@ -3063,7 +3063,7 @@ pub unsafe fn vpaddlq_s8(a: int8x16_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.s16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddlq_s16(a: int16x8_t) -> int32x4_t {
@@ -3077,7 +3077,7 @@ pub unsafe fn vpaddlq_s16(a: int16x8_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.s32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(saddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddlq_s32(a: int32x4_t) -> int64x2_t {
@@ -3091,7 +3091,7 @@ pub unsafe fn vpaddlq_s32(a: int32x4_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.u8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddl_u8(a: uint8x8_t) -> uint16x4_t {
@@ -3105,7 +3105,7 @@ pub unsafe fn vpaddl_u8(a: uint8x8_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.u16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddl_u16(a: uint16x4_t) -> uint32x2_t {
@@ -3119,7 +3119,7 @@ pub unsafe fn vpaddl_u16(a: uint16x4_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.u32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddl_u32(a: uint32x2_t) -> uint64x1_t {
@@ -3133,7 +3133,7 @@ pub unsafe fn vpaddl_u32(a: uint32x2_t) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.u8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddlq_u8(a: uint8x16_t) -> uint16x8_t {
@@ -3147,7 +3147,7 @@ pub unsafe fn vpaddlq_u8(a: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.u16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddlq_u16(a: uint16x8_t) -> uint32x4_t {
@@ -3161,7 +3161,7 @@ pub unsafe fn vpaddlq_u16(a: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpaddl.u32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uaddlp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpaddlq_u32(a: uint32x4_t) -> uint64x2_t {
@@ -3175,7 +3175,7 @@ pub unsafe fn vpaddlq_u32(a: uint32x4_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(xtn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovn_s16(a: int16x8_t) -> int8x8_t {
@@ -3189,7 +3189,7 @@ pub unsafe fn vmovn_s16(a: int16x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(xtn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovn_s32(a: int32x4_t) -> int16x4_t {
@@ -3203,7 +3203,7 @@ pub unsafe fn vmovn_s32(a: int32x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(xtn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovn_s64(a: int64x2_t) -> int32x2_t {
@@ -3217,7 +3217,7 @@ pub unsafe fn vmovn_s64(a: int64x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(xtn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovn_u16(a: uint16x8_t) -> uint8x8_t {
@@ -3231,7 +3231,7 @@ pub unsafe fn vmovn_u16(a: uint16x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(xtn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovn_u32(a: uint32x4_t) -> uint16x4_t {
@@ -3245,7 +3245,7 @@ pub unsafe fn vmovn_u32(a: uint32x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(xtn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovn_u64(a: uint64x2_t) -> uint32x2_t {
@@ -3259,7 +3259,7 @@ pub unsafe fn vmovn_u64(a: uint64x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sxtl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovl_s8(a: int8x8_t) -> int16x8_t {
@@ -3273,7 +3273,7 @@ pub unsafe fn vmovl_s8(a: int8x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sxtl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovl_s16(a: int16x4_t) -> int32x4_t {
@@ -3287,7 +3287,7 @@ pub unsafe fn vmovl_s16(a: int16x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sxtl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovl_s32(a: int32x2_t) -> int64x2_t {
@@ -3301,7 +3301,7 @@ pub unsafe fn vmovl_s32(a: int32x2_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uxtl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovl_u8(a: uint8x8_t) -> uint16x8_t {
@@ -3315,7 +3315,7 @@ pub unsafe fn vmovl_u8(a: uint8x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uxtl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovl_u16(a: uint16x4_t) -> uint32x4_t {
@@ -3329,7 +3329,7 @@ pub unsafe fn vmovl_u16(a: uint16x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmovl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uxtl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovl_u32(a: uint32x2_t) -> uint64x2_t {
@@ -3343,7 +3343,7 @@ pub unsafe fn vmovl_u32(a: uint32x2_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_s8(a: int8x8_t) -> int8x8_t {
@@ -3358,7 +3358,7 @@ pub unsafe fn vmvn_s8(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_s8(a: int8x16_t) -> int8x16_t {
@@ -3375,7 +3375,7 @@ pub unsafe fn vmvnq_s8(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_s16(a: int16x4_t) -> int16x4_t {
@@ -3390,7 +3390,7 @@ pub unsafe fn vmvn_s16(a: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_s16(a: int16x8_t) -> int16x8_t {
@@ -3405,7 +3405,7 @@ pub unsafe fn vmvnq_s16(a: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_s32(a: int32x2_t) -> int32x2_t {
@@ -3420,7 +3420,7 @@ pub unsafe fn vmvn_s32(a: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_s32(a: int32x4_t) -> int32x4_t {
@@ -3435,7 +3435,7 @@ pub unsafe fn vmvnq_s32(a: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_u8(a: uint8x8_t) -> uint8x8_t {
@@ -3450,7 +3450,7 @@ pub unsafe fn vmvn_u8(a: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_u8(a: uint8x16_t) -> uint8x16_t {
@@ -3467,7 +3467,7 @@ pub unsafe fn vmvnq_u8(a: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_u16(a: uint16x4_t) -> uint16x4_t {
@@ -3482,7 +3482,7 @@ pub unsafe fn vmvn_u16(a: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_u16(a: uint16x8_t) -> uint16x8_t {
@@ -3499,7 +3499,7 @@ pub unsafe fn vmvnq_u16(a: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_u32(a: uint32x2_t) -> uint32x2_t {
@@ -3514,7 +3514,7 @@ pub unsafe fn vmvn_u32(a: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_u32(a: uint32x4_t) -> uint32x4_t {
@@ -3529,7 +3529,7 @@ pub unsafe fn vmvnq_u32(a: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvn_p8(a: poly8x8_t) -> poly8x8_t {
@@ -3544,7 +3544,7 @@ pub unsafe fn vmvn_p8(a: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vmvn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(mvn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmvnq_p8(a: poly8x16_t) -> poly8x16_t {
@@ -3561,7 +3561,7 @@ pub unsafe fn vmvnq_p8(a: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
@@ -3576,7 +3576,7 @@ pub unsafe fn vbic_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
@@ -3593,7 +3593,7 @@ pub unsafe fn vbicq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
@@ -3608,7 +3608,7 @@ pub unsafe fn vbic_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
@@ -3623,7 +3623,7 @@ pub unsafe fn vbicq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
@@ -3638,7 +3638,7 @@ pub unsafe fn vbic_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
@@ -3653,7 +3653,7 @@ pub unsafe fn vbicq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_s64(a: int64x1_t, b: int64x1_t) -> int64x1_t {
@@ -3668,7 +3668,7 @@ pub unsafe fn vbic_s64(a: int64x1_t, b: int64x1_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
@@ -3683,7 +3683,7 @@ pub unsafe fn vbicq_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
@@ -3698,7 +3698,7 @@ pub unsafe fn vbic_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
@@ -3715,7 +3715,7 @@ pub unsafe fn vbicq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
@@ -3730,7 +3730,7 @@ pub unsafe fn vbic_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
@@ -3745,7 +3745,7 @@ pub unsafe fn vbicq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
@@ -3760,7 +3760,7 @@ pub unsafe fn vbic_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
@@ -3775,7 +3775,7 @@ pub unsafe fn vbicq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbic_u64(a: uint64x1_t, b: uint64x1_t) -> uint64x1_t {
@@ -3790,7 +3790,7 @@ pub unsafe fn vbic_u64(a: uint64x1_t, b: uint64x1_t) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbic))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bic))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbicq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
@@ -3809,7 +3809,7 @@ pub unsafe fn vbicq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_s8(a: uint8x8_t, b: int8x8_t, c: int8x8_t) -> int8x8_t {
@@ -3827,7 +3827,7 @@ pub unsafe fn vbsl_s8(a: uint8x8_t, b: int8x8_t, c: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_s16(a: uint16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
@@ -3845,7 +3845,7 @@ pub unsafe fn vbsl_s16(a: uint16x4_t, b: int16x4_t, c: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_s32(a: uint32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
@@ -3863,7 +3863,7 @@ pub unsafe fn vbsl_s32(a: uint32x2_t, b: int32x2_t, c: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_s64(a: uint64x1_t, b: int64x1_t, c: int64x1_t) -> int64x1_t {
@@ -3881,7 +3881,7 @@ pub unsafe fn vbsl_s64(a: uint64x1_t, b: int64x1_t, c: int64x1_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_u8(a: uint8x8_t, b: uint8x8_t, c: uint8x8_t) -> uint8x8_t {
@@ -3899,7 +3899,7 @@ pub unsafe fn vbsl_u8(a: uint8x8_t, b: uint8x8_t, c: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_u16(a: uint16x4_t, b: uint16x4_t, c: uint16x4_t) -> uint16x4_t {
@@ -3917,7 +3917,7 @@ pub unsafe fn vbsl_u16(a: uint16x4_t, b: uint16x4_t, c: uint16x4_t) -> uint16x4_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_u32(a: uint32x2_t, b: uint32x2_t, c: uint32x2_t) -> uint32x2_t {
@@ -3935,7 +3935,7 @@ pub unsafe fn vbsl_u32(a: uint32x2_t, b: uint32x2_t, c: uint32x2_t) -> uint32x2_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_u64(a: uint64x1_t, b: uint64x1_t, c: uint64x1_t) -> uint64x1_t {
@@ -3953,7 +3953,7 @@ pub unsafe fn vbsl_u64(a: uint64x1_t, b: uint64x1_t, c: uint64x1_t) -> uint64x1_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_f32(a: uint32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
@@ -3971,7 +3971,7 @@ pub unsafe fn vbsl_f32(a: uint32x2_t, b: float32x2_t, c: float32x2_t) -> float32
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_p8(a: uint8x8_t, b: poly8x8_t, c: poly8x8_t) -> poly8x8_t {
@@ -3989,7 +3989,7 @@ pub unsafe fn vbsl_p8(a: uint8x8_t, b: poly8x8_t, c: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbsl_p16(a: uint16x4_t, b: poly16x4_t, c: poly16x4_t) -> poly16x4_t {
@@ -4007,7 +4007,7 @@ pub unsafe fn vbsl_p16(a: uint16x4_t, b: poly16x4_t, c: poly16x4_t) -> poly16x4_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_s8(a: uint8x16_t, b: int8x16_t, c: int8x16_t) -> int8x16_t {
@@ -4027,7 +4027,7 @@ pub unsafe fn vbslq_s8(a: uint8x16_t, b: int8x16_t, c: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_s16(a: uint16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t {
@@ -4045,7 +4045,7 @@ pub unsafe fn vbslq_s16(a: uint16x8_t, b: int16x8_t, c: int16x8_t) -> int16x8_t 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_s32(a: uint32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t {
@@ -4063,7 +4063,7 @@ pub unsafe fn vbslq_s32(a: uint32x4_t, b: int32x4_t, c: int32x4_t) -> int32x4_t 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_s64(a: uint64x2_t, b: int64x2_t, c: int64x2_t) -> int64x2_t {
@@ -4081,7 +4081,7 @@ pub unsafe fn vbslq_s64(a: uint64x2_t, b: int64x2_t, c: int64x2_t) -> int64x2_t 
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_u8(a: uint8x16_t, b: uint8x16_t, c: uint8x16_t) -> uint8x16_t {
@@ -4101,7 +4101,7 @@ pub unsafe fn vbslq_u8(a: uint8x16_t, b: uint8x16_t, c: uint8x16_t) -> uint8x16_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_u16(a: uint16x8_t, b: uint16x8_t, c: uint16x8_t) -> uint16x8_t {
@@ -4119,7 +4119,7 @@ pub unsafe fn vbslq_u16(a: uint16x8_t, b: uint16x8_t, c: uint16x8_t) -> uint16x8
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_u32(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t) -> uint32x4_t {
@@ -4137,7 +4137,7 @@ pub unsafe fn vbslq_u32(a: uint32x4_t, b: uint32x4_t, c: uint32x4_t) -> uint32x4
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_u64(a: uint64x2_t, b: uint64x2_t, c: uint64x2_t) -> uint64x2_t {
@@ -4155,7 +4155,7 @@ pub unsafe fn vbslq_u64(a: uint64x2_t, b: uint64x2_t, c: uint64x2_t) -> uint64x2
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_p8(a: uint8x16_t, b: poly8x16_t, c: poly8x16_t) -> poly8x16_t {
@@ -4175,7 +4175,7 @@ pub unsafe fn vbslq_p8(a: uint8x16_t, b: poly8x16_t, c: poly8x16_t) -> poly8x16_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_p16(a: uint16x8_t, b: poly16x8_t, c: poly16x8_t) -> poly16x8_t {
@@ -4193,7 +4193,7 @@ pub unsafe fn vbslq_p16(a: uint16x8_t, b: poly16x8_t, c: poly16x8_t) -> poly16x8
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vbsl))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(bsl))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vbslq_f32(a: uint32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
@@ -4211,7 +4211,7 @@ pub unsafe fn vbslq_f32(a: uint32x4_t, b: float32x4_t, c: float32x4_t) -> float3
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
@@ -4226,7 +4226,7 @@ pub unsafe fn vorn_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
@@ -4243,7 +4243,7 @@ pub unsafe fn vornq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
@@ -4258,7 +4258,7 @@ pub unsafe fn vorn_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
@@ -4273,7 +4273,7 @@ pub unsafe fn vornq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
@@ -4288,7 +4288,7 @@ pub unsafe fn vorn_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
@@ -4303,7 +4303,7 @@ pub unsafe fn vornq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_s64(a: int64x1_t, b: int64x1_t) -> int64x1_t {
@@ -4318,7 +4318,7 @@ pub unsafe fn vorn_s64(a: int64x1_t, b: int64x1_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
@@ -4333,7 +4333,7 @@ pub unsafe fn vornq_s64(a: int64x2_t, b: int64x2_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
@@ -4348,7 +4348,7 @@ pub unsafe fn vorn_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
@@ -4365,7 +4365,7 @@ pub unsafe fn vornq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
@@ -4380,7 +4380,7 @@ pub unsafe fn vorn_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
@@ -4395,7 +4395,7 @@ pub unsafe fn vornq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
@@ -4410,7 +4410,7 @@ pub unsafe fn vorn_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
@@ -4425,7 +4425,7 @@ pub unsafe fn vornq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vorn_u64(a: uint64x1_t, b: uint64x1_t) -> uint64x1_t {
@@ -4440,7 +4440,7 @@ pub unsafe fn vorn_u64(a: uint64x1_t, b: uint64x1_t) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorn))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(orn))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vornq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
@@ -4455,7 +4455,7 @@ pub unsafe fn vornq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
@@ -4469,7 +4469,7 @@ pub unsafe fn vpmin_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
@@ -4483,7 +4483,7 @@ pub unsafe fn vpmin_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
@@ -4497,7 +4497,7 @@ pub unsafe fn vpmin_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
@@ -4511,7 +4511,7 @@ pub unsafe fn vpmin_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
@@ -4525,7 +4525,7 @@ pub unsafe fn vpmin_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
@@ -4539,7 +4539,7 @@ pub unsafe fn vpmin_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmin))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fminp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
@@ -4553,7 +4553,7 @@ pub unsafe fn vpmin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(smaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
@@ -4567,7 +4567,7 @@ pub unsafe fn vpmax_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(smaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
@@ -4581,7 +4581,7 @@ pub unsafe fn vpmax_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(smaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
@@ -4595,7 +4595,7 @@ pub unsafe fn vpmax_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(umaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
@@ -4609,7 +4609,7 @@ pub unsafe fn vpmax_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(umaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
@@ -4623,7 +4623,7 @@ pub unsafe fn vpmax_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(umaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
@@ -4637,7 +4637,7 @@ pub unsafe fn vpmax_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpmax))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fmaxp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpmax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
@@ -4651,7 +4651,7 @@ pub unsafe fn vpmax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_u64<const IMM5: i32>(v: uint64x2_t) -> u64 {
@@ -4666,7 +4666,7 @@ pub unsafe fn vgetq_lane_u64<const IMM5: i32>(v: uint64x2_t) -> u64 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_u64<const IMM5: i32>(v: uint64x1_t) -> u64 {
@@ -4681,7 +4681,7 @@ pub unsafe fn vget_lane_u64<const IMM5: i32>(v: uint64x1_t) -> u64 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_u16<const IMM5: i32>(v: uint16x4_t) -> u16 {
@@ -4696,7 +4696,7 @@ pub unsafe fn vget_lane_u16<const IMM5: i32>(v: uint16x4_t) -> u16 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_s16<const IMM5: i32>(v: int16x4_t) -> i16 {
@@ -4711,7 +4711,7 @@ pub unsafe fn vget_lane_s16<const IMM5: i32>(v: int16x4_t) -> i16 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_p16<const IMM5: i32>(v: poly16x4_t) -> p16 {
@@ -4726,7 +4726,7 @@ pub unsafe fn vget_lane_p16<const IMM5: i32>(v: poly16x4_t) -> p16 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_u32<const IMM5: i32>(v: uint32x2_t) -> u32 {
@@ -4741,7 +4741,7 @@ pub unsafe fn vget_lane_u32<const IMM5: i32>(v: uint32x2_t) -> u32 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_s32<const IMM5: i32>(v: int32x2_t) -> i32 {
@@ -4756,7 +4756,7 @@ pub unsafe fn vget_lane_s32<const IMM5: i32>(v: int32x2_t) -> i32 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_f32<const IMM5: i32>(v: float32x2_t) -> f32 {
@@ -4771,7 +4771,7 @@ pub unsafe fn vget_lane_f32<const IMM5: i32>(v: float32x2_t) -> f32 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 1))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_f32<const IMM5: i32>(v: float32x4_t) -> f32 {
@@ -4786,7 +4786,7 @@ pub unsafe fn vgetq_lane_f32<const IMM5: i32>(v: float32x4_t) -> f32 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_p64<const IMM5: i32>(v: poly64x1_t) -> p64 {
@@ -4801,7 +4801,7 @@ pub unsafe fn vget_lane_p64<const IMM5: i32>(v: poly64x1_t) -> p64 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_p64<const IMM5: i32>(v: poly64x2_t) -> p64 {
@@ -4816,7 +4816,7 @@ pub unsafe fn vgetq_lane_p64<const IMM5: i32>(v: poly64x2_t) -> p64 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_s64<const IMM5: i32>(v: int64x1_t) -> i64 {
@@ -4831,7 +4831,7 @@ pub unsafe fn vget_lane_s64<const IMM5: i32>(v: int64x1_t) -> i64 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 0))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_s64<const IMM5: i32>(v: int64x2_t) -> i64 {
@@ -4846,7 +4846,7 @@ pub unsafe fn vgetq_lane_s64<const IMM5: i32>(v: int64x2_t) -> i64 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_u16<const IMM5: i32>(v: uint16x8_t) -> u16 {
@@ -4861,7 +4861,7 @@ pub unsafe fn vgetq_lane_u16<const IMM5: i32>(v: uint16x8_t) -> u16 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_u32<const IMM5: i32>(v: uint32x4_t) -> u32 {
@@ -4876,7 +4876,7 @@ pub unsafe fn vgetq_lane_u32<const IMM5: i32>(v: uint32x4_t) -> u32 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_s16<const IMM5: i32>(v: int16x8_t) -> i16 {
@@ -4891,7 +4891,7 @@ pub unsafe fn vgetq_lane_s16<const IMM5: i32>(v: int16x8_t) -> i16 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_p16<const IMM5: i32>(v: poly16x8_t) -> p16 {
@@ -4906,7 +4906,7 @@ pub unsafe fn vgetq_lane_p16<const IMM5: i32>(v: poly16x8_t) -> p16 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_s32<const IMM5: i32>(v: int32x4_t) -> i32 {
@@ -4921,7 +4921,7 @@ pub unsafe fn vgetq_lane_s32<const IMM5: i32>(v: int32x4_t) -> i32 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_u8<const IMM5: i32>(v: uint8x8_t) -> u8 {
@@ -4936,7 +4936,7 @@ pub unsafe fn vget_lane_u8<const IMM5: i32>(v: uint8x8_t) -> u8 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_s8<const IMM5: i32>(v: int8x8_t) -> i8 {
@@ -4951,7 +4951,7 @@ pub unsafe fn vget_lane_s8<const IMM5: i32>(v: int8x8_t) -> i8 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_lane_p8<const IMM5: i32>(v: poly8x8_t) -> p8 {
@@ -4966,7 +4966,7 @@ pub unsafe fn vget_lane_p8<const IMM5: i32>(v: poly8x8_t) -> p8 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_u8<const IMM5: i32>(v: uint8x16_t) -> u8 {
@@ -4981,7 +4981,7 @@ pub unsafe fn vgetq_lane_u8<const IMM5: i32>(v: uint8x16_t) -> u8 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_s8<const IMM5: i32>(v: int8x16_t) -> i8 {
@@ -4996,7 +4996,7 @@ pub unsafe fn vgetq_lane_s8<const IMM5: i32>(v: int8x16_t) -> i8 {
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(nop, IMM5 = 2))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vgetq_lane_p8<const IMM5: i32>(v: poly8x16_t) -> p8 {
@@ -5011,7 +5011,7 @@ pub unsafe fn vgetq_lane_p8<const IMM5: i32>(v: poly8x16_t) -> p8 {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s8(a: int8x16_t) -> int8x8_t {
@@ -5025,7 +5025,7 @@ pub unsafe fn vget_high_s8(a: int8x16_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s16(a: int16x8_t) -> int16x4_t {
@@ -5039,7 +5039,7 @@ pub unsafe fn vget_high_s16(a: int16x8_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s32(a: int32x4_t) -> int32x2_t {
@@ -5053,7 +5053,7 @@ pub unsafe fn vget_high_s32(a: int32x4_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_s64(a: int64x2_t) -> int64x1_t {
@@ -5067,7 +5067,7 @@ pub unsafe fn vget_high_s64(a: int64x2_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u8(a: uint8x16_t) -> uint8x8_t {
@@ -5081,7 +5081,7 @@ pub unsafe fn vget_high_u8(a: uint8x16_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u16(a: uint16x8_t) -> uint16x4_t {
@@ -5095,7 +5095,7 @@ pub unsafe fn vget_high_u16(a: uint16x8_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u32(a: uint32x4_t) -> uint32x2_t {
@@ -5109,7 +5109,7 @@ pub unsafe fn vget_high_u32(a: uint32x4_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_u64(a: uint64x2_t) -> uint64x1_t {
@@ -5123,7 +5123,7 @@ pub unsafe fn vget_high_u64(a: uint64x2_t) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_p8(a: poly8x16_t) -> poly8x8_t {
@@ -5137,7 +5137,7 @@ pub unsafe fn vget_high_p8(a: poly8x16_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_p16(a: poly16x8_t) -> poly16x4_t {
@@ -5151,7 +5151,7 @@ pub unsafe fn vget_high_p16(a: poly16x8_t) -> poly16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ext))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_high_f32(a: float32x4_t) -> float32x2_t {
@@ -5164,7 +5164,7 @@ pub unsafe fn vget_high_f32(a: float32x4_t) -> float32x2_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "vget_low_s8", since = "1.60.0")
 )]
 pub unsafe fn vget_low_s8(a: int8x16_t) -> int8x8_t {
@@ -5177,7 +5177,7 @@ pub unsafe fn vget_low_s8(a: int8x16_t) -> int8x8_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_s16(a: int16x8_t) -> int16x4_t {
@@ -5190,7 +5190,7 @@ pub unsafe fn vget_low_s16(a: int16x8_t) -> int16x4_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_s32(a: int32x4_t) -> int32x2_t {
@@ -5203,7 +5203,7 @@ pub unsafe fn vget_low_s32(a: int32x4_t) -> int32x2_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_s64(a: int64x2_t) -> int64x1_t {
@@ -5216,7 +5216,7 @@ pub unsafe fn vget_low_s64(a: int64x2_t) -> int64x1_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u8(a: uint8x16_t) -> uint8x8_t {
@@ -5229,7 +5229,7 @@ pub unsafe fn vget_low_u8(a: uint8x16_t) -> uint8x8_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u16(a: uint16x8_t) -> uint16x4_t {
@@ -5242,7 +5242,7 @@ pub unsafe fn vget_low_u16(a: uint16x8_t) -> uint16x4_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u32(a: uint32x4_t) -> uint32x2_t {
@@ -5255,7 +5255,7 @@ pub unsafe fn vget_low_u32(a: uint32x4_t) -> uint32x2_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_u64(a: uint64x2_t) -> uint64x1_t {
@@ -5268,7 +5268,7 @@ pub unsafe fn vget_low_u64(a: uint64x2_t) -> uint64x1_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_p8(a: poly8x16_t) -> poly8x8_t {
@@ -5281,7 +5281,7 @@ pub unsafe fn vget_low_p8(a: poly8x16_t) -> poly8x8_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_p16(a: poly16x8_t) -> poly16x4_t {
@@ -5294,7 +5294,7 @@ pub unsafe fn vget_low_p16(a: poly16x8_t) -> poly16x4_t {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(test, assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vget_low_f32(a: float32x4_t) -> float32x2_t {
@@ -5308,7 +5308,7 @@ pub unsafe fn vget_low_f32(a: float32x4_t) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_s8(value: i8) -> int8x16_t {
@@ -5325,7 +5325,7 @@ pub unsafe fn vdupq_n_s8(value: i8) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_s16(value: i16) -> int16x8_t {
@@ -5339,7 +5339,7 @@ pub unsafe fn vdupq_n_s16(value: i16) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_s32(value: i32) -> int32x4_t {
@@ -5353,7 +5353,7 @@ pub unsafe fn vdupq_n_s32(value: i32) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_s64(value: i64) -> int64x2_t {
@@ -5367,7 +5367,7 @@ pub unsafe fn vdupq_n_s64(value: i64) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_u8(value: u8) -> uint8x16_t {
@@ -5384,7 +5384,7 @@ pub unsafe fn vdupq_n_u8(value: u8) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_u16(value: u16) -> uint16x8_t {
@@ -5398,7 +5398,7 @@ pub unsafe fn vdupq_n_u16(value: u16) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_u32(value: u32) -> uint32x4_t {
@@ -5412,7 +5412,7 @@ pub unsafe fn vdupq_n_u32(value: u32) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
@@ -5426,7 +5426,7 @@ pub unsafe fn vdupq_n_u64(value: u64) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_p8(value: p8) -> poly8x16_t {
@@ -5443,7 +5443,7 @@ pub unsafe fn vdupq_n_p8(value: p8) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_p16(value: p16) -> poly16x8_t {
@@ -5457,7 +5457,7 @@ pub unsafe fn vdupq_n_p16(value: p16) -> poly16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdupq_n_f32(value: f32) -> float32x4_t {
@@ -5474,7 +5474,7 @@ pub unsafe fn vdupq_n_f32(value: f32) -> float32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 unsafe fn vdupq_n_f32_vfp4(value: f32) -> float32x4_t {
@@ -5488,7 +5488,7 @@ unsafe fn vdupq_n_f32_vfp4(value: f32) -> float32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_s8(value: i8) -> int8x8_t {
@@ -5502,7 +5502,7 @@ pub unsafe fn vdup_n_s8(value: i8) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_s16(value: i16) -> int16x4_t {
@@ -5516,7 +5516,7 @@ pub unsafe fn vdup_n_s16(value: i16) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_s32(value: i32) -> int32x2_t {
@@ -5530,7 +5530,7 @@ pub unsafe fn vdup_n_s32(value: i32) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fmov))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_s64(value: i64) -> int64x1_t {
@@ -5544,7 +5544,7 @@ pub unsafe fn vdup_n_s64(value: i64) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_u8(value: u8) -> uint8x8_t {
@@ -5558,7 +5558,7 @@ pub unsafe fn vdup_n_u8(value: u8) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_u16(value: u16) -> uint16x4_t {
@@ -5572,7 +5572,7 @@ pub unsafe fn vdup_n_u16(value: u16) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_u32(value: u32) -> uint32x2_t {
@@ -5586,7 +5586,7 @@ pub unsafe fn vdup_n_u32(value: u32) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fmov))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
@@ -5600,7 +5600,7 @@ pub unsafe fn vdup_n_u64(value: u64) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_p8(value: p8) -> poly8x8_t {
@@ -5614,7 +5614,7 @@ pub unsafe fn vdup_n_p8(value: p8) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_p16(value: p16) -> poly16x4_t {
@@ -5628,7 +5628,7 @@ pub unsafe fn vdup_n_p16(value: p16) -> poly16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vdup_n_f32(value: f32) -> float32x2_t {
@@ -5645,7 +5645,7 @@ pub unsafe fn vdup_n_f32(value: f32) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 unsafe fn vdup_n_f32_vfp4(value: f32) -> float32x2_t {
@@ -5659,7 +5659,7 @@ unsafe fn vdup_n_f32_vfp4(value: f32) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vldrq_p128(a: *const p128) -> p128 {
@@ -5673,7 +5673,7 @@ pub unsafe fn vldrq_p128(a: *const p128) -> p128 {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(nop))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vstrq_p128(a: *mut p128, b: p128) {
@@ -5687,7 +5687,7 @@ pub unsafe fn vstrq_p128(a: *mut p128, b: p128) {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_s8(value: i8) -> int8x8_t {
@@ -5701,7 +5701,7 @@ pub unsafe fn vmov_n_s8(value: i8) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_s16(value: i16) -> int16x4_t {
@@ -5715,7 +5715,7 @@ pub unsafe fn vmov_n_s16(value: i16) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_s32(value: i32) -> int32x2_t {
@@ -5729,7 +5729,7 @@ pub unsafe fn vmov_n_s32(value: i32) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fmov))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_s64(value: i64) -> int64x1_t {
@@ -5743,7 +5743,7 @@ pub unsafe fn vmov_n_s64(value: i64) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_u8(value: u8) -> uint8x8_t {
@@ -5757,7 +5757,7 @@ pub unsafe fn vmov_n_u8(value: u8) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_u16(value: u16) -> uint16x4_t {
@@ -5771,7 +5771,7 @@ pub unsafe fn vmov_n_u16(value: u16) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_u32(value: u32) -> uint32x2_t {
@@ -5785,7 +5785,7 @@ pub unsafe fn vmov_n_u32(value: u32) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(fmov))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_u64(value: u64) -> uint64x1_t {
@@ -5799,7 +5799,7 @@ pub unsafe fn vmov_n_u64(value: u64) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_p8(value: p8) -> poly8x8_t {
@@ -5813,7 +5813,7 @@ pub unsafe fn vmov_n_p8(value: p8) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_p16(value: p16) -> poly16x4_t {
@@ -5827,7 +5827,7 @@ pub unsafe fn vmov_n_p16(value: p16) -> poly16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmov_n_f32(value: f32) -> float32x2_t {
@@ -5841,7 +5841,7 @@ pub unsafe fn vmov_n_f32(value: f32) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_s8(value: i8) -> int8x16_t {
@@ -5855,7 +5855,7 @@ pub unsafe fn vmovq_n_s8(value: i8) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_s16(value: i16) -> int16x8_t {
@@ -5869,7 +5869,7 @@ pub unsafe fn vmovq_n_s16(value: i16) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_s32(value: i32) -> int32x4_t {
@@ -5883,7 +5883,7 @@ pub unsafe fn vmovq_n_s32(value: i32) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_s64(value: i64) -> int64x2_t {
@@ -5897,7 +5897,7 @@ pub unsafe fn vmovq_n_s64(value: i64) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_u8(value: u8) -> uint8x16_t {
@@ -5911,7 +5911,7 @@ pub unsafe fn vmovq_n_u8(value: u8) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_u16(value: u16) -> uint16x8_t {
@@ -5925,7 +5925,7 @@ pub unsafe fn vmovq_n_u16(value: u16) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_u32(value: u32) -> uint32x4_t {
@@ -5939,7 +5939,7 @@ pub unsafe fn vmovq_n_u32(value: u32) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vmov"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_u64(value: u64) -> uint64x2_t {
@@ -5953,7 +5953,7 @@ pub unsafe fn vmovq_n_u64(value: u64) -> uint64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_p8(value: p8) -> poly8x16_t {
@@ -5967,7 +5967,7 @@ pub unsafe fn vmovq_n_p8(value: p8) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_p16(value: p16) -> poly16x8_t {
@@ -5981,7 +5981,7 @@ pub unsafe fn vmovq_n_p16(value: p16) -> poly16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vdup.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(dup))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vmovq_n_f32(value: f32) -> float32x4_t {
@@ -5996,7 +5996,7 @@ pub unsafe fn vmovq_n_f32(value: f32) -> float32x4_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("nop", N = 0))]
 #[rustc_legacy_const_generics(2)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vext_s64<const N: i32>(a: int64x1_t, _b: int64x1_t) -> int64x1_t {
@@ -6012,7 +6012,7 @@ pub unsafe fn vext_s64<const N: i32>(a: int64x1_t, _b: int64x1_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr("nop", N = 0))]
 #[rustc_legacy_const_generics(2)]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vext_u64<const N: i32>(a: uint64x1_t, _b: uint64x1_t) -> uint64x1_t {
@@ -6027,7 +6027,7 @@ pub unsafe fn vext_u64<const N: i32>(a: uint64x1_t, _b: uint64x1_t) -> uint64x1_
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcnt))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(cnt))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcnt_s8(a: int8x8_t) -> int8x8_t {
@@ -6040,7 +6040,7 @@ pub unsafe fn vcnt_s8(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcnt))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(cnt))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcntq_s8(a: int8x16_t) -> int8x16_t {
@@ -6053,7 +6053,7 @@ pub unsafe fn vcntq_s8(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcnt))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(cnt))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcnt_u8(a: uint8x8_t) -> uint8x8_t {
@@ -6066,7 +6066,7 @@ pub unsafe fn vcnt_u8(a: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcnt))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(cnt))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcntq_u8(a: uint8x16_t) -> uint8x16_t {
@@ -6079,7 +6079,7 @@ pub unsafe fn vcntq_u8(a: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcnt))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(cnt))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcnt_p8(a: poly8x8_t) -> poly8x8_t {
@@ -6092,7 +6092,7 @@ pub unsafe fn vcnt_p8(a: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcnt))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(cnt))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vcntq_p8(a: poly8x16_t) -> poly8x16_t {
@@ -6106,7 +6106,7 @@ pub unsafe fn vcntq_p8(a: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev16.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev16))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16_s8(a: int8x8_t) -> int8x8_t {
@@ -6120,7 +6120,7 @@ pub unsafe fn vrev16_s8(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev16.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev16))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16q_s8(a: int8x16_t) -> int8x16_t {
@@ -6134,7 +6134,7 @@ pub unsafe fn vrev16q_s8(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev16.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev16))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16_u8(a: uint8x8_t) -> uint8x8_t {
@@ -6148,7 +6148,7 @@ pub unsafe fn vrev16_u8(a: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev16.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev16))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16q_u8(a: uint8x16_t) -> uint8x16_t {
@@ -6162,7 +6162,7 @@ pub unsafe fn vrev16q_u8(a: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev16.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev16))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16_p8(a: poly8x8_t) -> poly8x8_t {
@@ -6176,7 +6176,7 @@ pub unsafe fn vrev16_p8(a: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev16.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev16))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev16q_p8(a: poly8x16_t) -> poly8x16_t {
@@ -6190,7 +6190,7 @@ pub unsafe fn vrev16q_p8(a: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_s8(a: int8x8_t) -> int8x8_t {
@@ -6204,7 +6204,7 @@ pub unsafe fn vrev32_s8(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_s8(a: int8x16_t) -> int8x16_t {
@@ -6218,7 +6218,7 @@ pub unsafe fn vrev32q_s8(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_u8(a: uint8x8_t) -> uint8x8_t {
@@ -6232,7 +6232,7 @@ pub unsafe fn vrev32_u8(a: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_u8(a: uint8x16_t) -> uint8x16_t {
@@ -6246,7 +6246,7 @@ pub unsafe fn vrev32q_u8(a: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_s16(a: int16x4_t) -> int16x4_t {
@@ -6260,7 +6260,7 @@ pub unsafe fn vrev32_s16(a: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_s16(a: int16x8_t) -> int16x8_t {
@@ -6274,7 +6274,7 @@ pub unsafe fn vrev32q_s16(a: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_p16(a: poly16x4_t) -> poly16x4_t {
@@ -6288,7 +6288,7 @@ pub unsafe fn vrev32_p16(a: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_p16(a: poly16x8_t) -> poly16x8_t {
@@ -6302,7 +6302,7 @@ pub unsafe fn vrev32q_p16(a: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_u16(a: uint16x4_t) -> uint16x4_t {
@@ -6316,7 +6316,7 @@ pub unsafe fn vrev32_u16(a: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_u16(a: uint16x8_t) -> uint16x8_t {
@@ -6330,7 +6330,7 @@ pub unsafe fn vrev32q_u16(a: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32_p8(a: poly8x8_t) -> poly8x8_t {
@@ -6344,7 +6344,7 @@ pub unsafe fn vrev32_p8(a: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev32.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev32))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev32q_p8(a: poly8x16_t) -> poly8x16_t {
@@ -6358,7 +6358,7 @@ pub unsafe fn vrev32q_p8(a: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_s8(a: int8x8_t) -> int8x8_t {
@@ -6372,7 +6372,7 @@ pub unsafe fn vrev64_s8(a: int8x8_t) -> int8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_s8(a: int8x16_t) -> int8x16_t {
@@ -6386,7 +6386,7 @@ pub unsafe fn vrev64q_s8(a: int8x16_t) -> int8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_s16(a: int16x4_t) -> int16x4_t {
@@ -6400,7 +6400,7 @@ pub unsafe fn vrev64_s16(a: int16x4_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_s16(a: int16x8_t) -> int16x8_t {
@@ -6414,7 +6414,7 @@ pub unsafe fn vrev64q_s16(a: int16x8_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_s32(a: int32x2_t) -> int32x2_t {
@@ -6428,7 +6428,7 @@ pub unsafe fn vrev64_s32(a: int32x2_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_s32(a: int32x4_t) -> int32x4_t {
@@ -6442,7 +6442,7 @@ pub unsafe fn vrev64q_s32(a: int32x4_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_u8(a: uint8x8_t) -> uint8x8_t {
@@ -6456,7 +6456,7 @@ pub unsafe fn vrev64_u8(a: uint8x8_t) -> uint8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_u8(a: uint8x16_t) -> uint8x16_t {
@@ -6470,7 +6470,7 @@ pub unsafe fn vrev64q_u8(a: uint8x16_t) -> uint8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_u16(a: uint16x4_t) -> uint16x4_t {
@@ -6484,7 +6484,7 @@ pub unsafe fn vrev64_u16(a: uint16x4_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_u16(a: uint16x8_t) -> uint16x8_t {
@@ -6498,7 +6498,7 @@ pub unsafe fn vrev64q_u16(a: uint16x8_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_u32(a: uint32x2_t) -> uint32x2_t {
@@ -6512,7 +6512,7 @@ pub unsafe fn vrev64_u32(a: uint32x2_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_u32(a: uint32x4_t) -> uint32x4_t {
@@ -6526,7 +6526,7 @@ pub unsafe fn vrev64q_u32(a: uint32x4_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_f32(a: float32x2_t) -> float32x2_t {
@@ -6540,7 +6540,7 @@ pub unsafe fn vrev64_f32(a: float32x2_t) -> float32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.32"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_f32(a: float32x4_t) -> float32x4_t {
@@ -6554,7 +6554,7 @@ pub unsafe fn vrev64q_f32(a: float32x4_t) -> float32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_p8(a: poly8x8_t) -> poly8x8_t {
@@ -6568,7 +6568,7 @@ pub unsafe fn vrev64_p8(a: poly8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.8"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_p8(a: poly8x16_t) -> poly8x16_t {
@@ -6582,7 +6582,7 @@ pub unsafe fn vrev64q_p8(a: poly8x16_t) -> poly8x16_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64_p16(a: poly16x4_t) -> poly16x4_t {
@@ -6596,7 +6596,7 @@ pub unsafe fn vrev64_p16(a: poly16x4_t) -> poly16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vrev64.16"))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(rev64))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vrev64q_p16(a: poly16x8_t) -> poly16x8_t {
@@ -6610,7 +6610,7 @@ pub unsafe fn vrev64q_p16(a: poly16x8_t) -> poly16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.s8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadal_s8(a: int16x4_t, b: int8x8_t) -> int16x4_t {
@@ -6631,7 +6631,7 @@ pub unsafe fn vpadal_s8(a: int16x4_t, b: int8x8_t) -> int16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.s16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadal_s16(a: int32x2_t, b: int16x4_t) -> int32x2_t {
@@ -6652,7 +6652,7 @@ pub unsafe fn vpadal_s16(a: int32x2_t, b: int16x4_t) -> int32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.s32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadal_s32(a: int64x1_t, b: int32x2_t) -> int64x1_t {
@@ -6673,7 +6673,7 @@ pub unsafe fn vpadal_s32(a: int64x1_t, b: int32x2_t) -> int64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.s8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadalq_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
@@ -6694,7 +6694,7 @@ pub unsafe fn vpadalq_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.s16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadalq_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
@@ -6715,7 +6715,7 @@ pub unsafe fn vpadalq_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.s32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(sadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadalq_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
@@ -6736,7 +6736,7 @@ pub unsafe fn vpadalq_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.u8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadal_u8(a: uint16x4_t, b: uint8x8_t) -> uint16x4_t {
@@ -6757,7 +6757,7 @@ pub unsafe fn vpadal_u8(a: uint16x4_t, b: uint8x8_t) -> uint16x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.u16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadal_u16(a: uint32x2_t, b: uint16x4_t) -> uint32x2_t {
@@ -6778,7 +6778,7 @@ pub unsafe fn vpadal_u16(a: uint32x2_t, b: uint16x4_t) -> uint32x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.u32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadal_u32(a: uint64x1_t, b: uint32x2_t) -> uint64x1_t {
@@ -6799,7 +6799,7 @@ pub unsafe fn vpadal_u32(a: uint64x1_t, b: uint32x2_t) -> uint64x1_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.u8))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadalq_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
@@ -6820,7 +6820,7 @@ pub unsafe fn vpadalq_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.u16))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadalq_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
@@ -6841,7 +6841,7 @@ pub unsafe fn vpadalq_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vpadal.u32))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(uadalp))]
 #[cfg_attr(
-    target_arch = "aarch64",
+    not(target_arch = "arm"),
     stable(feature = "neon_intrinsics", since = "1.59.0")
 )]
 pub unsafe fn vpadalq_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {


### PR DESCRIPTION
This is a follow-up to #1345 where these appeared as unstable in the standard library docs because they are only stabilized for ARM. They were missed in the original PR.