### PR TITLE
Remove assert_instr exception for AArch64 *cvt*.

### DIFF
--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -141,11 +141,6 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
                 // vst4q_u32_vst4 : #instructions = 26 >= 22 (limit)
                 "vst4" => 27,
 
-                // Temporary, currently the fptosi.sat and fptoui.sat LLVM
-                // intrinsics emit unnecessary code on arm. This can be
-                // removed once it has been addressed in LLVM.
-                "fcvtzu" | "fcvtzs" | "vcvt" => 64,
-
                 // core_arch/src/arm_shared/simd32
                 // vst1q_p64_x4_nop : #instructions = 33 >= 22 (limit)
                 "nop" if fnname.contains("vst1q_p64") => 34,


### PR DESCRIPTION
The LLVM code generation was improved some time ago.