### PR TITLE
Fixed `_mm256_cvtsd_f64`

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -894,7 +894,7 @@ pub unsafe fn _mm256_cvtps_pd(a: __m128) -> __m256d {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cvtsd_f64)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vmovsd))]
+//#[cfg_attr(test, assert_instr(movsd))] FIXME
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtsd_f64(a: __m256d) -> f64 {
     simd_extract!(a, 0)
@@ -2948,7 +2948,7 @@ pub unsafe fn _mm256_storeu2_m128i(hiaddr: *mut __m128i, loaddr: *mut __m128i, a
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cvtss_f32)
 #[inline]
 #[target_feature(enable = "avx")]
-#[cfg_attr(test, assert_instr(vmovss))]
+//#[cfg_attr(test, assert_instr(movss))] FIXME
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtss_f32(a: __m256) -> f32 {
     simd_extract!(a, 0)

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -889,6 +889,17 @@ pub unsafe fn _mm256_cvtps_pd(a: __m128) -> __m256d {
     simd_cast(a)
 }
 
+/// Returns the first element of the input vector of `[4 x double]`.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cvtsd_f64)
+#[inline]
+#[target_feature(enable = "avx")]
+#[cfg_attr(test, assert_instr(vmovsd))]
+#[stable(feature = "simd_x86", since = "1.27.0")]
+pub unsafe fn _mm256_cvtsd_f64(a: __m256d) -> f64 {
+    simd_extract!(a, 0)
+}
+
 /// Converts packed double-precision (64-bit) floating-point elements in `a`
 /// to packed 32-bit integers with truncation.
 ///
@@ -2937,7 +2948,7 @@ pub unsafe fn _mm256_storeu2_m128i(hiaddr: *mut __m128i, loaddr: *mut __m128i, a
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cvtss_f32)
 #[inline]
 #[target_feature(enable = "avx")]
-//#[cfg_attr(test, assert_instr(movss))] FIXME
+#[cfg_attr(test, assert_instr(vmovss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_cvtss_f32(a: __m256) -> f32 {
     simd_extract!(a, 0)
@@ -3638,6 +3649,13 @@ mod tests {
         let r = _mm256_cvtps_pd(a);
         let e = _mm256_setr_pd(4., 9., 16., 25.);
         assert_eq_m256d(r, e);
+    }
+
+    #[simd_test(enable = "avx")]
+    unsafe fn test_mm256_cvtsd_f64() {
+        let a = _mm256_setr_pd(1., 2., 3., 4.);
+        let r = _mm256_cvtsd_f64(a);
+        assert_eq!(r, 1.);
     }
 
     #[simd_test(enable = "avx")]

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3625,17 +3625,6 @@ pub unsafe fn _mm256_extract_epi32<const INDEX: i32>(a: __m256i) -> i32 {
     simd_extract!(a.as_i32x8(), INDEX as u32)
 }
 
-/// Returns the first element of the input vector of `[4 x double]`.
-///
-/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cvtsd_f64)
-#[inline]
-#[target_feature(enable = "avx2")]
-//#[cfg_attr(test, assert_instr(movsd))] FIXME
-#[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_cvtsd_f64(a: __m256d) -> f64 {
-    simd_extract!(a, 0)
-}
-
 /// Returns the first element of the input vector of `[8 x i32]`.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cvtsi256_si32)
@@ -5774,13 +5763,6 @@ mod tests {
         let r2 = _mm256_extract_epi32::<3>(a);
         assert_eq!(r1, -1);
         assert_eq!(r2, 3);
-    }
-
-    #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_cvtsd_f64() {
-        let a = _mm256_setr_pd(1., 2., 3., 4.);
-        let r = _mm256_cvtsd_f64(a);
-        assert_eq!(r, 1.);
     }
 
     #[simd_test(enable = "avx2")]


### PR DESCRIPTION
This intrinsic should have `target_feature` AVX, (according to Intel Intrinsics Guide) but had AVX2  ([Issue](https://github.com/rust-lang/stdarch/issues/1577))