### PR TITLE
Fix `_mm_stream_si64`

### DIFF
--- a/crates/core_arch/src/x86_64/macros.rs
+++ b/crates/core_arch/src/x86_64/macros.rs
@@ -20,3 +20,16 @@ macro_rules! static_assert_sae {
         static_assert!($imm == 4 || $imm == 8, "Invalid IMM value")
     };
 }
+
+#[cfg(target_pointer_width = "32")]
+macro_rules! vps {
+    ($inst1:expr, $inst2:expr) => {
+        concat!($inst1, " [{p:e}]", $inst2)
+    };
+}
+#[cfg(target_pointer_width = "64")]
+macro_rules! vps {
+    ($inst1:expr, $inst2:expr) => {
+        concat!($inst1, " [{p}]", $inst2)
+    };
+}

--- a/crates/core_arch/src/x86_64/sse2.rs
+++ b/crates/core_arch/src/x86_64/sse2.rs
@@ -79,7 +79,7 @@ pub unsafe fn _mm_cvttsd_si64x(a: __m128d) -> i64 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_stream_si64(mem_addr: *mut i64, a: i64) {
     crate::arch::asm!(
-        "movnti [{p}], {a}",
+        vps!("movnti", ",{a}"),
         p = in(reg) mem_addr,
         a = in(reg) a,
         options(nostack, preserves_flags),


### PR DESCRIPTION
Fixes #1541 by using `vps!`. This bypassed all CI tests because this only shows up for `gnux32` target. https://github.com/rust-lang/rust/pull/128608#issuecomment-2267099257