### PR TITLE
std_detect: Use elf_aux_info on FreeBSD

### DIFF
--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -228,8 +228,11 @@ fn powerpc_linux() {
 }
 
 #[test]
-#[cfg(all(target_arch = "powerpc64", target_os = "linux"))]
-fn powerpc64_linux() {
+#[cfg(all(
+    target_arch = "powerpc64",
+    any(target_os = "linux", target_os = "freebsd"),
+))]
+fn powerpc64_linux_or_freebsd() {
     println!("altivec: {}", is_powerpc64_feature_detected!("altivec"));
     println!("vsx: {}", is_powerpc64_feature_detected!("vsx"));
     println!("power8: {}", is_powerpc64_feature_detected!("power8"));


### PR DESCRIPTION
[elf_aux_info](https://man.freebsd.org/elf_aux_info(3)) is a function that does the equivalent of our current sysctl-based archauxv, available in on FreeBSD 12.0+ (https://github.com/freebsd/freebsd-src/commit/0b08ae2120cdd08c20a2b806e2fcef4d0a36c470) and 11.4+ (backport by https://github.com/freebsd/freebsd-src/commit/03444a7d439755189e4dc8ccd56403bbaef3d6b0).

FreeBSD 11 support in std has been removed in Rust 1.75 (https://github.com/rust-lang/rust/pull/114521), so we can safely use this function.

(By the way, not directly related to this PR, but OpenBSD will provide the same function in the next release (7.6): https://github.com/openbsd/src/commit/ef873df06dac50249b2dd380dc6100eee3b0d23d)

Tested on powerpc64/powerpc64le FreeBSD 14.