### PR TITLE
Fix RISC-V Packed SIMD intrinsics compilation

### DIFF
--- a/crates/core_arch/src/riscv_shared/p.rs
+++ b/crates/core_arch/src/riscv_shared/p.rs
@@ -2,9 +2,22 @@
 //!
 //! RV64 only part is placed in riscv64 folder.
 use crate::arch::asm;
+#[cfg(test)]
+use stdarch_test::assert_instr;
+
+// FIXME: Currently the P extension is still unratified, so there is no support
+// for it in the upstream LLVM for now, and thus no LLVM built-in functions or
+// serialization of instructions are provided.
+//
+// We add `assert_instr(unknown)` to each function so that we can at least make
+// sure they compile. Since there is no serialization yet, we can only write
+// "unknown" here, so that if LLVM upstream provides support for the P extension
+// at some point in the future, we can know in time and then update our
+// implementation.
 
 /// Adds packed 16-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn add16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -16,6 +29,7 @@ pub fn add16(a: usize, b: usize) -> usize {
 
 /// Halves the sum of packed 16-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn radd16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -27,6 +41,7 @@ pub fn radd16(a: usize, b: usize) -> usize {
 
 /// Halves the sum of packed 16-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn uradd16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -38,6 +53,7 @@ pub fn uradd16(a: usize, b: usize) -> usize {
 
 /// Adds packed 16-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kadd16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -49,6 +65,7 @@ pub fn kadd16(a: usize, b: usize) -> usize {
 
 /// Adds packed 16-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukadd16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -60,6 +77,7 @@ pub fn ukadd16(a: usize, b: usize) -> usize {
 
 /// Subtracts packed 16-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sub16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -71,6 +89,7 @@ pub fn sub16(a: usize, b: usize) -> usize {
 
 /// Halves the subtraction result of packed 16-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn rsub16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -82,6 +101,7 @@ pub fn rsub16(a: usize, b: usize) -> usize {
 
 /// Halves the subtraction result of packed 16-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ursub16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -93,6 +113,7 @@ pub fn ursub16(a: usize, b: usize) -> usize {
 
 /// Subtracts packed 16-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ksub16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -104,6 +125,7 @@ pub fn ksub16(a: usize, b: usize) -> usize {
 
 /// Subtracts packed 16-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn uksub16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -115,6 +137,7 @@ pub fn uksub16(a: usize, b: usize) -> usize {
 
 /// Cross adds and subtracts packed 16-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn cras16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -126,6 +149,7 @@ pub fn cras16(a: usize, b: usize) -> usize {
 
 /// Cross halves of adds and subtracts packed 16-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn rcras16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -137,6 +161,7 @@ pub fn rcras16(a: usize, b: usize) -> usize {
 
 /// Cross halves of adds and subtracts packed 16-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn urcras16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -148,6 +173,7 @@ pub fn urcras16(a: usize, b: usize) -> usize {
 
 /// Cross adds and subtracts packed 16-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kcras16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -159,6 +185,7 @@ pub fn kcras16(a: usize, b: usize) -> usize {
 
 /// Cross adds and subtracts packed 16-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukcras16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -170,6 +197,7 @@ pub fn ukcras16(a: usize, b: usize) -> usize {
 
 /// Cross subtracts and adds packed 16-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn crsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -181,6 +209,7 @@ pub fn crsa16(a: usize, b: usize) -> usize {
 
 /// Cross halves of subtracts and adds packed 16-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn rcrsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -192,6 +221,7 @@ pub fn rcrsa16(a: usize, b: usize) -> usize {
 
 /// Cross halves of subtracts and adds packed 16-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn urcrsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -203,6 +233,7 @@ pub fn urcrsa16(a: usize, b: usize) -> usize {
 
 /// Cross subtracts and adds packed 16-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kcrsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -214,6 +245,7 @@ pub fn kcrsa16(a: usize, b: usize) -> usize {
 
 /// Cross subtracts and adds packed 16-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukcrsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -225,6 +257,7 @@ pub fn ukcrsa16(a: usize, b: usize) -> usize {
 
 /// Straight adds and subtracts packed 16-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn stas16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -236,6 +269,7 @@ pub fn stas16(a: usize, b: usize) -> usize {
 
 /// Straight halves of adds and subtracts packed 16-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn rstas16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -247,6 +281,7 @@ pub fn rstas16(a: usize, b: usize) -> usize {
 
 /// Straight halves of adds and subtracts packed 16-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn urstas16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -258,6 +293,7 @@ pub fn urstas16(a: usize, b: usize) -> usize {
 
 /// Straight adds and subtracts packed 16-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kstas16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -269,6 +305,7 @@ pub fn kstas16(a: usize, b: usize) -> usize {
 
 /// Straight adds and subtracts packed 16-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukstas16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -280,6 +317,7 @@ pub fn ukstas16(a: usize, b: usize) -> usize {
 
 /// Straight subtracts and adds packed 16-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn stsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -291,6 +329,7 @@ pub fn stsa16(a: usize, b: usize) -> usize {
 
 /// Straight halves of subtracts and adds packed 16-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn rstsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -302,6 +341,7 @@ pub fn rstsa16(a: usize, b: usize) -> usize {
 
 /// Straight halves of subtracts and adds packed 16-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn urstsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -313,6 +353,7 @@ pub fn urstsa16(a: usize, b: usize) -> usize {
 
 /// Straight subtracts and adds packed 16-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kstsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -324,6 +365,7 @@ pub fn kstsa16(a: usize, b: usize) -> usize {
 
 /// Straight subtracts and adds packed 16-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukstsa16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -335,6 +377,7 @@ pub fn ukstsa16(a: usize, b: usize) -> usize {
 
 /// Adds packed 8-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn add8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -346,6 +389,7 @@ pub fn add8(a: usize, b: usize) -> usize {
 
 /// Halves the sum of packed 8-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn radd8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -357,6 +401,7 @@ pub fn radd8(a: usize, b: usize) -> usize {
 
 /// Halves the sum of packed 8-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn uradd8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -368,6 +413,7 @@ pub fn uradd8(a: usize, b: usize) -> usize {
 
 /// Adds packed 8-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kadd8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -379,6 +425,7 @@ pub fn kadd8(a: usize, b: usize) -> usize {
 
 /// Adds packed 8-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukadd8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -390,6 +437,7 @@ pub fn ukadd8(a: usize, b: usize) -> usize {
 
 /// Subtracts packed 8-bit signed numbers, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sub8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -401,6 +449,7 @@ pub fn sub8(a: usize, b: usize) -> usize {
 
 /// Halves the subtraction result of packed 8-bit signed numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn rsub8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -412,6 +461,7 @@ pub fn rsub8(a: usize, b: usize) -> usize {
 
 /// Halves the subtraction result of packed 8-bit unsigned numbers, dropping least bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ursub8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -423,6 +473,7 @@ pub fn ursub8(a: usize, b: usize) -> usize {
 
 /// Subtracts packed 8-bit signed numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ksub8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -434,6 +485,7 @@ pub fn ksub8(a: usize, b: usize) -> usize {
 
 /// Subtracts packed 8-bit unsigned numbers, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn uksub8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -445,6 +497,7 @@ pub fn uksub8(a: usize, b: usize) -> usize {
 
 /// Arithmetic right shift packed 16-bit elements without rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sra16(a: usize, b: u32) -> usize {
     let value: usize;
@@ -456,6 +509,7 @@ pub fn sra16(a: usize, b: u32) -> usize {
 
 /// Arithmetic right shift packed 16-bit elements with rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sra16u(a: usize, b: u32) -> usize {
     let value: usize;
@@ -467,6 +521,7 @@ pub fn sra16u(a: usize, b: u32) -> usize {
 
 /// Logical right shift packed 16-bit elements without rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn srl16(a: usize, b: u32) -> usize {
     let value: usize;
@@ -478,6 +533,7 @@ pub fn srl16(a: usize, b: u32) -> usize {
 
 /// Logical right shift packed 16-bit elements with rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn srl16u(a: usize, b: u32) -> usize {
     let value: usize;
@@ -489,6 +545,7 @@ pub fn srl16u(a: usize, b: u32) -> usize {
 
 /// Logical left shift packed 16-bit elements, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sll16(a: usize, b: u32) -> usize {
     let value: usize;
@@ -500,6 +557,7 @@ pub fn sll16(a: usize, b: u32) -> usize {
 
 /// Logical left shift packed 16-bit elements, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ksll16(a: usize, b: u32) -> usize {
     let value: usize;
@@ -511,6 +569,7 @@ pub fn ksll16(a: usize, b: u32) -> usize {
 
 /// Logical saturating left then arithmetic right shift packed 16-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kslra16(a: usize, b: i32) -> usize {
     let value: usize;
@@ -522,6 +581,7 @@ pub fn kslra16(a: usize, b: i32) -> usize {
 
 /// Logical saturating left then arithmetic right shift packed 16-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kslra16u(a: usize, b: i32) -> usize {
     let value: usize;
@@ -533,6 +593,7 @@ pub fn kslra16u(a: usize, b: i32) -> usize {
 
 /// Arithmetic right shift packed 8-bit elements without rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sra8(a: usize, b: u32) -> usize {
     let value: usize;
@@ -544,6 +605,7 @@ pub fn sra8(a: usize, b: u32) -> usize {
 
 /// Arithmetic right shift packed 8-bit elements with rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sra8u(a: usize, b: u32) -> usize {
     let value: usize;
@@ -555,6 +617,7 @@ pub fn sra8u(a: usize, b: u32) -> usize {
 
 /// Logical right shift packed 8-bit elements without rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn srl8(a: usize, b: u32) -> usize {
     let value: usize;
@@ -566,6 +629,7 @@ pub fn srl8(a: usize, b: u32) -> usize {
 
 /// Logical right shift packed 8-bit elements with rounding up
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn srl8u(a: usize, b: u32) -> usize {
     let value: usize;
@@ -577,6 +641,7 @@ pub fn srl8u(a: usize, b: u32) -> usize {
 
 /// Logical left shift packed 8-bit elements, discarding overflow bits
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sll8(a: usize, b: u32) -> usize {
     let value: usize;
@@ -588,6 +653,7 @@ pub fn sll8(a: usize, b: u32) -> usize {
 
 /// Logical left shift packed 8-bit elements, saturating at the numeric bounds
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ksll8(a: usize, b: u32) -> usize {
     let value: usize;
@@ -599,6 +665,7 @@ pub fn ksll8(a: usize, b: u32) -> usize {
 
 /// Logical saturating left then arithmetic right shift packed 8-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kslra8(a: usize, b: i32) -> usize {
     let value: usize;
@@ -610,6 +677,7 @@ pub fn kslra8(a: usize, b: i32) -> usize {
 
 /// Logical saturating left then arithmetic right shift packed 8-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kslra8u(a: usize, b: i32) -> usize {
     let value: usize;
@@ -621,6 +689,7 @@ pub fn kslra8u(a: usize, b: i32) -> usize {
 
 /// Compare equality for packed 16-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn cmpeq16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -632,6 +701,7 @@ pub fn cmpeq16(a: usize, b: usize) -> usize {
 
 /// Compare whether 16-bit packed signed integers are less than the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn scmplt16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -643,6 +713,7 @@ pub fn scmplt16(a: usize, b: usize) -> usize {
 
 /// Compare whether 16-bit packed signed integers are less than or equal to the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn scmple16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -654,6 +725,7 @@ pub fn scmple16(a: usize, b: usize) -> usize {
 
 /// Compare whether 16-bit packed unsigned integers are less than the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ucmplt16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -665,6 +737,7 @@ pub fn ucmplt16(a: usize, b: usize) -> usize {
 
 /// Compare whether 16-bit packed unsigned integers are less than or equal to the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ucmple16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -676,6 +749,7 @@ pub fn ucmple16(a: usize, b: usize) -> usize {
 
 /// Compare equality for packed 8-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn cmpeq8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -687,6 +761,7 @@ pub fn cmpeq8(a: usize, b: usize) -> usize {
 
 /// Compare whether 8-bit packed signed integers are less than the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn scmplt8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -698,6 +773,7 @@ pub fn scmplt8(a: usize, b: usize) -> usize {
 
 /// Compare whether 8-bit packed signed integers are less than or equal to the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn scmple8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -709,6 +785,7 @@ pub fn scmple8(a: usize, b: usize) -> usize {
 
 /// Compare whether 8-bit packed unsigned integers are less than the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ucmplt8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -720,6 +797,7 @@ pub fn ucmplt8(a: usize, b: usize) -> usize {
 
 /// Compare whether 8-bit packed unsigned integers are less than or equal to the others
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ucmple8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -731,6 +809,7 @@ pub fn ucmple8(a: usize, b: usize) -> usize {
 
 /// Get minimum values from 16-bit packed signed integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn smin16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -742,6 +821,7 @@ pub fn smin16(a: usize, b: usize) -> usize {
 
 /// Get minimum values from 16-bit packed unsigned integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn umin16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -753,6 +833,7 @@ pub fn umin16(a: usize, b: usize) -> usize {
 
 /// Get maximum values from 16-bit packed signed integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn smax16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -764,6 +845,7 @@ pub fn smax16(a: usize, b: usize) -> usize {
 
 /// Get maximum values from 16-bit packed unsigned integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn umax16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -777,39 +859,43 @@ pub fn umax16(a: usize, b: usize) -> usize {
 
 /// Compute the absolute value of packed 16-bit signed integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kabs16(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAD1", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAD1)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Count the number of redundant sign bits of the packed 16-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn clrs16(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAE8", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAE8)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Count the number of leading zero bits of the packed 16-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn clz16(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAE9", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAE9)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Swap the 16-bit halfwords within each 32-bit word of a register
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn swap16(a: usize) -> usize {
     let value: usize;
@@ -822,6 +908,7 @@ pub fn swap16(a: usize) -> usize {
 
 /// Get minimum values from 8-bit packed signed integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn smin8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -833,6 +920,7 @@ pub fn smin8(a: usize, b: usize) -> usize {
 
 /// Get minimum values from 8-bit packed unsigned integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn umin8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -844,6 +932,7 @@ pub fn umin8(a: usize, b: usize) -> usize {
 
 /// Get maximum values from 8-bit packed signed integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn smax8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -855,6 +944,7 @@ pub fn smax8(a: usize, b: usize) -> usize {
 
 /// Get maximum values from 8-bit packed unsigned integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn umax8(a: usize, b: usize) -> usize {
     let value: usize;
@@ -868,154 +958,168 @@ pub fn umax8(a: usize, b: usize) -> usize {
 
 /// Compute the absolute value of packed 8-bit signed integers
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kabs8(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAD0", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAD0)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Count the number of redundant sign bits of the packed 8-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn clrs8(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAE0", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAE0)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Count the number of leading zero bits of the packed 8-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn clz8(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAE1", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAE1)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Swap the 8-bit bytes within each 16-bit halfword of a register.
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn swap8(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAD8", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAD8)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack first and zeroth into two 16-bit signed halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sunpkd810(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAC8", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAC8)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack second and zeroth into two 16-bit signed halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sunpkd820(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAC9", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAC9)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack third and zeroth into two 16-bit signed halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sunpkd830(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xACA", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xACA)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack third and first into two 16-bit signed halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sunpkd831(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xACB", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xACB)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack third and second into two 16-bit signed halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn sunpkd832(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAD3", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAD3)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack first and zeroth into two 16-bit unsigned halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn zunpkd810(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xACC", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xACC)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack second and zeroth into two 16-bit unsigned halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn zunpkd820(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xACD", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xACD)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack third and zeroth into two 16-bit unsigned halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn zunpkd830(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xACE", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xACE)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack third and first into two 16-bit unsigned halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn zunpkd831(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xACF", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xACF)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Unpack third and second into two 16-bit unsigned halfwords in each 32-bit chunk
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn zunpkd832(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAD7", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAD7)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
@@ -1024,6 +1128,7 @@ pub fn zunpkd832(a: usize) -> usize {
 
 /// Pack two 16-bit data from bottom and top half from 32-bit chunks
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn pkbt16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -1035,6 +1140,7 @@ pub fn pkbt16(a: usize, b: usize) -> usize {
 
 /// Pack two 16-bit data from top and bottom half from 32-bit chunks
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn pktb16(a: usize, b: usize) -> usize {
     let value: usize;
@@ -1046,28 +1152,31 @@ pub fn pktb16(a: usize, b: usize) -> usize {
 
 /// Count the number of redundant sign bits of the packed 32-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn clrs32(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAF8", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAF8)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Count the number of leading zero bits of the packed 32-bit elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn clz32(a: usize) -> usize {
     let value: usize;
     unsafe {
-        asm!(".insn i 0x77, 0x0, {}, {}, 0xAF9", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
+        asm!(".insn i 0x77, 0x0, {}, {}, %lo(0xAF9)", lateout(reg) value, in(reg) a, options(pure, nomem, nostack))
     }
     value
 }
 
 /// Calculate the sum of absolute difference of unsigned 8-bit data elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn pbsad(a: usize, b: usize) -> usize {
     let value: usize;
@@ -1079,6 +1188,7 @@ pub fn pbsad(a: usize, b: usize) -> usize {
 
 /// Calculate and accumulate the sum of absolute difference of unsigned 8-bit data elements
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn pbsada(t: usize, a: usize, b: usize) -> usize {
     let mut value: usize;
@@ -1090,6 +1200,7 @@ pub fn pbsada(t: usize, a: usize, b: usize) -> usize {
 
 /// Multiply signed 8-bit elements and add 16-bit elements on results for packed 32-bit chunks
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn smaqa(t: usize, a: usize, b: usize) -> usize {
     let mut value: usize;
@@ -1101,6 +1212,7 @@ pub fn smaqa(t: usize, a: usize, b: usize) -> usize {
 
 /// Multiply unsigned 8-bit elements and add 16-bit elements on results for packed 32-bit chunks
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn umaqa(t: usize, a: usize, b: usize) -> usize {
     let mut value: usize;
@@ -1112,6 +1224,7 @@ pub fn umaqa(t: usize, a: usize, b: usize) -> usize {
 
 /// Multiply signed to unsigned 8-bit and add 16-bit elements on results for packed 32-bit chunks
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn smaqasu(t: usize, a: usize, b: usize) -> usize {
     let mut value: usize;
@@ -1123,6 +1236,7 @@ pub fn smaqasu(t: usize, a: usize, b: usize) -> usize {
 
 /// Adds signed lower 16-bit content of two registers with Q15 saturation
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn kaddh(a: usize, b: usize) -> usize {
     let value: usize;
@@ -1134,6 +1248,7 @@ pub fn kaddh(a: usize, b: usize) -> usize {
 
 /// Subtracts signed lower 16-bit content of two registers with Q15 saturation
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ksubh(a: usize, b: usize) -> usize {
     let value: usize;
@@ -1145,6 +1260,7 @@ pub fn ksubh(a: usize, b: usize) -> usize {
 
 /// Adds signed lower 16-bit content of two registers with U16 saturation
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn ukaddh(a: usize, b: usize) -> usize {
     let value: usize;
@@ -1156,6 +1272,7 @@ pub fn ukaddh(a: usize, b: usize) -> usize {
 
 /// Subtracts signed lower 16-bit content of two registers with U16 saturation
 #[inline]
+#[cfg_attr(test, assert_instr(unknown))]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn uksubh(a: usize, b: usize) -> usize {
     let value: usize;


### PR DESCRIPTION
Fixes rust-lang/rust#129593.

Currently the P extension is still unratified, so there is no support for it in the upstream LLVM for now, and thus no LLVM built-in functions or serialization of instructions are provided.

This PR implements quick fixes to some of the instructions to fix them causing compilation failures (see issue rust-lang/rust#129593). Calling it a "quick fix" because ideally we could replace all `.insn` with LLVM built-in functions in the future when LLVM supports the P extension.

This PR also adds `assert_instr(unknown)` to each function so that we can at least make sure they compile. Since there is no serialization yet, the stdout of `assert_instr` is like

```
---- core_arch::riscv_shared::p::assert_kabs16_unkno1wn stdout ----
disassembly for stdarch_test_shim_kabs16_unkno1wn: 
         0: <unknown>
         1: ret
thread 'core_arch::riscv_shared::p::assert_kabs16_unkno1wn' panicked at crates/stdarch-test/src/lib.rs:172:9:
failed to find instruction `unkno1wn` in the disassembly
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    core_arch::riscv_shared::p::assert_kabs16_unkno1wn
```

So I left "unknown" here, also with the idea that if LLVM upstream provides support for the P extension at some point in the future, we can know in time and then update our implementation.

r? @workingjubilee 
CC @Amanieu 