### PR TITLE
Remove buffers in tests for `{f,}xsave{c,}{64,}`

### DIFF
--- a/crates/core_arch/src/x86/fxsr.rs
+++ b/crates/core_arch/src/x86/fxsr.rs
@@ -75,30 +75,6 @@ mod tests {
         }
     }
 
-    impl PartialEq<FxsaveArea> for FxsaveArea {
-        fn eq(&self, other: &FxsaveArea) -> bool {
-            for i in 0..self.data.len() {
-                if self.data[i] != other.data[i] {
-                    return false;
-                }
-            }
-            true
-        }
-    }
-
-    impl fmt::Debug for FxsaveArea {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "[")?;
-            for i in 0..self.data.len() {
-                write!(f, "{}", self.data[i])?;
-                if i != self.data.len() - 1 {
-                    write!(f, ", ")?;
-                }
-            }
-            write!(f, "]")
-        }
-    }
-
     #[simd_test(enable = "fxsr")]
     #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn test_fxsave() {
@@ -108,6 +84,5 @@ mod tests {
         fxsr::_fxsave(a.ptr());
         fxsr::_fxrstor(a.ptr());
         fxsr::_fxsave(b.ptr());
-        assert_eq!(a, b);
     }
 }

--- a/crates/core_arch/src/x86/xsave.rs
+++ b/crates/core_arch/src/x86/xsave.rs
@@ -185,20 +185,6 @@ mod tests {
         }
     }
 
-    impl PartialEq<XsaveArea> for XsaveArea {
-        fn eq(&self, other: &XsaveArea) -> bool {
-            for i in 0..self.data.len() {
-                // Ignore XSTATE_BV (state-component bitmap) that occupies the first byte of the XSAVE Header
-                // (at offset 512 bytes from the start). The value may change, for more information see the following chapter:
-                // 13.7 OPERATION OF XSAVE - Intel® 64 and IA-32 Architectures Software Developer’s Manual.
-                if i != 512 && self.data[i] != other.data[i] {
-                    return false;
-                }
-            }
-            true
-        }
-    }
-
     // We cannot test for `_xsave`, `xrstor`, `_xsetbv`, `_xsaveopt`, `_xsaves`, `_xrstors` as they
     // are privileged instructions and will need access to kernel mode to execute and test them.
     // see https://github.com/rust-lang/stdarch/issues/209
@@ -214,7 +200,6 @@ mod tests {
         _xsave(a.ptr(), m);
         _xrstor(a.ptr(), m);
         _xsave(b.ptr(), m);
-        assert_eq!(a, b);
     }
 
     #[simd_test(enable = "xsave")]
@@ -238,7 +223,6 @@ mod tests {
         _xsaveopt(a.ptr(), m);
         _xrstor(a.ptr(), m);
         _xsaveopt(b.ptr(), m);
-        assert_eq!(a, b);
     }
 
     #[simd_test(enable = "xsave,xsavec")]
@@ -251,6 +235,5 @@ mod tests {
         _xsavec(a.ptr(), m);
         _xrstor(a.ptr(), m);
         _xsavec(b.ptr(), m);
-        assert_eq!(a, b);
     }
 }

--- a/crates/core_arch/src/x86_64/fxsr.rs
+++ b/crates/core_arch/src/x86_64/fxsr.rs
@@ -75,30 +75,6 @@ mod tests {
         }
     }
 
-    impl PartialEq<FxsaveArea> for FxsaveArea {
-        fn eq(&self, other: &FxsaveArea) -> bool {
-            for i in 0..self.data.len() {
-                if self.data[i] != other.data[i] {
-                    return false;
-                }
-            }
-            true
-        }
-    }
-
-    impl fmt::Debug for FxsaveArea {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "[")?;
-            for i in 0..self.data.len() {
-                write!(f, "{}", self.data[i])?;
-                if i != self.data.len() - 1 {
-                    write!(f, ", ")?;
-                }
-            }
-            write!(f, "]")
-        }
-    }
-
     #[simd_test(enable = "fxsr")]
     #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
     unsafe fn test_fxsave64() {
@@ -108,6 +84,5 @@ mod tests {
         fxsr::_fxsave64(a.ptr());
         fxsr::_fxrstor64(a.ptr());
         fxsr::_fxsave64(b.ptr());
-        assert_eq!(a, b);
     }
 }

--- a/crates/core_arch/src/x86_64/xsave.rs
+++ b/crates/core_arch/src/x86_64/xsave.rs
@@ -149,20 +149,6 @@ mod tests {
         }
     }
 
-    impl PartialEq<XsaveArea> for XsaveArea {
-        fn eq(&self, other: &XsaveArea) -> bool {
-            for i in 0..self.data.len() {
-                // Ignore XSTATE_BV (state-component bitmap) that occupies the first byte of the XSAVE Header
-                // (at offset 512 bytes from the start). The value may change, for more information see the following chapter:
-                // 13.7 OPERATION OF XSAVE - Intel® 64 and IA-32 Architectures Software Developer’s Manual.
-                if i != 512 && self.data[i] != other.data[i] {
-                    return false;
-                }
-            }
-            true
-        }
-    }
-
     // We cannot test `_xsave64`, `_xrstor64`, `_xsaveopt64`, `_xsaves64` and `_xrstors64` directly
     // as they are privileged instructions and will need access to the kernel to run and test them.
     // See https://github.com/rust-lang/stdarch/issues/209
@@ -178,7 +164,6 @@ mod tests {
         xsave::_xsave64(a.ptr(), m);
         xsave::_xrstor64(a.ptr(), m);
         xsave::_xsave64(b.ptr(), m);
-        assert_eq!(a, b);
     }
 
     #[cfg_attr(stdarch_intel_sde, ignore)]
@@ -192,7 +177,6 @@ mod tests {
         xsave::_xsaveopt64(a.ptr(), m);
         xsave::_xrstor64(a.ptr(), m);
         xsave::_xsaveopt64(b.ptr(), m);
-        assert_eq!(a, b);
     }
 
     #[simd_test(enable = "xsave,xsavec")]
@@ -205,6 +189,5 @@ mod tests {
         xsave::_xsavec64(a.ptr(), m);
         xsave::_xrstor64(a.ptr(), m);
         xsave::_xsavec64(b.ptr(), m);
-        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
Fixes: #1672