### PR TITLE
Update CI to FreeBSD 13.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: x86_64-unknown-freebsd
   freebsd_instance:
-    image_family: freebsd-13-3
+    image_family: freebsd-13-4
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain nightly -y

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -33,7 +33,6 @@
     rtm_target_feature,
     allow_internal_unstable,
     decl_macro,
-    target_feature_11,
     generic_arg_infer,
     asm_experimental_arch,
     sha512_sm_x86,


### PR DESCRIPTION
The 13.3 image is no longer provided by Google Cloud.