### PR TITLE
std_detect: loongarch: Sync runtime detectable features from LLVM

### DIFF
--- a/crates/std_detect/src/detect/arch/loongarch.rs
+++ b/crates/std_detect/src/detect/arch/loongarch.rs
@@ -8,41 +8,17 @@ features! {
     /// Checks if `loongarch` feature is enabled.
     /// Supported arguments are:
     ///
-    /// * `"lam"`
     /// * `"ual"`
-    /// * `"fpu"`
     /// * `"lsx"`
     /// * `"lasx"`
-    /// * `"crc32"`
-    /// * `"complex"`
-    /// * `"crypto"`
     /// * `"lvz"`
-    /// * `"lbtx86"`
-    /// * `"lbtarm"`
-    /// * `"lbtmips"`
     #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")]
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lam: "lam";
-    /// LAM
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] ual: "ual";
     /// UAL
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] fpu: "fpu";
-    /// FPU
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lsx: "lsx";
     /// LSX
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lasx: "lasx";
     /// LASX
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] crc32: "crc32";
-    /// FPU
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] complex: "complex";
-    /// Complex
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] crypto: "crypto";
-    /// Crypto
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lvz: "lvz";
     /// LVZ
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lbtx86: "lbtx86";
-    /// LBT.X86
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lbtarm: "lbtarm";
-    /// LBT.ARM
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lbtmips: "lbtmips";
-    /// LBT.MIPS
 }

--- a/crates/std_detect/src/detect/arch/loongarch.rs
+++ b/crates/std_detect/src/detect/arch/loongarch.rs
@@ -8,17 +8,29 @@ features! {
     /// Checks if `loongarch` feature is enabled.
     /// Supported arguments are:
     ///
-    /// * `"ual"`
+    /// * `"f"`
+    /// * `"d"`
+    /// * `"frecipe"`
     /// * `"lsx"`
     /// * `"lasx"`
+    /// * `"lbt"`
     /// * `"lvz"`
+    /// * `"ual"`
     #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")]
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] ual: "ual";
-    /// UAL
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] f: "f";
+    /// F
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] d: "d";
+    /// D
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] frecipe: "frecipe";
+    /// Frecipe
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lsx: "lsx";
     /// LSX
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lasx: "lasx";
     /// LASX
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lbt: "lbt";
+    /// LBT
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lvz: "lvz";
     /// LVZ
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] ual: "ual";
+    /// UAL
 }

--- a/crates/std_detect/src/detect/os/linux/loongarch.rs
+++ b/crates/std_detect/src/detect/os/linux/loongarch.rs
@@ -16,18 +16,10 @@ pub(crate) fn detect_features() -> cache::Initializer {
     //
     // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/loongarch/include/uapi/asm/hwcap.h
     if let Ok(auxv) = auxvec::auxv() {
-        enable_feature(&mut value, Feature::lam, bit::test(auxv.hwcap, 1));
         enable_feature(&mut value, Feature::ual, bit::test(auxv.hwcap, 2));
-        enable_feature(&mut value, Feature::fpu, bit::test(auxv.hwcap, 3));
         enable_feature(&mut value, Feature::lsx, bit::test(auxv.hwcap, 4));
         enable_feature(&mut value, Feature::lasx, bit::test(auxv.hwcap, 5));
-        enable_feature(&mut value, Feature::crc32, bit::test(auxv.hwcap, 6));
-        enable_feature(&mut value, Feature::complex, bit::test(auxv.hwcap, 7));
-        enable_feature(&mut value, Feature::crypto, bit::test(auxv.hwcap, 8));
         enable_feature(&mut value, Feature::lvz, bit::test(auxv.hwcap, 9));
-        enable_feature(&mut value, Feature::lbtx86, bit::test(auxv.hwcap, 10));
-        enable_feature(&mut value, Feature::lbtarm, bit::test(auxv.hwcap, 11));
-        enable_feature(&mut value, Feature::lbtmips, bit::test(auxv.hwcap, 12));
         return value;
     }
     value


### PR DESCRIPTION
This PR removes features that are not supported by LLVM and adds LLVM target features that are detectable runtime:

* f
* d
* frecipe
* lbt