### PR TITLE
Remove useless drop (clippy drop_ref and drop_copy lint)

### DIFF
--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -4719,7 +4719,7 @@ pub mod tests {
                         let v2_v128: v128 = mem::transmute(v2);
                         let v3_v128 = super::$f(v1_v128, v2_v128);
                         let mut v3 = [$($vec1)*];
-                        drop(v3);
+                        let _ignore = v3;
                         v3 = mem::transmute(v3_v128);
 
                         for (i, actual) in v3.iter().enumerate() {
@@ -4746,7 +4746,7 @@ pub mod tests {
                         let v1_v128: v128 = mem::transmute(v1);
                         let v2_v128 = super::$f(v1_v128);
                         let mut v2 = [$($vec1)*];
-                        drop(v2);
+                        let _ignore = v2;
                         v2 = mem::transmute(v2_v128);
 
                         for (i, actual) in v2.iter().enumerate() {

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -109,7 +109,9 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
                     }
                 }
             }
-            drop(hwcap);
+
+            // Intentionnaly not used
+            let _ = hwcap;
         }
     }
 
@@ -251,7 +253,8 @@ fn auxv_from_buf(buf: &[usize]) -> Result<AuxVec, ()> {
             return Ok(AuxVec { hwcap, hwcap2 });
         }
     }
-    drop(buf);
+    // Suppress unused variable
+    let _ = buf;
     Err(())
 }
 


### PR DESCRIPTION
This removes all the instances of drop call that drop copy and ref types and replace them with `let _ = ...;` (as it is the T-lang approved way to suppress the unused variable lint).

Found in https://github.com/rust-lang/rust/pull/109732#issuecomment-1512132280 while uplifting `clippy::{drop,forget}_{ref,copy}`.