### PR TITLE
core_arch: Fix ARMv6 CP15 barrier

### DIFF
--- a/crates/core_arch/src/arm_shared/barrier/cp15.rs
+++ b/crates/core_arch/src/arm_shared/barrier/cp15.rs
@@ -11,7 +11,8 @@ impl super::super::sealed::Dmb for SY {
     #[inline(always)]
     unsafe fn __dmb(&self) {
         asm!(
-            "mcr p15, 0, r0, c7, c10, 5",
+            "mcr p15, 0, {}, c7, c10, 5",
+            in(reg) 0_u32,
             options(preserves_flags, nostack)
         )
     }
@@ -21,7 +22,8 @@ impl super::super::sealed::Dsb for SY {
     #[inline(always)]
     unsafe fn __dsb(&self) {
         asm!(
-            "mcr p15, 0, r0, c7, c10, 4",
+            "mcr p15, 0, {}, c7, c10, 4",
+            in(reg) 0_u32,
             options(preserves_flags, nostack)
         )
     }
@@ -31,7 +33,8 @@ impl super::super::sealed::Isb for SY {
     #[inline(always)]
     unsafe fn __isb(&self) {
         asm!(
-            "mcr p15, 0, r0, c7, c5, 4",
+            "mcr p15, 0, {}, c7, c5, 4",
+            in(reg) 0_u32,
             options(preserves_flags, nostack)
         )
     }


### PR DESCRIPTION
[ARM11 MPCore Processor Technical Reference Manual](https://developer.arm.com/documentation/ddi0360/e/control-coprocessor-cp15/register-descriptions/c7--cache-operations-register?lang=en) says the value in the Rd register of these instructions is SBZ (should be zero).

> ```
> MCR p15, 0, <Rd>, c7, <CRm>, <Opcode_2>
> ```

> Data
>
> This is the value that is written to CP15 c7. This is the value in the Rd register specified in the MCR instruction.


<img width="1101" alt="a1" src="https://github.com/rust-lang/stdarch/assets/43724913/852ed2d7-986f-49ff-8134-5100d88e4f49">
<img width="1101" alt="a2" src="https://github.com/rust-lang/stdarch/assets/43724913/c256e9ab-4922-4a01-9bff-ddf4f6f5348d">
<img width="1101" alt="a3" src="https://github.com/rust-lang/stdarch/assets/43724913/dc37e53b-9315-4c73-af45-4ef3a54b23d1">
