### PR TITLE
Add x86 target features

### DIFF
--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -129,6 +129,12 @@ features! {
     /// SSE4a (Streaming SIMD Extensions 4a)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] sha: "sha";
     /// SHA
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] sha512: "sha512";
+    /// SHA-512
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] sm3: "sm3";
+    /// SM3
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] sm4: "sm4";
+    /// SM4
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx: "avx";
     /// AVX (Advanced Vector Extensions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx2: "avx2";
@@ -138,7 +144,7 @@ features! {
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512cd: "avx512cd" ;
     /// AVX-512 CD (Conflict Detection Instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512er: "avx512er";
-    /// AVX-512 ER (Expo nential and Reciprocal Instructions)
+    /// AVX-512 ER (Exponential and Reciprocal Instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512pf: "avx512pf";
     /// AVX-512 PF (Prefetch Instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512bw: "avx512bw";
@@ -172,6 +178,26 @@ features! {
     /// AVX-512 P2INTERSECT
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512fp16: "avx512fp16";
     /// AVX-512 FP16 (FLOAT16 instructions)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxifma: "avxifma";
+    /// AVX-IFMA (Integer Fused Multiply Add)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxneconvert: "avxneconvert";
+    /// AVX-NE-CONVERT
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxvnni: "avxvnni";
+    /// AVX-VNNI (Vector Neural Network Instructions)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxvnniint8: "avxvnniint8";
+    /// AVX-VNNI_INT8
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxvnniint16: "avxvnniint16";
+    /// AVX-VNNI_INT16
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-tile: "amx-tile";
+    /// AMX (Advanced Matrix Extensions) Tile Instructions
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-int8: "amx-int8";
+    /// AMX-INT8 (8-bit Integer Instructions)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-bf16: "amx-bf16";
+    /// AMX-BF16 (BFloat16 Instructions)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-fp16: "amx-fp16";
+    /// AMX-FP16 (Float16 Instructions)
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-complex: "amx-complex";
+    /// AMX-COMPLEX (Complex Number Instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] f16c: "f16c";
     /// F16C (Conversions between IEEE-754 `binary16` and `binary32` formats)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] fma: "fma";

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -181,22 +181,22 @@ features! {
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxifma: "avxifma";
     /// AVX-IFMA (Integer Fused Multiply Add)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxneconvert: "avxneconvert";
-    /// AVX-NE-CONVERT
+    /// AVX-NE-CONVERT (No Exception Conversions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxvnni: "avxvnni";
     /// AVX-VNNI (Vector Neural Network Instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxvnniint8: "avxvnniint8";
     /// AVX-VNNI_INT8
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avxvnniint16: "avxvnniint16";
     /// AVX-VNNI_INT16
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-tile: "amx-tile";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx_tile: "amx-tile";
     /// AMX (Advanced Matrix Extensions) Tile Instructions
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-int8: "amx-int8";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx_int8: "amx-int8";
     /// AMX-INT8 (8-bit Integer Instructions)
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-bf16: "amx-bf16";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx_bf16: "amx-bf16";
     /// AMX-BF16 (BFloat16 Instructions)
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-fp16: "amx-fp16";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx_fp16: "amx-fp16";
     /// AMX-FP16 (Float16 Instructions)
-    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx-complex: "amx-complex";
+    @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] amx_complex: "amx-complex";
     /// AMX-COMPLEX (Complex Number Instructions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] f16c: "f16c";
     /// F16C (Conversions between IEEE-754 `binary16` and `binary32` formats)

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -74,11 +74,12 @@ pub(crate) fn detect_features() -> cache::Initializer {
         extended_features_ecx,
         extended_features_edx,
         extended_features_eax_leaf_1,
+        extended_features_edx_leaf_1,
     ) = if max_basic_leaf >= 7 {
         let CpuidResult { ebx, ecx, edx, .. } = unsafe { __cpuid(0x0000_0007_u32) };
-        let CpuidResult { eax: eax_1, .. } =
+        let CpuidResult { eax: eax_1, edx: edx_1, .. } =
             unsafe { __cpuid_count(0x0000_0007_u32, 0x0000_0001_u32) };
-        (ebx, ecx, edx, eax_1)
+        (ebx, ecx, edx, eax_1, edx_1)
     } else {
         (0, 0, 0, 0) // CPUID does not support "Extended Features"
     };
@@ -129,6 +130,11 @@ pub(crate) fn detect_features() -> cache::Initializer {
         enable(proc_info_edx, 26, Feature::sse2);
         enable(extended_features_ebx, 29, Feature::sha);
 
+        // These features can be enabled even without AVX=512 support
+        enable(extended_features_ecx, 8, Feature::gfni);
+        enable(extended_features_ecx, 9, Feature::vaes);
+        enable(extended_features_ecx, 10, Feature::vpclmulqdq);
+
         enable(extended_features_ebx, 3, Feature::bmi1);
         enable(extended_features_ebx, 8, Feature::bmi2);
 
@@ -167,6 +173,8 @@ pub(crate) fn detect_features() -> cache::Initializer {
                 let os_avx_support = xcr0 & 6 == 6;
                 // Test `XCR0.AVX-512[7:5]` with the mask `0b1110_0000 == 224`:
                 let os_avx512_support = xcr0 & 224 == 224;
+                // Test `XCR0.AMX[18:17]` with the mask `0b110_00000000_00000000 == 0x60000`
+                let os_amx_support = xcr0 & 0x60000 == 0x60000;
 
                 // Only if the OS and the CPU support saving/restoring the AVX
                 // registers we enable `xsave` support:
@@ -203,6 +211,18 @@ pub(crate) fn detect_features() -> cache::Initializer {
                     enable(proc_info_ecx, 28, Feature::avx);
                     enable(extended_features_ebx, 5, Feature::avx2);
 
+                    // These are VEX-encoded versions of AVX512, can be enabled without AVX512
+                    enable(extended_features_eax_leaf_1, 23, Feature::avxifma);
+                    enable(extended_features_eax_leaf_1, 4, Feature::avxvnni);
+                    enable(extended_features_edx_leaf_1, 5, Feature::avxneconvert);
+                    enable(extended_features_edx_leaf_1, 4, Feature::avxvnniint8);
+                    enable(extended_features_edx_leaf_1, 10, Feature::avxvnniint16);
+
+                    // These Instructions require AVX
+                    enable(extended_features_eax_leaf_1, 0, Feature::sha512);
+                    enable(extended_features_eax_leaf_1, 1, Feature::sm3);
+                    enable(extended_features_eax_leaf_1, 2, Feature::sm4);
+                    
                     // For AVX-512 the OS also needs to support saving/restoring
                     // the extended state, only then we enable AVX-512 support:
                     if os_avx512_support {
@@ -216,15 +236,22 @@ pub(crate) fn detect_features() -> cache::Initializer {
                         enable(extended_features_ebx, 31, Feature::avx512vl);
                         enable(extended_features_ecx, 1, Feature::avx512vbmi);
                         enable(extended_features_ecx, 6, Feature::avx512vbmi2);
-                        enable(extended_features_ecx, 8, Feature::gfni);
-                        enable(extended_features_ecx, 9, Feature::vaes);
-                        enable(extended_features_ecx, 10, Feature::vpclmulqdq);
                         enable(extended_features_ecx, 11, Feature::avx512vnni);
                         enable(extended_features_ecx, 12, Feature::avx512bitalg);
                         enable(extended_features_ecx, 14, Feature::avx512vpopcntdq);
                         enable(extended_features_edx, 8, Feature::avx512vp2intersect);
                         enable(extended_features_edx, 23, Feature::avx512fp16);
                         enable(extended_features_eax_leaf_1, 5, Feature::avx512bf16);
+                    }
+
+                    // For AMX the OS also needs to support saving/restoring
+                    // the extended state, only then we enable AMX support:
+                    if os_amx_support {
+                        enable(extended_features_edx, 24, Feature::amx_tile);
+                        enable(extended_features_edx, 25, Feature::amx_int8);
+                        enable(extended_features_edx, 22, Feature::amx_bf16);
+                        enable(extended_features_eax_leaf_1, 21, Feature::amx_fp16);
+                        enable(extended_features_edx_leaf_1, 8, Feature::amx_complex);
                     }
                 }
             }

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -84,7 +84,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
         } = unsafe { __cpuid_count(0x0000_0007_u32, 0x0000_0001_u32) };
         (ebx, ecx, edx, eax_1, edx_1)
     } else {
-        (0, 0, 0, 0) // CPUID does not support "Extended Features"
+        (0, 0, 0, 0, 0) // CPUID does not support "Extended Features"
     };
 
     // EAX = 0x8000_0000, ECX = 0: Get Highest Extended Function Supported

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -77,8 +77,11 @@ pub(crate) fn detect_features() -> cache::Initializer {
         extended_features_edx_leaf_1,
     ) = if max_basic_leaf >= 7 {
         let CpuidResult { ebx, ecx, edx, .. } = unsafe { __cpuid(0x0000_0007_u32) };
-        let CpuidResult { eax: eax_1, edx: edx_1, .. } =
-            unsafe { __cpuid_count(0x0000_0007_u32, 0x0000_0001_u32) };
+        let CpuidResult {
+            eax: eax_1,
+            edx: edx_1,
+            ..
+        } = unsafe { __cpuid_count(0x0000_0007_u32, 0x0000_0001_u32) };
         (ebx, ecx, edx, eax_1, edx_1)
     } else {
         (0, 0, 0, 0) // CPUID does not support "Extended Features"
@@ -222,7 +225,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
                     enable(extended_features_eax_leaf_1, 0, Feature::sha512);
                     enable(extended_features_eax_leaf_1, 1, Feature::sm3);
                     enable(extended_features_eax_leaf_1, 2, Feature::sm4);
-                    
+
                     // For AVX-512 the OS also needs to support saving/restoring
                     // the extended state, only then we enable AVX-512 support:
                     if os_avx512_support {


### PR DESCRIPTION
Add the missing target-features for x86
 - SHA512
 - SM3
 - SM4
 - AMX (all 5)
 - AVX-VNNI (all 3)
 - AVX-IFMA
 - AVX-NE-CONVERT

See rustc PR [126599](https://github.com/rust-lang/rust/pull/126599)