### PR TITLE
Clarify undefined can still mean init

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -2687,7 +2687,9 @@ pub unsafe fn _mm256_zextpd128_pd256(a: __m128d) -> __m256d {
     simd_shuffle!(a, _mm_setzero_pd(), [0, 1, 2, 3])
 }
 
-/// Returns vector of type `__m256` with undefined elements.
+/// Returns vector of type `__m256` with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_undefined_ps)
 #[inline]
@@ -2698,7 +2700,9 @@ pub unsafe fn _mm256_undefined_ps() -> __m256 {
     _mm256_set1_ps(0.0)
 }
 
-/// Returns vector of type `__m256d` with undefined elements.
+/// Returns vector of type `__m256d` with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_undefined_pd)
 #[inline]
@@ -2709,7 +2713,9 @@ pub unsafe fn _mm256_undefined_pd() -> __m256d {
     _mm256_set1_pd(0.0)
 }
 
-/// Returns vector of type __m256i with undefined elements.
+/// Returns vector of type __m256i with with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_undefined_si256)
 #[inline]

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -29616,7 +29616,9 @@ pub unsafe fn _mm512_mask_reduce_or_epi64(k: __mmask8, a: __m512i) -> i64 {
     ))
 }
 
-/// Returns vector of type `__m512d` with undefined elements.
+/// Returns vector of type `__m512d` with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_undefined_pd)
 #[inline]
@@ -29626,7 +29628,9 @@ pub unsafe fn _mm512_undefined_pd() -> __m512d {
     _mm512_set1_pd(0.0)
 }
 
-/// Returns vector of type `__m512` with undefined elements.
+/// Returns vector of type `__m512` with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_undefined_ps)
 #[inline]
@@ -29636,7 +29640,9 @@ pub unsafe fn _mm512_undefined_ps() -> __m512 {
     _mm512_set1_ps(0.0)
 }
 
-/// Return vector of type __m512i with undefined elements.
+/// Return vector of type __m512i with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_undefined_epi32&expand=5995)
 #[inline]
@@ -29646,7 +29652,9 @@ pub unsafe fn _mm512_undefined_epi32() -> __m512i {
     _mm512_set1_epi32(0)
 }
 
-/// Return vector of type __m512 with undefined elements.
+/// Return vector of type __m512 with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_undefined&expand=5994)
 #[inline]

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1754,7 +1754,9 @@ pub unsafe fn _mm_prefetch<const STRATEGY: i32>(p: *const i8) {
     prefetch(p, (STRATEGY >> 2) & 1, STRATEGY & 3, 1);
 }
 
-/// Returns vector of type __m128 with undefined elements.
+/// Returns vector of type __m128 with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_undefined_ps)
 #[inline]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2737,7 +2737,9 @@ pub unsafe fn _mm_castsi128_ps(a: __m128i) -> __m128 {
     transmute(a)
 }
 
-/// Returns vector of type __m128d with undefined elements.
+/// Returns vector of type __m128d with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_undefined_pd)
 #[inline]
@@ -2747,7 +2749,9 @@ pub unsafe fn _mm_undefined_pd() -> __m128d {
     __m128d(0.0, 0.0)
 }
 
-/// Returns vector of type __m128i with undefined elements.
+/// Returns vector of type __m128i with indeterminate elements.
+/// Despite being "undefined", this is some valid value and not equivalent to [`mem::MaybeUninit`].
+/// In practice, this is equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_undefined_si128)
 #[inline]


### PR DESCRIPTION
These intrinsics actually are zeroing, so we should be upfront that these still return a valid value in reality. At most, we might in the future want to use a "freezing" semantics here. In any case, they are definitely not returning MaybeUninit, or any other possibly-poison value.

Motivated partly by https://github.com/rust-lang/rust/issues/107945