### PR TITLE
Fix intrinsic-test rejecting the new `instructions` JSON field

### DIFF
--- a/crates/intrinsic-test/src/json_parser.rs
+++ b/crates/intrinsic-test/src/json_parser.rs
@@ -29,7 +29,6 @@ pub enum ArgPrep {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 struct JsonIntrinsic {
     #[serde(rename = "SIMD_ISA")]
     simd_isa: String,


### PR DESCRIPTION
Fixes CI for https://github.com/rust-lang/stdarch/pull/1427  which didn't run due to a Github outage. The second commit in the chain broke the intrinsic-test tool.