### PR TITLE
Add ping groups from Rust to stdarch

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,3 +2,51 @@
 
 [assign.owners]
 "*" = ["@Amanieu"]
+
+[ping.windows]
+message = """\
+Hey Windows Group! This issue could use some guidance on how it can be resolved
+on Windows platforms.
+Could one of you weigh in please? In case it's useful, here are some
+[instructions] for tackling these sorts of bugs.
+Thanks!
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/windows.html
+"""
+
+[ping.arm]
+message = """\
+Hey Arm-interested people! This issue could use some guidance on how it can be
+resolved on Arm platforms.
+Could one of you weigh in please? In case it's useful, here are some
+[instructions] for tackling these sorts of bugs.
+Thanks!
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/arm.html
+"""
+
+[ping.risc-v]
+message = """\
+Hey RISC-V Group! This issue could use some guidance on how it can be resolved
+on RISC-V platforms.
+Could one of you weigh in please? In case it's useful, here are some
+[instructions] for tackling these sorts of bugs.
+Thanks!
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/risc-v.html
+"""
+
+[ping.fuchsia]
+message = """\
+Hey friends of Fuchsia! This issue could use some guidance on how this should be
+resolved/implemented on Fuchsia. Could one of you weigh in please?
+Thanks!
+"""
+
+[ping.macos]
+message = """\
+Hey MacOS Group! This issue or PR could use some MacOS-specific guidance. Could
+one of you weigh in please?
+Thanks!
+"""
+


### PR DESCRIPTION
Recently we missed a ping due to this confusion: https://github.com/rust-lang/stdarch/issues/1479

I haven't added any labels since there didn't seem to be any that fit the ping groups exactly.