### PR TITLE
Fix documentation of arguments of function `core::arch::x86::_mm_blendv_epi8`

### DIFF
--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -51,8 +51,8 @@ pub const _MM_FROUND_NEARBYINT: i32 = _MM_FROUND_NO_EXC | _MM_FROUND_CUR_DIRECTI
 /// Blend packed 8-bit integers from `a` and `b` using `mask`
 ///
 /// The high bit of each corresponding mask byte determines the selection.
-/// If the high bit is set the element of `a` is selected. The element
-/// of `b` is selected otherwise.
+/// If the high bit is set, the element of `b` is selected.
+/// Otherwise, the element of `a` is selected.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blendv_epi8)
 #[inline]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/126935

This PR corrects the doc comment on the function and rewords it for clarity.

---

According to the issue linked above, the behavior of this function is correct and corresponds to [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_blendv_epi8&ig_expand=487).

This can be verified by inspecting the unit tests here: [library/stdarch/examples/hex.rs](https://github.com/mtilda/stdarch/blob/c7eaae44727e626d2f61ae7510c6b91b8cb6919d/examples/hex.rs#L222-L318).

I am able to run these tests with the commands

```bash
cd examples
```

```bash
cargo +nightly test
```

_So far I have not gotten `ci/run.sh` to work correctly. I have also had no luck with the command `cargo +nightly test --example hex -p stdarch` provided in [this comment](https://github.com/mtilda/stdarch/blob/c7eaae44727e626d2f61ae7510c6b91b8cb6919d/examples/hex.rs#L220). But perhaps those problems are not so relevant to this PR._