### PR TITLE
Fix markdown list in docs

### DIFF
--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2920,9 +2920,8 @@ pub unsafe fn _mm_undefined_si128() -> __m128i {
 /// The resulting `__m128d` element is composed by the low-order values of
 /// the two `__m128d` interleaved input elements, i.e.:
 ///
-/// * The `[127:64]` bits are copied from the `[127:64]` bits of the second
-/// input * The `[63:0]` bits are copied from the `[127:64]` bits of the first
-/// input
+/// * The `[127:64]` bits are copied from the `[127:64]` bits of the second input
+/// * The `[63:0]` bits are copied from the `[127:64]` bits of the first input
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_unpackhi_pd)
 #[inline]


### PR DESCRIPTION
I stumbled upon this while [reading the docs](https://doc.rust-lang.org/beta/core/arch/x86/fn._mm_unpackhi_pd.html).