### PR TITLE
Remove last mention of `stdsimd`

### DIFF
--- a/crates/std_detect/src/lib.rs
+++ b/crates/std_detect/src/lib.rs
@@ -20,15 +20,8 @@
 #![cfg_attr(test, allow(unused_imports))]
 #![no_std]
 #![allow(internal_features)]
-// Temporary hack: needed to build against toolchains from before the mass feature renaming.
-// Remove this as soon as the stdarch submodule is updated on nightly.
-#![allow(stable_features)]
-#![cfg_attr(not(feature = "rustc-dep-of-std"), feature(stdsimd))]
 #![cfg_attr(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        feature = "rustc-dep-of-std"
-    ),
+    any(target_arch = "x86", target_arch = "x86_64"),
     feature(stdarch_x86_has_cpuid)
 )]
 


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/117372 has been merged, we have to remove the mention to `stdsimd`.