### PR TITLE
Remove the auxv dev dependency.

### DIFF
--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -30,7 +30,6 @@ compiler_builtins = { version = "0.1.2", optional = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
 [dev-dependencies]
-auxv = "0.3.3"
 cupid = "0.6.0"
 
 [features]


### PR DESCRIPTION
It hasn't been used since roughly 2018. The latest published version of auxv has a less common license and doesn't specify any license in it's Cargo.toml file.