### PR TITLE
Fix redundant import warnings

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -15,9 +15,7 @@
 
 use crate::{
     core_arch::{simd::*, simd_llvm::*, x86::*},
-    intrinsics,
-    mem::{self, transmute},
-    ptr,
+    mem, ptr,
 };
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -18,10 +18,7 @@
 //! [wiki_avx]: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/avx512bf16.rs
+++ b/crates/core_arch/src/x86/avx512bf16.rs
@@ -2,10 +2,7 @@
 //!
 //! [AVX512BF16 intrinsics]: https://software.intel.com/sites/landingpage/IntrinsicsGuide/#expand=1769&avx512techs=AVX512_BF16
 
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -1,8 +1,7 @@
 use crate::{
     arch::asm,
     core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::{self, transmute},
-    ptr,
+    mem, ptr,
 };
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/avx512cd.rs
+++ b/crates/core_arch/src/x86/avx512cd.rs
@@ -1,7 +1,4 @@
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -1,8 +1,7 @@
 use crate::{
     arch::asm,
     core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::{self, transmute},
-    ptr,
+    mem, ptr,
 };
 
 // x86-32 wants to use a 32-bit address size, but asm! defaults to using the full

--- a/crates/core_arch/src/x86/avx512vnni.rs
+++ b/crates/core_arch/src/x86/avx512vnni.rs
@@ -1,7 +1,4 @@
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/f16c.rs
+++ b/crates/core_arch/src/x86/f16c.rs
@@ -2,11 +2,7 @@
 //!
 //! [F16C intrinsics]: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=fp16&expand=1769
 
-use crate::{
-    core_arch::{simd::*, x86::*},
-    //    hint::unreachable_unchecked,
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -1,6 +1,8 @@
 //! `x86` and `x86_64` intrinsics.
 
-use crate::{intrinsics, marker::Sized, mem::transmute};
+#[allow(unused_imports)]
+use crate::marker::Sized;
+use crate::{intrinsics, mem::transmute};
 
 #[macro_use]
 mod macros;

--- a/crates/core_arch/src/x86/sha.rs
+++ b/crates/core_arch/src/x86/sha.rs
@@ -1,7 +1,4 @@
-use crate::{
-    core_arch::{simd::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, x86::*};
 
 #[allow(improper_ctypes)]
 extern "C" {

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     core_arch::{simd::*, simd_llvm::*, x86::*},
-    intrinsics, mem, ptr,
+    mem, ptr,
 };
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -5,9 +5,7 @@ use stdarch_test::assert_instr;
 
 use crate::{
     core_arch::{simd::*, simd_llvm::*, x86::*},
-    intrinsics,
-    mem::{self, transmute},
-    ptr,
+    mem, ptr,
 };
 
 /// Provides a hint to the processor that the code sequence is a spin-wait loop.

--- a/crates/core_arch/src/x86/sse3.rs
+++ b/crates/core_arch/src/x86/sse3.rs
@@ -1,9 +1,6 @@
 //! Streaming SIMD Extensions 3 (SSE3)
 
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -1,9 +1,6 @@
 //! Streaming SIMD Extensions 4.1 (SSE4.1)
 
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/sse42.rs
+++ b/crates/core_arch/src/x86/sse42.rs
@@ -5,10 +5,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 /// String contains unsigned 8-bit characters *(Default)*
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/crates/core_arch/src/x86/sse4a.rs
+++ b/crates/core_arch/src/x86/sse4a.rs
@@ -1,9 +1,6 @@
 //! `i686`'s Streaming SIMD Extensions 4a (`SSE4a`)
 
-use crate::{
-    core_arch::{simd::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86/ssse3.rs
+++ b/crates/core_arch/src/x86/ssse3.rs
@@ -1,9 +1,6 @@
 //! Supplemental Streaming SIMD Extensions 3 (SSSE3)
 
-use crate::{
-    core_arch::{simd::*, simd_llvm::*, x86::*},
-    mem::transmute,
-};
+use crate::core_arch::{simd::*, simd_llvm::*, x86::*};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;


### PR DESCRIPTION
These were introduced by rust-lang/rust#117772.