### PR TITLE
do not use const stability attribute when we don't even need to call the intrinsic in const

### DIFF
--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -571,7 +571,6 @@ mod sealed {
 
                 // Workaround ptr::copy_nonoverlapping not being inlined
                 extern "rust-intrinsic" {
-                    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
                     #[rustc_nounwind]
                     pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
                 }


### PR DESCRIPTION
Id' like to revert https://github.com/rust-lang/rust/pull/97276 since we didn't actually mean to support writing to mutable references in `const`. But that won't work if stdarch uses the stability attribute. I hope we can just remove it here, otherwise this will be a pain to land...