### PR TITLE
std_detect: Add sme-b16b16 as an explicit aarch64 target feature

### DIFF
--- a/crates/std_detect/src/detect/arch/aarch64.rs
+++ b/crates/std_detect/src/detect/arch/aarch64.rs
@@ -62,6 +62,7 @@ features! {
     /// * `"sha3"` - FEAT_SHA512 & FEAT_SHA3
     /// * `"sm4"` - FEAT_SM3 & FEAT_SM4
     /// * `"sme"` - FEAT_SME
+    /// * `"sme-b16b16"` - FEAT_SME_B16B16
     /// * `"sme-f16f16"` - FEAT_SME_F16F16
     /// * `"sme-f64f64"` - FEAT_SME_F64F64
     /// * `"sme-f8f16"` - FEAT_SME_F8F16
@@ -76,7 +77,7 @@ features! {
     /// * `"ssve-fp8dot4"` - FEAT_SSVE_FP8DOT4
     /// * `"ssve-fp8fma"` - FEAT_SSVE_FP8FMA
     /// * `"sve"` - FEAT_SVE
-    /// * `"sve-b16b16"` - FEAT_SVE_B16B16
+    /// * `"sve-b16b16"` - FEAT_SVE_B16B16 (SVE or SME Z-targeting instructions)
     /// * `"sve2"` - FEAT_SVE2
     /// * `"sve2-aes"` - FEAT_SVE_AES & FEAT_SVE_PMULL128 (SVE2 AES crypto)
     /// * `"sve2-bitperm"` - FEAT_SVE2_BitPerm
@@ -207,6 +208,8 @@ features! {
     /// FEAT_SME2 (SME Version 2)
     @FEATURE: #[unstable(feature = "stdarch_aarch64_feature_detection", issue = "127764")] sme2p1: "sme2p1";
     /// FEAT_SME2p1 (SME Version 2.1)
+    @FEATURE: #[unstable(feature = "stdarch_aarch64_feature_detection", issue = "127764")] sme_b16b16: "sme-b16b16";
+    /// FEAT_SME_B16B16
     @FEATURE: #[unstable(feature = "stdarch_aarch64_feature_detection", issue = "127764")] sme_f16f16: "sme-f16f16";
     /// FEAT_SME_F16F16 (Non-widening half-precision FP16 to FP16 arithmetic for SME2)
     @FEATURE: #[unstable(feature = "stdarch_aarch64_feature_detection", issue = "127764")] sme_f64f64: "sme-f64f64";
@@ -238,7 +241,7 @@ features! {
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sve2_aes: "sve2-aes";
     /// FEAT_SVE_AES & FEAT_SVE_PMULL128 (SVE2 AES crypto)
     @FEATURE: #[unstable(feature = "stdarch_aarch64_feature_detection", issue = "127764")] sve_b16b16: "sve-b16b16";
-    /// FEAT_SVE_B16B16 (SVE or SME Instructions)
+    /// FEAT_SVE_B16B16 (SVE or SME Z-targeting instructions)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sve2_bitperm: "sve2-bitperm";
     /// FEAT_SVE_BitPerm (SVE2 bit permutation instructions)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] sve2_sha3: "sve2-sha3";

--- a/crates/std_detect/src/detect/os/linux/aarch64.rs
+++ b/crates/std_detect/src/detect/os/linux/aarch64.rs
@@ -469,11 +469,7 @@ impl AtHwcap {
                 self.svesha3 && sve2 && self.sha512 && self.sha3 && self.sha1 && self.sha2,
             );
             enable_feature(Feature::sve2_bitperm, self.svebitperm && self.sve2);
-            // SVE_B16B16 can be implemented either for SVE or SME
-            enable_feature(
-                Feature::sve_b16b16,
-                self.bf16 && (self.sveb16b16 || self.smeb16b16),
-            );
+            enable_feature(Feature::sve_b16b16, self.bf16 && self.sveb16b16);
             enable_feature(Feature::hbc, self.hbc);
             enable_feature(Feature::mops, self.mops);
             enable_feature(Feature::ecv, self.ecv);
@@ -497,6 +493,10 @@ impl AtHwcap {
             let sme2 = self.sme2 && sme;
             enable_feature(Feature::sme2, sme2);
             enable_feature(Feature::sme2p1, self.sme2p1 && sme2);
+            enable_feature(
+                Feature::sme_b16b16,
+                sme2 && self.bf16 && self.sveb16b16 && self.smeb16b16,
+            );
             enable_feature(Feature::sme_f16f16, self.smef16f16 && sme2);
             enable_feature(Feature::sme_lutv2, self.smelutv2);
             let sme_f8f32 = self.smef8f32 && sme2 && fp8;

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -122,6 +122,7 @@ fn aarch64_linux() {
     println!("fp8dot2: {}", is_aarch64_feature_detected!("fp8dot2"));
     println!("wfxt: {}", is_aarch64_feature_detected!("wfxt"));
     println!("sme: {}", is_aarch64_feature_detected!("sme"));
+    println!("sme-b16b16: {}", is_aarch64_feature_detected!("sme-b16b16"));
     println!("sme-i16i64: {}", is_aarch64_feature_detected!("sme-i16i64"));
     println!("sme-f64f64: {}", is_aarch64_feature_detected!("sme-f64f64"));
     println!("sme-fa64: {}", is_aarch64_feature_detected!("sme-fa64"));


### PR DESCRIPTION
LLVM 20 split out what used to be called b16b16 and correspond to aarch64 FEAT_SVE_B16B16 into sve-b16b16 and sme-b16b16.
Add sme-b16b16 as an explicit feature and update the detection accordingly.