### PR TITLE
Add all crates to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,8 @@
 [workspace]
 resolver = "1"
 members = [
-  "crates/stdarch-verify",
-  "crates/core_arch",
-  "crates/std_detect",
-  "crates/stdarch-gen-arm",
-  "crates/stdarch-gen-loongarch",
-  "crates/intrinsic-test",
-  "examples/"
-]
-exclude = [
-  "crates/wasm-assert-instr-tests"
+  "crates/*",
+  "examples"
 ]
 
 [profile.release]

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -29,3 +29,8 @@ syscalls = { version = "0.6.18", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = {level = "warn", check-cfg = ['cfg(stdarch_intel_sde)'] }
+
+[lints.clippy]
+too_long_first_doc_paragraph = "allow"
+missing_transmute_annotations = "allow"
+useless_transmute = "allow"


### PR DESCRIPTION
I am not certain why some crates are missing - it might be by accident or on purpose, so feel free to reject.  This makes sure no crate is missed by accident, and also removed the non-existent `wasm-assert-instr-tests` crate.

P.S. Also, added some crate-level lints, but perhaps these should be added to all crates in the workspace?