### PR TITLE
Remove MIPS from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,13 +74,15 @@ jobs:
         - aarch64-unknown-linux-gnu
         - riscv64gc-unknown-linux-gnu
         - powerpc64le-unknown-linux-gnu
-        - mips-unknown-linux-gnu
-        - mips64-unknown-linux-gnuabi64
-        - mips64el-unknown-linux-gnuabi64
+        # MIPS targets disabled since they are dropped to tier 3.
+        # See https://github.com/rust-lang/compiler-team/issues/648
+        #- mips-unknown-linux-gnu
+        #- mips64-unknown-linux-gnuabi64
+        #- mips64el-unknown-linux-gnuabi64
+        #- mipsel-unknown-linux-musl
         - s390x-unknown-linux-gnu
         - wasm32-wasi
         - i586-unknown-linux-gnu
-        - mipsel-unknown-linux-musl
         - nvptx64-nvidia-cuda
         - thumbv6m-none-eabi
         - thumbv7m-none-eabi
@@ -114,15 +116,20 @@ jobs:
           os: ubuntu-latest
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-latest
-        - target: mips-unknown-linux-gnu
-          os: ubuntu-latest
-          norun: true
-        - target: mips64-unknown-linux-gnuabi64
-          os: ubuntu-latest
-          norun: true
-        - target: mips64el-unknown-linux-gnuabi64
-          os: ubuntu-latest
-          norun: true
+        # MIPS targets disabled since they are dropped to tier 3.
+        # See https://github.com/rust-lang/compiler-team/issues/648
+        #- target: mips-unknown-linux-gnu
+        #  os: ubuntu-latest
+        #  norun: true
+        #- target: mips64-unknown-linux-gnuabi64
+        #  os: ubuntu-latest
+        #  norun: true
+        #- target: mips64el-unknown-linux-gnuabi64
+        #  os: ubuntu-latest
+        #  norun: true
+        #- target: mipsel-unknown-linux-musl
+        #  os: ubuntu-latest
+        #  norun: 1
         - target: powerpc64le-unknown-linux-gnu
           os: ubuntu-latest
           disable_assert_instr: true
@@ -143,9 +150,6 @@ jobs:
           os: windows-latest
         - target: i586-unknown-linux-gnu
           os: ubuntu-latest
-        - target: mipsel-unknown-linux-musl
-          os: ubuntu-latest
-          norun: 1
         - target: nvptx64-nvidia-cuda
           os: ubuntu-latest
         - target: thumbv6m-none-eabi

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -45,6 +45,8 @@ dox arm armv7-unknown-linux-gnueabihf
 dox aarch64 aarch64-unknown-linux-gnu
 dox powerpc powerpc-unknown-linux-gnu
 dox powerpc64le powerpc64le-unknown-linux-gnu
-dox mips mips-unknown-linux-gnu
-dox mips64 mips64-unknown-linux-gnuabi64
+# MIPS targets disabled since they are dropped to tier 3.
+# See https://github.com/rust-lang/compiler-team/issues/648
+#dox mips mips-unknown-linux-gnu
+#dox mips64 mips64-unknown-linux-gnuabi64
 dox wasm32 wasm32-unknown-unknown

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -672,7 +672,6 @@ pub unsafe fn v128_store64_lane<const L: usize>(v: v128, m: *mut u64) {
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[cfg_attr(
     test,
     assert_instr(
@@ -727,7 +726,6 @@ pub const fn i8x16(
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
@@ -760,7 +758,6 @@ pub const fn u8x16(
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[cfg_attr(
     test,
     assert_instr(
@@ -787,7 +784,6 @@ pub const fn i16x8(a0: i16, a1: i16, a2: i16, a3: i16, a4: i16, a5: i16, a6: i16
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
@@ -800,7 +796,6 @@ pub const fn u16x8(a0: u16, a1: u16, a2: u16, a3: u16, a4: u16, a5: u16, a6: u16
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[cfg_attr(test, assert_instr(v128.const, a0 = 0, a1 = 1, a2 = 2, a3 = 3))]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -814,7 +809,6 @@ pub const fn i32x4(a0: i32, a1: i32, a2: i32, a3: i32) -> v128 {
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
@@ -827,7 +821,6 @@ pub const fn u32x4(a0: u32, a1: u32, a2: u32, a3: u32) -> v128 {
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[cfg_attr(test, assert_instr(v128.const, a0 = 1, a1 = 2))]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -841,7 +834,6 @@ pub const fn i64x2(a0: i64, a1: i64) -> v128 {
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
@@ -854,7 +846,6 @@ pub const fn u64x2(a0: u64, a1: u64) -> v128 {
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[cfg_attr(test, assert_instr(v128.const, a0 = 0.0, a1 = 1.0, a2 = 2.0, a3 = 3.0))]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -868,7 +859,6 @@ pub const fn f32x4(a0: f32, a1: f32, a2: f32, a3: f32) -> v128 {
 /// If possible this will generate a `v128.const` instruction, otherwise it may
 /// be lowered to a sequence of instructions to materialize the vector value.
 #[inline]
-#[target_feature(enable = "simd128")]
 #[cfg_attr(test, assert_instr(v128.const, a0 = 0.0, a1 = 1.0))]
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]


### PR DESCRIPTION
- MIPS targets have been removed from rustup, see https://github.com/rust-lang/compiler-team/issues/648.
- Removed `#[target_feature]` requirements from `const fn`, since that caused const-eval to fail.