### PR TITLE
remove test --skip that references a long-closed issue

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -75,10 +75,10 @@ cargo_test() {
     cmd="$cmd ${subcmd} --target=$TARGET $1"
     cmd="$cmd -- $2"
 
-    # wasm targets can't catch panics so if a test failures make sure the test
-    # harness isn't trying to capture output, otherwise we won't get any useful
-    # output.
     case ${TARGET} in
+        # wasm targets can't catch panics so if a test failures make sure the test
+        # harness isn't trying to capture output, otherwise we won't get any useful
+        # output.
         wasm32*)
             cmd="$cmd --nocapture"
             ;;

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -86,10 +86,6 @@ cargo_test() {
         powerpc64*)
             cmd="$cmd --skip test_vec_lde_u16 --skip test_vec_lde_u32 --skip test_vec_expte"
             ;;
-        # Miscompilation: https://github.com/rust-lang/rust/issues/112460
-        arm*)
-            cmd="$cmd --skip vld2q_dup_f32"
-            ;;
     esac
 
     if [ "$SKIP_TESTS" != "" ]; then


### PR DESCRIPTION
Looks like this was forgotten to be re-enabled when https://github.com/rust-lang/rust/issues/112460 was fixed