### PR TITLE
Fix the powerpc feature guards

### DIFF
--- a/crates/core_arch/src/powerpc/mod.rs
+++ b/crates/core_arch/src/powerpc/mod.rs
@@ -1,11 +1,12 @@
 //! PowerPC intrinsics
-
-#[cfg(target_feature = "altivec")]
+#[cfg(any(target_feature = "altivec", doc))]
 mod altivec;
-#[cfg(target_feature = "altivec")]
+#[cfg(any(target_feature = "altivec", doc))]
 pub use self::altivec::*;
 
+#[cfg(any(target_feature = "vsx", doc))]
 mod vsx;
+#[cfg(any(target_feature = "vsx", doc))]
 pub use self::vsx::*;
 
 #[cfg(test)]


### PR DESCRIPTION
Now the documentation should be generated correctly and vsx isn't always present.