### PR TITLE
Fix some test naming, and refactor `stdarch-verify` in general

### DIFF
--- a/crates/core_arch/src/x86/eflags.rs
+++ b/crates/core_arch/src/x86/eflags.rs
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // Uses inline assembly
     #[allow(deprecated)]
-    fn test_eflags() {
+    fn test_readeflags() {
         unsafe {
             // reads eflags, writes them back, reads them again,
             // and compare for equality:

--- a/crates/core_arch/src/x86/f16c.rs
+++ b/crates/core_arch/src/x86/f16c.rs
@@ -98,23 +98,48 @@ mod tests {
     use crate::{core_arch::x86::*, mem::transmute};
     use stdarch_test::simd_test;
 
+    const F16_ONE: i16 = 0x3c00;
+    const F16_TWO: i16 = 0x4000;
+    const F16_THREE: i16 = 0x4200;
+    const F16_FOUR: i16 = 0x4400;
+    const F16_FIVE: i16 = 0x4500;
+    const F16_SIX: i16 = 0x4600;
+    const F16_SEVEN: i16 = 0x4700;
+    const F16_EIGHT: i16 = 0x4800;
+
     #[simd_test(enable = "f16c")]
     unsafe fn test_mm_cvtph_ps() {
-        let array = [1_f32, 2_f32, 3_f32, 4_f32];
-        let float_vec: __m128 = transmute(array);
-        let halfs: __m128i = _mm_cvtps_ph::<0>(float_vec);
-        let floats: __m128 = _mm_cvtph_ps(halfs);
-        let result: [f32; 4] = transmute(floats);
-        assert_eq!(result, array);
+        let a = _mm_set_epi16(0, 0, 0, 0, F16_ONE, F16_TWO, F16_THREE, F16_FOUR);
+        let r = _mm_cvtph_ps(a);
+        let e = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
+        assert_eq_m128(r, e);
     }
 
     #[simd_test(enable = "f16c")]
     unsafe fn test_mm256_cvtph_ps() {
-        let array = [1_f32, 2_f32, 3_f32, 4_f32, 5_f32, 6_f32, 7_f32, 8_f32];
-        let float_vec: __m256 = transmute(array);
-        let halfs: __m128i = _mm256_cvtps_ph::<0>(float_vec);
-        let floats: __m256 = _mm256_cvtph_ps(halfs);
-        let result: [f32; 8] = transmute(floats);
-        assert_eq!(result, array);
+        let a = _mm_set_epi16(
+            F16_ONE, F16_TWO, F16_THREE, F16_FOUR, F16_FIVE, F16_SIX, F16_SEVEN, F16_EIGHT,
+        );
+        let r = _mm256_cvtph_ps(a);
+        let e = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
+        assert_eq_m256(r, e);
+    }
+
+    #[simd_test(enable = "f16c")]
+    unsafe fn test_mm_cvtps_ph() {
+        let a = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
+        let r = _mm_cvtps_ph::<_MM_FROUND_CUR_DIRECTION>(a);
+        let e = _mm_set_epi16(0, 0, 0, 0, F16_ONE, F16_TWO, F16_THREE, F16_FOUR);
+        assert_eq_m128i(r, e);
+    }
+
+    #[simd_test(enable = "f16c")]
+    unsafe fn test_mm256_cvtps_ph() {
+        let a = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
+        let r = _mm256_cvtps_ph::<_MM_FROUND_CUR_DIRECTION>(a);
+        let e = _mm_set_epi16(
+            F16_ONE, F16_TWO, F16_THREE, F16_FOUR, F16_FIVE, F16_SIX, F16_SEVEN, F16_EIGHT,
+        );
+        assert_eq_m128i(r, e);
     }
 }

--- a/crates/core_arch/src/x86/rdtsc.rs
+++ b/crates/core_arch/src/x86/rdtsc.rs
@@ -63,15 +63,15 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse2")]
-    unsafe fn _rdtsc() {
-        let r = rdtsc::_rdtsc();
+    unsafe fn test_rdtsc() {
+        let r = _rdtsc();
         assert_ne!(r, 0); // The chances of this being 0 are infinitesimal
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn _rdtscp() {
+    unsafe fn test_rdtscp() {
         let mut aux = 0;
-        let r = rdtsc::__rdtscp(&mut aux);
+        let r = __rdtscp(&mut aux);
         assert_ne!(r, 0); // The chances of this being 0 are infinitesimal
     }
 }

--- a/crates/core_arch/src/x86/rtm.rs
+++ b/crates/core_arch/src/x86/rtm.rs
@@ -120,13 +120,13 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "rtm")]
-    unsafe fn test_xbegin_xend() {
+    unsafe fn test_xbegin() {
         let mut x = 0;
         for _ in 0..10 {
-            let code = rtm::_xbegin();
+            let code = _xbegin();
             if code == _XBEGIN_STARTED {
                 x += 1;
-                rtm::_xend();
+                _xend();
                 assert_eq!(x, 1);
                 break;
             }

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -1310,7 +1310,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_min_epi8_1() {
+    unsafe fn test_mm_min_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 4, 5, 8, 9, 12, 13, 16,
@@ -1328,10 +1328,7 @@ mod tests {
             17, 19, 21, 23, 25, 27, 29, 31,
         );
         assert_eq_m128i(r, e);
-    }
 
-    #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_min_epi8_2() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, -4, -5, 8, -9, -12, 13, -16,
@@ -1361,16 +1358,13 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_min_epi32_1() {
+    unsafe fn test_mm_min_epi32() {
         let a = _mm_setr_epi32(1, 4, 5, 8);
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_min_epi32(a, b);
         let e = _mm_setr_epi32(1, 3, 5, 7);
         assert_eq_m128i(r, e);
-    }
 
-    #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_min_epi32_2() {
         let a = _mm_setr_epi32(-1, 4, 5, -7);
         let b = _mm_setr_epi32(-2, 3, -6, 8);
         let r = _mm_min_epi32(a, b);

--- a/crates/core_arch/src/x86/xsave.rs
+++ b/crates/core_arch/src/x86/xsave.rs
@@ -185,10 +185,6 @@ mod tests {
         }
     }
 
-    // We cannot test for `_xsave`, `xrstor`, `_xsetbv`, `_xsaveopt`, `_xsaves`, `_xrstors` as they
-    // are privileged instructions and will need access to kernel mode to execute and test them.
-    // see https://github.com/rust-lang/stdarch/issues/209
-
     #[cfg_attr(stdarch_intel_sde, ignore)]
     #[simd_test(enable = "xsave")]
     #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri

--- a/crates/core_arch/src/x86_64/tbm.rs
+++ b/crates/core_arch/src/x86_64/tbm.rs
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    unsafe fn test_t1mksc_u64() {
+    unsafe fn test_t1mskc_u64() {
         assert_eq!(
             _t1mskc_u64(0b0101_0111u64),
             0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000u64

--- a/crates/core_arch/src/x86_64/xsave.rs
+++ b/crates/core_arch/src/x86_64/xsave.rs
@@ -149,10 +149,6 @@ mod tests {
         }
     }
 
-    // We cannot test `_xsave64`, `_xrstor64`, `_xsaveopt64`, `_xsaves64` and `_xrstors64` directly
-    // as they are privileged instructions and will need access to the kernel to run and test them.
-    // See https://github.com/rust-lang/stdarch/issues/209
-
     #[cfg_attr(stdarch_intel_sde, ignore)]
     #[simd_test(enable = "xsave")]
     #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -1,14 +1,13 @@
 #![allow(internal_features)]
 #![feature(stdarch_internal)]
 #![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
-#![cfg_attr(target_arch = "aarch64", feature(stdarch_aarch64_feature_detection))]
+#![cfg_attr(
+    any(target_arch = "aarch64", target_arch = "arm64ec"),
+    feature(stdarch_aarch64_feature_detection)
+)]
 #![cfg_attr(target_arch = "powerpc", feature(stdarch_powerpc_feature_detection))]
 #![cfg_attr(target_arch = "powerpc64", feature(stdarch_powerpc_feature_detection))]
 #![cfg_attr(target_arch = "s390x", feature(stdarch_s390x_feature_detection))]
-#![cfg_attr(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    feature(sha512_sm_x86, x86_amx_intrinsics, xop_target_feature)
-)]
 #![allow(clippy::unwrap_used, clippy::use_debug, clippy::print_stdout)]
 
 #[cfg_attr(
@@ -16,8 +15,6 @@
         target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "arm64ec",
-        target_arch = "x86",
-        target_arch = "x86_64",
         target_arch = "powerpc",
         target_arch = "powerpc64",
         target_arch = "s390x",
@@ -246,88 +243,4 @@ fn powerpc64_linux_or_freebsd() {
 #[cfg(all(target_arch = "s390x", target_os = "linux",))]
 fn s390x_linux() {
     println!("vector: {}", is_s390x_feature_detected!("vector"));
-}
-
-#[test]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn x86_all() {
-    println!("aes: {:?}", is_x86_feature_detected!("aes"));
-    println!("pcmulqdq: {:?}", is_x86_feature_detected!("pclmulqdq"));
-    println!("rdrand: {:?}", is_x86_feature_detected!("rdrand"));
-    println!("rdseed: {:?}", is_x86_feature_detected!("rdseed"));
-    println!("tsc: {:?}", is_x86_feature_detected!("tsc"));
-    println!("mmx: {:?}", is_x86_feature_detected!("mmx"));
-    println!("sse: {:?}", is_x86_feature_detected!("sse"));
-    println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
-    println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
-    println!("ssse3: {:?}", is_x86_feature_detected!("ssse3"));
-    println!("sse4.1: {:?}", is_x86_feature_detected!("sse4.1"));
-    println!("sse4.2: {:?}", is_x86_feature_detected!("sse4.2"));
-    println!("sse4a: {:?}", is_x86_feature_detected!("sse4a"));
-    println!("sha: {:?}", is_x86_feature_detected!("sha"));
-    println!("avx: {:?}", is_x86_feature_detected!("avx"));
-    println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
-    println!("sha512: {:?}", is_x86_feature_detected!("sha512"));
-    println!("sm3: {:?}", is_x86_feature_detected!("sm3"));
-    println!("sm4: {:?}", is_x86_feature_detected!("sm4"));
-    println!("avx512f: {:?}", is_x86_feature_detected!("avx512f"));
-    println!("avx512cd: {:?}", is_x86_feature_detected!("avx512cd"));
-    println!("avx512er: {:?}", is_x86_feature_detected!("avx512er"));
-    println!("avx512pf: {:?}", is_x86_feature_detected!("avx512pf"));
-    println!("avx512bw: {:?}", is_x86_feature_detected!("avx512bw"));
-    println!("avx512dq: {:?}", is_x86_feature_detected!("avx512dq"));
-    println!("avx512vl: {:?}", is_x86_feature_detected!("avx512vl"));
-    println!("avx512ifma: {:?}", is_x86_feature_detected!("avx512ifma"));
-    println!("avx512vbmi: {:?}", is_x86_feature_detected!("avx512vbmi"));
-    println!(
-        "avx512vpopcntdq: {:?}",
-        is_x86_feature_detected!("avx512vpopcntdq")
-    );
-    println!("avx512vbmi2 {:?}", is_x86_feature_detected!("avx512vbmi2"));
-    println!("gfni {:?}", is_x86_feature_detected!("gfni"));
-    println!("vaes {:?}", is_x86_feature_detected!("vaes"));
-    println!("vpclmulqdq {:?}", is_x86_feature_detected!("vpclmulqdq"));
-    println!("avx512vnni {:?}", is_x86_feature_detected!("avx512vnni"));
-    println!(
-        "avx512bitalg {:?}",
-        is_x86_feature_detected!("avx512bitalg")
-    );
-    println!("avx512bf16 {:?}", is_x86_feature_detected!("avx512bf16"));
-    println!(
-        "avx512vp2intersect {:?}",
-        is_x86_feature_detected!("avx512vp2intersect")
-    );
-    println!("avx512fp16 {:?}", is_x86_feature_detected!("avx512fp16"));
-    println!("f16c: {:?}", is_x86_feature_detected!("f16c"));
-    println!("fma: {:?}", is_x86_feature_detected!("fma"));
-    println!("bmi1: {:?}", is_x86_feature_detected!("bmi1"));
-    println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
-    println!("abm: {:?}", is_x86_feature_detected!("abm"));
-    println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
-    println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
-    println!("movbe: {:?}", is_x86_feature_detected!("movbe"));
-    println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
-    println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
-    println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
-    println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
-    println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
-    println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
-    println!("amx-bf16: {:?}", is_x86_feature_detected!("amx-bf16"));
-    println!("amx-tile: {:?}", is_x86_feature_detected!("amx-tile"));
-    println!("amx-int8: {:?}", is_x86_feature_detected!("amx-int8"));
-    println!("amx-fp16: {:?}", is_x86_feature_detected!("amx-fp16"));
-    println!("amx-complex: {:?}", is_x86_feature_detected!("amx-complex"));
-    println!("xop: {:?}", is_x86_feature_detected!("xop"));
-}
-
-#[test]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(deprecated)]
-fn x86_deprecated() {
-    println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
-    println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
-    println!(
-        "avx512vpclmulqdq {:?}",
-        is_x86_feature_detected!("avx512vpclmulqdq")
-    );
 }

--- a/crates/std_detect/tests/x86-specific.rs
+++ b/crates/std_detect/tests/x86-specific.rs
@@ -185,3 +185,14 @@ fn compare_with_cupid() {
     assert_eq!(is_x86_feature_detected!("rtm"), information.rtm(),);
     assert_eq!(is_x86_feature_detected!("movbe"), information.movbe(),);
 }
+
+#[test]
+#[allow(deprecated)]
+fn x86_deprecated() {
+    println!("avx512gfni {:?}", is_x86_feature_detected!("avx512gfni"));
+    println!("avx512vaes {:?}", is_x86_feature_detected!("avx512vaes"));
+    println!(
+        "avx512vpclmulqdq {:?}",
+        is_x86_feature_detected!("avx512vpclmulqdq")
+    );
+}

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -181,12 +181,7 @@ fn verify_all_signatures() {
         if !rust.has_test {
             // FIXME: this list should be almost empty
             let skip = [
-                // EFLAGS
-                "__readeflags",
-                "__readeflags",
-                "__writeeflags",
-                "__writeeflags",
-                // MXCSR - deprecated
+                // MXCSR - deprecated, immediate UB
                 "_mm_getcsr",
                 "_mm_setcsr",
                 "_MM_GET_EXCEPTION_MASK",
@@ -207,14 +202,6 @@ fn verify_all_signatures() {
                 "_xrstors",
                 "_xsaves64",
                 "_xrstors64",
-                // TSC
-                "_rdtsc",
-                "__rdtscp",
-                // TBM
-                "_t1mskc_u64",
-                // RTM
-                "_xbegin",
-                "_xend",
                 // RDRAND
                 "_rdrand16_step",
                 "_rdrand32_step",
@@ -250,16 +237,13 @@ fn verify_all_signatures() {
                 "_mm256_unpacklo_epi32",
                 "_mm256_unpackhi_epi64",
                 "_mm256_unpacklo_epi64",
-                // Has tests with different name
-                "_mm_min_epi8",
-                "_mm_min_epi32",
+                // Has tests with some other intrinsic
+                "__writeeflags",
                 "_xrstor",
                 "_xrstor64",
                 "_fxrstor",
                 "_fxrstor64",
-                // Needs `f16` to test
-                "_mm_cvtps_ph",
-                "_mm256_cvtps_ph",
+                "_xend",
                 // Aliases
                 "_mm_comige_ss",
                 "_mm_cvt_ss2si",


### PR DESCRIPTION
Remove the following tests in `sse.rs` due to UB
 - `test_mm_comieq_ss_vs_ucomieq_ss`
 - `test_mm_getcsr_setcsr_1`
 - `test_mm_getcsr_setcsr_2`
 - `test_mm_getcsr_setcsr_underflow`

Move all x86 std_detect tests to `x86-specific.rs` to reduce duplication