### PR TITLE
Add missing `aes64im` of RISC-V Zk extension

### DIFF
--- a/crates/core_arch/src/riscv64/zk.rs
+++ b/crates/core_arch/src/riscv64/zk.rs
@@ -20,6 +20,9 @@ extern "unadjusted" {
     #[link_name = "llvm.riscv.aes64ks2"]
     fn _aes64ks2(rs1: i64, rs2: i64) -> i64;
 
+    #[link_name = "llvm.riscv.aes64im"]
+    fn _aes64im(rs1: i64) -> i64;
+
     #[link_name = "llvm.riscv.sha512sig0"]
     fn _sha512sig0(rs1: i64) -> i64;
 
@@ -176,6 +179,30 @@ pub unsafe fn aes64ks1i<const RNUM: u8>(rs1: u64) -> u64 {
 #[inline]
 pub unsafe fn aes64ks2(rs1: u64, rs2: u64) -> u64 {
     _aes64ks2(rs1 as i64, rs2 as i64) as u64
+}
+
+/// This instruction accelerates the inverse MixColumns step of the AES Block Cipher, and is used to aid creation of
+/// the decryption KeySchedule.
+///
+/// The instruction applies the inverse MixColumns transformation to two columns of the state array, packed
+/// into a single 64-bit register. It is used to create the inverse cipher KeySchedule, according to the equivalent
+/// inverse cipher construction in (Page 23, Section 5.3.5). This instruction must always be implemented
+/// such that its execution latency does not depend on the data being operated on.
+///
+/// Source: RISC-V Cryptography Extensions Volume I: Scalar & Entropy Source Instructions
+///
+/// Version: v1.0.1
+///
+/// Section: 3.9
+///
+/// # Safety
+///
+/// This function is safe to use if the `zkne` or `zknd` target feature is present.
+#[target_feature(enable = "zkne", enable = "zknd")]
+#[cfg_attr(test, assert_instr(aes64im))]
+#[inline]
+pub unsafe fn aes64im(rs1: u64) -> u64 {
+    _aes64im(rs1 as i64) as u64
 }
 
 /// Implements the Sigma0 transformation function as used in the SHA2-512 hash function \[49\]


### PR DESCRIPTION
This PR fixes a mistake in #1453 where the `aes64im` is missing.