### PR TITLE
Fix documentation for carryless multiplication

### DIFF
--- a/crates/core_arch/src/x86/pclmulqdq.rs
+++ b/crates/core_arch/src/x86/pclmulqdq.rs
@@ -17,7 +17,7 @@ extern "C" {
 }
 
 /// Performs a carry-less multiplication of two 64-bit polynomials over the
-/// finite field GF(2^k).
+/// finite field GF(2).
 ///
 /// The immediate byte is used for determining which halves of `a` and `b`
 /// should be used. Immediate bits other than 0 and 4 are ignored.

--- a/crates/core_arch/src/x86/vpclmulqdq.rs
+++ b/crates/core_arch/src/x86/vpclmulqdq.rs
@@ -24,7 +24,7 @@ extern "C" {
 // so we need to special-case on that...
 
 /// Performs a carry-less multiplication of two 64-bit polynomials over the
-/// finite field GF(2^k) - in each of the 4 128-bit lanes.
+/// finite field GF(2) - in each of the 4 128-bit lanes.
 ///
 /// The immediate byte is used for determining which halves of each lane `a` and `b`
 /// should be used. Immediate bits other than 0 and 4 are ignored.
@@ -42,7 +42,7 @@ pub unsafe fn _mm512_clmulepi64_epi128<const IMM8: i32>(a: __m512i, b: __m512i) 
 }
 
 /// Performs a carry-less multiplication of two 64-bit polynomials over the
-/// finite field GF(2^k) - in each of the 2 128-bit lanes.
+/// finite field GF(2) - in each of the 2 128-bit lanes.
 ///
 /// The immediate byte is used for determining which halves of each lane `a` and `b`
 /// should be used. Immediate bits other than 0 and 4 are ignored.


### PR DESCRIPTION
The documentation says that the multiplication is using polynomials over the field GF(2^k) while those are actually just polynomials over the field GF(2). The k comes from nowhere and is misleading.

This PR replaces the occurences of GF(2^k) in the documentation for those the carryless multiplication intrinsics with GF(2).