### PR TITLE
Reenable RISC-V Zk and Zb `assert_instr`

### DIFF
--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -2,8 +2,12 @@ FROM ubuntu:23.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \
-        gcc-riscv64-linux-gnu libc6-dev-riscv64-cross
+        gcc-riscv64-linux-gnu libc6-dev-riscv64-cross \
+        llvm
 
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc \
-    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="qemu-riscv64 -L /usr/riscv64-linux-gnu -cpu rv64,zk=true,zbb=true,zbc=true" \
-    OBJDUMP=riscv64-linux-gnu-objdump
+    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="qemu-riscv64 \
+      -L /usr/riscv64-linux-gnu \
+      -cpu rv64,zk=true,zks=true,zbb=true,zbc=true \
+    " \
+    OBJDUMP=llvm-objdump

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -47,7 +47,7 @@ case ${TARGET} in
     # Some of our test dependencies use the deprecated `gcc` crates which
     # doesn't detect RISC-V compilers automatically, so do it manually here.
     riscv64*)
-        export RUSTFLAGS="${RUSTFLAGS} -Ctarget-feature=+zk,+zbb,+zbc"
+        export RUSTFLAGS="${RUSTFLAGS} -Ctarget-feature=+zk,+zks,+zbb,+zbc"
         export TARGET_CC="riscv64-linux-gnu-gcc"
         ;;
 esac

--- a/crates/core_arch/src/riscv64/zk.rs
+++ b/crates/core_arch/src/riscv64/zk.rs
@@ -50,8 +50,7 @@ extern "unadjusted" {
 ///
 /// This function is safe to use if the `zkne` target feature is present.
 #[target_feature(enable = "zkne")]
-// See #1464
-// #[cfg_attr(test, assert_instr(aes64es))]
+#[cfg_attr(test, assert_instr(aes64es))]
 #[inline]
 pub unsafe fn aes64es(rs1: u64, rs2: u64) -> u64 {
     _aes64es(rs1 as i64, rs2 as i64) as u64
@@ -74,8 +73,7 @@ pub unsafe fn aes64es(rs1: u64, rs2: u64) -> u64 {
 ///
 /// This function is safe to use if the `zkne` target feature is present.
 #[target_feature(enable = "zkne")]
-// See #1464
-// #[cfg_attr(test, assert_instr(aes64esm))]
+#[cfg_attr(test, assert_instr(aes64esm))]
 #[inline]
 pub unsafe fn aes64esm(rs1: u64, rs2: u64) -> u64 {
     _aes64esm(rs1 as i64, rs2 as i64) as u64
@@ -98,8 +96,7 @@ pub unsafe fn aes64esm(rs1: u64, rs2: u64) -> u64 {
 ///
 /// This function is safe to use if the `zknd` target feature is present.
 #[target_feature(enable = "zknd")]
-// See #1464
-// #[cfg_attr(test, assert_instr(aes64ds))]
+#[cfg_attr(test, assert_instr(aes64ds))]
 #[inline]
 pub unsafe fn aes64ds(rs1: u64, rs2: u64) -> u64 {
     _aes64ds(rs1 as i64, rs2 as i64) as u64
@@ -122,8 +119,7 @@ pub unsafe fn aes64ds(rs1: u64, rs2: u64) -> u64 {
 ///
 /// This function is safe to use if the `zknd` target feature is present.
 #[target_feature(enable = "zknd")]
-// See #1464
-// #[cfg_attr(test, assert_instr(aes64dsm))]
+#[cfg_attr(test, assert_instr(aes64dsm))]
 #[inline]
 pub unsafe fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
     _aes64dsm(rs1 as i64, rs2 as i64) as u64
@@ -152,8 +148,7 @@ pub unsafe fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
 /// This function is safe to use if the `zkne` or `zknd` target feature is present.
 #[target_feature(enable = "zkne", enable = "zknd")]
 #[rustc_legacy_const_generics(1)]
-// See #1464
-// #[cfg_attr(test, assert_instr(aes64ks1i, RNUM = 0))]
+#[cfg_attr(test, assert_instr(aes64ks1i, RNUM = 0))]
 #[inline]
 pub unsafe fn aes64ks1i<const RNUM: u8>(rs1: u64) -> u64 {
     static_assert!(RNUM <= 10);
@@ -177,8 +172,7 @@ pub unsafe fn aes64ks1i<const RNUM: u8>(rs1: u64) -> u64 {
 ///
 /// This function is safe to use if the `zkne` or `zknd` target feature is present.
 #[target_feature(enable = "zkne", enable = "zknd")]
-// See #1464
-// #[cfg_attr(test, assert_instr(aes64ks2))]
+#[cfg_attr(test, assert_instr(aes64ks2))]
 #[inline]
 pub unsafe fn aes64ks2(rs1: u64, rs2: u64) -> u64 {
     _aes64ks2(rs1 as i64, rs2 as i64) as u64
@@ -201,8 +195,7 @@ pub unsafe fn aes64ks2(rs1: u64, rs2: u64) -> u64 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha512sig0))]
+#[cfg_attr(test, assert_instr(sha512sig0))]
 #[inline]
 pub unsafe fn sha512sig0(rs1: u64) -> u64 {
     _sha512sig0(rs1 as i64) as u64
@@ -225,8 +218,7 @@ pub unsafe fn sha512sig0(rs1: u64) -> u64 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha512sig1))]
+#[cfg_attr(test, assert_instr(sha512sig1))]
 #[inline]
 pub unsafe fn sha512sig1(rs1: u64) -> u64 {
     _sha512sig1(rs1 as i64) as u64
@@ -249,8 +241,7 @@ pub unsafe fn sha512sig1(rs1: u64) -> u64 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha512sum0))]
+#[cfg_attr(test, assert_instr(sha512sum0))]
 #[inline]
 pub unsafe fn sha512sum0(rs1: u64) -> u64 {
     _sha512sum0(rs1 as i64) as u64
@@ -273,8 +264,7 @@ pub unsafe fn sha512sum0(rs1: u64) -> u64 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha512sum1))]
+#[cfg_attr(test, assert_instr(sha512sum1))]
 #[inline]
 pub unsafe fn sha512sum1(rs1: u64) -> u64 {
     _sha512sum1(rs1 as i64) as u64

--- a/crates/core_arch/src/riscv_shared/zb.rs
+++ b/crates/core_arch/src/riscv_shared/zb.rs
@@ -47,8 +47,7 @@ extern "unadjusted" {
 ///
 /// This function is safe to use if the `zbb` target feature is present.
 #[target_feature(enable = "zbb")]
-// See #1464
-// #[cfg_attr(test, assert_instr(orc.b))]
+#[cfg_attr(test, assert_instr(orc.b))]
 #[inline]
 pub unsafe fn orc_b(rs: usize) -> usize {
     #[cfg(target_arch = "riscv32")]
@@ -76,8 +75,7 @@ pub unsafe fn orc_b(rs: usize) -> usize {
 ///
 /// This function is safe to use if the `zbc` target feature is present.
 #[target_feature(enable = "zbc")]
-// See #1464
-// #[cfg_attr(test, assert_instr(clmul))]
+#[cfg_attr(test, assert_instr(clmul))]
 #[inline]
 pub unsafe fn clmul(rs1: usize, rs2: usize) -> usize {
     #[cfg(target_arch = "riscv32")]
@@ -105,8 +103,7 @@ pub unsafe fn clmul(rs1: usize, rs2: usize) -> usize {
 ///
 /// This function is safe to use if the `zbc` target feature is present.
 #[target_feature(enable = "zbc")]
-// See #1464
-// #[cfg_attr(test, assert_instr(clmulh))]
+#[cfg_attr(test, assert_instr(clmulh))]
 #[inline]
 pub unsafe fn clmulh(rs1: usize, rs2: usize) -> usize {
     #[cfg(target_arch = "riscv32")]
@@ -134,8 +131,7 @@ pub unsafe fn clmulh(rs1: usize, rs2: usize) -> usize {
 ///
 /// This function is safe to use if the `zbc` target feature is present.
 #[target_feature(enable = "zbc")]
-// See #1464
-// #[cfg_attr(test, assert_instr(clmulr))]
+#[cfg_attr(test, assert_instr(clmulr))]
 #[inline]
 pub unsafe fn clmulr(rs1: usize, rs2: usize) -> usize {
     #[cfg(target_arch = "riscv32")]

--- a/crates/core_arch/src/riscv_shared/zk.rs
+++ b/crates/core_arch/src/riscv_shared/zk.rs
@@ -62,8 +62,7 @@ extern "unadjusted" {
 ///
 /// This function is safe to use if the `zbkx` target feature is present.
 #[target_feature(enable = "zbkx")]
-// See #1464
-// #[cfg_attr(test, assert_instr(xperm8))]
+#[cfg_attr(test, assert_instr(xperm8))]
 #[inline]
 pub unsafe fn xperm8(rs1: usize, rs2: usize) -> usize {
     #[cfg(target_arch = "riscv32")]
@@ -94,8 +93,7 @@ pub unsafe fn xperm8(rs1: usize, rs2: usize) -> usize {
 ///
 /// This function is safe to use if the `zbkx` target feature is present.
 #[target_feature(enable = "zbkx")]
-// See #1464
-// #[cfg_attr(test, assert_instr(xperm4))]
+#[cfg_attr(test, assert_instr(xperm4))]
 #[inline]
 pub unsafe fn xperm4(rs1: usize, rs2: usize) -> usize {
     #[cfg(target_arch = "riscv32")]
@@ -129,8 +127,7 @@ pub unsafe fn xperm4(rs1: usize, rs2: usize) -> usize {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha256sig0))]
+#[cfg_attr(test, assert_instr(sha256sig0))]
 #[inline]
 pub unsafe fn sha256sig0(rs1: u32) -> u32 {
     _sha256sig0(rs1 as i32) as u32
@@ -156,8 +153,7 @@ pub unsafe fn sha256sig0(rs1: u32) -> u32 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha256sig1))]
+#[cfg_attr(test, assert_instr(sha256sig1))]
 #[inline]
 pub unsafe fn sha256sig1(rs1: u32) -> u32 {
     _sha256sig1(rs1 as i32) as u32
@@ -183,8 +179,7 @@ pub unsafe fn sha256sig1(rs1: u32) -> u32 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha256sum0))]
+#[cfg_attr(test, assert_instr(sha256sum0))]
 #[inline]
 pub unsafe fn sha256sum0(rs1: u32) -> u32 {
     _sha256sum0(rs1 as i32) as u32
@@ -210,8 +205,7 @@ pub unsafe fn sha256sum0(rs1: u32) -> u32 {
 ///
 /// This function is safe to use if the `zknh` target feature is present.
 #[target_feature(enable = "zknh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sha256sum1))]
+#[cfg_attr(test, assert_instr(sha256sum1))]
 #[inline]
 pub unsafe fn sha256sum1(rs1: u32) -> u32 {
     _sha256sum1(rs1 as i32) as u32
@@ -288,8 +282,7 @@ pub unsafe fn sha256sum1(rs1: u32) -> u32 {
 /// ```
 #[target_feature(enable = "zksed")]
 #[rustc_legacy_const_generics(2)]
-// See #1464
-// #[cfg_attr(test, assert_instr(sm4ed, BS = 0))]
+#[cfg_attr(test, assert_instr(sm4ed, BS = 0))]
 #[inline]
 pub unsafe fn sm4ed<const BS: u8>(rs1: u32, rs2: u32) -> u32 {
     static_assert!(BS < 4);
@@ -368,8 +361,7 @@ pub unsafe fn sm4ed<const BS: u8>(rs1: u32, rs2: u32) -> u32 {
 /// ```
 #[target_feature(enable = "zksed")]
 #[rustc_legacy_const_generics(2)]
-// See #1464
-// #[cfg_attr(test, assert_instr(sm4ks, BS = 0))]
+#[cfg_attr(test, assert_instr(sm4ks, BS = 0))]
 #[inline]
 pub unsafe fn sm4ks<const BS: u8>(rs1: u32, rs2: u32) -> u32 {
     static_assert!(BS < 4);
@@ -409,8 +401,7 @@ pub unsafe fn sm4ks<const BS: u8>(rs1: u32, rs2: u32) -> u32 {
 /// compression function `CF` uses the intermediate value `TT2` to calculate
 /// the variable `E` in one iteration for subsequent processes.
 #[target_feature(enable = "zksh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sm3p0))]
+#[cfg_attr(test, assert_instr(sm3p0))]
 #[inline]
 pub unsafe fn sm3p0(rs1: u32) -> u32 {
     _sm3p0(rs1 as i32) as u32
@@ -454,8 +445,7 @@ pub unsafe fn sm3p0(rs1: u32) -> u32 {
 /// ENDFOR
 /// ```
 #[target_feature(enable = "zksh")]
-// See #1464
-// #[cfg_attr(test, assert_instr(sm3p1))]
+#[cfg_attr(test, assert_instr(sm3p1))]
 #[inline]
 pub unsafe fn sm3p1(rs1: u32) -> u32 {
     _sm3p1(rs1 as i32) as u32

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -82,7 +82,7 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
         // Target features need to be enabled for LLVM objdump on Macos ARM64
         vec!["--mattr=+v8.6a,+crypto,+tme"]
     } else if cfg!(target_arch = "riscv64") {
-        vec!["--mattr=+zk,+zks"]
+        vec!["--mattr=+zk,+zks,+zbc,+zbb"]
     } else {
         vec![]
     };

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -81,6 +81,8 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
     let add_args = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
         // Target features need to be enabled for LLVM objdump on Macos ARM64
         vec!["--mattr=+v8.6a,+crypto,+tme"]
+    } else if cfg!(target_arch = "riscv64") {
+        vec!["--mattr=+zk,+zks"]
     } else {
         vec![]
     };


### PR DESCRIPTION
This switches to `llvm-objdump` instead of the gnu `objdump` variant, and additionally enables `zks` for the SM instructions. This fixes #1464.

There is still a problem with testing for riscv32, I am not 100% sure how to a docker image for this target. Just adding the `NOSTD` and `NORUN` flags, does to do very little.