### PR TITLE
Don't depend on libc for cfg(windows)

### DIFF
--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -21,13 +21,15 @@ is-it-maintained-open-issues = { repository = "rust-lang/stdarch" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-libc = { version = "0.2", optional = true, default-features = false }
 cfg-if = "1.0.0"
 
 # When built as part of libstd
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
+
+[target.'cfg(not(windows))'.dependencies]
+libc = { version = "0.2.0", optional = true, default-features = false }
 
 [dev-dependencies]
 cupid = "0.6.0"


### PR DESCRIPTION
@chrisdenton started a little project to make Windows targets not depend on libc. They already mostly don't, so I'm finishing things up. One of the obstacles to my own testing is that stdarch is dragging the libc rlib into the sysroot and making rustc's test suite pass when it shouldn't. Lol.