### PR TITLE
std_detect: Always avoid dlsym on *-android* targets

### DIFF
--- a/crates/std_detect/README.md
+++ b/crates/std_detect/README.md
@@ -30,14 +30,19 @@ run-time feature detection. When this feature is disabled, `std_detect` assumes
 that [`getauxval`] is linked to the binary. If that is not the case the behavior
 is undefined.
 
-  Note: This feature is ignored on `*-linux-gnu*` targets, since all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html)) have glibc requirements higher than [glibc 2.16 that added `getauxval`](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html), and we can safely assume [`getauxval`] is linked to the binary.
+  Note: This feature is ignored on `*-linux-gnu*` and `*-android*` targets
+  because we can safely assume `getauxval` is linked to the binary.
+  * `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html))
+  have glibc requirements higher than [glibc 2.16 that added `getauxval`](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html).
+  * `*-android*` targets ([since Rust 1.68](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html))
+  have the minimum supported API level higher than [Android 4.3 (API level 18) that added `getauxval`](https://github.com/aosp-mirror/platform_bionic/blob/d3ebc2f7c49a9893b114124d4a6b315f3a328764/libc/include/sys/auxv.h#L49).
 
 * `std_detect_file_io` (enabled by default, requires `std`): Enable to perform run-time feature
 detection using file APIs (e.g. `/proc/cpuinfo`, etc.) if other more performant
 methods fail. This feature requires `libstd` as a dependency, preventing the
 crate from working on applications in which `std` is not available.
 
-[`getauxval`]: http://man7.org/linux/man-pages/man3/getauxval.3.html
+[`getauxval`]: https://man7.org/linux/man-pages/man3/getauxval.3.html
 
 # Platform support
 

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -54,10 +54,13 @@ pub(crate) struct AuxVec {
 /// error, cpuinfo still can (and will) be used to try to perform run-time
 /// feature detection on some platforms.
 ///
-/// Note: The `std_detect_dlsym_getauxval` cargo feature is ignored on `*-linux-gnu*` targets,
-/// since [all `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html))
-/// have glibc requirements higher than [glibc 2.16 that added `getauxval`](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html),
-/// and we can safely assume [`getauxval`] is linked to the binary.
+///  Note: The `std_detect_dlsym_getauxval` cargo feature is ignored on
+/// `*-linux-gnu*` and `*-android*` targets because we can safely assume `getauxval`
+/// is linked to the binary.
+/// - `*-linux-gnu*` targets ([since Rust 1.64](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html))
+///   have glibc requirements higher than [glibc 2.16 that added `getauxval`](https://sourceware.org/legacy-ml/libc-announce/2012/msg00000.html).
+/// - `*-android*` targets ([since Rust 1.68](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html))
+///   have the minimum supported API level higher than [Android 4.3 (API level 18) that added `getauxval`](https://github.com/aosp-mirror/platform_bionic/blob/d3ebc2f7c49a9893b114124d4a6b315f3a328764/libc/include/sys/auxv.h#L49).
 ///
 /// For more information about when `getauxval` is available check the great
 /// [`auxv` crate documentation][auxv_docs].
@@ -67,7 +70,8 @@ pub(crate) struct AuxVec {
 pub(crate) fn auxv() -> Result<AuxVec, ()> {
     #[cfg(all(
         feature = "std_detect_dlsym_getauxval",
-        not(all(target_os = "linux", target_env = "gnu"))
+        not(all(target_os = "linux", target_env = "gnu")),
+        not(target_os = "android"),
     ))]
     {
         // Try to call a dynamically-linked getauxval function.
@@ -111,7 +115,8 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
 
     #[cfg(any(
         not(feature = "std_detect_dlsym_getauxval"),
-        all(target_os = "linux", target_env = "gnu")
+        all(target_os = "linux", target_env = "gnu"),
+        target_os = "android",
     ))]
     {
         // Targets with only AT_HWCAP:


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/stdarch/pull/1375, [since Rust 1.68](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html), `*-android*` targets have the minimum supported API level higher than [Android 4.3 (API level 18) that added `getauxval`](https://github.com/aosp-mirror/platform_bionic/blob/d3ebc2f7c49a9893b114124d4a6b315f3a328764/libc/include/sys/auxv.h#L49).