### PR TITLE
Use stdsimd instead of LLVM imports in more instances.

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -441,7 +441,7 @@ pub unsafe fn _mm256_floor_ps(a: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vsqrtps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_sqrt_ps(a: __m256) -> __m256 {
-    sqrtps256(a)
+    simd_fsqrt(a)
 }
 
 /// Returns the square root of packed double-precision (64-bit) floating point
@@ -2961,8 +2961,6 @@ extern "C" {
     fn roundpd256(a: __m256d, b: i32) -> __m256d;
     #[link_name = "llvm.x86.avx.round.ps.256"]
     fn roundps256(a: __m256, b: i32) -> __m256;
-    #[link_name = "llvm.x86.avx.sqrt.ps.256"]
-    fn sqrtps256(a: __m256) -> __m256;
     #[link_name = "llvm.x86.avx.dp.ps.256"]
     fn vdpps(a: __m256, b: __m256, imm8: i32) -> __m256;
     #[link_name = "llvm.x86.avx.hadd.pd.256"]

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -19,7 +19,7 @@
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
 use crate::core_arch::x86::*;
-use crate::intrinsics::simd::{simd_fma, simd_insert, simd_neg};
+use crate::intrinsics::simd::{simd_fma, simd_insert, simd_neg, simd_shuffle};
 use crate::intrinsics::{fmaf32, fmaf64};
 
 #[cfg(test)]
@@ -119,7 +119,9 @@ pub unsafe fn _mm_fmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfmaddsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmaddsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfmaddsubpd(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [2, 1])
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -132,7 +134,9 @@ pub unsafe fn _mm_fmaddsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfmaddsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmaddsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
-    vfmaddsubpd256(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [4, 1, 6, 3])
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -145,7 +149,9 @@ pub unsafe fn _mm256_fmaddsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d 
 #[cfg_attr(test, assert_instr(vfmaddsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmaddsub_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfmaddsubps(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [4, 1, 6, 3])
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -158,7 +164,9 @@ pub unsafe fn _mm_fmaddsub_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfmaddsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmaddsub_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
-    vfmaddsubps256(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [8, 1, 10, 3, 12, 5, 14, 7])
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -255,7 +263,9 @@ pub unsafe fn _mm_fmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfmsubadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmsubadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfmsubaddpd(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [0, 3])
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -268,7 +278,9 @@ pub unsafe fn _mm_fmsubadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfmsubadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmsubadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
-    vfmsubaddpd256(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [0, 5, 2, 7])
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -281,7 +293,9 @@ pub unsafe fn _mm256_fmsubadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d 
 #[cfg_attr(test, assert_instr(vfmsubadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmsubadd_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfmsubaddps(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [0, 5, 2, 7])
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -294,7 +308,9 @@ pub unsafe fn _mm_fmsubadd_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfmsubadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmsubadd_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
-    vfmsubaddps256(a, b, c)
+    let add = simd_fma(a, b, c);
+    let sub = simd_fma(a, b, simd_neg(c));
+    simd_shuffle!(add, sub, [0, 9, 2, 11, 4, 13, 6, 15])
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -469,26 +485,6 @@ pub unsafe fn _mm_fnmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
         0,
         fmaf32(_mm_cvtss_f32(a), -_mm_cvtss_f32(b), -_mm_cvtss_f32(c))
     )
-}
-
-#[allow(improper_ctypes)]
-extern "C" {
-    #[link_name = "llvm.x86.fma.vfmaddsub.pd"]
-    fn vfmaddsubpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfmaddsub.pd.256"]
-    fn vfmaddsubpd256(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.fma.vfmaddsub.ps"]
-    fn vfmaddsubps(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfmaddsub.ps.256"]
-    fn vfmaddsubps256(a: __m256, b: __m256, c: __m256) -> __m256;
-    #[link_name = "llvm.x86.fma.vfmsubadd.pd"]
-    fn vfmsubaddpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfmsubadd.pd.256"]
-    fn vfmsubaddpd256(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.fma.vfmsubadd.ps"]
-    fn vfmsubaddps(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfmsubadd.ps.256"]
-    fn vfmsubaddps256(a: __m256, b: __m256, c: __m256) -> __m256;
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -377,7 +377,7 @@ pub unsafe fn _mm_fnmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
     simd_insert!(
         a,
         0,
-        fmaf32(_mm_cvtss_f32(a, -_mm_cvtss_f32(b), _mm_cvtss_f32(c))
+        fmaf32(_mm_cvtss_f32(a), -_mm_cvtss_f32(b), _mm_cvtss_f32(c))
     )
 }
 

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -83,7 +83,11 @@ pub unsafe fn _mm256_fmadd_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vfmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmadd_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfmaddsd(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtsd_f64(a).mul_add(_mm_cvtsd_f64(b), _mm_cvtsd_f64(c))
+    )
 }
 
 /// Multiplies the lower single-precision (32-bit) floating-point elements in
@@ -97,7 +101,11 @@ pub unsafe fn _mm_fmadd_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfmaddss(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtss_f32(a).mul_add(_mm_cvtss_f32(b), _mm_cvtss_f32(c))
+    )
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -161,7 +169,7 @@ pub unsafe fn _mm256_fmaddsub_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vfmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfmsubpd(a, b, c)
+    simd_fma(a, b, simd_neg(c))
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -173,7 +181,7 @@ pub unsafe fn _mm_fmsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
-    vfmsubpd256(a, b, c)
+    simd_fma(a, b, simd_neg(c))
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -185,7 +193,7 @@ pub unsafe fn _mm256_fmsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vfmsub213ps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmsub_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfmsubps(a, b, c)
+    simd_fma(a, b, simd_neg(c))
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -197,7 +205,7 @@ pub unsafe fn _mm_fmsub_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfmsub213ps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fmsub_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
-    vfmsubps256(a, b, c)
+    simd_fma(a, b, simd_neg(c))
 }
 
 /// Multiplies the lower double-precision (64-bit) floating-point elements in
@@ -211,7 +219,11 @@ pub unsafe fn _mm256_fmsub_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vfmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmsub_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfmsubsd(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtsd_f64(a).mul_add(_mm_cvtsd_f64(b), -_mm_cvtsd_f64(c))
+    )
 }
 
 /// Multiplies the lower single-precision (32-bit) floating-point elements in
@@ -225,7 +237,11 @@ pub unsafe fn _mm_fmsub_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfmsubss(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtss_f32(a).mul_add(_mm_cvtss_f32(b), -_mm_cvtss_f32(c))
+    )
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -289,7 +305,7 @@ pub unsafe fn _mm256_fmsubadd_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vfnmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfnmaddpd(a, b, c)
+    simd_fma(simd_neg(a), b, c)
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -301,7 +317,7 @@ pub unsafe fn _mm_fnmadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfnmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fnmadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
-    vfnmaddpd256(a, b, c)
+    simd_fma(simd_neg(a), b, c)
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -313,7 +329,7 @@ pub unsafe fn _mm256_fnmadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vfnmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmadd_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfnmaddps(a, b, c)
+    simd_fma(simd_neg(a), b, c)
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -325,7 +341,7 @@ pub unsafe fn _mm_fnmadd_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfnmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fnmadd_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
-    vfnmaddps256(a, b, c)
+    simd_fma(simd_neg(a), b, c)
 }
 
 /// Multiplies the lower double-precision (64-bit) floating-point elements in
@@ -339,7 +355,11 @@ pub unsafe fn _mm256_fnmadd_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vfnmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmadd_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfnmaddsd(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtsd_f64(a).mul_add(-_mm_cvtsd_f64(b), _mm_cvtsd_f64(c))
+    )
 }
 
 /// Multiplies the lower single-precision (32-bit) floating-point elements in
@@ -353,7 +373,11 @@ pub unsafe fn _mm_fnmadd_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfnmadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfnmaddss(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtss_f32(a).mul_add(-_mm_cvtss_f32(b), _mm_cvtss_f32(c))
+    )
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -366,7 +390,7 @@ pub unsafe fn _mm_fnmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfnmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfnmsubpd(a, b, c)
+    simd_fma(simd_neg(a), b, simd_neg(c))
 }
 
 /// Multiplies packed double-precision (64-bit) floating-point elements in `a`
@@ -379,7 +403,7 @@ pub unsafe fn _mm_fnmsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfnmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fnmsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
-    vfnmsubpd256(a, b, c)
+    simd_fma(simd_neg(a), b, simd_neg(c))
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -392,7 +416,7 @@ pub unsafe fn _mm256_fnmsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
 #[cfg_attr(test, assert_instr(vfnmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmsub_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfnmsubps(a, b, c)
+    simd_fma(simd_neg(a), b, simd_neg(c))
 }
 
 /// Multiplies packed single-precision (32-bit) floating-point elements in `a`
@@ -405,7 +429,7 @@ pub unsafe fn _mm_fnmsub_ps(a: __m128, b: __m128, c: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(vfnmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_fnmsub_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
-    vfnmsubps256(a, b, c)
+    simd_fma(simd_neg(a), b, simd_neg(c))
 }
 
 /// Multiplies the lower double-precision (64-bit) floating-point elements in
@@ -420,7 +444,11 @@ pub unsafe fn _mm256_fnmsub_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[cfg_attr(test, assert_instr(vfnmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmsub_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
-    vfnmsubsd(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtsd_f64(a).mul_add(-_mm_cvtsd_f64(b), -_mm_cvtsd_f64(c))
+    )
 }
 
 /// Multiplies the lower single-precision (32-bit) floating-point elements in
@@ -435,15 +463,15 @@ pub unsafe fn _mm_fnmsub_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(vfnmsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_fnmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
-    vfnmsubss(a, b, c)
+    simd_insert!(
+        a,
+        0,
+        _mm_cvtss_f32(a).mul_add(-_mm_cvtss_f32(b), -_mm_cvtss_f32(c))
+    )
 }
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.x86.fma.vfmadd.sd"]
-    fn vfmaddsd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfmadd.ss"]
-    fn vfmaddss(a: __m128, b: __m128, c: __m128) -> __m128;
     #[link_name = "llvm.x86.fma.vfmaddsub.pd"]
     fn vfmaddsubpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
     #[link_name = "llvm.x86.fma.vfmaddsub.pd.256"]
@@ -452,18 +480,6 @@ extern "C" {
     fn vfmaddsubps(a: __m128, b: __m128, c: __m128) -> __m128;
     #[link_name = "llvm.x86.fma.vfmaddsub.ps.256"]
     fn vfmaddsubps256(a: __m256, b: __m256, c: __m256) -> __m256;
-    #[link_name = "llvm.x86.fma.vfmsub.pd"]
-    fn vfmsubpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfmsub.pd.256"]
-    fn vfmsubpd256(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.fma.vfmsub.ps"]
-    fn vfmsubps(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfmsub.ps.256"]
-    fn vfmsubps256(a: __m256, b: __m256, c: __m256) -> __m256;
-    #[link_name = "llvm.x86.fma.vfmsub.sd"]
-    fn vfmsubsd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfmsub.ss"]
-    fn vfmsubss(a: __m128, b: __m128, c: __m128) -> __m128;
     #[link_name = "llvm.x86.fma.vfmsubadd.pd"]
     fn vfmsubaddpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
     #[link_name = "llvm.x86.fma.vfmsubadd.pd.256"]
@@ -472,30 +488,6 @@ extern "C" {
     fn vfmsubaddps(a: __m128, b: __m128, c: __m128) -> __m128;
     #[link_name = "llvm.x86.fma.vfmsubadd.ps.256"]
     fn vfmsubaddps256(a: __m256, b: __m256, c: __m256) -> __m256;
-    #[link_name = "llvm.x86.fma.vfnmadd.pd"]
-    fn vfnmaddpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfnmadd.pd.256"]
-    fn vfnmaddpd256(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.fma.vfnmadd.ps"]
-    fn vfnmaddps(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfnmadd.ps.256"]
-    fn vfnmaddps256(a: __m256, b: __m256, c: __m256) -> __m256;
-    #[link_name = "llvm.x86.fma.vfnmadd.sd"]
-    fn vfnmaddsd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfnmadd.ss"]
-    fn vfnmaddss(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfnmsub.pd"]
-    fn vfnmsubpd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfnmsub.pd.256"]
-    fn vfnmsubpd256(a: __m256d, b: __m256d, c: __m256d) -> __m256d;
-    #[link_name = "llvm.x86.fma.vfnmsub.ps"]
-    fn vfnmsubps(a: __m128, b: __m128, c: __m128) -> __m128;
-    #[link_name = "llvm.x86.fma.vfnmsub.ps.256"]
-    fn vfnmsubps256(a: __m256, b: __m256, c: __m256) -> __m256;
-    #[link_name = "llvm.x86.fma.vfnmsub.sd"]
-    fn vfnmsubsd(a: __m128d, b: __m128d, c: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.fma.vfnmsub.ss"]
-    fn vfnmsubss(a: __m128, b: __m128, c: __m128) -> __m128;
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -19,7 +19,8 @@
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
 use crate::core_arch::x86::*;
-use crate::intrinsics::simd::simd_fma;
+use crate::intrinsics::simd::{simd_fma, simd_insert, simd_neg};
+use crate::intrinsics::{fmaf32, fmaf64};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;
@@ -86,7 +87,7 @@ pub unsafe fn _mm_fmadd_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
     simd_insert!(
         a,
         0,
-        _mm_cvtsd_f64(a).mul_add(_mm_cvtsd_f64(b), _mm_cvtsd_f64(c))
+        fmaf64(_mm_cvtsd_f64(a), _mm_cvtsd_f64(b), _mm_cvtsd_f64(c))
     )
 }
 
@@ -104,7 +105,7 @@ pub unsafe fn _mm_fmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
     simd_insert!(
         a,
         0,
-        _mm_cvtss_f32(a).mul_add(_mm_cvtss_f32(b), _mm_cvtss_f32(c))
+        fmaf32(_mm_cvtss_f32(a), _mm_cvtss_f32(b), _mm_cvtss_f32(c))
     )
 }
 
@@ -222,7 +223,7 @@ pub unsafe fn _mm_fmsub_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
     simd_insert!(
         a,
         0,
-        _mm_cvtsd_f64(a).mul_add(_mm_cvtsd_f64(b), -_mm_cvtsd_f64(c))
+        fmaf64(_mm_cvtsd_f64(a), _mm_cvtsd_f64(b), -_mm_cvtsd_f64(c))
     )
 }
 
@@ -240,7 +241,7 @@ pub unsafe fn _mm_fmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
     simd_insert!(
         a,
         0,
-        _mm_cvtss_f32(a).mul_add(_mm_cvtss_f32(b), -_mm_cvtss_f32(c))
+        fmaf32(_mm_cvtss_f32(a), _mm_cvtss_f32(b), -_mm_cvtss_f32(c))
     )
 }
 
@@ -358,7 +359,7 @@ pub unsafe fn _mm_fnmadd_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
     simd_insert!(
         a,
         0,
-        _mm_cvtsd_f64(a).mul_add(-_mm_cvtsd_f64(b), _mm_cvtsd_f64(c))
+        fmaf64(_mm_cvtsd_f64(a), -_mm_cvtsd_f64(b), _mm_cvtsd_f64(c))
     )
 }
 
@@ -376,7 +377,7 @@ pub unsafe fn _mm_fnmadd_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
     simd_insert!(
         a,
         0,
-        _mm_cvtss_f32(a).mul_add(-_mm_cvtss_f32(b), _mm_cvtss_f32(c))
+        fmaf32(_mm_cvtss_f32(a, -_mm_cvtss_f32(b), _mm_cvtss_f32(c))
     )
 }
 
@@ -447,7 +448,7 @@ pub unsafe fn _mm_fnmsub_sd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
     simd_insert!(
         a,
         0,
-        _mm_cvtsd_f64(a).mul_add(-_mm_cvtsd_f64(b), -_mm_cvtsd_f64(c))
+        fmaf64(_mm_cvtsd_f64(a), -_mm_cvtsd_f64(b), -_mm_cvtsd_f64(c))
     )
 }
 
@@ -466,7 +467,7 @@ pub unsafe fn _mm_fnmsub_ss(a: __m128, b: __m128, c: __m128) -> __m128 {
     simd_insert!(
         a,
         0,
-        _mm_cvtss_f32(a).mul_add(-_mm_cvtss_f32(b), -_mm_cvtss_f32(c))
+        fmaf32(_mm_cvtss_f32(a), -_mm_cvtss_f32(b), -_mm_cvtss_f32(c))
     )
 }
 

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -18,7 +18,7 @@ use stdarch_test::assert_instr;
 #[cfg_attr(test, assert_instr(addss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_add_ss(a: __m128, b: __m128) -> __m128 {
-    addss(a, b)
+    simd_insert!(a, 0, _mm_cvtss_f32(a) + _mm_cvtss_f32(b))
 }
 
 /// Adds __m128 vectors.
@@ -41,7 +41,7 @@ pub unsafe fn _mm_add_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(subss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sub_ss(a: __m128, b: __m128) -> __m128 {
-    subss(a, b)
+    simd_insert!(a, 0, _mm_cvtss_f32(a) - _mm_cvtss_f32(b))
 }
 
 /// Subtracts __m128 vectors.
@@ -64,7 +64,7 @@ pub unsafe fn _mm_sub_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(mulss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mul_ss(a: __m128, b: __m128) -> __m128 {
-    mulss(a, b)
+    simd_insert!(a, 0, _mm_cvtss_f32(a) * _mm_cvtss_f32(b))
 }
 
 /// Multiplies __m128 vectors.
@@ -87,7 +87,7 @@ pub unsafe fn _mm_mul_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(divss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_div_ss(a: __m128, b: __m128) -> __m128 {
-    divss(a, b)
+    simd_insert!(a, 0, _mm_cvtss_f32(a) / _mm_cvtss_f32(b))
 }
 
 /// Divides __m128 vectors.
@@ -110,7 +110,7 @@ pub unsafe fn _mm_div_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(sqrtss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sqrt_ss(a: __m128) -> __m128 {
-    sqrtss(a)
+    simd_insert!(a, 0, _mm_cvtss_f32(a).sqrt())
 }
 
 /// Returns the square root of packed single-precision (32-bit) floating-point
@@ -122,7 +122,7 @@ pub unsafe fn _mm_sqrt_ss(a: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(sqrtps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sqrt_ps(a: __m128) -> __m128 {
-    sqrtps(a)
+    simd_fsqrt(a)
 }
 
 /// Returns the approximate reciprocal of the first single-precision
@@ -1920,18 +1920,6 @@ pub unsafe fn _MM_TRANSPOSE4_PS(
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.x86.sse.add.ss"]
-    fn addss(a: __m128, b: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.sub.ss"]
-    fn subss(a: __m128, b: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.mul.ss"]
-    fn mulss(a: __m128, b: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.div.ss"]
-    fn divss(a: __m128, b: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.sqrt.ss"]
-    fn sqrtss(a: __m128) -> __m128;
-    #[link_name = "llvm.x86.sse.sqrt.ps"]
-    fn sqrtps(a: __m128) -> __m128;
     #[link_name = "llvm.x86.sse.rcp.ss"]
     fn rcpss(a: __m128) -> __m128;
     #[link_name = "llvm.x86.sse.rcp.ps"]

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -3,6 +3,7 @@
 use crate::{
     core_arch::{simd::*, x86::*},
     intrinsics::simd::*,
+    intrinsics::sqrtf32,
     mem, ptr,
 };
 
@@ -110,7 +111,7 @@ pub unsafe fn _mm_div_ps(a: __m128, b: __m128) -> __m128 {
 #[cfg_attr(test, assert_instr(sqrtss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sqrt_ss(a: __m128) -> __m128 {
-    simd_insert!(a, 0, _mm_cvtss_f32(a).sqrt())
+    simd_insert!(a, 0, sqrtf32(_mm_cvtss_f32(a)))
 }
 
 /// Returns the square root of packed single-precision (32-bit) floating-point

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -6,6 +6,7 @@ use stdarch_test::assert_instr;
 use crate::{
     core_arch::{simd::*, x86::*},
     intrinsics::simd::*,
+    intrinsics::sqrtf64,
     mem, ptr,
 };
 
@@ -1760,7 +1761,7 @@ pub unsafe fn _mm_mul_pd(a: __m128d, b: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(sqrtsd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sqrt_sd(a: __m128d, b: __m128d) -> __m128d {
-    simd_insert!(a, 0, _mm_cvtsd_f64(b).sqrt())
+    simd_insert!(a, 0, sqrtf64(_mm_cvtsd_f64(b)))
 }
 
 /// Returns a new vector with the square root of each of the values in `a`.

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1760,7 +1760,7 @@ pub unsafe fn _mm_mul_pd(a: __m128d, b: __m128d) -> __m128d {
 #[cfg_attr(test, assert_instr(sqrtsd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_sqrt_sd(a: __m128d, b: __m128d) -> __m128d {
-    simd_insert!(a, 0, _mm_cvtsd_f64(sqrtsd(b)))
+    simd_insert!(a, 0, _mm_cvtsd_f64(b).sqrt())
 }
 
 /// Returns a new vector with the square root of each of the values in `a`.
@@ -2911,10 +2911,6 @@ extern "C" {
     fn minsd(a: __m128d, b: __m128d) -> __m128d;
     #[link_name = "llvm.x86.sse2.min.pd"]
     fn minpd(a: __m128d, b: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.sse2.sqrt.sd"]
-    fn sqrtsd(a: __m128d) -> __m128d;
-    #[link_name = "llvm.x86.sse2.sqrt.pd"]
-    fn sqrtpd(a: __m128d) -> __m128d;
     #[link_name = "llvm.x86.sse2.cmp.sd"]
     fn cmpsd(a: __m128d, b: __m128d, imm8: i8) -> __m128d;
     #[link_name = "llvm.x86.sse2.cmp.pd"]


### PR DESCRIPTION
Continuation of #790. Back then, there were instances where it was not possible to use the generic SIMD intrinsics due to LLVM bugs. These bugs have since then been fixed.