### PR TITLE
Drop old link from intrinsic-test README.

### DIFF
--- a/crates/intrinsic-test/README.md
+++ b/crates/intrinsic-test/README.md
@@ -20,7 +20,3 @@ OPTIONS:
 ARGS:
     <INPUT>    The input file containing the intrinsics
 ```
-
-The intrinsic.csv is the arm neon tracking google sheet (https://docs.google.com/spreadsheets/d/1MqW1g8c7tlhdRWQixgdWvR4uJHNZzCYAf4V0oHjZkwA/edit#gid=0)
-that contains the intrinsic list. The done percentage column should be renamed to "enabled".
-


### PR DESCRIPTION
The tracking spreadsheet hasn't been relevant for some time, and seems to have been deleted.