### PR TITLE
Further debugability improvements for intrinsic-test.

### DIFF
--- a/crates/intrinsic-test/README.md
+++ b/crates/intrinsic-test/README.md
@@ -7,9 +7,10 @@ USAGE:
     intrinsic-test [FLAGS] [OPTIONS] <INPUT>
 
 FLAGS:
-        --a32        Run tests for A32 instrinsics instead of A64
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+        --a32              Run tests for A32 instrinsics instead of A64
+        --generate-only    Regenerate test programs, but don't build or run them
+    -h, --help             Prints help information
+    -V, --version          Prints version information
 
 OPTIONS:
         --cppcompiler <CPPCOMPILER>    The C++ compiler to use for compiling the c++ code [default: clang++]

--- a/crates/intrinsic-test/src/format.rs
+++ b/crates/intrinsic-test/src/format.rs
@@ -1,0 +1,28 @@
+//! Basic code formatting tools.
+//!
+//! We don't need perfect formatting for the generated tests, but simple indentation can make
+//! debugging a lot easier.
+
+#[derive(Copy, Clone, Debug)]
+pub struct Indentation(u32);
+
+impl std::default::Default for Indentation {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+impl Indentation {
+    pub fn nested(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+impl std::fmt::Display for Indentation {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        for _ in 0..self.0 {
+            write!(f, "    ")?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Basic indentation makes tests with deeply-nested scopes much easier to follow. Any more than this would be better done with `rustfmt` or `clang-format`, but simple indentation works for both languages and is enough to make the tests easy to follow and debug.

`--generate-only` is handy for quick iteration, and because it generates all tests, rather than stopping at the first one that fails to compile (or run).