### PR TITLE
Report missing features when skipping tests.

### DIFF
--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -188,11 +188,15 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
     }
 }
 
-pub fn assert_skip_test_ok(name: &str) {
-    if env::var("STDARCH_TEST_EVERYTHING").is_err() {
-        return;
+pub fn assert_skip_test_ok(name: &str, missing_features: &[&str]) {
+    println!("Skipping test `{name}` due to missing target features:");
+    for feature in missing_features {
+        println!("  - {feature}");
     }
-    panic!("skipped test `{name}` when it shouldn't be skipped");
+    match env::var("STDARCH_TEST_EVERYTHING") {
+        Ok(_) => panic!("skipped test `{name}` when it shouldn't be skipped"),
+        Err(_) => println!("Set STDARCH_TEST_EVERYTHING to make this an error."),
+    }
 }
 
 // See comment in `assert-instr-macro` crate for why this exists


### PR DESCRIPTION
There's no way for a `#[test]` to dynamically decide if it should be skipped, sadly, but we can still print a message (with `--show-output`).