### PR TITLE
Enable Aarch64 feature detection on all Apple/Darwin targets

### DIFF
--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -66,8 +66,8 @@ cfg_if! {
     } else if #[cfg(all(target_os = "windows", any(target_arch = "aarch64", target_arch = "arm64ec")))] {
         #[path = "os/windows/aarch64.rs"]
         mod os;
-    } else if #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "libc"))] {
-        #[path = "os/macos/aarch64.rs"]
+    } else if #[cfg(all(target_vendor = "apple", target_arch = "aarch64", feature = "libc"))] {
+        #[path = "os/darwin/aarch64.rs"]
         mod os;
     } else {
         #[path = "os/other.rs"]

--- a/crates/std_detect/src/detect/os/darwin/aarch64.rs
+++ b/crates/std_detect/src/detect/os/darwin/aarch64.rs
@@ -1,4 +1,6 @@
-//! Run-time feature detection for aarch64 on macOS.
+//! Run-time feature detection for aarch64 on Darwin (macOS/iOS/tvOS/watchOS/visionOS).
+//!
+//! <https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_instruction_set_characteristics>
 
 use crate::detect::{cache, Feature};
 

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -188,8 +188,8 @@ fn aarch64_bsd() {
 }
 
 #[test]
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-fn aarch64_macos() {
+#[cfg(all(target_arch = "aarch64", target_vendor = "apple"))]
+fn aarch64_darwin() {
     println!("asimd: {:?}", is_aarch64_feature_detected!("asimd"));
     println!("fp: {:?}", is_aarch64_feature_detected!("fp"));
     println!("fp16: {:?}", is_aarch64_feature_detected!("fp16"));

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -74,8 +74,8 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
     let me = env::current_exe().expect("failed to get current exe");
 
     let objdump = env::var("OBJDUMP").unwrap_or_else(|_| "objdump".to_string());
-    let add_args = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
-        // Target features need to be enabled for LLVM objdump on Macos ARM64
+    let add_args = if cfg!(target_vendor = "apple") && cfg!(target_arch = "aarch64") {
+        // Target features need to be enabled for LLVM objdump on Darwin ARM64
         vec!["--mattr=+v8.6a,+crypto,+tme"]
     } else if cfg!(target_arch = "riscv64") {
         vec!["--mattr=+zk,+zks,+zbc,+zbb"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -43,10 +43,10 @@ resolved/implemented on Fuchsia. Could one of you weigh in please?
 Thanks!
 """
 
-[ping.macos]
+[ping.apple]
+alias = ["macos", "ios", "tvos", "watchos", "visionos"]
 message = """\
-Hey MacOS Group! This issue or PR could use some MacOS-specific guidance. Could
+Hey Apple Group! This issue or PR could use some Darwin-specific guidance. Could
 one of you weigh in please?
 Thanks!
 """
-


### PR DESCRIPTION
This was originally added in https://github.com/rust-lang/stdarch/pull/1516.

I have tested this in the simulator and on the device I had lying around, a 1st generation iPad Mini (which isn't Aarch64, but shows that the `sysctlbyname` calls still work even there, even if they return false).

`sysctlbyname` _should_ be safe to use without causing rejections from the app store, as its usage is documented in:
https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_instruction_set_characteristics

Also, the standard library will use `sysctl` soon anyhow, see https://github.com/rust-lang/rust/pull/129019, so _if_ the standard library starts getting rejected by Apple, it won't be entirely `stdarch`'s fault.