### PR TITLE
Ignore int3 instructions when counting instructions in tests

### DIFF
--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -71,7 +71,7 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
     //eprintln!("  function: {:?}", function);
 
     let mut instrs = &function.instrs[..];
-    while instrs.last().map_or(false, |s| s == "nop") {
+    while instrs.last().map_or(false, |s| s == "nop" || s == "int3") {
         instrs = &instrs[..instrs.len() - 1];
     }
 


### PR DESCRIPTION
These are generated as padding and are not actually part of the function.