### PR TITLE
Remove duplicated `allow(dead_code)` attribute

### DIFF
--- a/crates/intrinsic-test/src/json_parser.rs
+++ b/crates/intrinsic-test/src/json_parser.rs
@@ -17,7 +17,6 @@ struct ReturnType {
 #[serde(untagged, deny_unknown_fields)]
 pub enum ArgPrep {
     Register {
-        #[allow(dead_code)]
         #[serde(rename = "register")]
         #[allow(dead_code)]
         reg: String,


### PR DESCRIPTION
Accidentally added in #1552