### PR TITLE
CI: add a success conclusion job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,3 +225,20 @@ jobs:
     - name: Install Rust
       run: rustup update nightly && rustup default nightly
     - run: ./ci/build-std-detect.sh
+
+  success:
+    needs:
+      - docs
+      - verify
+      - env_override
+      - test
+      - build-std-detect
+    runs-on: ubuntu-latest
+    # GitHub branch protection is exceedingly silly and treats "jobs skipped because a dependency
+    # failed" as success. So we have to do some contortions to ensure the job fails if any of its
+    # dependencies fails.
+    if: always() # make sure this is never "skipped"
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: check if any dependency failed
+        run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'


### PR DESCRIPTION
This PR adds a new CI job that only succeeds if all other CI jobs have succeeded. This should make it easier to check if CI was green. After this PR, we can easily gate CI behind the "success" job in `team`, to avoid having to enumerate all the individual jobs, and to make sure that if new jobs are added in the future, they will be gated without having to modify `team`.