### PR TITLE
cleanup wasm const fn

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -73,10 +73,6 @@
         stdarch_loongarch_feature_detection
     )
 )]
-#![cfg_attr(
-    any(target_arch = "wasm32", target_arch = "wasm64", doc),
-    feature(wasm_simd_const_internals)
-)]
 
 #[cfg(test)]
 #[macro_use]

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -51,8 +51,6 @@ macro_rules! conversions {
         $(
             impl $ty {
                 #[inline(always)]
-                // FIXME remove next line when const-stability v2 migration is done
-                #[rustc_const_unstable(feature = "wasm_simd_const_internals", issue = "none")]
                 pub(crate) const fn v128(self) -> v128 {
                     unsafe { mem::transmute(self) }
                 }
@@ -665,7 +663,6 @@ pub unsafe fn v128_store64_lane<const L: usize>(v: v128, m: *mut u64) {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn i8x16(
     a0: i8,
     a1: i8,
@@ -698,7 +695,6 @@ pub const fn i8x16(
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn u8x16(
     a0: u8,
     a1: u8,
@@ -745,7 +741,6 @@ pub const fn u8x16(
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn i16x8(a0: i16, a1: i16, a2: i16, a3: i16, a4: i16, a5: i16, a6: i16, a7: i16) -> v128 {
     simd::i16x8::new(a0, a1, a2, a3, a4, a5, a6, a7).v128()
 }
@@ -758,7 +753,6 @@ pub const fn i16x8(a0: i16, a1: i16, a2: i16, a3: i16, a4: i16, a5: i16, a6: i16
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn u16x8(a0: u16, a1: u16, a2: u16, a3: u16, a4: u16, a5: u16, a6: u16, a7: u16) -> v128 {
     simd::u16x8::new(a0, a1, a2, a3, a4, a5, a6, a7).v128()
 }
@@ -772,7 +766,6 @@ pub const fn u16x8(a0: u16, a1: u16, a2: u16, a3: u16, a4: u16, a5: u16, a6: u16
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn i32x4(a0: i32, a1: i32, a2: i32, a3: i32) -> v128 {
     simd::i32x4::new(a0, a1, a2, a3).v128()
 }
@@ -785,7 +778,6 @@ pub const fn i32x4(a0: i32, a1: i32, a2: i32, a3: i32) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn u32x4(a0: u32, a1: u32, a2: u32, a3: u32) -> v128 {
     simd::u32x4::new(a0, a1, a2, a3).v128()
 }
@@ -799,7 +791,6 @@ pub const fn u32x4(a0: u32, a1: u32, a2: u32, a3: u32) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn i64x2(a0: i64, a1: i64) -> v128 {
     simd::i64x2::new(a0, a1).v128()
 }
@@ -812,7 +803,6 @@ pub const fn i64x2(a0: i64, a1: i64) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn u64x2(a0: u64, a1: u64) -> v128 {
     simd::u64x2::new(a0, a1).v128()
 }
@@ -826,7 +816,6 @@ pub const fn u64x2(a0: u64, a1: u64) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd_const", since = "1.56.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn f32x4(a0: f32, a1: f32, a2: f32, a3: f32) -> v128 {
     simd::f32x4::new(a0, a1, a2, a3).v128()
 }
@@ -840,7 +829,6 @@ pub const fn f32x4(a0: f32, a1: f32, a2: f32, a3: f32) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd_const", since = "1.56.0")]
-#[rustc_allow_const_fn_unstable(wasm_simd_const_internals)] // FIXME remove when const-stability v2 migration is done
 pub const fn f64x2(a0: f64, a1: f64) -> v128 {
     simd::f64x2::new(a0, a1).v128()
 }


### PR DESCRIPTION
We shouldn't need these feature gates any more, that was just an attempt at a transition that didn't quite work out.