### PR TITLE
Runtime detection of `xop` target-feature

### DIFF
--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -245,4 +245,6 @@ features! {
     /// MOVBE (Move Data After Swapping Bytes)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] ermsb: "ermsb";
     /// ERMSB, Enhanced REP MOVSB and STOSB
+    @FEATURE: #[unstable(feature = "xop_target_feature", issue = "127208")] xop: "xop";
+    /// XOP: eXtended Operations (AMD)
 }

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -279,6 +279,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
             // These features are available on AMD arch CPUs:
             enable(extended_proc_info_ecx, 6, Feature::sse4a);
             enable(extended_proc_info_ecx, 21, Feature::tbm);
+            enable(extended_proc_info_ecx, 11, Feature::xop);
         }
     }
 

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(target_arch = "powerpc64", feature(stdarch_powerpc_feature_detection))]
 #![cfg_attr(
     any(target_arch = "x86", target_arch = "x86_64"),
-    feature(sha512_sm_x86, x86_amx_intrinsics)
+    feature(sha512_sm_x86, x86_amx_intrinsics, xop_target_feature)
 )]
 #![allow(clippy::unwrap_used, clippy::use_debug, clippy::print_stdout)]
 
@@ -264,6 +264,7 @@ fn x86_all() {
     println!("amx-int8: {:?}", is_x86_feature_detected!("amx-int8"));
     println!("amx-fp16: {:?}", is_x86_feature_detected!("amx-fp16"));
     println!("amx-complex: {:?}", is_x86_feature_detected!("amx-complex"));
+    println!("xop: {:?}", is_x86_feature_detected!("xop"));
 }
 
 #[test]

--- a/crates/std_detect/tests/x86-specific.rs
+++ b/crates/std_detect/tests/x86-specific.rs
@@ -4,7 +4,8 @@
     stdarch_internal,
     avx512_target_feature,
     sha512_sm_x86,
-    x86_amx_intrinsics
+    x86_amx_intrinsics,
+    xop_target_feature
 )]
 
 extern crate cupid;
@@ -92,6 +93,7 @@ fn dump() {
     println!("amx-int8: {:?}", is_x86_feature_detected!("amx-int8"));
     println!("amx-fp16: {:?}", is_x86_feature_detected!("amx-fp16"));
     println!("amx-complex: {:?}", is_x86_feature_detected!("amx-complex"));
+    println!("xop: {:?}", is_x86_feature_detected!("xop"));
 }
 
 #[cfg(feature = "std_detect_env_override")]


### PR DESCRIPTION
This is an effort towards rust-lang/rust#127208. This Implements the runtime detection of `xop`.