### PR TITLE
Add Mac Catalyst to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,10 +144,15 @@ jobs:
           os: ubuntu-latest
         - target: aarch64-apple-darwin
           os: macos-latest
-          norun: true
+          norun: true # https://github.com/rust-lang/stdarch/issues/1206
+        - target: aarch64-apple-ios-macabi
+          os: macos-latest
+          norun: true # https://github.com/rust-lang/stdarch/issues/1206
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-latest
         - target: x86_64-apple-darwin
+          os: macos-13
+        - target: x86_64-apple-ios-macabi
           os: macos-13
         - target: x86_64-pc-windows-msvc
           os: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,11 +185,6 @@ jobs:
         rustup default nightly
     - run: rustup target add ${{ matrix.target }}
       if: "!endsWith(matrix.target, 'emulated')"
-    - name: Setup (aarch64-apple-darwin)
-      run: |
-        echo "SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)" >> $GITHUB_ENV
-        echo "MACOS_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)" >> $GITHUB_ENV
-      if: matrix.target == 'aarch64-apple-darwin'
     - run: cargo generate-lockfile
 
     # Configure some env vars based on matrix configuration


### PR DESCRIPTION
Currently `NORUN=1` like `aarch64-apple-darwin`, that should change after https://github.com/rust-lang/stdarch/issues/1206.