### PR TITLE
Fix the bug in CMPINT intrinsics with `IMM3=7`

### DIFF
--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -3907,7 +3907,7 @@ pub unsafe fn _mm512_mask_cmp_epu16_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i16x32::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -3962,7 +3962,7 @@ pub unsafe fn _mm256_mask_cmp_epu16_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i16x16::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4017,7 +4017,7 @@ pub unsafe fn _mm_mask_cmp_epu16_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i16x8::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4072,7 +4072,7 @@ pub unsafe fn _mm512_mask_cmp_epu8_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i8x64::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4127,7 +4127,7 @@ pub unsafe fn _mm256_mask_cmp_epu8_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i8x32::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4182,7 +4182,7 @@ pub unsafe fn _mm_mask_cmp_epu8_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i8x16::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4237,7 +4237,7 @@ pub unsafe fn _mm512_mask_cmp_epi16_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i16x32::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4292,7 +4292,7 @@ pub unsafe fn _mm256_mask_cmp_epi16_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i16x16::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4347,7 +4347,7 @@ pub unsafe fn _mm_mask_cmp_epi16_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i16x8::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4402,7 +4402,7 @@ pub unsafe fn _mm512_mask_cmp_epi8_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i8x64::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4457,7 +4457,7 @@ pub unsafe fn _mm256_mask_cmp_epi8_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i8x32::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -4512,7 +4512,7 @@ pub unsafe fn _mm_mask_cmp_epi8_mask<const IMM8: i32>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i8x16::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -29722,7 +29722,7 @@ pub unsafe fn _mm512_mask_cmp_epu32_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i32x16::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -29780,7 +29780,7 @@ pub unsafe fn _mm256_mask_cmp_epu32_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i32x8::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -29835,7 +29835,7 @@ pub unsafe fn _mm_mask_cmp_epu32_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i32x4::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -30289,7 +30289,7 @@ pub unsafe fn _mm512_mask_cmp_epi32_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i32x16::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -30347,7 +30347,7 @@ pub unsafe fn _mm256_mask_cmp_epi32_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i32x8::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -30402,7 +30402,7 @@ pub unsafe fn _mm_mask_cmp_epi32_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i32x4::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -30856,7 +30856,7 @@ pub unsafe fn _mm512_mask_cmp_epu64_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i64x8::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -30914,7 +30914,7 @@ pub unsafe fn _mm256_mask_cmp_epu64_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i64x4::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -30969,7 +30969,7 @@ pub unsafe fn _mm_mask_cmp_epu64_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i64x2::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -31423,7 +31423,7 @@ pub unsafe fn _mm512_mask_cmp_epi64_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i64x8::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -31481,7 +31481,7 @@ pub unsafe fn _mm256_mask_cmp_epi64_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i64x4::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }
@@ -31536,7 +31536,7 @@ pub unsafe fn _mm_mask_cmp_epi64_mask<const IMM3: _MM_CMPINT_ENUM>(
         4 => simd_and(k1, simd_ne(a, b)),
         5 => simd_and(k1, simd_ge(a, b)),
         6 => simd_and(k1, simd_gt(a, b)),
-        _ => i64x2::splat(-1),
+        _ => k1,
     };
     simd_bitmask(r)
 }


### PR DESCRIPTION
Fixing a small oversight.

Fixes: rust-lang/rust#133067