### PR TITLE
ci: add debug testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        profile:
+        - dev
+        - release
         target:
         # Dockers that are run through docker on linux
         - i686-unknown-linux-gnu
@@ -192,6 +195,8 @@ jobs:
     - run: cargo generate-lockfile
 
     # Configure some env vars based on matrix configuration
+    - run: echo "PROFILE=--profile=${{matrix.profile}}" >> $GITHUB_ENV
+      shell: bash
     - run: echo "NORUN=1" >> $GITHUB_ENV
       shell: bash
       if: matrix.norun != '' || startsWith(matrix.target, 'thumb') || matrix.target == 'nvptx64-nvidia-cuda'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
   test:
     needs: [style]
     name: Test
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     strategy:
       matrix:
         profile:
@@ -73,114 +73,122 @@ jobs:
         - release
         target:
         # Dockers that are run through docker on linux
-        - i686-unknown-linux-gnu
-        - x86_64-unknown-linux-gnu
-        - x86_64-unknown-linux-gnu-emulated
-        - arm-unknown-linux-gnueabihf
-        - armv7-unknown-linux-gnueabihf
-        - aarch64-unknown-linux-gnu
-        - riscv64gc-unknown-linux-gnu
-        - powerpc64le-unknown-linux-gnu
+        - tuple: i686-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: x86_64-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: x86_64-unknown-linux-gnu-emulated
+          os: ubuntu-latest
+        - tuple: arm-unknown-linux-gnueabihf
+          os: ubuntu-latest
+        - tuple: armv7-unknown-linux-gnueabihf
+          os: ubuntu-latest
+        - tuple: aarch64-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: riscv64gc-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: powerpc64le-unknown-linux-gnu
+          os: ubuntu-latest
         # MIPS targets disabled since they are dropped to tier 3.
         # See https://github.com/rust-lang/compiler-team/issues/648
-        #- mips-unknown-linux-gnu
-        #- mips64-unknown-linux-gnuabi64
-        #- mips64el-unknown-linux-gnuabi64
-        #- mipsel-unknown-linux-musl
-        - s390x-unknown-linux-gnu
-        - wasm32-wasip1
-        - i586-unknown-linux-gnu
-        - nvptx64-nvidia-cuda
-        - thumbv6m-none-eabi
-        - thumbv7m-none-eabi
-        - thumbv7em-none-eabi
-        - thumbv7em-none-eabihf
-        - loongarch64-unknown-linux-gnu
+        #- tuple: mips-unknown-linux-gnu
+        #  os: ubuntu-latest
+        #- tuple: mips64-unknown-linux-gnuabi64
+        #  os: ubuntu-latest
+        #- tuple: mips64el-unknown-linux-gnuabi64
+        #  os: ubuntu-latest
+        #- tuple: mipsel-unknown-linux-musl
+        #  os: ubuntu-latest
+        - tuple: s390x-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: i586-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: nvptx64-nvidia-cuda
+          os: ubuntu-latest
+        - tuple: thumbv6m-none-eabi
+          os: ubuntu-latest
+        - tuple: thumbv7m-none-eabi
+          os: ubuntu-latest
+        - tuple: thumbv7em-none-eabi
+          os: ubuntu-latest
+        - tuple: thumbv7em-none-eabihf
+          os: ubuntu-latest
+        - tuple: loongarch64-unknown-linux-gnu
+          os: ubuntu-latest
+        - tuple: wasm32-wasip1
+          os: ubuntu-latest
 
         # macOS targets
-        - x86_64-apple-darwin
-        - aarch64-apple-darwin
+        - tuple: x86_64-apple-darwin
+          os: macos-13
+        - tuple: x86_64-apple-ios-macabi
+          os: macos-13
+        - tuple: aarch64-apple-darwin
+          os: macos-latest
+        - tuple: aarch64-apple-ios-macabi
+          os: macos-latest
         # FIXME: gh-actions build environment doesn't have linker support
-        # - i686-apple-darwin
+        # - tuple: i686-apple-darwin
+        #   os: macos-13
 
         # Windows targets
-        - x86_64-pc-windows-msvc
-        - i686-pc-windows-msvc
-        - aarch64-pc-windows-msvc
-        - x86_64-pc-windows-gnu
-        # - i686-pc-windows-gnu:
+        - tuple: x86_64-pc-windows-msvc
+          os: windows-latest
+        - tuple: i686-pc-windows-msvc
+          os: windows-latest
+        - tuple: aarch64-pc-windows-msvc
+          os: windows-latest
+        - tuple: x86_64-pc-windows-gnu
+          os: windows-latest
+        # - tuple: i686-pc-windows-gnu
+        #   os: windows-latest
 
+        # Add additional variables to the matrix variations generated above using `include`:
         include:
-        - target: i686-unknown-linux-gnu
-          os: ubuntu-latest
-        - target: x86_64-unknown-linux-gnu
-          os: ubuntu-latest
-        - target: x86_64-unknown-linux-gnu-emulated
-          os: ubuntu-latest
+        - target:
+            tuple: x86_64-unknown-linux-gnu-emulated
+            os: ubuntu-latest
           test_everything: true
           rustflags: --cfg stdarch_intel_sde
-        - target: arm-unknown-linux-gnueabihf
-          os: ubuntu-latest
-        - target: armv7-unknown-linux-gnueabihf
-          os: ubuntu-latest
         # MIPS targets disabled since they are dropped to tier 3.
         # See https://github.com/rust-lang/compiler-team/issues/648
-        #- target: mips-unknown-linux-gnu
-        #  os: ubuntu-latest
+        #- target:
+        #    tuple: mips-unknown-linux-gnu
+        #    os: ubuntu-latest
         #  norun: true
-        #- target: mips64-unknown-linux-gnuabi64
-        #  os: ubuntu-latest
+        #- target:
+        #    tuple: mips64-unknown-linux-gnuabi64
+        #    os: ubuntu-latest
         #  norun: true
-        #- target: mips64el-unknown-linux-gnuabi64
-        #  os: ubuntu-latest
+        #- target:
+        #    tuple: mips64el-unknown-linux-gnuabi64
+        #    os: ubuntu-latest
         #  norun: true
-        #- target: mipsel-unknown-linux-musl
-        #  os: ubuntu-latest
-        #  norun: 1
-        - target: powerpc64le-unknown-linux-gnu
-          os: ubuntu-latest
+        #- target:
+        #    tuple: mipsel-unknown-linux-musl
+        #    os: ubuntu-latest
+        #  norun: true
+        - target:
+            tuple: powerpc64le-unknown-linux-gnu
+            os: ubuntu-latest
           disable_assert_instr: true
-        - target: s390x-unknown-linux-gnu
-          os: ubuntu-latest
-        - target: wasm32-wasip1
-          os: ubuntu-latest
-        - target: aarch64-apple-darwin
-          os: macos-latest
+        - target:
+            tuple: aarch64-apple-darwin
+            os: macos-latest
           norun: true # https://github.com/rust-lang/stdarch/issues/1206
-        - target: aarch64-apple-ios-macabi
-          os: macos-latest
+        - target:
+            tuple: aarch64-apple-ios-macabi
+            os: macos-latest
           norun: true # https://github.com/rust-lang/stdarch/issues/1206
-        - target: aarch64-unknown-linux-gnu
-          os: ubuntu-latest
-        - target: x86_64-apple-darwin
-          os: macos-13
-        - target: x86_64-apple-ios-macabi
-          os: macos-13
-        - target: x86_64-pc-windows-msvc
-          os: windows-latest
-        - target: i686-pc-windows-msvc
-          os: windows-latest
-        - target: aarch64-pc-windows-msvc
-          os: windows-latest
+        - target:
+            tuple: aarch64-pc-windows-msvc
+            os: windows-latest
           norun: true
-        - target: x86_64-pc-windows-gnu
-          os: windows-latest
-        - target: i586-unknown-linux-gnu
-          os: ubuntu-latest
-        - target: nvptx64-nvidia-cuda
-          os: ubuntu-latest
-        - target: thumbv6m-none-eabi
-          os: ubuntu-latest
-        - target: thumbv7m-none-eabi
-          os: ubuntu-latest
-        - target: thumbv7em-none-eabi
-          os: ubuntu-latest
-        - target: thumbv7em-none-eabihf
-          os: ubuntu-latest
-        - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
-        - target: loongarch64-unknown-linux-gnu
-          os: ubuntu-latest
+        - target:
+            tuple: x86_64-pc-windows-msvc
+            os: windows-latest
+          profile: dev
+          norun: true # FIXME: why doesn't this work in debug mode?
 
     steps:
     - uses: actions/checkout@v4
@@ -190,8 +198,8 @@ jobs:
       run: |
         rustup update nightly --no-self-update
         rustup default nightly
-    - run: rustup target add ${{ matrix.target }}
-      if: "!endsWith(matrix.target, 'emulated')"
+    - run: rustup target add ${{ matrix.target.tuple }}
+      if: "!endsWith(matrix.target.tuple, 'emulated')"
     - run: cargo generate-lockfile
 
     # Configure some env vars based on matrix configuration
@@ -199,7 +207,7 @@ jobs:
       shell: bash
     - run: echo "NORUN=1" >> $GITHUB_ENV
       shell: bash
-      if: matrix.norun != '' || startsWith(matrix.target, 'thumb') || matrix.target == 'nvptx64-nvidia-cuda'
+      if: matrix.norun != '' || startsWith(matrix.target.tuple, 'thumb') || matrix.target.tuple == 'nvptx64-nvidia-cuda'
     - run: echo "STDARCH_TEST_EVERYTHING=1" >> $GITHUB_ENV
       shell: bash
       if: matrix.test_everything != ''
@@ -211,21 +219,21 @@ jobs:
       if: matrix.disable_assert_instr != ''
     - run: echo "NOSTD=1" >> $GITHUB_ENV
       shell: bash
-      if: startsWith(matrix.target, 'thumb') || matrix.target == 'nvptx64-nvidia-cuda'
+      if: startsWith(matrix.target.tuple, 'thumb') || matrix.target.tuple == 'nvptx64-nvidia-cuda'
 
     # Windows & OSX go straight to `run.sh` ...
     - run: ./ci/run.sh
       shell: bash
-      if: matrix.os != 'ubuntu-latest' || startsWith(matrix.target, 'thumb')
+      if: matrix.target.os != 'ubuntu-latest' || startsWith(matrix.target.tuple, 'thumb')
       env:
-        TARGET: ${{ matrix.target }}
+        TARGET: ${{ matrix.target.tuple }}
 
     # ... while Linux goes to `run-docker.sh`
-    - run: ./ci/run-docker.sh ${{ matrix.target }}
+    - run: ./ci/run-docker.sh ${{ matrix.target.tuple }}
       shell: bash
-      if: "matrix.os == 'ubuntu-latest' && !startsWith(matrix.target, 'thumb')"
+      if: "matrix.target.os == 'ubuntu-latest' && !startsWith(matrix.target.tuple, 'thumb')"
       env:
-        TARGET: ${{ matrix.target }}
+        TARGET: ${{ matrix.target.tuple }}
 
   build-std-detect:
     needs: [style]

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,6 +12,7 @@ set -ex
 
 export RUSTFLAGS="${RUSTFLAGS} -D warnings -Z merge-functions=disabled "
 export HOST_RUSTFLAGS="${RUSTFLAGS}"
+export PROFILE="${PROFILE:="--profile=release"}"
 
 export STDARCH_DISABLE_DEDUP_GUARD=1
 
@@ -63,6 +64,7 @@ echo "FEATURES=${FEATURES}"
 echo "OBJDUMP=${OBJDUMP}"
 echo "STDARCH_DISABLE_ASSERT_INSTR=${STDARCH_DISABLE_ASSERT_INSTR}"
 echo "STDARCH_TEST_EVERYTHING=${STDARCH_TEST_EVERYTHING}"
+echo "PROFILE=${PROFILE}"
 
 cargo_test() {
     cmd="cargo"
@@ -101,19 +103,17 @@ STD_DETECT="--manifest-path=crates/std_detect/Cargo.toml"
 STDARCH_EXAMPLES="--manifest-path=examples/Cargo.toml"
 INTRINSIC_TEST="--manifest-path=crates/intrinsic-test/Cargo.toml"
 
-cargo_test "${CORE_ARCH} --release"
+cargo_test "${CORE_ARCH} ${PROFILE}"
 
 if [ "$NOSTD" != "1" ]; then
-    cargo_test "${STD_DETECT}"
-    cargo_test "${STD_DETECT} --release"
+    cargo_test "${STD_DETECT} ${PROFILE}"
 
     cargo_test "${STD_DETECT} --no-default-features"
     cargo_test "${STD_DETECT} --no-default-features --features=std_detect_file_io"
     cargo_test "${STD_DETECT} --no-default-features --features=std_detect_dlsym_getauxval"
     cargo_test "${STD_DETECT} --no-default-features --features=std_detect_dlsym_getauxval,std_detect_file_io"
 
-    cargo_test "${STDARCH_EXAMPLES}"
-    cargo_test "${STDARCH_EXAMPLES} --release"
+    cargo_test "${STDARCH_EXAMPLES} ${PROFILE}"
 fi
 
 # Test targets compiled with extra features.
@@ -121,26 +121,26 @@ case ${TARGET} in
     x86*)
         export STDARCH_DISABLE_ASSERT_INSTR=1
         export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+avx"
-        cargo_test "--release"
+        cargo_test "${PROFILE}"
         ;;
     # FIXME: don't build anymore
     #mips-*gnu* | mipsel-*gnu*)
     #    export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+msa,+fp64,+mips32r5"
-    #    cargo_test "--release"
+    #    cargo_test "${PROFILE}"
 	  #    ;;
     mips64*)
         export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+msa"
-        cargo_test "--release"
+        cargo_test "${PROFILE}"
 	      ;;
     powerpc64*)
         # We don't build the ppc 32-bit targets with these - these targets
         # are mostly unsupported for now.
         OLD_RUSTFLAGS="${RUSTFLAGS}"
         export RUSTFLAGS="${OLD_RUSTFLAGS} -C target-feature=+altivec"
-        cargo_test "--release"
+        cargo_test "${PROFILE}"
 
         export RUSTFLAGS="${OLD_RUSTFLAGS} -C target-feature=+vsx"
-        cargo_test "--release"
+        cargo_test "${PROFILE}"
         ;;
     *)
         ;;
@@ -152,14 +152,14 @@ if [ "${TARGET}" = "aarch64-unknown-linux-gnu" ]; then
         CPPFLAGS="-fuse-ld=lld -I/usr/aarch64-linux-gnu/include/ -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu/" \
             RUSTFLAGS="$HOST_RUSTFLAGS" \
             RUST_LOG=warn \
-            cargo run ${INTRINSIC_TEST} --release --bin intrinsic-test -- intrinsics_data/arm_intrinsics.json --runner "${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER}" --cppcompiler "clang++-15" --skip crates/intrinsic-test/missing_aarch64.txt
+            cargo run ${INTRINSIC_TEST} "${PROFILE}" --bin intrinsic-test -- intrinsics_data/arm_intrinsics.json --runner "${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER}" --cppcompiler "clang++-15" --skip crates/intrinsic-test/missing_aarch64.txt
     )
 elif [ "${TARGET}" = "armv7-unknown-linux-gnueabihf" ]; then
     (
         CPPFLAGS="-fuse-ld=lld -I/usr/arm-linux-gnueabihf/include/ -I/usr/arm-linux-gnueabihf/include/c++/9/arm-linux-gnueabihf/" \
             RUSTFLAGS="$HOST_RUSTFLAGS" \
             RUST_LOG=warn \
-            cargo run ${INTRINSIC_TEST} --release --bin intrinsic-test -- intrinsics_data/arm_intrinsics.json --runner "${CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER}" --cppcompiler "clang++-15" --skip crates/intrinsic-test/missing_arm.txt --a32
+            cargo run ${INTRINSIC_TEST} "${PROFILE}" --bin intrinsic-test -- intrinsics_data/arm_intrinsics.json --runner "${CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER}" --cppcompiler "clang++-15" --skip crates/intrinsic-test/missing_arm.txt --a32
     )
 fi
 
@@ -167,7 +167,7 @@ if [ "$NORUN" != "1" ] && [ "$NOSTD" != 1 ]; then
     # Test examples
     (
         cd examples
-        cargo test --target "$TARGET"
-        echo test | cargo run --target "$TARGET" --release hex
+        cargo test --target "$TARGET" "${PROFILE}"
+        echo test | cargo run --target "$TARGET" "${PROFILE}" hex
     )
 fi


### PR DESCRIPTION
Previous changes in Rust and LLVM have caused stdarch to be broken in debug (e.g. like those fixed in earlier PRs such as rust-lang/stdarch#1503) - this PR adds debug builds to the CI so that these breakages can be caught earlier.