### PR TITLE
Remove ud2 intrinsic (in favor of `asm!` or `abort` as needed)

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -804,13 +804,6 @@ pub use self::adx::*;
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-/// Generates the trap instruction `UD2`
-#[cfg_attr(test, assert_instr(ud2))]
-#[inline]
-pub unsafe fn ud2() -> ! {
-    intrinsics::abort()
-}
-
 mod avx512f;
 pub use self::avx512f::*;
 

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -261,7 +261,6 @@ fn verify_all_signatures() {
                 "_mm_setr_pi16",
                 "_mm_setr_pi32",
                 "_mm_setr_pi8",
-                "ud2",
                 "_mm_min_epi8",
                 "_mm_min_epi32",
                 "_xbegin",
@@ -332,11 +331,7 @@ fn verify_all_signatures() {
             "__cpuid" |
             "__get_cpuid_max" |
             // Not listed with intel, but manually verified
-            "cmpxchg16b" |
-            // The UD2 intrinsic is not defined by Intel, but it was agreed on
-            // in the RFC Issue 2512:
-            // https://github.com/rust-lang/rfcs/issues/2512
-            "ud2"
+            "cmpxchg16b"
                 => continue,
             // Intel requires the mask argument for _mm_shuffle_ps to be an
             // unsigned integer, but all other _mm_shuffle_.. intrinsics


### PR DESCRIPTION
Preparing in anticipation of FCP in
https://github.com/rust-lang/rust/issues/111193 completing.
