### PR TITLE
Update FreeBSD CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: x86_64-unknown-freebsd
   freebsd_instance:
-    image_family: freebsd-12-4
+    image_family: freebsd-13-2
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain nightly -y


### PR DESCRIPTION
FreeBSD 12.4 will be EoL on 31-Dec-2023.  Update CI to the oldest supported version, 13.2.