### PR TITLE
simd_extract, simd_insert: use absolute path in macro

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -132,16 +132,16 @@ macro_rules! simd_shuffle {
 #[allow(unused)]
 macro_rules! simd_insert {
     ($x:expr, $idx:expr, $val:expr $(,)?) => {{
-        simd_insert($x, const { $idx }, $val)
+        $crate::intrinsics::simd::simd_insert($x, const { $idx }, $val)
     }};
 }
 
 #[allow(unused)]
 macro_rules! simd_extract {
     ($x:expr, $idx:expr $(,)?) => {{
-        simd_extract($x, const { $idx })
+        $crate::intrinsics::simd::simd_extract($x, const { $idx })
     }};
     ($x:expr, $idx:expr, $ty:ty $(,)?) => {{
-        simd_extract::<_, $ty>($x, const { $idx })
+        $crate::intrinsics::simd::simd_extract::<_, $ty>($x, const { $idx })
     }};
 }

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -19,7 +19,7 @@
 //! [wiki_fma]: https://en.wikipedia.org/wiki/Fused_multiply-accumulate
 
 use crate::core_arch::x86::*;
-use crate::intrinsics::simd::{simd_fma, simd_insert, simd_neg};
+use crate::intrinsics::simd::{simd_fma, simd_neg};
 use crate::intrinsics::{fmaf32, fmaf64};
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86_64/avx.rs
+++ b/crates/core_arch/src/x86_64/avx.rs
@@ -13,7 +13,7 @@
 //! [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
 //! [wiki]: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
 
-use crate::{core_arch::x86::*, intrinsics::simd::*, mem::transmute};
+use crate::{core_arch::x86::*, mem::transmute};
 
 /// Copies `a` to result, and insert the 64-bit integer `i` into result
 /// at the location specified by `index`.

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -1,6 +1,5 @@
 use crate::{
     core_arch::{simd::*, x86::*, x86_64::*},
-    intrinsics::simd::*,
     mem::transmute,
 };
 

--- a/crates/core_arch/src/x86_64/sse2.rs
+++ b/crates/core_arch/src/x86_64/sse2.rs
@@ -1,6 +1,6 @@
 //! `x86_64`'s Streaming SIMD Extensions 2 (SSE2)
 
-use crate::{core_arch::x86::*, intrinsics::simd::*};
+use crate::core_arch::x86::*;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;

--- a/crates/core_arch/src/x86_64/sse41.rs
+++ b/crates/core_arch/src/x86_64/sse41.rs
@@ -1,6 +1,6 @@
 //! `i686`'s Streaming SIMD Extensions 4.1 (SSE4.1)
 
-use crate::{core_arch::x86::*, intrinsics::simd::*, mem::transmute};
+use crate::{core_arch::x86::*, mem::transmute};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;


### PR DESCRIPTION
https://github.com/rust-lang/stdarch/pull/1630 did this for simd_shuffle, let's also do this for the other macros. Macros depending on imports in the modules where they are used is not a good style.