### PR TITLE
Use C-unwind abi for the llvm.wasm.throw intrinsic

### DIFF
--- a/crates/core_arch/src/wasm32/mod.rs
+++ b/crates/core_arch/src/wasm32/mod.rs
@@ -32,7 +32,7 @@ pub fn unreachable() -> ! {
     crate::intrinsics::abort()
 }
 
-extern "C" {
+extern "C-unwind" {
     #[link_name = "llvm.wasm.throw"]
     fn wasm_throw(tag: i32, ptr: *mut u8) -> !;
 }


### PR DESCRIPTION
Discovered in rust-lang/rust#132416. Before, it was outputting a `nounwind` attribute on `unwind::wasm::_Unwind_RaiseException`, which was definitely incorrect.