### PR TITLE
Remove uses of arm crypto target feature

### DIFF
--- a/crates/core_arch/src/arm_shared/crypto.rs
+++ b/crates/core_arch/src/arm_shared/crypto.rs
@@ -55,8 +55,8 @@ use stdarch_test::assert_instr;
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaeseq_u8)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "aes")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(aese))]
 pub unsafe fn vaeseq_u8(data: uint8x16_t, key: uint8x16_t) -> uint8x16_t {
     vaeseq_u8_(data, key)
@@ -66,8 +66,8 @@ pub unsafe fn vaeseq_u8(data: uint8x16_t, key: uint8x16_t) -> uint8x16_t {
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaesdq_u8)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "aes")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(aesd))]
 pub unsafe fn vaesdq_u8(data: uint8x16_t, key: uint8x16_t) -> uint8x16_t {
     vaesdq_u8_(data, key)
@@ -77,8 +77,8 @@ pub unsafe fn vaesdq_u8(data: uint8x16_t, key: uint8x16_t) -> uint8x16_t {
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaesmcq_u8)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "aes")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(aesmc))]
 pub unsafe fn vaesmcq_u8(data: uint8x16_t) -> uint8x16_t {
     vaesmcq_u8_(data)
@@ -88,8 +88,8 @@ pub unsafe fn vaesmcq_u8(data: uint8x16_t) -> uint8x16_t {
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaesimcq_u8)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "aes"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "aes")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(aesimc))]
 pub unsafe fn vaesimcq_u8(data: uint8x16_t) -> uint8x16_t {
     vaesimcq_u8_(data)
@@ -99,8 +99,8 @@ pub unsafe fn vaesimcq_u8(data: uint8x16_t) -> uint8x16_t {
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1h_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha1h))]
 pub unsafe fn vsha1h_u32(hash_e: u32) -> u32 {
     vsha1h_u32_(hash_e)
@@ -110,8 +110,8 @@ pub unsafe fn vsha1h_u32(hash_e: u32) -> u32 {
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1cq_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha1c))]
 pub unsafe fn vsha1cq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t {
     vsha1cq_u32_(hash_abcd, hash_e, wk)
@@ -121,8 +121,8 @@ pub unsafe fn vsha1cq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) ->
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1mq_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha1m))]
 pub unsafe fn vsha1mq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t {
     vsha1mq_u32_(hash_abcd, hash_e, wk)
@@ -132,8 +132,8 @@ pub unsafe fn vsha1mq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) ->
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1pq_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha1p))]
 pub unsafe fn vsha1pq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t {
     vsha1pq_u32_(hash_abcd, hash_e, wk)
@@ -143,8 +143,8 @@ pub unsafe fn vsha1pq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) ->
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1su0q_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha1su0))]
 pub unsafe fn vsha1su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_t) -> uint32x4_t {
     vsha1su0q_u32_(w0_3, w4_7, w8_11)
@@ -154,8 +154,8 @@ pub unsafe fn vsha1su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha1su1q_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha1su1))]
 pub unsafe fn vsha1su1q_u32(tw0_3: uint32x4_t, w12_15: uint32x4_t) -> uint32x4_t {
     vsha1su1q_u32_(tw0_3, w12_15)
@@ -165,8 +165,8 @@ pub unsafe fn vsha1su1q_u32(tw0_3: uint32x4_t, w12_15: uint32x4_t) -> uint32x4_t
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256hq_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha256h))]
 pub unsafe fn vsha256hq_u32(
     hash_abcd: uint32x4_t,
@@ -180,8 +180,8 @@ pub unsafe fn vsha256hq_u32(
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256h2q_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha256h2))]
 pub unsafe fn vsha256h2q_u32(
     hash_efgh: uint32x4_t,
@@ -195,8 +195,8 @@ pub unsafe fn vsha256h2q_u32(
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256su0q_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha256su0))]
 pub unsafe fn vsha256su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t {
     vsha256su0q_u32_(w0_3, w4_7)
@@ -206,8 +206,8 @@ pub unsafe fn vsha256su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t 
 ///
 /// [Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsha256su1q_u32)
 #[inline]
-#[cfg_attr(not(target_arch = "arm"), target_feature(enable = "sha2"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "crypto,v8"))]
+#[target_feature(enable = "sha2")]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(test, assert_instr(sha256su1))]
 pub unsafe fn vsha256su1q_u32(
     tw0_3: uint32x4_t,
@@ -224,8 +224,7 @@ mod tests {
     use std::mem;
     use stdarch_test::simd_test;
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "aes"))]
+    #[simd_test(enable = "aes")]
     unsafe fn test_vaeseq_u8() {
         let data = mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
         let key = mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
@@ -238,8 +237,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "aes"))]
+    #[simd_test(enable = "aes")]
     unsafe fn test_vaesdq_u8() {
         let data = mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
         let key = mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
@@ -250,8 +248,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "aes"))]
+    #[simd_test(enable = "aes")]
     unsafe fn test_vaesmcq_u8() {
         let data = mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
         let r: u8x16 = mem::transmute(vaesmcq_u8(data));
@@ -261,8 +258,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "aes"))]
+    #[simd_test(enable = "aes")]
     unsafe fn test_vaesimcq_u8() {
         let data = mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
         let r: u8x16 = mem::transmute(vaesimcq_u8(data));
@@ -272,15 +268,13 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha1h_u32() {
         assert_eq!(vsha1h_u32(0x1234), 0x048d);
         assert_eq!(vsha1h_u32(0x5678), 0x159e);
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha1su0q_u32() {
         let r: u32x4 = mem::transmute(vsha1su0q_u32(
             mem::transmute(u32x4::new(0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32)),
@@ -290,8 +284,7 @@ mod tests {
         assert_eq!(r, u32x4::new(0x9abc, 0xdef0, 0x1234, 0x5678));
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha1su1q_u32() {
         let r: u32x4 = mem::transmute(vsha1su1q_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -303,8 +296,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha1cq_u32() {
         let r: u32x4 = mem::transmute(vsha1cq_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -317,8 +309,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha1pq_u32() {
         let r: u32x4 = mem::transmute(vsha1pq_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -331,8 +322,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha1mq_u32() {
         let r: u32x4 = mem::transmute(vsha1mq_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -345,8 +335,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha256hq_u32() {
         let r: u32x4 = mem::transmute(vsha256hq_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -359,8 +348,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha256h2q_u32() {
         let r: u32x4 = mem::transmute(vsha256h2q_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -373,8 +361,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha256su0q_u32() {
         let r: u32x4 = mem::transmute(vsha256su0q_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),
@@ -386,8 +373,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "arm", simd_test(enable = "crypto"))]
-    #[cfg_attr(not(target_arch = "arm"), simd_test(enable = "sha2"))]
+    #[simd_test(enable = "sha2")]
     unsafe fn test_vsha256su1q_u32() {
         let r: u32x4 = mem::transmute(vsha256su1q_u32(
             mem::transmute(u32x4::new(0x1234, 0x5678, 0x9abc, 0xdef0)),

--- a/crates/std_detect/src/detect/arch/arm.rs
+++ b/crates/std_detect/src/detect/arch/arm.rs
@@ -17,8 +17,6 @@ features! {
     /// Polynomial Multiply
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] crc: "crc";
     /// CRC32 (Cyclic Redundancy Check)
-    @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] crypto: "crypto";
-    /// Crypto: AES + PMULL + SHA1 + SHA256. Prefer using the individual features where possible.
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] aes: "aes";
     /// FEAT_AES (AES instructions)
     @FEATURE: #[unstable(feature = "stdsimd", issue = "27731")] sha2: "sha2";

--- a/crates/std_detect/src/detect/os/freebsd/arm.rs
+++ b/crates/std_detect/src/detect/os/freebsd/arm.rs
@@ -23,16 +23,13 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
     if let Ok(auxv) = auxvec::auxv() {
         enable_feature(&mut value, Feature::neon, auxv.hwcap & HWCAP_NEON != 0);
-        let pmull = auxv.hwcap2 & HWCAP2_PMULL != 0;
-        enable_feature(&mut value, Feature::pmull, pmull);
+        enable_feature(&mut value, Feature::pmull, auxv.hwcap2 & HWCAP2_PMULL != 0);
         enable_feature(&mut value, Feature::crc, auxv.hwcap2 & HWCAP2_CRC32 != 0);
-        let aes = auxv.hwcap2 & HWCAP2_AES != 0;
-        enable_feature(&mut value, Feature::aes, aes);
+        enable_feature(&mut value, Feature::aes, auxv.hwcap2 & HWCAP2_AES != 0);
         // SHA2 requires SHA1 & SHA2 features
         let sha1 = auxv.hwcap2 & HWCAP2_SHA1 != 0;
         let sha2 = auxv.hwcap2 & HWCAP2_SHA2 != 0;
         enable_feature(&mut value, Feature::sha2, sha1 && sha2);
-        enable_feature(&mut value, Feature::crypto, aes && pmull && sha1 && sha2);
         return value;
     }
     value

--- a/crates/std_detect/src/detect/os/linux/arm.rs
+++ b/crates/std_detect/src/detect/os/linux/arm.rs
@@ -20,14 +20,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
         enable_feature(&mut value, Feature::neon, bit::test(auxv.hwcap, 12));
         enable_feature(&mut value, Feature::pmull, bit::test(auxv.hwcap2, 1));
         enable_feature(&mut value, Feature::crc, bit::test(auxv.hwcap2, 4));
-        enable_feature(
-            &mut value,
-            Feature::crypto,
-            bit::test(auxv.hwcap2, 0)
-                && bit::test(auxv.hwcap2, 1)
-                && bit::test(auxv.hwcap2, 2)
-                && bit::test(auxv.hwcap2, 3),
-        );
         enable_feature(&mut value, Feature::aes, bit::test(auxv.hwcap2, 0));
         // SHA2 requires SHA1 & SHA2 features
         enable_feature(
@@ -47,14 +39,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
         );
         enable_feature(&mut value, Feature::pmull, c.field("Features").has("pmull"));
         enable_feature(&mut value, Feature::crc, c.field("Features").has("crc32"));
-        enable_feature(
-            &mut value,
-            Feature::crypto,
-            c.field("Features").has("aes")
-                && c.field("Features").has("pmull")
-                && c.field("Features").has("sha1")
-                && c.field("Features").has("sha2"),
-        );
         enable_feature(&mut value, Feature::aes, c.field("Features").has("aes"));
         enable_feature(
             &mut value,

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -28,7 +28,6 @@ fn arm_linux_or_freebsd() {
     println!("neon: {}", is_arm_feature_detected!("neon"));
     println!("pmull: {}", is_arm_feature_detected!("pmull"));
     println!("crc: {}", is_arm_feature_detected!("crc"));
-    println!("crypto: {}", is_arm_feature_detected!("crypto"));
     println!("aes: {}", is_arm_feature_detected!("aes"));
     println!("sha2: {}", is_arm_feature_detected!("sha2"));
 }


### PR DESCRIPTION
Similar to https://github.com/rust-lang/stdarch/pull/1192 and https://github.com/rust-lang/stdarch/pull/1146 done for aarch64, but for arm.

Those PRs skipped arm for compatibility with older LLVM (https://github.com/rust-lang/stdarch/pull/1146#issuecomment-849723187), but the current nightly's minimum LLVM version is 14 (https://github.com/rust-lang/rust/commit/2970ad8aeeaa94ad5af5fc49150c14bcf86bf7c9), so we can do this.

Original motivation is: https://github.com/rust-lang/rust/pull/84665#discussion_r622937124

> LLVM has moved away from a combined "crypto" feature and now uses separate "aes" and "sha2" features. We should do the same here.

(After this is merged, I will send a patch to rust-lang/rust to remove the "crypto" target feature.)