### PR TITLE
Make std_detect::detect::check_for unstably public

### DIFF
--- a/crates/std_detect/src/detect/arch/mod.rs
+++ b/crates/std_detect/src/detect/arch/mod.rs
@@ -53,7 +53,7 @@ cfg_if! {
     } else {
         // Unimplemented architecture:
         #[doc(hidden)]
-        pub(crate) enum Feature {
+        pub enum Feature {
             Null
         }
         #[doc(hidden)]

--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -123,7 +123,7 @@ macro_rules! features {
         #[repr(u8)]
         #[unstable(feature = "stdarch_internal", issue = "none")]
         #[cfg($cfg)]
-        pub(crate) enum Feature {
+        pub enum Feature {
             $(
                 $(#[$feature_comment])*
                 $feature,

--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -77,8 +77,8 @@ cfg_if! {
 
 /// Performs run-time feature detection.
 #[inline]
-#[allow(dead_code)]
-fn check_for(x: Feature) -> bool {
+#[unstable(feature = "stdarch_internal", issue = "none")]
+pub fn check_for(x: Feature) -> bool {
     cache::test(x as u32)
 }
 


### PR DESCRIPTION
This is a requirement for my idea of how to make feature detection usable in core when std is present. See more information at [my Zulip post proposing the idea.](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Allowing.20runtime.20CPU.20feature.20detection.20in.20core/near/431776274)

I do not see any downside from this being merged, as if the idea turns out to not be wanted it doesn't affect any public API outside of libstd's usage due to the unstable attribute.