### PR TITLE
remove rustc_allow_const_fn_unstable feature gate

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -36,8 +36,7 @@
     asm_experimental_arch,
     sha512_sm_x86,
     x86_amx_intrinsics,
-    f16,
-    rustc_allow_const_fn_unstable
+    f16
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]
 #![deny(clippy::missing_inline_in_public_items)]


### PR DESCRIPTION
It is not currently used, and given that coordinating unstable feature changes with a submodule is painful, it'd be better if we wouldn't use it in the future either. :)  (At least until https://github.com/rust-lang/stdarch/issues/1655 is resolved.)