### PR TITLE
Stabilize `simd_x86_updates`

### DIFF
--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -593,7 +593,7 @@ pub unsafe fn _mm256_broadcastsd_pd(a: __m128d) -> __m256d {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_broadcastsi128_si256)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_broadcastsi128_si256(a: __m128i) -> __m256i {
     let zero = _mm_setzero_si128();
     let ret = simd_shuffle!(a.as_i64x2(), zero.as_i64x2(), [0, 1, 0, 1]);
@@ -3145,7 +3145,7 @@ pub unsafe fn _mm256_srlv_epi64(a: __m256i, count: __m256i) -> __m256i {
 #[inline]
 #[target_feature(enable = "avx,avx2")]
 #[cfg_attr(test, assert_instr(vmovntdqa))]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm256_stream_load_si256(mem_addr: *const __m256i) -> __m256i {
     let dst: __m256i;
     crate::arch::asm!(

--- a/crates/core_arch/src/x86/bmi1.rs
+++ b/crates/core_arch/src/x86/bmi1.rs
@@ -93,7 +93,7 @@ pub unsafe fn _blsr_u32(x: u32) -> u32 {
 #[inline]
 #[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(tzcnt))]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _tzcnt_u16(x: u16) -> u16 {
     x.trailing_zeros() as u16
 }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2595,7 +2595,7 @@ pub unsafe fn _mm_storeu_pd(mem_addr: *mut f64, a: __m128d) {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_storeu_si16(mem_addr: *mut u8, a: __m128i) {
     ptr::write_unaligned(mem_addr as *mut i16, simd_extract(a.as_i16x8(), 0))
 }
@@ -2607,7 +2607,7 @@ pub unsafe fn _mm_storeu_si16(mem_addr: *mut u8, a: __m128i) {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_storeu_si32(mem_addr: *mut u8, a: __m128i) {
     ptr::write_unaligned(mem_addr as *mut i32, simd_extract(a.as_i32x4(), 0))
 }
@@ -2619,7 +2619,7 @@ pub unsafe fn _mm_storeu_si32(mem_addr: *mut u8, a: __m128i) {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_storeu_si64)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_storeu_si64(mem_addr: *mut u8, a: __m128i) {
     ptr::write_unaligned(mem_addr as *mut i64, simd_extract(a.as_i64x2(), 0))
 }
@@ -2756,7 +2756,7 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> __m128d {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_loadu_si16(mem_addr: *const u8) -> __m128i {
     transmute(i16x8::new(
         ptr::read_unaligned(mem_addr as *const i16),
@@ -2777,7 +2777,7 @@ pub unsafe fn _mm_loadu_si16(mem_addr: *const u8) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_loadu_si32(mem_addr: *const u8) -> __m128i {
     transmute(i32x4::new(
         ptr::read_unaligned(mem_addr as *const i32),

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -1150,7 +1150,7 @@ pub unsafe fn _mm_test_mix_ones_zeros(a: __m128i, mask: __m128i) -> i32 {
 #[inline]
 #[target_feature(enable = "sse,sse4.1")]
 #[cfg_attr(test, assert_instr(movntdqa))]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_stream_load_si128(mem_addr: *const __m128i) -> __m128i {
     let dst: __m128i;
     crate::arch::asm!(

--- a/crates/core_arch/src/x86/sse4a.rs
+++ b/crates/core_arch/src/x86/sse4a.rs
@@ -52,7 +52,7 @@ pub unsafe fn _mm_extract_si64(x: __m128i, y: __m128i) -> __m128i {
 #[target_feature(enable = "sse4a")]
 #[cfg_attr(test, assert_instr(extrq, LEN = 5, IDX = 5))]
 #[rustc_legacy_const_generics(1, 2)]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_extracti_si64<const LEN: i32, const IDX: i32>(x: __m128i) -> __m128i {
     // LLVM mentions that it is UB if these are not satisfied
     static_assert_uimm_bits!(LEN, 6);
@@ -88,7 +88,7 @@ pub unsafe fn _mm_insert_si64(x: __m128i, y: __m128i) -> __m128i {
 #[target_feature(enable = "sse4a")]
 #[cfg_attr(test, assert_instr(insertq, LEN = 5, IDX = 5))]
 #[rustc_legacy_const_generics(2, 3)]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_inserti_si64<const LEN: i32, const IDX: i32>(x: __m128i, y: __m128i) -> __m128i {
     // LLVM mentions that it is UB if these are not satisfied
     static_assert_uimm_bits!(LEN, 6);

--- a/crates/core_arch/src/x86/tbm.rs
+++ b/crates/core_arch/src/x86/tbm.rs
@@ -29,7 +29,7 @@ extern "C" {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(bextr, CONTROL = 0x0404))]
 #[rustc_legacy_const_generics(1)]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _bextri_u32<const CONTROL: u32>(a: u32) -> u32 {
     static_assert_uimm_bits!(CONTROL, 16);
     unsafe { bextri_u32(a, CONTROL) }

--- a/crates/core_arch/src/x86_64/tbm.rs
+++ b/crates/core_arch/src/x86_64/tbm.rs
@@ -29,7 +29,7 @@ extern "C" {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(bextr, CONTROL = 0x0404))]
 #[rustc_legacy_const_generics(1)]
-#[unstable(feature = "simd_x86_updates", issue = "126936")]
+#[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _bextri_u64<const CONTROL: u64>(a: u64) -> u64 {
     static_assert_uimm_bits!(CONTROL, 16);
     unsafe { bextri_u64(a, CONTROL) }


### PR DESCRIPTION
As per the FCP in rust-lang/rust#126936, this PR stabilizes the 13 new intrinsics. 