### PR TITLE
std_detect: Add pauth-lr aarch64 target feature

### DIFF
--- a/crates/std_detect/src/detect/arch/aarch64.rs
+++ b/crates/std_detect/src/detect/arch/aarch64.rs
@@ -51,6 +51,7 @@ features! {
     /// * `"mte"` - FEAT_MTE & FEAT_MTE2
     /// * `"paca"` - FEAT_PAuth (address authentication)
     /// * `"pacg"` - FEAT_Pauth (generic authentication)
+    /// * `"pauth-lr"` - FEAT_PAuth_LR
     /// * `"pmull"` - FEAT_PMULL
     /// * `"rand"` - FEAT_RNG
     /// * `"rcpc"` - FEAT_LRCPC
@@ -184,6 +185,8 @@ features! {
     /// FEAT_PAuth (address authentication)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] pacg: "pacg";
     /// FEAT_PAuth (generic authentication)
+    @FEATURE: #[unstable(feature = "stdarch_aarch64_feature_detection", issue = "127764")] pauth_lr: "pauth-lr";
+    /// FEAT_PAuth_LR
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] rand: "rand";
     /// FEAT_RNG (Random Number Generator)
     @FEATURE: #[stable(feature = "simd_aarch64", since = "1.60.0")] rcpc: "rcpc";

--- a/crates/std_detect/src/detect/os/linux/aarch64.rs
+++ b/crates/std_detect/src/detect/os/linux/aarch64.rs
@@ -140,6 +140,7 @@ struct AtHwcap {
     smesf8fma: bool,
     smesf8dp4: bool,
     smesf8dp2: bool,
+    // pauthlr: bool,
 }
 
 impl From<auxvec::AuxVec> for AtHwcap {
@@ -243,6 +244,7 @@ impl From<auxvec::AuxVec> for AtHwcap {
             smesf8fma: bit::test(auxv.hwcap2, 60),
             smesf8dp4: bit::test(auxv.hwcap2, 61),
             smesf8dp2: bit::test(auxv.hwcap2, 62),
+            // pauthlr: bit::test(auxv.hwcap2, ??),
         }
     }
 }
@@ -353,6 +355,7 @@ impl From<super::cpuinfo::CpuInfo> for AtHwcap {
             smesf8fma: f.has("smesf8fma"),
             smesf8dp4: f.has("smesf8dp4"),
             smesf8dp2: f.has("smesf8dp2"),
+            // pauthlr: f.has("pauthlr"),
         }
     }
 }
@@ -413,6 +416,7 @@ impl AtHwcap {
             enable_feature(Feature::sb, self.sb);
             enable_feature(Feature::paca, self.paca);
             enable_feature(Feature::pacg, self.pacg);
+            // enable_feature(Feature::pauth_lr, self.pauthlr);
             enable_feature(Feature::dpb, self.dcpop);
             enable_feature(Feature::dpb2, self.dcpodp);
             enable_feature(Feature::rand, self.rng);

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -83,6 +83,7 @@ fn aarch64_linux() {
     println!("sb: {}", is_aarch64_feature_detected!("sb"));
     println!("paca: {}", is_aarch64_feature_detected!("paca"));
     println!("pacg: {}", is_aarch64_feature_detected!("pacg"));
+    // println!("pauth-lr: {}", is_aarch64_feature_detected!("pauth-lr"));
     println!("dpb: {}", is_aarch64_feature_detected!("dpb"));
     println!("dpb2: {}", is_aarch64_feature_detected!("dpb2"));
     println!("sve-b16b16: {}", is_aarch64_feature_detected!("sve-b16b16"));


### PR DESCRIPTION
Add feature detection for aarch64 FEAT_PAuth_LR.
There is currently no Linux cpuinfo support so the OS-specific lines are commented out.