### PR TITLE
`s390x_is_feature_detected!`: detect more features

### DIFF
--- a/crates/std_detect/src/detect/arch/s390x.rs
+++ b/crates/std_detect/src/detect/arch/s390x.rs
@@ -7,6 +7,39 @@ features! {
     @MACRO_ATTRS:
     /// Checks if `s390x` feature is enabled.
     #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] deflate_conversion: "deflate-conversion";
+    /// s390x deflate-conversion facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] enhanced_sort: "enhanced-sort";
+    /// s390x enhanced-sort facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] guarded_storage: "guarded-storage";
+    /// s390x guarded-storage facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] high_word: "high-word";
+    /// s390x high-word facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] nnp_assist: "nnp-assist";
+    /// s390x nnp-assist facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] transactional_execution: "transactional-execution";
+    /// s390x transactional-execution facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
     @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] vector: "vector";
     /// s390x vector facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] vector_enhancements_1: "vector-enhancements-1";
+    /// s390x vector-enhancements-1 facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] vector_enhancements_2: "vector-enhancements-2";
+    /// s390x vector-enhancements-2 facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] vector_packed_decimal: "vector-packed-decimal";
+    /// s390x vector-packed-decimal facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] vector_packed_decimal_enhancement: "vector-packed-decimal-enhancement";
+    /// s390x vector-packed-decimal-enhancement facility
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    @FEATURE: #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")] vector_packed_decimal_enhancement_2: "vector-packed-decimal-enhancement-2";
+    /// s390x vector-packed-decimal-enhancement-2 facility
 }

--- a/crates/std_detect/src/detect/os/linux/s390x.rs
+++ b/crates/std_detect/src/detect/os/linux/s390x.rs
@@ -87,8 +87,45 @@ impl AtHwcap {
                 }
             };
 
+            // vector and related
+
             // bit 129 of the extended facility list
             enable_feature(Feature::vector, self.vxrs);
+
+            // bit 135 of the extended facility list
+            enable_feature(Feature::vector_enhancements_1, self.vxrs_ext);
+
+            // bit 148 of the extended facility list
+            enable_feature(Feature::vector_enhancements_2, self.vxrs_ext2);
+
+            // bit 134 of the extended facility list
+            enable_feature(Feature::vector_packed_decimal, self.vxrs_bcd);
+
+            // bit 152 of the extended facility list
+            enable_feature(Feature::vector_packed_decimal_enhancement, self.vxrs_pde);
+
+            // bit 192 of the extended facility list
+            enable_feature(Feature::vector_packed_decimal_enhancement_2, self.vxrs_pde2);
+
+            // bit 165 of the extended facility list
+            enable_feature(Feature::nnp_assist, self.nnpa);
+
+            // others
+
+            // bit 45 of the extended facility list
+            enable_feature(Feature::high_word, self.high_gprs);
+
+            // bit 73 of the extended facility list
+            enable_feature(Feature::transactional_execution, self.te);
+
+            // bit 133 of the extended facility list
+            enable_feature(Feature::guarded_storage, self.gs);
+
+            // bit 150 of the extended facility list
+            enable_feature(Feature::enhanced_sort, self.sort);
+
+            // bit 151 of the extended facility list
+            enable_feature(Feature::deflate_conversion, self.dflt);
         }
         value
     }


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/130869
follow-up to https://github.com/rust-lang/stdarch/pull/1699

with https://github.com/rust-lang/rust/pull/135630 merged, we can now also check for these facilities at runtime.

 I am now using the `stfle` instruction to get the facilities. From what I can tell [`AT_HWCAP` ](https://github.com/torvalds/linux/blob/b62cef9a5c673f1b8083159f5dc03c1c5daced2f/arch/s390/include/asm/elf.h#L129-L152) does not include a bit for the `vector-packed-decimal` facility. Also the `stfle` version is just shorter, and I like that the factility bit index is now actually used.

@uweigand previously [said](https://github.com/rust-lang/rust/pull/135630#issuecomment-2598872726) that using the `stfle` instruction is safe because LLVM only supports CPUs with this instruction. This is also the official [specification of the target](https://doc.rust-lang.org/stable/rustc/platform-support/s390x-unknown-linux-gnu.htmll)

> Code generated by the target uses the z/Architecture ISA assuming a minimum architecture level of z10 (Eighth Edition of the z/Architecture Principles of Operation), and is compliant with the s390x ELF ABI.

In theory that might change if e.g. the GCC backend wants to support something older (gcc [appears to still support z900](https://godbolt.org/z/hW7vzMczo)). We can deal with that if it ever becomes relevant.

## Testing

I could not find a qemu CPU that works with rust programs and also does not support `vx`. I did test the logic using the `vxrs_ext2` field, and a custom CPU:

```toml
runner = "qemu-s390x -cpu qemu,vx=on,vxeh=on,vxeh2=off -L /usr/s390x-linux-gnu"
```

I verified that toggling the `vxeh2` flag is observed by the implementation.