### PR TITLE
Stabilize `__m512i`, `__m512`, and `__m512d`

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -258,6 +258,7 @@ types! {
     ///
     /// Note that this means that an instance of `__m512i` typically just means
     /// a "bag of bits" which is left up to interpretation at the point of use.
+    #[stable(feature = "simd_avx512_types", since = "CURRENT_RUSTC_VERSION")]
     pub struct __m512i(i64, i64, i64, i64, i64, i64, i64, i64);
 
     /// 512-bit wide set of sixteen `f32` types, x86-specific
@@ -275,6 +276,7 @@ types! {
     /// Most intrinsics using `__m512` are prefixed with `_mm512_` and are
     /// suffixed with "ps" (or otherwise contain "ps"). Not to be confused with
     /// "pd" which is used for `__m512d`.
+    #[stable(feature = "simd_avx512_types", since = "CURRENT_RUSTC_VERSION")]
     pub struct __m512(
         f32, f32, f32, f32, f32, f32, f32, f32,
         f32, f32, f32, f32, f32, f32, f32, f32,
@@ -295,6 +297,7 @@ types! {
     /// Most intrinsics using `__m512d` are prefixed with `_mm512_` and are
     /// suffixed with "pd" (or otherwise contain "pd"). Not to be confused with
     /// "ps" which is used for `__m512`.
+    #[stable(feature = "simd_avx512_types", since = "CURRENT_RUSTC_VERSION")]
     pub struct __m512d(f64, f64, f64, f64, f64, f64, f64, f64);
 
     /// 128-bit wide set of eight 'u16' types, x86-specific


### PR DESCRIPTION
While there might be some uncertainty still with all the intrinsics and other related items, could we perhaps stabilize the types?

It seems like there's not much choice to be had, since m512 is definitely f32x16 and m512d is likewise f64x8.

I didn't include `__m512bh` since `__m128bh` is also unstable.

<https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Stabilizing.20AVX2.20.26.20AVX512.20*types*/near/362541037>