### PR TITLE
Add numeric instructions for Wasm not available in `core`

### DIFF
--- a/crates/core_arch/src/wasm32/mod.rs
+++ b/crates/core_arch/src/wasm32/mod.rs
@@ -32,6 +32,148 @@ pub fn unreachable() -> ! {
     crate::intrinsics::abort()
 }
 
+/// Generates the [`f32.ceil`] instruction, returning the smallest integer greater than or equal to `a`.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f32::ceil()`].
+///
+/// [`std::f32::ceil()`]: https://doc.rust-lang.org/std/primitive.f32.html#method.ceil
+/// [`f32.ceil`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f32.ceil))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f32_ceil(a: f32) -> f32 {
+    unsafe { crate::intrinsics::ceilf32(a) }
+}
+
+/// Generates the [`f32.floor`] instruction, returning the largest integer less than or equal to `a`.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f32::floor()`].
+///
+/// [`std::f32::floor()`]: https://doc.rust-lang.org/std/primitive.f32.html#method.floor
+/// [`f32.floor`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f32.floor))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f32_floor(a: f32) -> f32 {
+    unsafe { crate::intrinsics::floorf32(a) }
+}
+
+/// Generates the [`f32.trunc`] instruction, roundinging to the nearest integer towards zero.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f32::trunc()`].
+///
+/// [`std::f32::trunc()`]: https://doc.rust-lang.org/std/primitive.f32.html#method.trunc
+/// [`f32.trunc`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f32.trunc))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f32_trunc(a: f32) -> f32 {
+    unsafe { crate::intrinsics::truncf32(a) }
+}
+
+/// Generates the [`f32.nearest`] instruction, roundinging to the nearest integer. Rounds half-way
+/// cases to the number with an even least significant digit.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f32::round_ties_even()`].
+///
+/// [`std::f32::round_ties_even()`]: https://doc.rust-lang.org/std/primitive.f32.html#method.round_ties_even
+/// [`f32.nearest`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f32.nearest))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f32_nearest(a: f32) -> f32 {
+    unsafe { crate::intrinsics::rintf32(a) }
+}
+
+/// Generates the [`f32.sqrt`] instruction, returning the square root of the number `a`.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f32::sqrt()`].
+///
+/// [`std::f32::sqrt()`]: https://doc.rust-lang.org/std/primitive.f32.html#method.sqrt
+/// [`f32.nearest`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f32.sqrt))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f32_sqrt(a: f32) -> f32 {
+    unsafe { crate::intrinsics::sqrtf32(a) }
+}
+
+/// Generates the [`f64.ceil`] instruction, returning the smallest integer greater than or equal to `a`.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f64::ceil()`].
+///
+/// [`std::f64::ceil()`]: https://doc.rust-lang.org/std/primitive.f64.html#method.ceil
+/// [`f64.ceil`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f64.ceil))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f64_ceil(a: f64) -> f64 {
+    unsafe { crate::intrinsics::ceilf64(a) }
+}
+
+/// Generates the [`f64.floor`] instruction, returning the largest integer less than or equal to `a`.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f64::floor()`].
+///
+/// [`std::f64::floor()`]: https://doc.rust-lang.org/std/primitive.f64.html#method.floor
+/// [`f64.floor`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f64.floor))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f64_floor(a: f64) -> f64 {
+    unsafe { crate::intrinsics::floorf64(a) }
+}
+
+/// Generates the [`f64.trunc`] instruction, roundinging to the nearest integer towards zero.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f64::trunc()`].
+///
+/// [`std::f64::trunc()`]: https://doc.rust-lang.org/std/primitive.f64.html#method.trunc
+/// [`f64.trunc`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f64.trunc))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f64_trunc(a: f64) -> f64 {
+    unsafe { crate::intrinsics::truncf64(a) }
+}
+
+/// Generates the [`f64.nearest`] instruction, roundinging to the nearest integer. Rounds half-way
+/// cases to the number with an even least significant digit.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f64::round_ties_even()`].
+///
+/// [`std::f64::round_ties_even()`]: https://doc.rust-lang.org/std/primitive.f64.html#method.round_ties_even
+/// [`f64.nearest`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f64.nearest))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f64_nearest(a: f64) -> f64 {
+    unsafe { crate::intrinsics::rintf64(a) }
+}
+
+/// Generates the [`f64.sqrt`] instruction, returning the square root of the number `a`.
+///
+/// This method is useful when targeting `no_std` and is equivalent to [`std::f64::sqrt()`].
+///
+/// [`std::f64::sqrt()`]: https://doc.rust-lang.org/std/primitive.f64.html#method.sqrt
+/// [`f64.nearest`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-numeric
+#[cfg_attr(test, assert_instr(f64.sqrt))]
+#[inline]
+#[must_use = "method returns a new number and does not mutate the original value"]
+#[unstable(feature = "wasm_numeric_instr", issue = "133908")]
+pub fn f64_sqrt(a: f64) -> f64 {
+    unsafe { crate::intrinsics::sqrtf64(a) }
+}
+
 extern "C-unwind" {
     #[link_name = "llvm.wasm.throw"]
     fn wasm_throw(tag: i32, ptr: *mut u8) -> !;


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/133908

The recently added [`wasm32v1-none` target](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32v1-none.html) comes without `std`. This has caused some `f32` and `f64` methods to not be available for this target:
- [`f32/f64::ceil()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.ceil)
- [`f32/f64::floor()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.floor)
- [`f32/f64::trunc()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.trunc) and [`f32/f64::fract()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.fract)
- [`f32/f64::round_ties_even()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.round_ties_even)
- [`f32/f64::sqrt()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.sqrt)

However, all these methods are available in Wasm via instructions that are part of Wasm v1. This PR exposes these methods as platform specific intrinsics.

It should be noted that there is a tracking issue (https://github.com/rust-lang/rust/issues/50145) for bringing [`f32/f64::sqrt()`](https://doc.rust-lang.org/1.82.0/std/primitive.f32.html#method.sqrt) to `core`, which would make adding this instruction obsolete.

I also made these functions insta-stable, is that alright? Should I make an ACP first? I'm also targetting v1.84, the release of the new [`wasm32v1-none` target](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32v1-none.html). Considering that the fork date is the 22nd, its unlikely this will make it in time.

Cc @alexcrichton.