### PR TITLE
Move Wasm's relaxed SIMD to Rust v1.82

### DIFF
--- a/crates/core_arch/src/wasm32/mod.rs
+++ b/crates/core_arch/src/wasm32/mod.rs
@@ -12,7 +12,7 @@ mod simd128;
 pub use self::simd128::*;
 
 mod relaxed_simd;
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use self::relaxed_simd::*;
 
 mod memory;

--- a/crates/core_arch/src/wasm32/relaxed_simd.rs
+++ b/crates/core_arch/src/wasm32/relaxed_simd.rs
@@ -68,12 +68,12 @@ extern "C" {
 #[cfg_attr(test, assert_instr(i8x16.relaxed_swizzle))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i8x16.relaxed_swizzle"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i8x16_relaxed_swizzle(a: v128, s: v128) -> v128 {
     unsafe { llvm_relaxed_swizzle(a.as_i8x16(), s.as_i8x16()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i8x16_relaxed_swizzle as u8x16_relaxed_swizzle;
 
 /// A relaxed version of `i32x4_trunc_sat_f32x4(a)` converts the `f32` lanes
@@ -85,7 +85,7 @@ pub use i8x16_relaxed_swizzle as u8x16_relaxed_swizzle;
 #[cfg_attr(test, assert_instr(i32x4.relaxed_trunc_f32x4_s))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i32x4.relaxed_trunc_f32x4_s"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i32x4_relaxed_trunc_f32x4(a: v128) -> v128 {
     unsafe { llvm_relaxed_trunc_signed(a.as_f32x4()).v128() }
 }
@@ -99,7 +99,7 @@ pub fn i32x4_relaxed_trunc_f32x4(a: v128) -> v128 {
 #[cfg_attr(test, assert_instr(i32x4.relaxed_trunc_f32x4_u))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i32x4.relaxed_trunc_f32x4_u"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn u32x4_relaxed_trunc_f32x4(a: v128) -> v128 {
     unsafe { llvm_relaxed_trunc_unsigned(a.as_f32x4()).v128() }
 }
@@ -113,7 +113,7 @@ pub fn u32x4_relaxed_trunc_f32x4(a: v128) -> v128 {
 #[cfg_attr(test, assert_instr(i32x4.relaxed_trunc_f64x2_s_zero))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i32x4.relaxed_trunc_f64x2_s_zero"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i32x4_relaxed_trunc_f64x2_zero(a: v128) -> v128 {
     unsafe { llvm_relaxed_trunc_signed_zero(a.as_f64x2()).v128() }
 }
@@ -127,7 +127,7 @@ pub fn i32x4_relaxed_trunc_f64x2_zero(a: v128) -> v128 {
 #[cfg_attr(test, assert_instr(i32x4.relaxed_trunc_f64x2_u_zero))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i32x4.relaxed_trunc_f64x2_u_zero"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn u32x4_relaxed_trunc_f64x2_zero(a: v128) -> v128 {
     unsafe { llvm_relaxed_trunc_unsigned_zero(a.as_f64x2()).v128() }
 }
@@ -137,7 +137,7 @@ pub fn u32x4_relaxed_trunc_f64x2_zero(a: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f32x4.relaxed_madd))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f32x4.relaxed_madd"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f32x4_relaxed_madd(a: v128, b: v128, c: v128) -> v128 {
     unsafe { llvm_f32x4_fma(a.as_f32x4(), b.as_f32x4(), c.as_f32x4()).v128() }
 }
@@ -147,7 +147,7 @@ pub fn f32x4_relaxed_madd(a: v128, b: v128, c: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f32x4.relaxed_nmadd))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f32x4.relaxed_nmadd"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f32x4_relaxed_nmadd(a: v128, b: v128, c: v128) -> v128 {
     unsafe { llvm_f32x4_fms(a.as_f32x4(), b.as_f32x4(), c.as_f32x4()).v128() }
 }
@@ -157,7 +157,7 @@ pub fn f32x4_relaxed_nmadd(a: v128, b: v128, c: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f64x2.relaxed_madd))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f64x2.relaxed_madd"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f64x2_relaxed_madd(a: v128, b: v128, c: v128) -> v128 {
     unsafe { llvm_f64x2_fma(a.as_f64x2(), b.as_f64x2(), c.as_f64x2()).v128() }
 }
@@ -167,7 +167,7 @@ pub fn f64x2_relaxed_madd(a: v128, b: v128, c: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f64x2.relaxed_nmadd))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f64x2.relaxed_nmadd"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f64x2_relaxed_nmadd(a: v128, b: v128, c: v128) -> v128 {
     unsafe { llvm_f64x2_fms(a.as_f64x2(), b.as_f64x2(), c.as_f64x2()).v128() }
 }
@@ -183,12 +183,12 @@ pub fn f64x2_relaxed_nmadd(a: v128, b: v128, c: v128) -> v128 {
 #[cfg_attr(test, assert_instr(i8x16.relaxed_laneselect))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i8x16.relaxed_laneselect"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i8x16_relaxed_laneselect(a: v128, b: v128, m: v128) -> v128 {
     unsafe { llvm_i8x16_laneselect(a.as_i8x16(), b.as_i8x16(), m.as_i8x16()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i8x16_relaxed_laneselect as u8x16_relaxed_laneselect;
 
 /// A relaxed version of `v128_bitselect` where this either behaves the same as
@@ -202,12 +202,12 @@ pub use i8x16_relaxed_laneselect as u8x16_relaxed_laneselect;
 #[cfg_attr(test, assert_instr(i16x8.relaxed_laneselect))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i16x8.relaxed_laneselect"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i16x8_relaxed_laneselect(a: v128, b: v128, m: v128) -> v128 {
     unsafe { llvm_i16x8_laneselect(a.as_i16x8(), b.as_i16x8(), m.as_i16x8()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i16x8_relaxed_laneselect as u16x8_relaxed_laneselect;
 
 /// A relaxed version of `v128_bitselect` where this either behaves the same as
@@ -221,12 +221,12 @@ pub use i16x8_relaxed_laneselect as u16x8_relaxed_laneselect;
 #[cfg_attr(test, assert_instr(i32x4.relaxed_laneselect))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i32x4.relaxed_laneselect"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i32x4_relaxed_laneselect(a: v128, b: v128, m: v128) -> v128 {
     unsafe { llvm_i32x4_laneselect(a.as_i32x4(), b.as_i32x4(), m.as_i32x4()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i32x4_relaxed_laneselect as u32x4_relaxed_laneselect;
 
 /// A relaxed version of `v128_bitselect` where this either behaves the same as
@@ -240,12 +240,12 @@ pub use i32x4_relaxed_laneselect as u32x4_relaxed_laneselect;
 #[cfg_attr(test, assert_instr(i64x2.relaxed_laneselect))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i64x2.relaxed_laneselect"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i64x2_relaxed_laneselect(a: v128, b: v128, m: v128) -> v128 {
     unsafe { llvm_i64x2_laneselect(a.as_i64x2(), b.as_i64x2(), m.as_i64x2()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i64x2_relaxed_laneselect as u64x2_relaxed_laneselect;
 
 /// A relaxed version of `f32x4_min` which is either `f32x4_min` or
@@ -254,7 +254,7 @@ pub use i64x2_relaxed_laneselect as u64x2_relaxed_laneselect;
 #[cfg_attr(test, assert_instr(f32x4.relaxed_min))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f32x4.relaxed_min"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f32x4_relaxed_min(a: v128, b: v128) -> v128 {
     unsafe { llvm_f32x4_relaxed_min(a.as_f32x4(), b.as_f32x4()).v128() }
 }
@@ -265,7 +265,7 @@ pub fn f32x4_relaxed_min(a: v128, b: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f32x4.relaxed_max))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f32x4.relaxed_max"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f32x4_relaxed_max(a: v128, b: v128) -> v128 {
     unsafe { llvm_f32x4_relaxed_max(a.as_f32x4(), b.as_f32x4()).v128() }
 }
@@ -276,7 +276,7 @@ pub fn f32x4_relaxed_max(a: v128, b: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f64x2.relaxed_min))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f64x2.relaxed_min"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f64x2_relaxed_min(a: v128, b: v128) -> v128 {
     unsafe { llvm_f64x2_relaxed_min(a.as_f64x2(), b.as_f64x2()).v128() }
 }
@@ -287,7 +287,7 @@ pub fn f64x2_relaxed_min(a: v128, b: v128) -> v128 {
 #[cfg_attr(test, assert_instr(f64x2.relaxed_max))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("f64x2.relaxed_max"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn f64x2_relaxed_max(a: v128, b: v128) -> v128 {
     unsafe { llvm_f64x2_relaxed_max(a.as_f64x2(), b.as_f64x2()).v128() }
 }
@@ -298,12 +298,12 @@ pub fn f64x2_relaxed_max(a: v128, b: v128) -> v128 {
 #[cfg_attr(test, assert_instr(i16x8.relaxed_q15mulr_s))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i16x8.relaxed_q15mulr_s"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i16x8_relaxed_q15mulr(a: v128, b: v128) -> v128 {
     unsafe { llvm_relaxed_q15mulr_signed(a.as_i16x8(), b.as_i16x8()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i16x8_relaxed_q15mulr as u16x8_relaxed_q15mulr;
 
 /// A relaxed dot-product instruction.
@@ -321,12 +321,12 @@ pub use i16x8_relaxed_q15mulr as u16x8_relaxed_q15mulr;
 #[cfg_attr(test, assert_instr(i16x8.relaxed_dot_i8x16_i7x16_s))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i16x8.relaxed_dot_i8x16_i7x16_s"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i16x8_relaxed_dot_i8x16_i7x16(a: v128, b: v128) -> v128 {
     unsafe { llvm_i16x8_relaxed_dot_i8x16_i7x16_s(a.as_i8x16(), b.as_i8x16()).v128() }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i16x8_relaxed_dot_i8x16_i7x16 as u16x8_relaxed_dot_i8x16_i7x16;
 
 /// Similar to [`i16x8_relaxed_dot_i8x16_i7x16`] except that the intermediate
@@ -336,14 +336,14 @@ pub use i16x8_relaxed_dot_i8x16_i7x16 as u16x8_relaxed_dot_i8x16_i7x16;
 #[cfg_attr(test, assert_instr(i32x4.relaxed_dot_i8x16_i7x16_add_s))]
 #[target_feature(enable = "relaxed-simd")]
 #[doc(alias("i32x4.relaxed_dot_i8x16_i7x16_add_s"))]
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub fn i32x4_relaxed_dot_i8x16_i7x16_add(a: v128, b: v128, c: v128) -> v128 {
     unsafe {
         llvm_i32x4_relaxed_dot_i8x16_i7x16_add_s(a.as_i8x16(), b.as_i8x16(), c.as_i32x4()).v128()
     }
 }
 
-#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.81.0")]
+#[stable(feature = "stdarch_wasm_relaxed_simd", since = "1.82.0")]
 pub use i32x4_relaxed_dot_i8x16_i7x16_add as u32x4_relaxed_dot_i8x16_i7x16_add;
 
 #[cfg(test)]


### PR DESCRIPTION
This moves the stabilization of Wasm's relaxed SIMD to Rust v1.82.

Related https://github.com/rust-lang/rust/pull/117468.
Thanks @sayantn for pointing this out in https://github.com/rust-lang/rust/pull/117468#issuecomment-2241656878.