### PR TITLE
 Use full path to refer `simd_shuffle` intrinsic from `simd_shuffle!` macro

### DIFF
--- a/crates/core_arch/src/arm/dsp.rs
+++ b/crates/core_arch/src/arm/dsp.rs
@@ -23,7 +23,6 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-use crate::intrinsics::simd::simd_shuffle;
 use crate::mem::transmute;
 
 types! {

--- a/crates/core_arch/src/arm/simd32.rs
+++ b/crates/core_arch/src/arm/simd32.rs
@@ -65,7 +65,6 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-use crate::intrinsics::simd::simd_shuffle;
 use crate::{core_arch::arm::dsp::int16x2_t, mem::transmute};
 
 types! {

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -31,7 +31,6 @@
     rtm_target_feature,
     allow_internal_unstable,
     decl_macro,
-    asm_const,
     target_feature_11,
     generic_arg_infer,
     asm_experimental_arch,

--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -117,7 +117,7 @@ macro_rules! types {
 #[allow(unused)]
 macro_rules! simd_shuffle {
     ($x:expr, $y:expr, $idx:expr $(,)?) => {{
-        simd_shuffle::<_, [u32; _], _>($x, $y, const { $idx })
+        $crate::intrinsics::simd::simd_shuffle::<_, [u32; _], _>($x, $y, const { $idx })
     }};
 }
 

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -9,7 +9,6 @@
 #![allow(non_camel_case_types)]
 
 use crate::core_arch::powerpc::*;
-use crate::intrinsics::simd::*;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/simd.rs
+++ b/crates/core_arch/src/simd.rs
@@ -2,8 +2,6 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::intrinsics::simd::simd_shuffle;
-
 macro_rules! simd_ty {
     ($id:ident [$elem_type:ty ; $len:literal]: $($param_name:ident),*) => {
         #[repr(simd)]

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -19,7 +19,7 @@
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
 use crate::core_arch::x86::*;
-use crate::intrinsics::simd::{simd_fma, simd_insert, simd_neg, simd_shuffle};
+use crate::intrinsics::simd::{simd_fma, simd_insert, simd_neg};
 use crate::intrinsics::{fmaf32, fmaf64};
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -1,6 +1,5 @@
 //! `x86` and `x86_64` intrinsics.
 
-use crate::intrinsics::simd::simd_shuffle;
 #[allow(unused_imports)]
 use crate::marker::Sized;
 use crate::mem::transmute;


### PR DESCRIPTION
Avoids needing to import `crate::intrinsics::simd::simd_shuffle` in each file where `simd_shuffle!` is used and fixes loongarch64.