### PR TITLE
Add Runtime detection for SHA512, SM3 and SM4

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -33,7 +33,8 @@
     asm_const,
     target_feature_11,
     generic_arg_infer,
-    asm_experimental_arch
+    asm_experimental_arch,
+    sha512_sm_x86
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]
 #![deny(clippy::missing_inline_in_public_items)]

--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -325,3 +325,15 @@ mod nvptx;
 #[cfg(any(target_arch = "loongarch64", doc))]
 #[doc(cfg(target_arch = "loongarch64"))]
 mod loongarch64;
+
+// TODO: remove after merge of rustc #126704
+#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+unsafe fn dummy() {
+    // This has to be here until PR #126704 gets merged into rustc,
+    // because otherwise rustc cannot compile because aarch64 also has
+    // a target feature named sm4, and that is stable. For `doc` env this
+    // gets compiled also in x86, but in x86 the feature sm4 is unstable
+    // So we need `feature(sha512_sm_x86)` somewhere, but if we place it without
+    // any unstable attr, rustc cannot compile stage0, because it doesn't know about
+    // this feature yet.
+}

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -57,6 +57,9 @@ features! {
     /// * `"sha"`
     /// * `"avx"`
     /// * `"avx2"`
+    /// * `"sha512"`
+    /// * `"sm3"`
+    /// * `"sm4"`
     /// * `"avx512f"`
     /// * `"avx512cd"`
     /// * `"avx512er"`
@@ -138,6 +141,12 @@ features! {
     /// AVX (Advanced Vector Extensions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx2: "avx2";
     /// AVX2 (Advanced Vector Extensions 2)
+    @FEATURE: #[unstable(feature = "sha512_sm_x86", issue = "126624")] sha512: "sha512";
+    /// SHA512
+    @FEATURE: #[unstable(feature = "sha512_sm_x86", issue = "126624")] sm3: "sm3";
+    /// SM3
+    @FEATURE: #[unstable(feature = "sha512_sm_x86", issue = "126624")] sm4: "sm4";
+    /// SM4
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512f: "avx512f" ;
     /// AVX-512 F (Foundation)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512cd: "avx512cd" ;

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -217,6 +217,10 @@ pub(crate) fn detect_features() -> cache::Initializer {
                     enable(extended_features_edx_leaf_1, 5, Feature::avxneconvert);
                     enable(extended_features_edx_leaf_1, 10, Feature::avxvnniint16);
 
+                    enable(extended_features_eax_leaf_1, 0, Feature::sha512);
+                    enable(extended_features_eax_leaf_1, 1, Feature::sm3);
+                    enable(extended_features_eax_leaf_1, 2, Feature::sm4);
+
                     // For AVX-512 the OS also needs to support saving/restoring
                     // the extended state, only then we enable AVX-512 support:
                     if os_avx512_support {

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -3,6 +3,10 @@
 #![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
 #![cfg_attr(target_arch = "powerpc", feature(stdarch_powerpc_feature_detection))]
 #![cfg_attr(target_arch = "powerpc64", feature(stdarch_powerpc_feature_detection))]
+#![cfg_attr(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature(sha512_sm_x86)
+)]
 #![allow(clippy::unwrap_used, clippy::use_debug, clippy::print_stdout)]
 
 #[cfg_attr(
@@ -210,6 +214,9 @@ fn x86_all() {
     println!("sha: {:?}", is_x86_feature_detected!("sha"));
     println!("avx: {:?}", is_x86_feature_detected!("avx"));
     println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
+    println!("sha512: {:?}", is_x86_feature_detected!("sha512"));
+    println!("sm3: {:?}", is_x86_feature_detected!("sm3"));
+    println!("sm4: {:?}", is_x86_feature_detected!("sm4"));
     println!("avx512f: {:?}", is_x86_feature_detected!("avx512f"));
     println!("avx512cd: {:?}", is_x86_feature_detected!("avx512cd"));
     println!("avx512er: {:?}", is_x86_feature_detected!("avx512er"));

--- a/crates/std_detect/tests/x86-specific.rs
+++ b/crates/std_detect/tests/x86-specific.rs
@@ -1,6 +1,6 @@
 #![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #![allow(internal_features)]
-#![feature(stdarch_internal, avx512_target_feature)]
+#![feature(stdarch_internal, avx512_target_feature, sha512_sm_x86)]
 
 extern crate cupid;
 #[macro_use]
@@ -24,6 +24,9 @@ fn dump() {
     println!("f16c: {:?}", is_x86_feature_detected!("f16c"));
     println!("avx: {:?}", is_x86_feature_detected!("avx"));
     println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
+    println!("sha512: {:?}", is_x86_feature_detected!("sha512"));
+    println!("sm3: {:?}", is_x86_feature_detected!("sm3"));
+    println!("sm4: {:?}", is_x86_feature_detected!("sm4"));
     println!("avx512f {:?}", is_x86_feature_detected!("avx512f"));
     println!("avx512cd {:?}", is_x86_feature_detected!("avx512cd"));
     println!("avx512er {:?}", is_x86_feature_detected!("avx512er"));


### PR DESCRIPTION
This is an effort towards [#126624](https://github.com/rust-lang/rust/issues/126624). This adds run-time detection for these target features. 