### PR TITLE
Use inline assembly for Arm64EC

### DIFF
--- a/crates/core_arch/src/arm_shared/hints.rs
+++ b/crates/core_arch/src/arm_shared/hints.rs
@@ -101,8 +101,6 @@ pub unsafe fn __yield() {
 /// those that do, it is unspecified whether this intrinsic generates it or
 /// another instruction. It is not guaranteed that inserting this instruction
 /// will increase execution time.
-// Inline ASM is not support on ARM64EC yet.
-#[cfg(not(target_arch = "arm64ec"))]
 #[inline(always)]
 #[unstable(feature = "stdarch_arm_hints", issue = "117218")]
 pub unsafe fn __nop() {

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -33,7 +33,8 @@
     asm_const,
     target_feature_11,
     inline_const,
-    generic_arg_infer
+    generic_arg_infer,
+    asm_experimental_arch
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]
 #![deny(clippy::missing_inline_in_public_items)]


### PR DESCRIPTION
Support for Arm64EC inline assembly was recently added to Rust (<https://github.com/rust-lang/rust/pull/123507>), so we can enable functions that were previously disabled since they were implemented using inline assembly (namely `__nop`).