### PR TITLE
Fix incorrect documentation for _mm_loadu_si64 function

### DIFF
--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -2784,7 +2784,7 @@ pub unsafe fn _mm_loadu_si32(mem_addr: *const u8) -> __m128i {
     ))
 }
 
-/// Loads unaligned 16-bits of integer data from memory into new vector.
+/// Loads unaligned 64-bits of integer data from memory into new vector.
 ///
 /// `mem_addr` does not need to be aligned on any particular boundary.
 ///


### PR DESCRIPTION
The documentation incorrectly stated that the function loads 16 bits of integer data.  This commit corrects the documentation to accurately reflect that the function loads  64 bits (8 bytes) of integer data from memory into a new vector.

closes rust-lang/rust#133062
