### PR TITLE
Disable vld2q_dup_f32 test in CI

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -76,6 +76,11 @@ cargo_test() {
         # qemu has an erratic behavior on those tests
         powerpc64*)
             cmd="$cmd --skip test_vec_lde_u16 --skip test_vec_lde_u32 --skip test_vec_expte"
+            ;;
+        # Miscompilation: https://github.com/rust-lang/rust/issues/112460
+        arm*)
+            cmd="$cmd --skip vld2q_dup_f32"
+            ;;
     esac
 
     if [ "$SKIP_TESTS" != "" ]; then


### PR DESCRIPTION
This is broken due to rust-lang/rust#112460.