### PR TITLE
Fix `std_detect_env_override` feature on Windows by avoiding `libc`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update nightly && rustup default nightly
+      run: rustup update nightly --no-self-update && rustup default nightly
     - run: ci/style.sh
 
   docs:
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update nightly && rustup default nightly
+      run: rustup update nightly --no-self-update && rustup default nightly
     - run: ci/dox.sh
       env:
         CI: 1
@@ -45,18 +45,22 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update nightly && rustup default nightly
+      run: rustup update nightly --no-self-update && rustup default nightly
     - run: cargo test --manifest-path crates/stdarch-verify/Cargo.toml
 
   env_override:
     name: Env Override
     needs: [style]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update nightly && rustup default nightly
+      run: rustup update nightly --no-self-update && rustup default nightly
     - run: RUST_STD_DETECT_UNSTABLE=avx cargo test --features=std_detect_env_override --manifest-path crates/std_detect/Cargo.toml env_override_no_avx
+      shell: bash
 
   test:
     needs: [style]


### PR DESCRIPTION
As noted in #1563, the only dependency on `libc` when building `stdarch` for Windows was a call to `getenv` when the `std_detect_env_override` feature was enabled. Since the `libc` dependency is only enabled for non-Windows platforms, enabling the `std_detect_env_override` feature on Windows would cause a build break.

This change replaces the use of `getenv` with a call to `GetEnvironmentVariableA` on Windows and enables testing the `std_detect_env_override` feature.

Fixes #1563

r? @ChrisDenton