### PR TITLE
Rename `wasm32-wasi` to `wasm32-wasi-preview1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         - mips64-unknown-linux-gnuabi64
         - mips64el-unknown-linux-gnuabi64
         - s390x-unknown-linux-gnu
-        - wasm32-wasi
+        - wasm32-wasi-preview1
         - i586-unknown-linux-gnu
         - mipsel-unknown-linux-musl
         - nvptx64-nvidia-cuda
@@ -128,7 +128,7 @@ jobs:
           disable_assert_instr: true
         - target: s390x-unknown-linux-gnu
           os: ubuntu-latest
-        - target: wasm32-wasi
+        - target: wasm32-wasi-preview1
           os: ubuntu-latest
         - target: aarch64-apple-darwin
           os: macos-latest

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -12,5 +12,5 @@ ENV PATH=$PATH:/wasmtime-v8.0.0-x86_64-linux
 
 ENV CARGO_TARGET_WASM32_WASI_RUNNER="wasmtime \
   --wasm-features=threads,relaxed-simd \
-  --mapdir .::/checkout/target/wasm32-wasi/release/deps \
+  --mapdir .::/checkout/target/wasm32-wasi-preview1/release/deps \
   --"


### PR DESCRIPTION
Implements https://github.com/rust-lang/compiler-team/issues/607. Sibling to https://github.com/rust-lang/rust/pull/110596 and https://github.com/rust-lang/rustc-dev-guide/pull/1678.

This PR renames the `wasm32-wasi` target to `wasm32-wasi-preview1`, in accordance to the accepted compiler team MCP. I'm not sure what the right ordering is wrt merging this PR? Does this need to wait on https://github.com/rust-lang/rust/pull/110596 being merged first?