### PR TITLE
Fixes for use in the standard library

### DIFF
--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -8707,8 +8707,7 @@ pub unsafe fn vpadalq_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
 
 /// 8-bit integer matrix multiply-accumulate
 #[inline]
-#[cfg_attr(not(bootstrap), target_feature(enable = "i8mm"))]
-#[target_feature(enable = "neon")]
+#[target_feature(enable = "neon,i8mm")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(smmla))]
@@ -8735,8 +8734,7 @@ pub unsafe fn vmmlaq_s32(a: int32x4_t, b: int8x16_t, c: int8x16_t) -> int32x4_t 
 
 /// 8-bit integer matrix multiply-accumulate
 #[inline]
-#[cfg_attr(not(bootstrap), target_feature(enable = "i8mm"))]
-#[target_feature(enable = "neon")]
+#[target_feature(enable = "neon,i8mm")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(ummla))]
@@ -8763,8 +8761,7 @@ pub unsafe fn vmmlaq_u32(a: uint32x4_t, b: uint8x16_t, c: uint8x16_t) -> uint32x
 
 /// Unsigned and signed 8-bit integer matrix multiply-accumulate
 #[inline]
-#[cfg_attr(not(bootstrap), target_feature(enable = "i8mm"))]
-#[target_feature(enable = "neon")]
+#[target_feature(enable = "neon,i8mm")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[cfg_attr(all(test, target_arch = "aarch64"), assert_instr(usmmla))]

--- a/crates/std_detect/src/lib.rs
+++ b/crates/std_detect/src/lib.rs
@@ -24,6 +24,7 @@
 // Remove this as soon as the stdarch submodule is updated on nightly.
 #![allow(stable_features)]
 #![feature(stdsimd)]
+#![cfg_attr(feature = "rustc-dep-of-std", feature(stdarch_x86_has_cpuid))]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Some details were missed in #1486 which caused build failures when integrated in std.