### PR TITLE
std_detect: Do not use libc::getauxval on 32-bit Android

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,3 +211,13 @@ jobs:
       if: "matrix.os == 'ubuntu-latest' && !startsWith(matrix.target, 'thumb')"
       env:
         TARGET: ${{ matrix.target }}
+
+  build-std-detect:
+    needs: [style]
+    name: Build std_detect
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update nightly && rustup default nightly
+    - run: ./ci/build-std-detect.sh

--- a/ci/build-std-detect.sh
+++ b/ci/build-std-detect.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Build std_detect on non-Linux & non-x86 targets.
+#
+# In std_detect, non-x86 targets have OS-specific implementations,
+# but we can test only Linux in CI. This script builds targets supported
+# by std_detect but cannot be tested in CI.
+
+set -ex
+cd "$(dirname "$0")"/..
+
+targets=(
+    # Android
+    aarch64-linux-android
+    arm-linux-androideabi
+
+    # FreeBSD
+    aarch64-unknown-freebsd
+    armv6-unknown-freebsd
+    powerpc-unknown-freebsd
+    powerpc64-unknown-freebsd
+
+    # OpenBSD
+    aarch64-unknown-openbsd
+
+    # Windows
+    aarch64-pc-windows-msvc
+)
+
+rustup component add rust-src # for -Z build-std
+
+cd crates/std_detect
+for target in "${targets[@]}"; do
+    if rustup target add "${target}" &>/dev/null; then
+        cargo build --target "${target}"
+    else
+        # tier 3 targets requires -Z build-std.
+        cargo build -Z build-std="core,alloc" --target "${target}"
+    fi
+done

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -71,7 +71,8 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
     #[cfg(all(
         feature = "std_detect_dlsym_getauxval",
         not(all(target_os = "linux", target_env = "gnu")),
-        not(target_os = "android"),
+        // TODO: libc crate currently doesn't provide getauxval on 32-bit Android.
+        not(all(target_os = "android", target_pointer_width = "64")),
     ))]
     {
         // Try to call a dynamically-linked getauxval function.
@@ -118,7 +119,8 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
     #[cfg(any(
         not(feature = "std_detect_dlsym_getauxval"),
         all(target_os = "linux", target_env = "gnu"),
-        target_os = "android",
+        // TODO: libc crate currently doesn't provide getauxval on 32-bit Android.
+        all(target_os = "android", target_pointer_width = "64"),
     ))]
     {
         // Targets with only AT_HWCAP:


### PR DESCRIPTION
This fixes the build error in https://github.com/rust-lang/rust/pull/110285#issuecomment-1519837713.

In https://github.com/rust-lang/stdarch/pull/1406 I checked only aarch64 android and missed the fact that libc crate does not provide getauxval on 32-bit android (although I believe [android provides getauxval on these targets](https://github.com/aosp-mirror/platform_bionic/commit/2c5153b043b44e9935a334ae9b2d5a4bc5258b40)). Sorry.

The second commit in this PR adds a job to CI that builds non-Linux targets that are not currently tested in CI to prevent such an oversight from occurring again in the future.
