### PR TITLE
Add `#[cfg_attr(miri, ignore)]` to tests of functions that cannot be supported by Miri

### DIFF
--- a/crates/core_arch/src/x86/bt.rs
+++ b/crates/core_arch/src/x86/bt.rs
@@ -91,6 +91,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittest() {
         unsafe {
             let a = 0b0101_0000i32;
@@ -100,6 +101,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittestandset() {
         unsafe {
             let mut a = 0b0101_0000i32;
@@ -111,6 +113,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittestandreset() {
         unsafe {
             let mut a = 0b0101_0000i32;
@@ -122,6 +125,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittestandcomplement() {
         unsafe {
             let mut a = 0b0101_0000i32;

--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -184,6 +184,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_always_has_cpuid() {
         // all currently-tested targets have the instruction
         // FIXME: add targets without `cpuid` to CI
@@ -191,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_has_cpuid_idempotent() {
         assert_eq!(cpuid::has_cpuid(), cpuid::has_cpuid());
     }

--- a/crates/core_arch/src/x86/eflags.rs
+++ b/crates/core_arch/src/x86/eflags.rs
@@ -71,6 +71,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     #[allow(deprecated)]
     fn test_eflags() {
         unsafe {

--- a/crates/core_arch/src/x86/fxsr.rs
+++ b/crates/core_arch/src/x86/fxsr.rs
@@ -100,6 +100,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fxsr")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn fxsave() {
         let mut a = FxsaveArea::new();
         let mut b = FxsaveArea::new();

--- a/crates/core_arch/src/x86/sse4a.rs
+++ b/crates/core_arch/src/x86/sse4a.rs
@@ -122,6 +122,9 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4a")]
+    // Miri cannot support this until it is clear how it fits in the Rust memory model
+    // (non-temporal store)
+    #[cfg_attr(miri, ignore)]
     unsafe fn test_mm_stream_sd() {
         let mut mem = MemoryF64 {
             data: [1.0_f64, 2.0],
@@ -144,6 +147,9 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4a")]
+    // Miri cannot support this until it is clear how it fits in the Rust memory model
+    // (non-temporal store)
+    #[cfg_attr(miri, ignore)]
     unsafe fn test_mm_stream_ss() {
         let mut mem = MemoryF32 {
             data: [1.0_f32, 2.0, 3.0, 4.0],

--- a/crates/core_arch/src/x86/xsave.rs
+++ b/crates/core_arch/src/x86/xsave.rs
@@ -211,6 +211,7 @@ mod tests {
     // FIXME: https://github.com/rust-lang/stdarch/issues/209
     /*
     #[simd_test(enable = "xsave")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsave() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();
@@ -224,6 +225,7 @@ mod tests {
     */
 
     #[simd_test(enable = "xsave")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xgetbv_xsetbv() {
         let xcr_n: u32 = _XCR_XFEATURE_ENABLED_MASK;
 
@@ -239,6 +241,7 @@ mod tests {
     // FIXME: https://github.com/rust-lang/stdarch/issues/209
     /*
     #[simd_test(enable = "xsave,xsaveopt")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsaveopt() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();
@@ -254,6 +257,7 @@ mod tests {
     // FIXME: this looks like a bug in Intel's SDE:
     #[cfg(not(stdarch_intel_sde))]
     #[simd_test(enable = "xsave,xsavec")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsavec() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();

--- a/crates/core_arch/src/x86_64/bt.rs
+++ b/crates/core_arch/src/x86_64/bt.rs
@@ -91,6 +91,7 @@ mod tests {
     use crate::core_arch::x86_64::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittest64() {
         unsafe {
             let a = 0b0101_0000i64;
@@ -100,6 +101,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittestandset64() {
         unsafe {
             let mut a = 0b0101_0000i64;
@@ -111,6 +113,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittestandreset64() {
         unsafe {
             let mut a = 0b0101_0000i64;
@@ -122,6 +125,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Uses inline assembly
     fn test_bittestandcomplement64() {
         unsafe {
             let mut a = 0b0101_0000i64;

--- a/crates/core_arch/src/x86_64/fxsr.rs
+++ b/crates/core_arch/src/x86_64/fxsr.rs
@@ -100,6 +100,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fxsr")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn fxsave64() {
         let mut a = FxsaveArea::new();
         let mut b = FxsaveArea::new();

--- a/crates/core_arch/src/x86_64/xsave.rs
+++ b/crates/core_arch/src/x86_64/xsave.rs
@@ -177,6 +177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "xsave")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsave64() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();
@@ -189,6 +190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "xsave,xsaveopt")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsaveopt64() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();
@@ -201,6 +203,7 @@ mod tests {
     }
 
     #[simd_test(enable = "xsave,xsavec")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsavec64() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();
@@ -213,6 +216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "xsave,xsaves")]
+    #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn xsaves64() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
         let mut a = XsaveArea::new();


### PR DESCRIPTION
This includes functions that use inline assemby or that do certains operations such as saving/restoring the processor state.