### PR TITLE
Small fixes and cleanups

### DIFF
--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3137,7 +3137,7 @@ pub unsafe fn _mm256_srlv_epi64(a: __m256i, count: __m256i) -> __m256i {
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_stream_load_si256)
 #[inline]
-#[target_feature(enable = "avx,avx2")]
+#[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vmovntdqa))]
 #[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm256_stream_load_si256(mem_addr: *const __m256i) -> __m256i {

--- a/crates/core_arch/src/x86/avx512bf16.rs
+++ b/crates/core_arch/src/x86/avx512bf16.rs
@@ -486,7 +486,7 @@ pub unsafe fn _mm_cvtsbh_ss(a: bf16) -> f32 {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cvtneps_pbh)
 #[inline]
-#[target_feature(enable = "avx512bf16,avx512vl,sse")]
+#[target_feature(enable = "avx512bf16,avx512vl")]
 #[cfg_attr(test, assert_instr("vcvtneps2bf16"))]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_cvtneps_pbh(a: __m128) -> __m128bh {
@@ -506,7 +506,7 @@ pub unsafe fn _mm_cvtneps_pbh(a: __m128) -> __m128bh {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_cvtneps_pbh)
 #[inline]
-#[target_feature(enable = "avx512bf16,avx512vl,sse,avx512f")]
+#[target_feature(enable = "avx512bf16,avx512vl")]
 #[cfg_attr(test, assert_instr("vcvtneps2bf16"))]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_mask_cvtneps_pbh(src: __m128bh, k: __mmask8, a: __m128) -> __m128bh {
@@ -527,7 +527,7 @@ pub unsafe fn _mm_mask_cvtneps_pbh(src: __m128bh, k: __mmask8, a: __m128) -> __m
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_cvtneps_pbh)
 #[inline]
-#[target_feature(enable = "avx512bf16,avx512vl,sse,avx512f")]
+#[target_feature(enable = "avx512bf16,avx512vl")]
 #[cfg_attr(test, assert_instr("vcvtneps2bf16"))]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_maskz_cvtneps_pbh(k: __mmask8, a: __m128) -> __m128bh {

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -33670,7 +33670,7 @@ pub unsafe fn _mm_maskz_load_pd(k: __mmask8, mem_addr: *const f64) -> __m128d {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_load_ss)
 #[inline]
 #[cfg_attr(test, assert_instr(vmovss))]
-#[target_feature(enable = "sse,avx512f")]
+#[target_feature(enable = "avx512f")]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_mask_load_ss(src: __m128, k: __mmask8, mem_addr: *const f32) -> __m128 {
     let mut dst: __m128 = src;
@@ -33692,7 +33692,7 @@ pub unsafe fn _mm_mask_load_ss(src: __m128, k: __mmask8, mem_addr: *const f32) -
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_load_ss)
 #[inline]
 #[cfg_attr(test, assert_instr(vmovss))]
-#[target_feature(enable = "sse,avx512f")]
+#[target_feature(enable = "avx512f")]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_maskz_load_ss(k: __mmask8, mem_addr: *const f32) -> __m128 {
     let mut dst: __m128;
@@ -33714,7 +33714,7 @@ pub unsafe fn _mm_maskz_load_ss(k: __mmask8, mem_addr: *const f32) -> __m128 {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_load_sd)
 #[inline]
 #[cfg_attr(test, assert_instr(vmovsd))]
-#[target_feature(enable = "sse,avx512f")]
+#[target_feature(enable = "avx512f")]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_mask_load_sd(src: __m128d, k: __mmask8, mem_addr: *const f64) -> __m128d {
     let mut dst: __m128d = src;
@@ -33736,7 +33736,7 @@ pub unsafe fn _mm_mask_load_sd(src: __m128d, k: __mmask8, mem_addr: *const f64) 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_load_sd)
 #[inline]
 #[cfg_attr(test, assert_instr(vmovsd))]
-#[target_feature(enable = "sse,avx512f")]
+#[target_feature(enable = "avx512f")]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_maskz_load_sd(k: __mmask8, mem_addr: *const f64) -> __m128d {
     let mut dst: __m128d;
@@ -34044,7 +34044,7 @@ pub unsafe fn _mm_mask_store_pd(mem_addr: *mut f64, mask: __mmask8, a: __m128d) 
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_store_ss)
 #[inline]
 #[cfg_attr(test, assert_instr(vmovss))]
-#[target_feature(enable = "sse,avx512f")]
+#[target_feature(enable = "avx512f")]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_mask_store_ss(mem_addr: *mut f32, k: __mmask8, a: __m128) {
     asm!(
@@ -34062,7 +34062,7 @@ pub unsafe fn _mm_mask_store_ss(mem_addr: *mut f32, k: __mmask8, a: __m128) {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_store_sd)
 #[inline]
 #[cfg_attr(test, assert_instr(vmovsd))]
-#[target_feature(enable = "sse,avx512f")]
+#[target_feature(enable = "avx512f")]
 #[unstable(feature = "stdarch_x86_avx512", issue = "111137")]
 pub unsafe fn _mm_mask_store_sd(mem_addr: *mut f64, k: __mmask8, a: __m128d) {
     asm!(

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -1,6 +1,6 @@
 use crate::arch::asm;
 use crate::core_arch::{simd::*, x86::*};
-use crate::intrinsics::simd::*;
+use crate::intrinsics::{fmaf16, simd::*};
 use crate::ptr;
 
 /// Set packed half-precision (16-bit) floating-point elements in dst with the supplied values.
@@ -16070,8 +16070,6 @@ extern "C" {
 
     #[link_name = "llvm.x86.avx512fp16.vfmadd.ph.512"]
     fn vfmaddph_512(a: __m512h, b: __m512h, c: __m512h, rounding: i32) -> __m512h;
-    #[link_name = "llvm.fma.f16"]
-    fn fmaf16(a: f16, b: f16, c: f16) -> f16; // TODO: use `crate::intrinsics::fmaf16` when it's available
     #[link_name = "llvm.x86.avx512fp16.vfmadd.f16"]
     fn vfmaddsh(a: f16, b: f16, c: f16, rounding: i32) -> f16;
 

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -667,7 +667,7 @@ macro_rules! cmp_asm { // FIXME: use LLVM intrinsics
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cmp_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,sse")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm_cmp_ph_mask<const IMM5: i32>(a: __m128h, b: __m128h) -> __mmask8 {
@@ -681,7 +681,7 @@ pub unsafe fn _mm_cmp_ph_mask<const IMM5: i32>(a: __m128h, b: __m128h) -> __mmas
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_cmp_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,sse")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[rustc_legacy_const_generics(3)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm_mask_cmp_ph_mask<const IMM5: i32>(
@@ -698,7 +698,7 @@ pub unsafe fn _mm_mask_cmp_ph_mask<const IMM5: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_cmp_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,avx")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm256_cmp_ph_mask<const IMM5: i32>(a: __m256h, b: __m256h) -> __mmask16 {
@@ -712,7 +712,7 @@ pub unsafe fn _mm256_cmp_ph_mask<const IMM5: i32>(a: __m256h, b: __m256h) -> __m
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_cmp_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,avx")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[rustc_legacy_const_generics(3)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm256_mask_cmp_ph_mask<const IMM5: i32>(
@@ -729,7 +729,7 @@ pub unsafe fn _mm256_mask_cmp_ph_mask<const IMM5: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_cmp_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512bw,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm512_cmp_ph_mask<const IMM5: i32>(a: __m512h, b: __m512h) -> __mmask32 {
@@ -743,7 +743,7 @@ pub unsafe fn _mm512_cmp_ph_mask<const IMM5: i32>(a: __m512h, b: __m512h) -> __m
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_cmp_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512bw,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[rustc_legacy_const_generics(3)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm512_mask_cmp_ph_mask<const IMM5: i32>(
@@ -762,7 +762,7 @@ pub unsafe fn _mm512_mask_cmp_ph_mask<const IMM5: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_cmp_round_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512bw,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[rustc_legacy_const_generics(2, 3)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm512_cmp_round_ph_mask<const IMM5: i32, const SAE: i32>(
@@ -795,7 +795,7 @@ pub unsafe fn _mm512_cmp_round_ph_mask<const IMM5: i32, const SAE: i32>(
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_cmp_round_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512bw,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[rustc_legacy_const_generics(3, 4)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm512_mask_cmp_round_ph_mask<const IMM5: i32, const SAE: i32>(
@@ -1098,7 +1098,7 @@ pub unsafe fn _mm_load_sh(mem_addr: *const f16) -> __m128h {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_load_sh)
 #[inline]
-#[target_feature(enable = "avx512fp16,sse,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm_mask_load_sh(src: __m128h, k: __mmask8, mem_addr: *const f16) -> __m128h {
     let mut dst = src;
@@ -1117,7 +1117,7 @@ pub unsafe fn _mm_mask_load_sh(src: __m128h, k: __mmask8, mem_addr: *const f16) 
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_maskz_load_sh)
 #[inline]
-#[target_feature(enable = "avx512fp16,sse,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm_maskz_load_sh(k: __mmask8, mem_addr: *const f16) -> __m128h {
     let mut dst: __m128h;
@@ -1255,7 +1255,7 @@ pub unsafe fn _mm_store_sh(mem_addr: *mut f16, a: __m128h) {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_store_sh)
 #[inline]
-#[target_feature(enable = "avx512fp16,sse,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
 pub unsafe fn _mm_mask_store_sh(mem_addr: *mut f16, k: __mmask8, a: __m128h) {
     asm!(
@@ -11049,7 +11049,7 @@ macro_rules! fpclass_asm { // FIXME: use LLVM intrinsics
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_fpclass_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,sse")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[cfg_attr(test, assert_instr(vfpclassph, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
@@ -11074,7 +11074,7 @@ pub unsafe fn _mm_fpclass_ph_mask<const IMM8: i32>(a: __m128h) -> __mmask8 {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_mask_fpclass_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,sse")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[cfg_attr(test, assert_instr(vfpclassph, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
@@ -11098,7 +11098,7 @@ pub unsafe fn _mm_mask_fpclass_ph_mask<const IMM8: i32>(k1: __mmask8, a: __m128h
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_fpclass_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,avx")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[cfg_attr(test, assert_instr(vfpclassph, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
@@ -11123,7 +11123,7 @@ pub unsafe fn _mm256_fpclass_ph_mask<const IMM8: i32>(a: __m256h) -> __mmask16 {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_mask_fpclass_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512vl,avx512f,avx")]
+#[target_feature(enable = "avx512fp16,avx512vl")]
 #[cfg_attr(test, assert_instr(vfpclassph, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
@@ -11147,7 +11147,7 @@ pub unsafe fn _mm256_mask_fpclass_ph_mask<const IMM8: i32>(k1: __mmask16, a: __m
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_fpclass_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512bw,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[cfg_attr(test, assert_instr(vfpclassph, IMM8 = 0))]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
@@ -11172,7 +11172,7 @@ pub unsafe fn _mm512_fpclass_ph_mask<const IMM8: i32>(a: __m512h) -> __mmask32 {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_mask_fpclass_ph_mask)
 #[inline]
-#[target_feature(enable = "avx512fp16,avx512bw,avx512f")]
+#[target_feature(enable = "avx512fp16")]
 #[cfg_attr(test, assert_instr(vfpclassph, IMM8 = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]

--- a/crates/core_arch/src/x86/avxneconvert.rs
+++ b/crates/core_arch/src/x86/avxneconvert.rs
@@ -193,7 +193,7 @@ pub unsafe fn _mm256_cvtneoph_ps(a: *const __m256h) -> __m256 {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cvtneps_avx_pbh)
 #[inline]
-#[target_feature(enable = "avxneconvert,sse")]
+#[target_feature(enable = "avxneconvert")]
 #[cfg_attr(
     all(test, any(target_os = "linux", target_env = "msvc")),
     assert_instr(vcvtneps2bf16)
@@ -215,7 +215,7 @@ pub unsafe fn _mm_cvtneps_avx_pbh(a: __m128) -> __m128bh {
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_cvtneps_avx_pbh)
 #[inline]
-#[target_feature(enable = "avxneconvert,sse,avx")]
+#[target_feature(enable = "avxneconvert")]
 #[cfg_attr(
     all(test, any(target_os = "linux", target_env = "msvc")),
     assert_instr(vcvtneps2bf16)

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1305,7 +1305,7 @@ pub unsafe fn _mm_storel_epi64(mem_addr: *mut __m128i, a: __m128i) {
 ///
 /// See [`_mm_sfence`] for details.
 #[inline]
-#[target_feature(enable = "sse,sse2")]
+#[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movntdq))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_stream_si128(mem_addr: *mut __m128i, a: __m128i) {
@@ -2533,7 +2533,7 @@ pub unsafe fn _mm_loadl_pd(a: __m128d, mem_addr: *const f64) -> __m128d {
 ///
 /// See [`_mm_sfence`] for details.
 #[inline]
-#[target_feature(enable = "sse,sse2")]
+#[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movntpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[allow(clippy::cast_ptr_alignment)]

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -1072,7 +1072,7 @@ pub unsafe fn _mm_test_mix_ones_zeros(a: __m128i, mask: __m128i) -> i32 {
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_stream_load_si128)
 #[inline]
-#[target_feature(enable = "sse,sse4.1")]
+#[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(movntdqa))]
 #[stable(feature = "simd_x86_updates", since = "1.82.0")]
 pub unsafe fn _mm_stream_load_si128(mem_addr: *const __m128i) -> __m128i {

--- a/crates/core_arch/src/x86_64/amx.rs
+++ b/crates/core_arch/src/x86_64/amx.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use stdarch_test::assert_instr;
+
 /// Load tile configuration from a 64-byte memory location specified by mem_addr.
 /// The tile configuration format is specified below, and includes the tile type pallette,
 /// the number of bytes per row, and the number of rows. If the specified pallette_id is zero,
@@ -7,6 +10,7 @@
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_tile_loadconfig&ig_expand=6875)
 #[inline]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(ldtilecfg))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_loadconfig(mem_addr: *const u8) {
     ldtilecfg(mem_addr);
@@ -19,6 +23,7 @@ pub unsafe fn _tile_loadconfig(mem_addr: *const u8) {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_tile_storeconfig&ig_expand=6879)
 #[inline]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(sttilecfg))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_storeconfig(mem_addr: *mut u8) {
     sttilecfg(mem_addr);
@@ -30,6 +35,7 @@ pub unsafe fn _tile_storeconfig(mem_addr: *mut u8) {
 #[inline]
 #[rustc_legacy_const_generics(0)]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(tileloadd, DST = 0))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_loadd<const DST: i32>(base: *const u8, stride: usize) {
     static_assert_uimm_bits!(DST, 3);
@@ -41,6 +47,7 @@ pub unsafe fn _tile_loadd<const DST: i32>(base: *const u8, stride: usize) {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_tile_release&ig_expand=6878)
 #[inline]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(tilerelease))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_release() {
     tilerelease();
@@ -52,6 +59,7 @@ pub unsafe fn _tile_release() {
 #[inline]
 #[rustc_legacy_const_generics(0)]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(tilestored, DST = 0))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_stored<const DST: i32>(base: *mut u8, stride: usize) {
     static_assert_uimm_bits!(DST, 3);
@@ -66,6 +74,7 @@ pub unsafe fn _tile_stored<const DST: i32>(base: *mut u8, stride: usize) {
 #[inline]
 #[rustc_legacy_const_generics(0)]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(tileloaddt1, DST = 0))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_stream_loadd<const DST: i32>(base: *const u8, stride: usize) {
     static_assert_uimm_bits!(DST, 3);
@@ -78,6 +87,7 @@ pub unsafe fn _tile_stream_loadd<const DST: i32>(base: *const u8, stride: usize)
 #[inline]
 #[rustc_legacy_const_generics(0)]
 #[target_feature(enable = "amx-tile")]
+#[cfg_attr(test, assert_instr(tilezero, DST = 0))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_zero<const DST: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -92,6 +102,7 @@ pub unsafe fn _tile_zero<const DST: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-bf16")]
+#[cfg_attr(test, assert_instr(tdpbf16ps, DST = 0, A = 1, B = 2))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_dpbf16ps<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -109,6 +120,7 @@ pub unsafe fn _tile_dpbf16ps<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-int8")]
+#[cfg_attr(test, assert_instr(tdpbssd, DST = 0, A = 1, B = 2))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_dpbssd<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -126,6 +138,7 @@ pub unsafe fn _tile_dpbssd<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-int8")]
+#[cfg_attr(test, assert_instr(tdpbsud, DST = 0, A = 1, B = 2))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_dpbsud<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -143,6 +156,7 @@ pub unsafe fn _tile_dpbsud<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-int8")]
+#[cfg_attr(test, assert_instr(tdpbusd, DST = 0, A = 1, B = 2))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_dpbusd<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -160,6 +174,7 @@ pub unsafe fn _tile_dpbusd<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-int8")]
+#[cfg_attr(test, assert_instr(tdpbuud, DST = 0, A = 1, B = 2))]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_dpbuud<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -176,6 +191,10 @@ pub unsafe fn _tile_dpbuud<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-fp16")]
+#[cfg_attr(
+    all(test, any(target_os = "linux", target_env = "msvc")),
+    assert_instr(tdpfp16ps, DST = 0, A = 1, B = 2)
+)]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_dpfp16ps<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -196,6 +215,10 @@ pub unsafe fn _tile_dpfp16ps<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-complex")]
+#[cfg_attr(
+    all(test, any(target_os = "linux", target_env = "msvc")),
+    assert_instr(tcmmimfp16ps, DST = 0, A = 1, B = 2)
+)]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_cmmimfp16ps<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);
@@ -216,6 +239,10 @@ pub unsafe fn _tile_cmmimfp16ps<const DST: i32, const A: i32, const B: i32>() {
 #[inline]
 #[rustc_legacy_const_generics(0, 1, 2)]
 #[target_feature(enable = "amx-complex")]
+#[cfg_attr(
+    all(test, any(target_os = "linux", target_env = "msvc")),
+    assert_instr(tcmmrlfp16ps, DST = 0, A = 1, B = 2)
+)]
 #[unstable(feature = "x86_amx_intrinsics", issue = "126622")]
 pub unsafe fn _tile_cmmrlfp16ps<const DST: i32, const A: i32, const B: i32>() {
     static_assert_uimm_bits!(DST, 3);


### PR DESCRIPTION
 - Remove redundant target features - these were due to the inline asm requirement, which was removed with implied target features
 - Use `core::intrinsics::fmaf16` in avx512fp16 intrinsics
 - Add instruction assertions for AMX - `windows-gnu`, `apple-darwin` and `ios-macabi` targets are problematic as usual