### PR TITLE
Run aarch64-pc-windows-msvc tests on ARM64 Windows runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,8 +153,7 @@ jobs:
         - target: i686-pc-windows-msvc
           os: windows-latest
         - target: aarch64-pc-windows-msvc
-          os: windows-latest
-          norun: true
+          os: windows-11-arm64-8core-32gb
         - target: i586-unknown-linux-gnu
           os: ubuntu-latest
         - target: nvptx64-nvidia-cuda


### PR DESCRIPTION
We recently got [ARM64 Windows runner enabled](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/GitHub.20Arm64.20runners.20private.20preview/near/444190113), so now we should be able to run the `aarch64-pc-windows-msvc` tests on them.