### PR TITLE
wasm: Add missing `#[target_feature]` to simd ctors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,8 +103,8 @@ jobs:
         # Temporarily disabled due to fallout from SIMD ABI checking.
         #- tuple: loongarch64-unknown-linux-gnu
         #  os: ubuntu-latest
-        #- tuple: wasm32-wasip1
-        #  os: ubuntu-latest
+        - tuple: wasm32-wasip1
+          os: ubuntu-latest
 
         # macOS targets
         - tuple: x86_64-apple-darwin

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -663,6 +663,7 @@ pub unsafe fn v128_store64_lane<const L: usize>(v: v128, m: *mut u64) {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn i8x16(
     a0: i8,
     a1: i8,
@@ -695,6 +696,7 @@ pub const fn i8x16(
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn u8x16(
     a0: u8,
     a1: u8,
@@ -741,6 +743,7 @@ pub const fn u8x16(
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn i16x8(a0: i16, a1: i16, a2: i16, a3: i16, a4: i16, a5: i16, a6: i16, a7: i16) -> v128 {
     simd::i16x8::new(a0, a1, a2, a3, a4, a5, a6, a7).v128()
 }
@@ -753,6 +756,7 @@ pub const fn i16x8(a0: i16, a1: i16, a2: i16, a3: i16, a4: i16, a5: i16, a6: i16
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn u16x8(a0: u16, a1: u16, a2: u16, a3: u16, a4: u16, a5: u16, a6: u16, a7: u16) -> v128 {
     simd::u16x8::new(a0, a1, a2, a3, a4, a5, a6, a7).v128()
 }
@@ -766,6 +770,7 @@ pub const fn u16x8(a0: u16, a1: u16, a2: u16, a3: u16, a4: u16, a5: u16, a6: u16
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn i32x4(a0: i32, a1: i32, a2: i32, a3: i32) -> v128 {
     simd::i32x4::new(a0, a1, a2, a3).v128()
 }
@@ -778,6 +783,7 @@ pub const fn i32x4(a0: i32, a1: i32, a2: i32, a3: i32) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn u32x4(a0: u32, a1: u32, a2: u32, a3: u32) -> v128 {
     simd::u32x4::new(a0, a1, a2, a3).v128()
 }
@@ -791,6 +797,7 @@ pub const fn u32x4(a0: u32, a1: u32, a2: u32, a3: u32) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn i64x2(a0: i64, a1: i64) -> v128 {
     simd::i64x2::new(a0, a1).v128()
 }
@@ -803,6 +810,7 @@ pub const fn i64x2(a0: i64, a1: i64) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd", since = "1.54.0")]
+#[target_feature(enable = "simd128")]
 pub const fn u64x2(a0: u64, a1: u64) -> v128 {
     simd::u64x2::new(a0, a1).v128()
 }
@@ -816,6 +824,7 @@ pub const fn u64x2(a0: u64, a1: u64) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd_const", since = "1.56.0")]
+#[target_feature(enable = "simd128")]
 pub const fn f32x4(a0: f32, a1: f32, a2: f32, a3: f32) -> v128 {
     simd::f32x4::new(a0, a1, a2, a3).v128()
 }
@@ -829,6 +838,7 @@ pub const fn f32x4(a0: f32, a1: f32, a2: f32, a3: f32) -> v128 {
 #[doc(alias("v128.const"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
 #[rustc_const_stable(feature = "wasm_simd_const", since = "1.56.0")]
+#[target_feature(enable = "simd128")]
 pub const fn f64x2(a0: f64, a1: f64) -> v128 {
     simd::f64x2::new(a0, a1).v128()
 }
@@ -4206,6 +4216,17 @@ mod tests {
     use std::mem::transmute;
     use std::num::Wrapping;
     use std::prelude::v1::*;
+
+    const _C1: v128 = i8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const _C2: v128 = u8x16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const _C3: v128 = i16x8(0, 1, 2, 3, 4, 5, 6, 7);
+    const _C4: v128 = u16x8(0, 1, 2, 3, 4, 5, 6, 7);
+    const _C5: v128 = i32x4(0, 1, 2, 3);
+    const _C6: v128 = u32x4(0, 1, 2, 3);
+    const _C7: v128 = i64x2(0, 1);
+    const _C8: v128 = u64x2(0, 1);
+    const _C9: v128 = f32x4(0.0, 1.0, 2.0, 3.0);
+    const _C10: v128 = f64x2(0.0, 1.0);
 
     fn compare_bytes(a: v128, b: v128) {
         let a: [u8; 16] = unsafe { transmute(a) };


### PR DESCRIPTION
This is a resubmission of #1609 which was ruled optional but not necessary at the time but it's now necessary. These weren't originally applied as they weren't allowed in a `const` context but that's no longer applicable. At the same time though be sure to add some small tests to ensure that these intrinsics can be used in a `const` context.