### PR TITLE
Explicitly set the cargo resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "1"
 members = [
   "crates/stdarch-verify",
   "crates/core_arch",


### PR DESCRIPTION
Cargo will soon be generating a warning if the `resolver` field is not set in a virtual workspace. I'm opening this to proactively help avoid the warning in this repo. More information about this change can be found at https://github.com/rust-lang/cargo/issues/10112.