### PR TITLE
Improve feature detect for combined aarch64 features

### DIFF
--- a/crates/std_detect/src/detect/arch/aarch64.rs
+++ b/crates/std_detect/src/detect/arch/aarch64.rs
@@ -30,7 +30,7 @@ features! {
     /// * `"fhm"` - FEAT_FHM
     /// * `"dit"` - FEAT_DIT
     /// * `"flagm"` - FEAT_FLAGM
-    /// * `"ssbs"` - FEAT_SSBS
+    /// * `"ssbs"` - FEAT_SSBS & FEAT_SSBS2
     /// * `"sb"` - FEAT_SB
     /// * `"paca"` - FEAT_PAuth (address authentication)
     /// * `"pacg"` - FEAT_Pauth (generic authentication)
@@ -48,10 +48,10 @@ features! {
     /// * `"bf16"` - FEAT_BF16
     /// * `"rand"` - FEAT_RNG
     /// * `"bti"` - FEAT_BTI
-    /// * `"mte"` - FEAT_MTE
+    /// * `"mte"` - FEAT_MTE & FEAT_MTE2
     /// * `"jsconv"` - FEAT_JSCVT
     /// * `"fcma"` - FEAT_FCMA
-    /// * `"aes"` - FEAT_AES
+    /// * `"aes"` - FEAT_AES & FEAT_PMULL
     /// * `"sha2"` - FEAT_SHA1 & FEAT_SHA256
     /// * `"sha3"` - FEAT_SHA512 & FEAT_SHA3
     /// * `"sm4"` - FEAT_SM3 & FEAT_SM4
@@ -70,7 +70,8 @@ features! {
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] asimd: "neon";
     /// FEAT_AdvSIMD (Advanced SIMD/NEON)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] pmull: "pmull";
-    /// FEAT_PMULL (Polynomial Multiply)
+    implied by target_features: ["aes"];
+    /// FEAT_PMULL (Polynomial Multiply) - Implied by `aes` target_feature
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] fp: "fp";
     implied by target_features: ["neon"];
     /// FEAT_FP (Floating point support) - Implied by `neon` target_feature
@@ -101,7 +102,7 @@ features! {
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] flagm: "flagm";
     /// FEAT_FLAGM (flag manipulation instructions)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] ssbs: "ssbs";
-    /// FEAT_SSBS (speculative store bypass safe)
+    /// FEAT_SSBS & FEAT_SSBS2 (speculative store bypass safe)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sb: "sb";
     /// FEAT_SB (speculation barrier)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] paca: "paca";
@@ -137,13 +138,13 @@ features! {
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] bti: "bti";
     /// FEAT_BTI (Branch Target Identification)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] mte: "mte";
-    /// FEAT_MTE (Memory Tagging Extension)
+    /// FEAT_MTE & FEAT_MTE2 (Memory Tagging Extension)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] jsconv: "jsconv";
     /// FEAT_JSCVT (JavaScript float conversion instructions)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] fcma: "fcma";
     /// FEAT_FCMA (float complex number operations)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] aes: "aes";
-    /// FEAT_AES (AES instructions)
+    /// FEAT_AES (AES SIMD instructions) & FEAT_PMULL (PMULL{2}, 64-bit operand variants)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sha2: "sha2";
     /// FEAT_SHA1 & FEAT_SHA256 (SHA1 & SHA2-256 instructions)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sha3: "sha3";

--- a/crates/std_detect/src/detect/os/aarch64.rs
+++ b/crates/std_detect/src/detect/os/aarch64.rs
@@ -99,7 +99,7 @@ pub(crate) fn parse_system_registers(
         // supported, it also requires half-float support:
         enable_feature(Feature::asimd, fp && asimd && (!fphp | asimdhp));
         // SIMD extensions require SIMD support:
-        enable_feature(Feature::aes, asimd && bits_shift(aa64isar0, 7, 4) >= 1);
+        enable_feature(Feature::aes, asimd && bits_shift(aa64isar0, 7, 4) >= 2);
         let sha1 = bits_shift(aa64isar0, 11, 8) >= 1;
         let sha2 = bits_shift(aa64isar0, 15, 12) >= 1;
         enable_feature(Feature::sha2, asimd && sha1 && sha2);

--- a/crates/std_detect/src/detect/os/linux/aarch64.rs
+++ b/crates/std_detect/src/detect/os/linux/aarch64.rs
@@ -252,7 +252,8 @@ impl AtHwcap {
                 let asimd = self.fp && self.asimd && (!self.fphp | self.asimdhp);
                 enable_feature(Feature::asimd, asimd);
                 // Cryptographic extensions require ASIMD
-                enable_feature(Feature::aes, self.aes && asimd);
+                // AES also covers FEAT_PMULL
+                enable_feature(Feature::aes, self.aes && self.pmull && asimd);
                 enable_feature(Feature::sha2, self.sha1 && self.sha2 && asimd);
                 return value;
             }

--- a/crates/std_detect/src/detect/os/macos/aarch64.rs
+++ b/crates/std_detect/src/detect/os/macos/aarch64.rs
@@ -89,7 +89,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     enable_feature(Feature::bf16, bf16);
     enable_feature(Feature::bti, bti);
     enable_feature(Feature::fcma, fcma);
-    enable_feature(Feature::aes, aes);
+    enable_feature(Feature::aes, aes && pmull);
     enable_feature(Feature::jsconv, jsconv);
     enable_feature(Feature::sha2, sha1 && sha2 && asimd);
     enable_feature(Feature::sha3, sha512 && sha3 && asimd);


### PR DESCRIPTION
LLVM's `ssbs` and `mte` target_features represent two Arm features. Linux's HWCAP also represents the same two features, so this is just a documentation update.

LLVM's `ras` target_feature represents two Arm features - FEAT_RAS and FEAT_RASv1p1. There is no runtime detection for this, so this is a no-op in stdarch.

LLVM's `aes` feature covers both `FEAT_AES` and `FEAT_PMULL`, but Linux exposes seperate feature bits. This patch makes the `aes` target_feature correctly shortcut runtime `pmull` detection and also makes the `aes` feature check for `pmull` at runtime to bring it in line with the target_feature behaviour. In practice I think this makes the two runtime features identical since the ID_AA64ISAR0_EL1 register does not allow for PMULL without AES. I haven't added a `pmull` target_feature because it would behave identically to the `aes` one, but I could do if you see fit.

https://github.com/rust-lang/stdarch/issues/1432

For reference:
Linux HWCAPs are documented here: https://www.kernel.org/doc/html/latest/arch/arm64/elf_hwcaps.html
They reference the ID registers documented here: https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers
LLVM target features are defined here: https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64.td