### PR TITLE
Reimplement some x86 intrinsics without arch-specific LLVM intrinsics

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1439,7 +1439,7 @@ pub unsafe fn _mm256_loadu_pd(mem_addr: *const f64) -> __m256d {
 #[cfg_attr(test, assert_instr(vmovups))] // FIXME vmovupd expected
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_storeu_pd(mem_addr: *mut f64, a: __m256d) {
-    storeupd256(mem_addr, a);
+    mem_addr.cast::<__m256d>().write_unaligned(a);
 }
 
 /// Loads 256-bits (composed of 8 packed single-precision (32-bit)
@@ -1471,7 +1471,7 @@ pub unsafe fn _mm256_loadu_ps(mem_addr: *const f32) -> __m256 {
 #[cfg_attr(test, assert_instr(vmovups))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_storeu_ps(mem_addr: *mut f32, a: __m256) {
-    storeups256(mem_addr, a);
+    mem_addr.cast::<__m256>().write_unaligned(a);
 }
 
 /// Loads 256-bits of integer data from memory into result.
@@ -1527,7 +1527,7 @@ pub unsafe fn _mm256_loadu_si256(mem_addr: *const __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vmovups))] // FIXME vmovdqu expected
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_storeu_si256(mem_addr: *mut __m256i, a: __m256i) {
-    storeudq256(mem_addr as *mut i8, a.as_i8x32());
+    mem_addr.write_unaligned(a);
 }
 
 /// Loads packed double-precision (64-bit) floating-point elements from memory
@@ -2974,12 +2974,6 @@ extern "C" {
     fn vbroadcastf128ps256(a: &__m128) -> __m256;
     #[link_name = "llvm.x86.avx.vbroadcastf128.pd.256"]
     fn vbroadcastf128pd256(a: &__m128d) -> __m256d;
-    #[link_name = "llvm.x86.avx.storeu.pd.256"]
-    fn storeupd256(mem_addr: *mut f64, a: __m256d);
-    #[link_name = "llvm.x86.avx.storeu.ps.256"]
-    fn storeups256(mem_addr: *mut f32, a: __m256);
-    #[link_name = "llvm.x86.avx.storeu.dq.256"]
-    fn storeudq256(mem_addr: *mut i8, a: i8x32);
     #[link_name = "llvm.x86.avx.maskload.pd.256"]
     fn maskloadpd256(mem_addr: *const i8, mask: i64x4) -> __m256d;
     #[link_name = "llvm.x86.avx.maskstore.pd.256"]

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2557,7 +2557,11 @@ pub unsafe fn _mm256_sll_epi64(a: __m256i, count: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_slli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(pslliw(a.as_i16x16(), IMM8))
+    if IMM8 >= 16 {
+        _mm256_setzero_si256()
+    } else {
+        transmute(simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
+    }
 }
 
 /// Shifts packed 32-bit integers in `a` left by `IMM8` while
@@ -2571,7 +2575,11 @@ pub unsafe fn _mm256_slli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_slli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(psllid(a.as_i32x8(), IMM8))
+    if IMM8 >= 32 {
+        _mm256_setzero_si256()
+    } else {
+        transmute(simd_shl(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
+    }
 }
 
 /// Shifts packed 64-bit integers in `a` left by `IMM8` while
@@ -2585,7 +2593,11 @@ pub unsafe fn _mm256_slli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_slli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(pslliq(a.as_i64x4(), IMM8))
+    if IMM8 >= 64 {
+        _mm256_setzero_si256()
+    } else {
+        transmute(simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
+    }
 }
 
 /// Shifts 128-bit lanes in `a` left by `imm8` bytes while shifting in zeros.
@@ -2749,7 +2761,7 @@ pub unsafe fn _mm256_sra_epi32(a: __m256i, count: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_srai_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(psraiw(a.as_i16x16(), IMM8))
+    transmute(simd_shr(a.as_i16x16(), i16x16::splat(IMM8.min(15) as i16)))
 }
 
 /// Shifts packed 32-bit integers in `a` right by `IMM8` while
@@ -2763,7 +2775,7 @@ pub unsafe fn _mm256_srai_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_srai_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(psraid(a.as_i32x8(), IMM8))
+    transmute(simd_shr(a.as_i32x8(), i32x8::splat(IMM8.min(31))))
 }
 
 /// Shifts packed 32-bit integers in `a` right by the amount specified by the
@@ -2996,7 +3008,11 @@ pub unsafe fn _mm256_srl_epi64(a: __m256i, count: __m128i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_srli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(psrliw(a.as_i16x16(), IMM8))
+    if IMM8 >= 16 {
+        _mm256_setzero_si256()
+    } else {
+        transmute(simd_shr(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
+    }
 }
 
 /// Shifts packed 32-bit integers in `a` right by `IMM8` while shifting in
@@ -3010,7 +3026,11 @@ pub unsafe fn _mm256_srli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_srli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(psrlid(a.as_i32x8(), IMM8))
+    if IMM8 >= 32 {
+        _mm256_setzero_si256()
+    } else {
+        transmute(simd_shr(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
+    }
 }
 
 /// Shifts packed 64-bit integers in `a` right by `IMM8` while shifting in
@@ -3024,7 +3044,11 @@ pub unsafe fn _mm256_srli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_srli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    transmute(psrliq(a.as_i64x4(), IMM8))
+    if IMM8 >= 64 {
+        _mm256_setzero_si256()
+    } else {
+        transmute(simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
+    }
 }
 
 /// Shifts packed 32-bit integers in `a` right by the amount specified by
@@ -3677,12 +3701,6 @@ extern "C" {
     fn pslld(a: i32x8, count: i32x4) -> i32x8;
     #[link_name = "llvm.x86.avx2.psll.q"]
     fn psllq(a: i64x4, count: i64x2) -> i64x4;
-    #[link_name = "llvm.x86.avx2.pslli.w"]
-    fn pslliw(a: i16x16, imm8: i32) -> i16x16;
-    #[link_name = "llvm.x86.avx2.pslli.d"]
-    fn psllid(a: i32x8, imm8: i32) -> i32x8;
-    #[link_name = "llvm.x86.avx2.pslli.q"]
-    fn pslliq(a: i64x4, imm8: i32) -> i64x4;
     #[link_name = "llvm.x86.avx2.psllv.d"]
     fn psllvd(a: i32x4, count: i32x4) -> i32x4;
     #[link_name = "llvm.x86.avx2.psllv.d.256"]
@@ -3695,10 +3713,6 @@ extern "C" {
     fn psraw(a: i16x16, count: i16x8) -> i16x16;
     #[link_name = "llvm.x86.avx2.psra.d"]
     fn psrad(a: i32x8, count: i32x4) -> i32x8;
-    #[link_name = "llvm.x86.avx2.psrai.w"]
-    fn psraiw(a: i16x16, imm8: i32) -> i16x16;
-    #[link_name = "llvm.x86.avx2.psrai.d"]
-    fn psraid(a: i32x8, imm8: i32) -> i32x8;
     #[link_name = "llvm.x86.avx2.psrav.d"]
     fn psravd(a: i32x4, count: i32x4) -> i32x4;
     #[link_name = "llvm.x86.avx2.psrav.d.256"]
@@ -3709,12 +3723,6 @@ extern "C" {
     fn psrld(a: i32x8, count: i32x4) -> i32x8;
     #[link_name = "llvm.x86.avx2.psrl.q"]
     fn psrlq(a: i64x4, count: i64x2) -> i64x4;
-    #[link_name = "llvm.x86.avx2.psrli.w"]
-    fn psrliw(a: i16x16, imm8: i32) -> i16x16;
-    #[link_name = "llvm.x86.avx2.psrli.d"]
-    fn psrlid(a: i32x8, imm8: i32) -> i32x8;
-    #[link_name = "llvm.x86.avx2.psrli.q"]
-    fn psrliq(a: i64x4, imm8: i32) -> i64x4;
     #[link_name = "llvm.x86.avx2.psrlv.d"]
     fn psrlvd(a: i32x4, count: i32x4) -> i32x4;
     #[link_name = "llvm.x86.avx2.psrlv.d.256"]

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -5996,9 +5996,7 @@ pub unsafe fn _mm_maskz_sra_epi16(k: __mmask8, a: __m128i, count: __m128i) -> __
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_srai_epi16<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i16x32();
-    let r = vpsraiw(a, IMM8);
-    transmute(r)
+    transmute(simd_shr(a.as_i16x32(), i16x32::splat(IMM8.min(15) as i16)))
 }
 
 /// Shift packed 16-bit integers in a right by imm8 while shifting in sign bits, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -6014,8 +6012,7 @@ pub unsafe fn _mm512_mask_srai_epi16<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i16x32();
-    let shf = vpsraiw(a, IMM8);
+    let shf = simd_shr(a.as_i16x32(), i16x32::splat(IMM8.min(15) as i16));
     transmute(simd_select_bitmask(k, shf, src.as_i16x32()))
 }
 
@@ -6028,9 +6025,8 @@ pub unsafe fn _mm512_mask_srai_epi16<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_srai_epi16<const IMM8: u32>(k: __mmask32, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i16x32();
-    let shf = vpsraiw(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i16x32();
+    let shf = simd_shr(a.as_i16x32(), i16x32::splat(IMM8.min(15) as i16));
+    let zero = i16x32::splat(0);
     transmute(simd_select_bitmask(k, shf, zero))
 }
 
@@ -6047,8 +6043,7 @@ pub unsafe fn _mm256_mask_srai_epi16<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psraiw256(a.as_i16x16(), imm8);
+    let r = simd_shr(a.as_i16x16(), i16x16::splat(IMM8.min(15) as i16));
     transmute(simd_select_bitmask(k, r, src.as_i16x16()))
 }
 
@@ -6061,9 +6056,8 @@ pub unsafe fn _mm256_mask_srai_epi16<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_srai_epi16<const IMM8: u32>(k: __mmask16, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psraiw256(a.as_i16x16(), imm8);
-    let zero = _mm256_setzero_si256().as_i16x16();
+    let r = simd_shr(a.as_i16x16(), i16x16::splat(IMM8.min(15) as i16));
+    let zero = i16x16::splat(0);
     transmute(simd_select_bitmask(k, r, zero))
 }
 
@@ -6080,8 +6074,7 @@ pub unsafe fn _mm_mask_srai_epi16<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psraiw128(a.as_i16x8(), imm8);
+    let r = simd_shr(a.as_i16x8(), i16x8::splat(IMM8.min(15) as i16));
     transmute(simd_select_bitmask(k, r, src.as_i16x8()))
 }
 
@@ -6094,9 +6087,8 @@ pub unsafe fn _mm_mask_srai_epi16<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_srai_epi16<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psraiw128(a.as_i16x8(), imm8);
-    let zero = _mm_setzero_si128().as_i16x8();
+    let r = simd_shr(a.as_i16x8(), i16x8::splat(IMM8.min(15) as i16));
+    let zero = i16x8::splat(0);
     transmute(simd_select_bitmask(k, r, zero))
 }
 
@@ -10013,13 +10005,6 @@ extern "C" {
 
     #[link_name = "llvm.x86.avx512.psra.w.512"]
     fn vpsraw(a: i16x32, count: i16x8) -> i16x32;
-    #[link_name = "llvm.x86.avx512.psrai.w.512"]
-    fn vpsraiw(a: i16x32, imm8: u32) -> i16x32;
-
-    #[link_name = "llvm.x86.avx2.psrai.w"]
-    fn psraiw256(a: i16x16, imm8: i32) -> i16x16;
-    #[link_name = "llvm.x86.sse2.psrai.w"]
-    fn psraiw128(a: i16x8, imm8: i32) -> i16x8;
 
     #[link_name = "llvm.x86.avx512.psrav.w.512"]
     fn vpsravw(a: i16x32, count: i16x32) -> i16x32;

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -5339,9 +5339,11 @@ pub unsafe fn _mm_maskz_sll_epi16(k: __mmask8, a: __m128i, count: __m128i) -> __
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_slli_epi16<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i16x32();
-    let r = vpslliw(a, IMM8);
-    transmute(r)
+    if IMM8 >= 16 {
+        _mm512_setzero_si512()
+    } else {
+        transmute(simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
+    }
 }
 
 /// Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -5357,9 +5359,12 @@ pub unsafe fn _mm512_mask_slli_epi16<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i16x32();
-    let shf = vpslliw(a, IMM8);
-    transmute(simd_select_bitmask(k, shf, src.as_i16x32()))
+    let shf = if IMM8 >= 16 {
+        u16x32::splat(0)
+    } else {
+        simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u16x32()))
 }
 
 /// Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -5371,10 +5376,13 @@ pub unsafe fn _mm512_mask_slli_epi16<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_slli_epi16<const IMM8: u32>(k: __mmask32, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i16x32();
-    let shf = vpslliw(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i16x32();
-    transmute(simd_select_bitmask(k, shf, zero))
+    if IMM8 >= 16 {
+        _mm512_setzero_si512()
+    } else {
+        let shf = simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16));
+        let zero = u16x32::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -5390,9 +5398,12 @@ pub unsafe fn _mm256_mask_slli_epi16<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliw256(a.as_i16x16(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i16x16()))
+    let shf = if IMM8 >= 16 {
+        u16x16::splat(0)
+    } else {
+        simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u16x16()))
 }
 
 /// Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -5404,10 +5415,13 @@ pub unsafe fn _mm256_mask_slli_epi16<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_slli_epi16<const IMM8: u32>(k: __mmask16, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliw256(a.as_i16x16(), imm8);
-    let zero = _mm256_setzero_si256().as_i16x16();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 16 {
+        _mm256_setzero_si256()
+    } else {
+        let shf = simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16));
+        let zero = u16x16::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -5423,9 +5437,12 @@ pub unsafe fn _mm_mask_slli_epi16<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliw128(a.as_i16x8(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i16x8()))
+    let shf = if IMM8 >= 16 {
+        u16x8::splat(0)
+    } else {
+        simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u16x8()))
 }
 
 /// Shift packed 16-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -5437,10 +5454,13 @@ pub unsafe fn _mm_mask_slli_epi16<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_slli_epi16<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliw128(a.as_i16x8(), imm8);
-    let zero = _mm_setzero_si128().as_i16x8();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 16 {
+        _mm_setzero_si128()
+    } else {
+        let shf = simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16));
+        let zero = u16x8::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 16-bit integers in a left by the amount specified by the corresponding element in count while shifting in zeros, and store the results in dst.
@@ -9965,13 +9985,6 @@ extern "C" {
 
     #[link_name = "llvm.x86.avx512.psll.w.512"]
     fn vpsllw(a: i16x32, count: i16x8) -> i16x32;
-    #[link_name = "llvm.x86.avx512.pslli.w.512"]
-    fn vpslliw(a: i16x32, imm8: u32) -> i16x32;
-
-    #[link_name = "llvm.x86.avx2.pslli.w"]
-    fn pslliw256(a: i16x16, imm8: i32) -> i16x16;
-    #[link_name = "llvm.x86.sse2.pslli.w"]
-    fn pslliw128(a: i16x8, imm8: i32) -> i16x8;
 
     #[link_name = "llvm.x86.avx512.psllv.w.512"]
     fn vpsllvw(a: i16x32, b: i16x32) -> i16x32;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -17540,9 +17540,11 @@ pub unsafe fn _mm_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_srli_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let r = vpsrliq(a, IMM8);
-    transmute(r)
+    if IMM8 >= 64 {
+        _mm512_setzero_si512()
+    } else {
+        transmute(simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
+    }
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17558,9 +17560,12 @@ pub unsafe fn _mm512_mask_srli_epi64<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let shf = vpsrliq(a, IMM8);
-    transmute(simd_select_bitmask(k, shf, src.as_i64x8()))
+    let shf = if IMM8 >= 64 {
+        u64x8::splat(0)
+    } else {
+        simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u64x8()))
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17572,10 +17577,13 @@ pub unsafe fn _mm512_mask_srli_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let shf = vpsrliq(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i64x8();
-    transmute(simd_select_bitmask(k, shf, zero))
+    if IMM8 >= 64 {
+        _mm512_setzero_si512()
+    } else {
+        let shf = simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64));
+        let zero = u64x8::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17591,9 +17599,12 @@ pub unsafe fn _mm256_mask_srli_epi64<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrliq256(a.as_i64x4(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i64x4()))
+    let r = if IMM8 >= 64 {
+        u64x4::splat(0)
+    } else {
+        simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u64x4()))
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17605,10 +17616,13 @@ pub unsafe fn _mm256_mask_srli_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrliq256(a.as_i64x4(), imm8);
-    let zero = _mm256_setzero_si256().as_i64x4();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 64 {
+        _mm256_setzero_si256()
+    } else {
+        let r = simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64));
+        let zero = u64x4::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17624,9 +17638,12 @@ pub unsafe fn _mm_mask_srli_epi64<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrliq128(a.as_i64x2(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i64x2()))
+    let r = if IMM8 >= 64 {
+        u64x2::splat(0)
+    } else {
+        simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u64x2()))
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17638,10 +17655,13 @@ pub unsafe fn _mm_mask_srli_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrliq128(a.as_i64x2(), imm8);
-    let zero = _mm_setzero_si128().as_i64x2();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 64 {
+        _mm_setzero_si128()
+    } else {
+        let r = simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64));
+        let zero = u64x2::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 32-bit integers in a left by count while shifting in zeros, and store the results in dst.
@@ -38508,14 +38528,6 @@ extern "C" {
     fn vpsllvq(a: i64x8, b: i64x8) -> i64x8;
     #[link_name = "llvm.x86.avx512.psrlv.q.512"]
     fn vpsrlvq(a: i64x8, b: i64x8) -> i64x8;
-
-    #[link_name = "llvm.x86.avx512.psrli.q.512"]
-    fn vpsrliq(a: i64x8, imm8: u32) -> i64x8;
-
-    #[link_name = "llvm.x86.avx2.psrli.q"]
-    fn psrliq256(a: i64x4, imm8: i32) -> i64x4;
-    #[link_name = "llvm.x86.sse2.psrli.q"]
-    fn psrliq128(a: i64x2, imm8: i32) -> i64x2;
 
     #[link_name = "llvm.x86.avx512.psll.d.512"]
     fn vpslld(a: i32x16, count: i32x4) -> i32x16;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -17141,9 +17141,11 @@ pub unsafe fn _mm_maskz_ror_epi64<const IMM8: i32>(k: __mmask8, a: __m128i) -> _
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_slli_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let r = vpsllid(a, IMM8);
-    transmute(r)
+    if IMM8 >= 32 {
+        _mm512_setzero_si512()
+    } else {
+        transmute(simd_shl(a.as_u32x16(), u32x16::splat(IMM8 as u32)))
+    }
 }
 
 /// Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17159,9 +17161,12 @@ pub unsafe fn _mm512_mask_slli_epi32<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let shf = vpsllid(a, IMM8);
-    transmute(simd_select_bitmask(k, shf, src.as_i32x16()))
+    let shf = if IMM8 >= 32 {
+        u32x16::splat(0)
+    } else {
+        simd_shl(a.as_u32x16(), u32x16::splat(IMM8))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u32x16()))
 }
 
 /// Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17173,10 +17178,13 @@ pub unsafe fn _mm512_mask_slli_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_slli_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let shf = vpsllid(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i32x16();
-    transmute(simd_select_bitmask(k, shf, zero))
+    if IMM8 >= 32 {
+        _mm512_setzero_si512()
+    } else {
+        let shf = simd_shl(a.as_u32x16(), u32x16::splat(IMM8));
+        let zero = u32x16::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17192,9 +17200,12 @@ pub unsafe fn _mm256_mask_slli_epi32<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psllid256(a.as_i32x8(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i32x8()))
+    let r = if IMM8 >= 32 {
+        u32x8::splat(0)
+    } else {
+        simd_shl(a.as_u32x8(), u32x8::splat(IMM8))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u32x8()))
 }
 
 /// Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17206,10 +17217,13 @@ pub unsafe fn _mm256_mask_slli_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psllid256(a.as_i32x8(), imm8);
-    let zero = _mm256_setzero_si256().as_i32x8();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 32 {
+        _mm256_setzero_si256()
+    } else {
+        let r = simd_shl(a.as_u32x8(), u32x8::splat(IMM8));
+        let zero = u32x8::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17225,9 +17239,12 @@ pub unsafe fn _mm_mask_slli_epi32<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psllid128(a.as_i32x4(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i32x4()))
+    let r = if IMM8 >= 32 {
+        u32x4::splat(0)
+    } else {
+        simd_shl(a.as_u32x4(), u32x4::splat(IMM8))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u32x4()))
 }
 
 /// Shift packed 32-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17239,10 +17256,13 @@ pub unsafe fn _mm_mask_slli_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psllid128(a.as_i32x4(), imm8);
-    let zero = _mm_setzero_si128().as_i32x4();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 32 {
+        _mm_setzero_si128()
+    } else {
+        let r = simd_shl(a.as_u32x4(), u32x4::splat(IMM8));
+        let zero = u32x4::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst.
@@ -38448,14 +38468,6 @@ extern "C" {
     fn vpsllvq(a: i64x8, b: i64x8) -> i64x8;
     #[link_name = "llvm.x86.avx512.psrlv.q.512"]
     fn vpsrlvq(a: i64x8, b: i64x8) -> i64x8;
-
-    #[link_name = "llvm.x86.avx512.pslli.d.512"]
-    fn vpsllid(a: i32x16, imm8: u32) -> i32x16;
-
-    #[link_name = "llvm.x86.avx2.pslli.d"]
-    fn psllid256(a: i32x8, imm8: i32) -> i32x8;
-    #[link_name = "llvm.x86.sse2.pslli.d"]
-    fn psllid128(a: i32x4, imm8: i32) -> i32x4;
 
     #[link_name = "llvm.x86.avx512.psrli.d.512"]
     fn vpsrlid(a: i32x16, imm8: u32) -> i32x16;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -17274,9 +17274,11 @@ pub unsafe fn _mm_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_srli_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let r = vpsrlid(a, IMM8);
-    transmute(r)
+    if IMM8 >= 32 {
+        _mm512_setzero_si512()
+    } else {
+        transmute(simd_shr(a.as_u32x16(), u32x16::splat(IMM8)))
+    }
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17292,9 +17294,12 @@ pub unsafe fn _mm512_mask_srli_epi32<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let shf = vpsrlid(a, IMM8);
-    transmute(simd_select_bitmask(k, shf, src.as_i32x16()))
+    let shf = if IMM8 >= 32 {
+        u32x16::splat(0)
+    } else {
+        simd_shr(a.as_u32x16(), u32x16::splat(IMM8))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u32x16()))
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17306,10 +17311,13 @@ pub unsafe fn _mm512_mask_srli_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_srli_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let shf = vpsrlid(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i32x16();
-    transmute(simd_select_bitmask(k, shf, zero))
+    if IMM8 >= 32 {
+        _mm512_setzero_si512()
+    } else {
+        let shf = simd_shr(a.as_u32x16(), u32x16::splat(IMM8));
+        let zero = u32x16::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17325,9 +17333,12 @@ pub unsafe fn _mm256_mask_srli_epi32<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrlid256(a.as_i32x8(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i32x8()))
+    let r = if IMM8 >= 32 {
+        u32x8::splat(0)
+    } else {
+        simd_shr(a.as_u32x8(), u32x8::splat(IMM8))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u32x8()))
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17339,10 +17350,13 @@ pub unsafe fn _mm256_mask_srli_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrlid256(a.as_i32x8(), imm8);
-    let zero = _mm256_setzero_si256().as_i32x8();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 32 {
+        _mm256_setzero_si256()
+    } else {
+        let r = simd_shr(a.as_u32x8(), u32x8::splat(IMM8));
+        let zero = u32x8::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17358,9 +17372,12 @@ pub unsafe fn _mm_mask_srli_epi32<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrlid128(a.as_i32x4(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i32x4()))
+    let r = if IMM8 >= 32 {
+        u32x4::splat(0)
+    } else {
+        simd_shr(a.as_u32x4(), u32x4::splat(IMM8))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u32x4()))
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17372,10 +17389,13 @@ pub unsafe fn _mm_mask_srli_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = psrlid128(a.as_i32x4(), imm8);
-    let zero = _mm_setzero_si128().as_i32x4();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 32 {
+        _mm_setzero_si128()
+    } else {
+        let r = simd_shr(a.as_u32x4(), u32x4::splat(IMM8));
+        let zero = u32x4::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst.
@@ -38488,14 +38508,6 @@ extern "C" {
     fn vpsllvq(a: i64x8, b: i64x8) -> i64x8;
     #[link_name = "llvm.x86.avx512.psrlv.q.512"]
     fn vpsrlvq(a: i64x8, b: i64x8) -> i64x8;
-
-    #[link_name = "llvm.x86.avx512.psrli.d.512"]
-    fn vpsrlid(a: i32x16, imm8: u32) -> i32x16;
-
-    #[link_name = "llvm.x86.avx2.psrli.d"]
-    fn psrlid256(a: i32x8, imm8: i32) -> i32x8;
-    #[link_name = "llvm.x86.sse2.psrli.d"]
-    fn psrlid128(a: i32x4, imm8: i32) -> i32x4;
 
     #[link_name = "llvm.x86.avx512.psrli.q.512"]
     fn vpsrliq(a: i64x8, imm8: u32) -> i64x8;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -18227,9 +18227,7 @@ pub unsafe fn _mm_maskz_sra_epi64(k: __mmask8, a: __m128i, count: __m128i) -> __
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_srai_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let r = vpsraid512(a, IMM8);
-    transmute(r)
+    transmute(simd_shr(a.as_i32x16(), i32x16::splat(IMM8.min(31) as i32)))
 }
 
 /// Shift packed 32-bit integers in a right by imm8 while shifting in sign bits, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -18245,8 +18243,7 @@ pub unsafe fn _mm512_mask_srai_epi32<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let r = vpsraid512(a, IMM8);
+    let r = simd_shr(a.as_i32x16(), i32x16::splat(IMM8.min(31) as i32));
     transmute(simd_select_bitmask(k, r, src.as_i32x16()))
 }
 
@@ -18259,9 +18256,8 @@ pub unsafe fn _mm512_mask_srai_epi32<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_srai_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i32x16();
-    let r = vpsraid512(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i32x16();
+    let r = simd_shr(a.as_i32x16(), i32x16::splat(IMM8.min(31) as i32));
+    let zero = i32x16::splat(0);
     transmute(simd_select_bitmask(k, r, zero))
 }
 
@@ -18277,8 +18273,7 @@ pub unsafe fn _mm256_mask_srai_epi32<const IMM8: u32>(
     k: __mmask8,
     a: __m256i,
 ) -> __m256i {
-    let imm8 = IMM8 as i32;
-    let r = psraid256(a.as_i32x8(), imm8);
+    let r = simd_shr(a.as_i32x8(), i32x8::splat(IMM8.min(31) as i32));
     transmute(simd_select_bitmask(k, r, src.as_i32x8()))
 }
 
@@ -18290,9 +18285,8 @@ pub unsafe fn _mm256_mask_srai_epi32<const IMM8: u32>(
 #[cfg_attr(test, assert_instr(vpsrad, IMM8 = 1))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_srai_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -> __m256i {
-    let imm8 = IMM8 as i32;
-    let r = psraid256(a.as_i32x8(), imm8);
-    let zero = _mm256_setzero_si256().as_i32x8();
+    let r = simd_shr(a.as_i32x8(), i32x8::splat(IMM8.min(31) as i32));
+    let zero = i32x8::splat(0);
     transmute(simd_select_bitmask(k, r, zero))
 }
 
@@ -18308,8 +18302,7 @@ pub unsafe fn _mm_mask_srai_epi32<const IMM8: u32>(
     k: __mmask8,
     a: __m128i,
 ) -> __m128i {
-    let imm8 = IMM8 as i32;
-    let r = psraid128(a.as_i32x4(), imm8);
+    let r = simd_shr(a.as_i32x4(), i32x4::splat(IMM8.min(31) as i32));
     transmute(simd_select_bitmask(k, r, src.as_i32x4()))
 }
 
@@ -18321,9 +18314,8 @@ pub unsafe fn _mm_mask_srai_epi32<const IMM8: u32>(
 #[cfg_attr(test, assert_instr(vpsrad, IMM8 = 1))]
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_srai_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
-    let imm8 = IMM8 as i32;
-    let r = psraid128(a.as_i32x4(), imm8);
-    let zero = _mm_setzero_si128().as_i32x4();
+    let r = simd_shr(a.as_i32x4(), i32x4::splat(IMM8.min(31) as i32));
+    let zero = i32x4::splat(0);
     transmute(simd_select_bitmask(k, r, zero))
 }
 
@@ -38547,13 +38539,6 @@ extern "C" {
     fn vpsraq256(a: i64x4, count: i64x2) -> i64x4;
     #[link_name = "llvm.x86.avx512.psra.q.128"]
     fn vpsraq128(a: i64x2, count: i64x2) -> i64x2;
-
-    #[link_name = "llvm.x86.avx512.psrai.d.512"]
-    fn vpsraid512(a: i32x16, imm8: u32) -> i32x16;
-    #[link_name = "llvm.x86.avx2.psrai.d"]
-    fn psraid256(a: i32x8, imm8: i32) -> i32x8;
-    #[link_name = "llvm.x86.sse2.psrai.d"]
-    fn psraid128(a: i32x4, imm8: i32) -> i32x4;
 
     #[link_name = "llvm.x86.avx512.psrai.q.512"]
     fn vpsraiq(a: i64x8, imm8: u32) -> i64x8;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -17387,9 +17387,11 @@ pub unsafe fn _mm_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_slli_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let r = vpslliq(a, IMM8);
-    transmute(r)
+    if IMM8 >= 64 {
+        _mm512_setzero_si512()
+    } else {
+        transmute(simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
+    }
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17405,9 +17407,12 @@ pub unsafe fn _mm512_mask_slli_epi64<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let shf = vpslliq(a, IMM8);
-    transmute(simd_select_bitmask(k, shf, src.as_i64x8()))
+    let shf = if IMM8 >= 64 {
+        u64x8::splat(0)
+    } else {
+        simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64))
+    };
+    transmute(simd_select_bitmask(k, shf, src.as_u64x8()))
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17419,10 +17424,13 @@ pub unsafe fn _mm512_mask_slli_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let shf = vpslliq(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i64x8();
-    transmute(simd_select_bitmask(k, shf, zero))
+    if IMM8 >= 64 {
+        _mm512_setzero_si512()
+    } else {
+        let shf = simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64));
+        let zero = u64x8::splat(0);
+        transmute(simd_select_bitmask(k, shf, zero))
+    }
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17438,9 +17446,12 @@ pub unsafe fn _mm256_mask_slli_epi64<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliq256(a.as_i64x4(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i64x4()))
+    let r = if IMM8 >= 64 {
+        u64x4::splat(0)
+    } else {
+        simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u64x4()))
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17452,10 +17463,13 @@ pub unsafe fn _mm256_mask_slli_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliq256(a.as_i64x4(), imm8);
-    let zero = _mm256_setzero_si256().as_i64x4();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 64 {
+        _mm256_setzero_si256()
+    } else {
+        let r = simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64));
+        let zero = u64x4::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -17471,9 +17485,12 @@ pub unsafe fn _mm_mask_slli_epi64<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliq128(a.as_i64x2(), imm8);
-    transmute(simd_select_bitmask(k, r, src.as_i64x2()))
+    let r = if IMM8 >= 64 {
+        u64x2::splat(0)
+    } else {
+        simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64))
+    };
+    transmute(simd_select_bitmask(k, r, src.as_u64x2()))
 }
 
 /// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and store the results in dst using zeromask k (elements are zeroed out when the corresponding mask bit is not set).
@@ -17485,10 +17502,13 @@ pub unsafe fn _mm_mask_slli_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let imm8 = IMM8 as i32;
-    let r = pslliq128(a.as_i64x2(), imm8);
-    let zero = _mm_setzero_si128().as_i64x2();
-    transmute(simd_select_bitmask(k, r, zero))
+    if IMM8 >= 64 {
+        _mm_setzero_si128()
+    } else {
+        let r = simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64));
+        let zero = u64x2::splat(0);
+        transmute(simd_select_bitmask(k, r, zero))
+    }
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and store the results in dst.
@@ -38476,14 +38496,6 @@ extern "C" {
     fn psrlid256(a: i32x8, imm8: i32) -> i32x8;
     #[link_name = "llvm.x86.sse2.psrli.d"]
     fn psrlid128(a: i32x4, imm8: i32) -> i32x4;
-
-    #[link_name = "llvm.x86.avx512.pslli.q.512"]
-    fn vpslliq(a: i64x8, imm8: u32) -> i64x8;
-
-    #[link_name = "llvm.x86.avx2.pslli.q"]
-    fn pslliq256(a: i64x4, imm8: i32) -> i64x4;
-    #[link_name = "llvm.x86.sse2.pslli.q"]
-    fn pslliq128(a: i64x2, imm8: i32) -> i64x2;
 
     #[link_name = "llvm.x86.avx512.psrli.q.512"]
     fn vpsrliq(a: i64x8, imm8: u32) -> i64x8;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -18328,9 +18328,7 @@ pub unsafe fn _mm_maskz_srai_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm512_srai_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let r = vpsraiq(a, IMM8);
-    transmute(r)
+    transmute(simd_shr(a.as_i64x8(), i64x8::splat(IMM8.min(63) as i64)))
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in sign bits, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -18346,8 +18344,7 @@ pub unsafe fn _mm512_mask_srai_epi64<const IMM8: u32>(
     a: __m512i,
 ) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let shf = vpsraiq(a, IMM8);
+    let shf = simd_shr(a.as_i64x8(), i64x8::splat(IMM8.min(63) as i64));
     transmute(simd_select_bitmask(k, shf, src.as_i64x8()))
 }
 
@@ -18360,9 +18357,8 @@ pub unsafe fn _mm512_mask_srai_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm512_maskz_srai_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -> __m512i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x8();
-    let shf = vpsraiq(a, IMM8);
-    let zero = _mm512_setzero_si512().as_i64x8();
+    let shf = simd_shr(a.as_i64x8(), i64x8::splat(IMM8.min(63) as i64));
+    let zero = i64x8::splat(0);
     transmute(simd_select_bitmask(k, shf, zero))
 }
 
@@ -18375,9 +18371,7 @@ pub unsafe fn _mm512_maskz_srai_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm256_srai_epi64<const IMM8: u32>(a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x4();
-    let r = vpsraiq256(a, IMM8);
-    transmute(r)
+    transmute(simd_shr(a.as_i64x4(), i64x4::splat(IMM8.min(63) as i64)))
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in sign bits, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -18393,8 +18387,7 @@ pub unsafe fn _mm256_mask_srai_epi64<const IMM8: u32>(
     a: __m256i,
 ) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x4();
-    let shf = vpsraiq256(a, IMM8);
+    let shf = simd_shr(a.as_i64x4(), i64x4::splat(IMM8.min(63) as i64));
     transmute(simd_select_bitmask(k, shf, src.as_i64x4()))
 }
 
@@ -18407,9 +18400,8 @@ pub unsafe fn _mm256_mask_srai_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm256_maskz_srai_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -> __m256i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x4();
-    let shf = vpsraiq256(a, IMM8);
-    let zero = _mm256_setzero_si256().as_i64x4();
+    let shf = simd_shr(a.as_i64x4(), i64x4::splat(IMM8.min(63) as i64));
+    let zero = i64x4::splat(0);
     transmute(simd_select_bitmask(k, shf, zero))
 }
 
@@ -18422,9 +18414,7 @@ pub unsafe fn _mm256_maskz_srai_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) 
 #[rustc_legacy_const_generics(1)]
 pub unsafe fn _mm_srai_epi64<const IMM8: u32>(a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x2();
-    let r = vpsraiq128(a, IMM8);
-    transmute(r)
+    transmute(simd_shr(a.as_i64x2(), i64x2::splat(IMM8.min(63) as i64)))
 }
 
 /// Shift packed 64-bit integers in a right by imm8 while shifting in sign bits, and store the results in dst using writemask k (elements are copied from src when the corresponding mask bit is not set).
@@ -18440,8 +18430,7 @@ pub unsafe fn _mm_mask_srai_epi64<const IMM8: u32>(
     a: __m128i,
 ) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x2();
-    let shf = vpsraiq128(a, IMM8);
+    let shf = simd_shr(a.as_i64x2(), i64x2::splat(IMM8.min(63) as i64));
     transmute(simd_select_bitmask(k, shf, src.as_i64x2()))
 }
 
@@ -18454,9 +18443,8 @@ pub unsafe fn _mm_mask_srai_epi64<const IMM8: u32>(
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn _mm_maskz_srai_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    let a = a.as_i64x2();
-    let shf = vpsraiq128(a, IMM8);
-    let zero = _mm_setzero_si128().as_i64x2();
+    let shf = simd_shr(a.as_i64x2(), i64x2::splat(IMM8.min(63) as i64));
+    let zero = i64x2::splat(0);
     transmute(simd_select_bitmask(k, shf, zero))
 }
 
@@ -38539,13 +38527,6 @@ extern "C" {
     fn vpsraq256(a: i64x4, count: i64x2) -> i64x4;
     #[link_name = "llvm.x86.avx512.psra.q.128"]
     fn vpsraq128(a: i64x2, count: i64x2) -> i64x2;
-
-    #[link_name = "llvm.x86.avx512.psrai.q.512"]
-    fn vpsraiq(a: i64x8, imm8: u32) -> i64x8;
-    #[link_name = "llvm.x86.avx512.psrai.q.256"]
-    fn vpsraiq256(a: i64x4, imm8: u32) -> i64x4;
-    #[link_name = "llvm.x86.avx512.psrai.q.128"]
-    fn vpsraiq128(a: i64x2, imm8: u32) -> i64x2;
 
     #[link_name = "llvm.x86.avx512.psrav.d.512"]
     fn vpsravd(a: i32x16, count: i32x16) -> i32x16;

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1248,7 +1248,7 @@ pub unsafe fn _mm_store_si128(mem_addr: *mut __m128i, a: __m128i) {
 #[cfg_attr(test, assert_instr(movups))] // FIXME movdqu expected
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_storeu_si128(mem_addr: *mut __m128i, a: __m128i) {
-    storeudq(mem_addr as *mut i8, a);
+    mem_addr.write_unaligned(a);
 }
 
 /// Stores the lower 64-bit integer `a` to a memory location.
@@ -2515,7 +2515,7 @@ pub unsafe fn _mm_store_pd(mem_addr: *mut f64, a: __m128d) {
 #[cfg_attr(test, assert_instr(movups))] // FIXME movupd expected
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_storeu_pd(mem_addr: *mut f64, a: __m128d) {
-    storeupd(mem_addr as *mut i8, a);
+    mem_addr.cast::<__m128d>().write_unaligned(a);
 }
 
 /// Stores the lower double-precision (64-bit) floating-point element from `a`
@@ -2920,10 +2920,6 @@ extern "C" {
     fn cvttsd2si(a: __m128d) -> i32;
     #[link_name = "llvm.x86.sse2.cvttps2dq"]
     fn cvttps2dq(a: __m128) -> i32x4;
-    #[link_name = "llvm.x86.sse2.storeu.dq"]
-    fn storeudq(mem_addr: *mut i8, a: __m128i);
-    #[link_name = "llvm.x86.sse2.storeu.pd"]
-    fn storeupd(mem_addr: *mut i8, a: __m128d);
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -752,7 +752,7 @@ pub unsafe fn _mm_srl_epi32(a: __m128i, count: __m128i) -> __m128i {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_srli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
     static_assert_uimm_bits!(IMM8, 8);
-    if IMM8 >= 32 {
+    if IMM8 >= 64 {
         _mm_setzero_si128()
     } else {
         transmute(simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64)))


### PR DESCRIPTION
Reimplements some x86 without using arch-specific LLVM intrinsics:

* Store unaligned (`_mm*_storeu_*`): Use `<*mut _>::write_unaligned` instead of `llvm.x86.*.storeu.*`.
* Shift by immediate (`_mm*_s{ll,rl,ra}i_epi*`): Use `if` (srl, sll) or `min` (sra) to simulate the behaviour when the RHS is out of range. RHS is constant, so the `if`/`min` will be optimized away.

The advantages are:

* codegen will not have to handle those LLVM instrinsics.
* miri will be able to emulate them without specific shims