### PR TITLE
Impr: Add a usage check for the ci/run-docker.sh script

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,6 +5,11 @@
 
 set -ex
 
+if [ $# -lt 1 ]; then
+    >&2 echo "Usage: $0 <TARGET>"
+    exit 1
+fi
+
 run() {
     target=$(echo "${1}" | sed 's/-emulated//')
     echo "Building docker container for TARGET=${1}"


### PR DESCRIPTION
This only adds a usage check for the `/ci/run-docker.sh` script.

I have tried to run this script many times without arguments and for some reason it it then defaults to using `ci/docker` as the target. This cost me some debugging time.