### PR TITLE
simd_shuffle: remove unnecessary let binding

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -66,14 +66,7 @@ macro_rules! types {
 #[allow(unused)]
 macro_rules! simd_shuffle {
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        simd_shuffle(
-            $x,
-            $y,
-            const {
-                let v: [u32; _] = $idx;
-                v
-            },
-        )
+        simd_shuffle::<_, [u32; _], _>($x, $y, const { $idx })
     }};
 }
 


### PR DESCRIPTION
Directly giving a type hint by instantiating the simd_shuffle generics seems nicer.