### PR TITLE
Use Wasmtime 8.0.0 on CI

### DIFF
--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   clang
 
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz | tar xJf -
+RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v8.0.0/wasmtime-v8.0.0-x86_64-linux.tar.xz | tar xJf -
 ENV PATH=$PATH:/wasmtime-dev-x86_64-linux
 
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   clang
 
 RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v8.0.0/wasmtime-v8.0.0-x86_64-linux.tar.xz | tar xJf -
-ENV PATH=$PATH:/wasmtime-dev-x86_64-linux
+ENV PATH=$PATH:/wasmtime-v8.0.0-x86_64-linux
 
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \
   --wasm-features=threads,relaxed-simd \


### PR DESCRIPTION
This moves from the "dev" release of Wasmtime, used for its relaxed-simd support, to an official release of Wasmtime just made which is the first with relaxed-simd support.