### PR TITLE
std_detect: Fix link in mips.rs

### DIFF
--- a/crates/std_detect/src/detect/os/linux/mips.rs
+++ b/crates/std_detect/src/detect/os/linux/mips.rs
@@ -15,7 +15,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
     // The values are part of the platform-specific [asm/hwcap.h][hwcap]
     //
-    // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/arm64/include/uapi/asm/hwcap.h
+    // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/mips/include/uapi/asm/hwcap.h
     if let Ok(auxv) = auxvec::auxv() {
         enable_feature(&mut value, Feature::msa, bit::test(auxv.hwcap, 1));
         return value;


### PR DESCRIPTION

https://github.com/rust-lang/stdarch/blob/b1edbf90955cb9b057a323f761e2c19edb591e6f/crates/std_detect/src/detect/os/linux/mips.rs#L18

This currently refers arm64 hwcap.h, but this file is for mips. (The values that used in this file is correct and just a link is wrong.)