### PR TITLE
s390x: add more intrinsics

### DIFF
--- a/crates/core_arch/src/macros.rs
+++ b/crates/core_arch/src/macros.rs
@@ -102,6 +102,30 @@ macro_rules! types {
                 // a simd type with exactly one element.
                 unsafe { simd_shuffle!(one, one, [0; $len]) }
             }
+
+            /// Returns an array reference containing the entire SIMD vector.
+            $v const fn as_array(&self) -> &[$elem_type; $len] {
+                // SAFETY: this type is just an overaligned `[T; N]` with
+                // potential padding at the end, so pointer casting to a
+                // `&[T; N]` is safe.
+                //
+                // NOTE: This deliberately doesn't just use `&self.0` because it may soon be banned
+                // see https://github.com/rust-lang/compiler-team/issues/838
+                unsafe { &*(self as *const Self as *const [$elem_type; $len]) }
+
+            }
+
+            /// Returns a mutable array reference containing the entire SIMD vector.
+            #[inline]
+            $v fn as_mut_array(&mut self) -> &mut [$elem_type; $len] {
+                // SAFETY: this type is just an overaligned `[T; N]` with
+                // potential padding at the end, so pointer casting to a
+                // `&mut [T; N]` is safe.
+                //
+                // NOTE: This deliberately doesn't just use `&mut self.0` because it may soon be banned
+                // see https://github.com/rust-lang/compiler-team/issues/838
+                unsafe { &mut *(self as *mut Self as *mut [$elem_type; $len]) }
+            }
         }
 
         $(#[$stability])+

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -55,6 +55,16 @@ macro_rules! impl_vec_trait {
             }
         }
     };
+    ([$Trait:ident $m:ident]+ $fun:ident ($a:ty)) => {
+        #[unstable(feature = "stdarch_s390x", issue = "135681")]
+        impl $Trait for $a {
+            #[inline]
+            #[target_feature(enable = "vector")]
+            unsafe fn $m(self) -> Self {
+                transmute($fun(transmute(self)))
+            }
+        }
+    };
     ([$Trait:ident $m:ident] $fun:ident ($a:ty) -> $r:ty) => {
         #[unstable(feature = "stdarch_s390x", issue = "135681")]
         impl $Trait for $a {

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -436,8 +436,7 @@ macro_rules! impl_neg {
         impl crate::ops::Neg for s_t_l!($s) {
             type Output = s_t_l!($s);
             fn neg(self) -> Self::Output {
-                let zero = $s::splat($zero);
-                unsafe { transmute(simd_sub(zero, transmute(self))) }
+                unsafe { simd_neg(self) }
             }
         }
     };

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -315,7 +315,7 @@ macro_rules! t_u {
         vector_unsigned_int
     };
     (vector_signed_long_long) => {
-        vector_signed_long_long
+        vector_unsigned_long_long
     };
     (vector_float) => {
         vector_unsigned_int

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -213,6 +213,41 @@ macro_rules! s_t_l {
     };
 }
 
+macro_rules! l_t_t {
+    (vector_signed_long_long) => {
+        i64
+    };
+    (vector_signed_int) => {
+        i32
+    };
+    (vector_signed_short) => {
+        i16
+    };
+    (vector_signed_char) => {
+        i8
+    };
+
+    (vector_unsigned_long_long ) => {
+        u64
+    };
+    (vector_unsigned_int ) => {
+        u32
+    };
+    (vector_unsigned_short ) => {
+        u16
+    };
+    (vector_unsigned_char ) => {
+        u8
+    };
+
+    (vector_float) => {
+        f32
+    };
+    (vector_double) => {
+        f64
+    };
+}
+
 macro_rules! t_t_l {
     (i64) => {
         vector_signed_long_long
@@ -401,6 +436,7 @@ macro_rules! impl_neg {
 pub(crate) use impl_from;
 pub(crate) use impl_neg;
 pub(crate) use impl_vec_trait;
+pub(crate) use l_t_t;
 pub(crate) use s_t_l;
 pub(crate) use t_b;
 pub(crate) use t_t_l;

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -507,6 +507,31 @@ mod sealed {
     impl_vec_trait! { [VectorAbs vec_abs] vec_abs_f64 (vector_double) }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorNabs {
+        unsafe fn vec_nabs(self) -> Self;
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    #[cfg_attr(
+        all(test, target_feature = "vector-enhancements-1"),
+        assert_instr(vflnsb)
+    )]
+    unsafe fn vec_nabs_f32(a: vector_float) -> vector_float {
+        simd_neg(simd_fabs(a))
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    #[cfg_attr(test, assert_instr(vflndb))]
+    unsafe fn vec_nabs_f64(a: vector_double) -> vector_double {
+        simd_neg(simd_fabs(a))
+    }
+
+    impl_vec_trait! { [VectorNabs vec_nabs] vec_nabs_f32 (vector_float) }
+    impl_vec_trait! { [VectorNabs vec_nabs] vec_nabs_f64 (vector_double) }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorSplats<Output> {
         unsafe fn vec_splats(self) -> Output;
     }
@@ -1528,6 +1553,17 @@ where
     a.vec_abs()
 }
 
+/// Vector negative abs.
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_nabs<T>(a: T) -> T
+where
+    T: sealed::VectorNabs,
+{
+    a.vec_nabs()
+}
+
 /// Vector splats.
 #[inline]
 #[target_feature(enable = "vector")]
@@ -2350,6 +2386,10 @@ mod tests {
     test_vec_abs! { test_vec_abs_i64, i64x2, -42i64, 42i64 }
     test_vec_abs! { test_vec_abs_f32, f32x4, -42f32, 42f32 }
     test_vec_abs! { test_vec_abs_f64, f64x2, -42f64, 42f64 }
+
+    test_vec_1! { test_vec_nabs, vec_nabs, f32x4,
+    [core::f32::consts::PI, 1.0, 0.0, -1.0],
+    [-core::f32::consts::PI, -1.0, 0.0, -1.0] }
 
     test_vec_2! { test_vec_andc, vec_andc, i32x4,
     [0b11001100, 0b11001100, 0b11001100, 0b11001100],

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -1570,6 +1570,21 @@ mod sealed {
     }
 
     macro_rules! impl_vfae {
+        ([idx_cc $Trait:ident $m:ident] $imm:ident $b:ident $h:ident $f:ident) => {
+            impl_vfae! { [idx_cc $Trait $m] $imm
+                $b vector_signed_char vector_signed_char
+                $b vector_unsigned_char vector_unsigned_char
+                $b vector_bool_char vector_unsigned_char
+
+                $h vector_signed_short vector_signed_short
+                $h vector_unsigned_short vector_unsigned_short
+                $h vector_bool_short vector_unsigned_short
+
+                $f vector_signed_int vector_signed_int
+                $f vector_unsigned_int vector_unsigned_int
+                $f vector_bool_int vector_unsigned_int
+            }
+        };
         ([idx_cc $Trait:ident $m:ident] $imm:ident $($fun:ident $ty:ident $r:ident)*) => {
             $(
                 #[unstable(feature = "stdarch_s390x", issue = "135681")]
@@ -1584,6 +1599,21 @@ mod sealed {
                     }
                 }
             )*
+        };
+        ([cc $Trait:ident $m:ident] $imm:ident $b:ident $h:ident $f:ident) => {
+            impl_vfae! { [cc $Trait $m] $imm
+                $b vector_signed_char
+                $b vector_unsigned_char
+                $b vector_bool_char
+
+                $h vector_signed_short
+                $h vector_unsigned_short
+                $h vector_bool_short
+
+                $f vector_signed_int
+                $f vector_unsigned_int
+                $f vector_bool_int
+            }
         };
         ([cc $Trait:ident $m:ident] $imm:ident $($fun:ident $ty:ident)*) => {
             $(
@@ -1600,6 +1630,21 @@ mod sealed {
                 }
             )*
         };
+        ([idx $Trait:ident $m:ident] $imm:ident $b:ident $h:ident $f:ident) => {
+            impl_vfae! { [idx $Trait $m] $imm
+                $b vector_signed_char vector_signed_char
+                $b vector_unsigned_char vector_unsigned_char
+                $b vector_bool_char vector_unsigned_char
+
+                $h vector_signed_short vector_signed_short
+                $h vector_unsigned_short vector_unsigned_short
+                $h vector_bool_short vector_unsigned_short
+
+                $f vector_signed_int vector_signed_int
+                $f vector_unsigned_int vector_unsigned_int
+                $f vector_bool_int vector_unsigned_int
+            }
+        };
         ([idx $Trait:ident $m:ident] $imm:ident $($fun:ident $ty:ident $r:ident)*) => {
             $(
                 #[unstable(feature = "stdarch_s390x", issue = "135681")]
@@ -1612,6 +1657,21 @@ mod sealed {
                     }
                 }
             )*
+        };
+        ([$Trait:ident $m:ident] $imm:ident $b:ident $h:ident $f:ident) => {
+            impl_vfae! { [$Trait $m] $imm
+                $b vector_signed_char
+                $b vector_unsigned_char
+                $b vector_bool_char
+
+                $h vector_signed_short
+                $h vector_unsigned_short
+                $h vector_bool_short
+
+                $f vector_signed_int
+                $f vector_unsigned_int
+                $f vector_bool_int
+            }
         };
         ([$Trait:ident $m:ident] $imm:ident $($fun:ident $ty:ident)*) => {
             $(
@@ -1641,19 +1701,7 @@ mod sealed {
         unsafe fn vec_find_any_eq(self, other: Other) -> Self::Result;
     }
 
-    impl_vfae! { [VectorFindAnyEq vec_find_any_eq] Eq
-        vfaeb vector_signed_char
-        vfaeb vector_unsigned_char
-        vfaeb vector_bool_char
-
-        vfaeh vector_signed_short
-        vfaeh vector_unsigned_short
-        vfaeh vector_bool_short
-
-        vfaef vector_signed_int
-        vfaef vector_unsigned_int
-        vfaef vector_bool_int
-    }
+    impl_vfae! { [VectorFindAnyEq vec_find_any_eq] Eq vfaeb vfaeh vfaef }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNe<Other> {
@@ -1661,19 +1709,7 @@ mod sealed {
         unsafe fn vec_find_any_ne(self, other: Other) -> Self::Result;
     }
 
-    impl_vfae! { [VectorFindAnyNe vec_find_any_ne] Ne
-        vfaeb vector_signed_char
-        vfaeb vector_unsigned_char
-        vfaeb vector_bool_char
-
-        vfaeh vector_signed_short
-        vfaeh vector_unsigned_short
-        vfaeh vector_bool_short
-
-        vfaef vector_signed_int
-        vfaef vector_unsigned_int
-        vfaef vector_bool_int
-    }
+    impl_vfae! { [VectorFindAnyNe vec_find_any_ne] Ne vfaeb vfaeh vfaef }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyEqOrZeroIdx<Other> {
@@ -1681,7 +1717,7 @@ mod sealed {
         unsafe fn vec_find_any_eq_or_0_idx(self, other: Other) -> Self::Result;
     }
 
-    impl_vfae! { [idx VectorFindAnyEqOrZeroIdx vec_find_any_eq_or_0_idx] Eq
+    impl_vfae! { [idx VectorFindAnyEqOrZeroIdx vec_find_any_eq_or_0_idx] EqIdx
         vfaezb vector_signed_char vector_signed_char
         vfaezb vector_unsigned_char vector_unsigned_char
         vfaezb vector_bool_char vector_unsigned_char
@@ -1701,7 +1737,7 @@ mod sealed {
         unsafe fn vec_find_any_ne_or_0_idx(self, other: Other) -> Self::Result;
     }
 
-    impl_vfae! { [idx VectorFindAnyNeOrZeroIdx vec_find_any_ne_or_0_idx] Ne
+    impl_vfae! { [idx VectorFindAnyNeOrZeroIdx vec_find_any_ne_or_0_idx] NeIdx
         vfaezb vector_signed_char vector_signed_char
         vfaezb vector_unsigned_char vector_unsigned_char
         vfaezb vector_bool_char vector_unsigned_char
@@ -1721,19 +1757,7 @@ mod sealed {
         unsafe fn vec_find_any_eq_idx(self, other: Other) -> Self::Result;
     }
 
-    impl_vfae! { [idx VectorFindAnyEqIdx vec_find_any_eq_idx] EqIdx
-        vfaeb vector_signed_char vector_signed_char
-        vfaeb vector_unsigned_char vector_unsigned_char
-        vfaeb vector_bool_char vector_unsigned_char
-
-        vfaeh vector_signed_short vector_signed_short
-        vfaeh vector_unsigned_short vector_unsigned_short
-        vfaeh vector_bool_short vector_unsigned_short
-
-        vfaef vector_signed_int vector_signed_int
-        vfaef vector_unsigned_int vector_unsigned_int
-        vfaef vector_bool_int vector_unsigned_int
-    }
+    impl_vfae! { [idx VectorFindAnyEqIdx vec_find_any_eq_idx] EqIdx vfaeb vfaeh vfaef }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNeIdx<Other> {
@@ -1741,46 +1765,32 @@ mod sealed {
         unsafe fn vec_find_any_ne_idx(self, other: Other) -> Self::Result;
     }
 
-    impl_vfae! { [idx VectorFindAnyNeIdx vec_find_any_ne_idx] NeIdx
-        vfaeb vector_signed_char vector_signed_char
-        vfaeb vector_unsigned_char vector_unsigned_char
-        vfaeb vector_bool_char vector_unsigned_char
+    impl_vfae! { [idx VectorFindAnyNeIdx vec_find_any_ne_idx] NeIdx vfaeb vfaeh vfaef }
 
-        vfaeh vector_signed_short vector_signed_short
-        vfaeh vector_unsigned_short vector_unsigned_short
-        vfaeh vector_bool_short vector_unsigned_short
+    macro_rules! vfaes_wrapper {
+        ($($name:ident $ty:ident)*) => {
+            $(
+                #[inline]
+                #[target_feature(enable = "vector")]
+                #[cfg_attr(test, assert_instr($name, IMM = 0))]
+                unsafe fn $name<const IMM: i32>(
+                    a: $ty,
+                    b: $ty,
+                ) -> PackedTuple<$ty, i32> {
+                    super::$name(a, b, IMM)
+                }
+            )*
+        }
+     }
 
-        vfaef vector_signed_int vector_signed_int
-        vfaef vector_unsigned_int vector_unsigned_int
-        vfaef vector_bool_int vector_unsigned_int
-    }
+    vfaes_wrapper! {
+       vfaebs vector_signed_char
+       vfaehs vector_signed_short
+       vfaefs vector_signed_int
 
-    #[inline]
-    #[target_feature(enable = "vector")]
-    #[cfg_attr(test, assert_instr(vfaebs, IMM = 0))]
-    unsafe fn vfaebs<const IMM: i32>(
-        a: vector_signed_char,
-        b: vector_signed_char,
-    ) -> PackedTuple<vector_signed_char, i32> {
-        super::vfaebs(a, b, IMM)
-    }
-    #[inline]
-    #[target_feature(enable = "vector")]
-    #[cfg_attr(test, assert_instr(vfaehs, IMM = 0))]
-    unsafe fn vfaehs<const IMM: i32>(
-        a: vector_signed_short,
-        b: vector_signed_short,
-    ) -> PackedTuple<vector_signed_short, i32> {
-        super::vfaehs(a, b, IMM)
-    }
-    #[inline]
-    #[target_feature(enable = "vector")]
-    #[cfg_attr(test, assert_instr(vfaefs, IMM = 0))]
-    unsafe fn vfaefs<const IMM: i32>(
-        a: vector_signed_int,
-        b: vector_signed_int,
-    ) -> PackedTuple<vector_signed_int, i32> {
-        super::vfaefs(a, b, IMM)
+       vfaezbs vector_signed_char
+       vfaezhs vector_signed_short
+       vfaezfs vector_signed_int
     }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
@@ -1789,19 +1799,7 @@ mod sealed {
         unsafe fn vec_find_any_eq_cc(self, other: Other, c: *mut i32) -> Self::Result;
     }
 
-    impl_vfae! { [cc VectorFindAnyEqCC vec_find_any_eq_cc] Eq
-        vfaebs vector_signed_char
-        vfaebs vector_unsigned_char
-        vfaebs vector_bool_char
-
-        vfaehs vector_signed_short
-        vfaehs vector_unsigned_short
-        vfaehs vector_bool_short
-
-        vfaefs vector_signed_int
-        vfaefs vector_unsigned_int
-        vfaefs vector_bool_int
-    }
+    impl_vfae! { [cc VectorFindAnyEqCC vec_find_any_eq_cc] Eq vfaebs vfaehs vfaefs }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNeCC<Other> {
@@ -1809,19 +1807,7 @@ mod sealed {
         unsafe fn vec_find_any_ne_cc(self, other: Other, c: *mut i32) -> Self::Result;
     }
 
-    impl_vfae! { [cc VectorFindAnyNeCC vec_find_any_ne_cc] Ne
-        vfaebs vector_signed_char
-        vfaebs vector_unsigned_char
-        vfaebs vector_bool_char
-
-        vfaehs vector_signed_short
-        vfaehs vector_unsigned_short
-        vfaehs vector_bool_short
-
-        vfaefs vector_signed_int
-        vfaefs vector_unsigned_int
-        vfaefs vector_bool_int
-    }
+    impl_vfae! { [cc VectorFindAnyNeCC vec_find_any_ne_cc] Ne vfaebs vfaehs vfaefs }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyEqIdxCC<Other> {
@@ -1829,19 +1815,7 @@ mod sealed {
         unsafe fn vec_find_any_eq_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
     }
 
-    impl_vfae! { [idx_cc VectorFindAnyEqIdxCC vec_find_any_eq_idx_cc] EqIdx
-        vfaebs vector_signed_char vector_signed_char
-        vfaebs vector_unsigned_char vector_unsigned_char
-        vfaebs vector_bool_char vector_unsigned_char
-
-        vfaehs vector_signed_short vector_signed_short
-        vfaehs vector_unsigned_short vector_unsigned_short
-        vfaehs vector_bool_short vector_unsigned_short
-
-        vfaefs vector_signed_int vector_signed_int
-        vfaefs vector_unsigned_int vector_unsigned_int
-        vfaefs vector_bool_int vector_unsigned_int
-    }
+    impl_vfae! { [idx_cc VectorFindAnyEqIdxCC vec_find_any_eq_idx_cc] EqIdx vfaebs vfaehs vfaefs }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNeIdxCC<Other> {
@@ -1849,19 +1823,23 @@ mod sealed {
         unsafe fn vec_find_any_ne_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
     }
 
-    impl_vfae! { [idx_cc VectorFindAnyNeIdxCC vec_find_any_ne_idx_cc] NeIdx
-        vfaebs vector_signed_char vector_signed_char
-        vfaebs vector_unsigned_char vector_unsigned_char
-        vfaebs vector_bool_char vector_unsigned_char
+    impl_vfae! { [idx_cc VectorFindAnyNeIdxCC vec_find_any_ne_idx_cc] NeIdx vfaebs vfaehs vfaefs }
 
-        vfaehs vector_signed_short vector_signed_short
-        vfaehs vector_unsigned_short vector_unsigned_short
-        vfaehs vector_bool_short vector_unsigned_short
-
-        vfaefs vector_signed_int vector_signed_int
-        vfaefs vector_unsigned_int vector_unsigned_int
-        vfaefs vector_bool_int vector_unsigned_int
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorFindAnyEqOrZeroIdxCC<Other> {
+        type Result;
+        unsafe fn vec_find_any_eq_or_0_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
     }
+
+    impl_vfae! { [idx_cc VectorFindAnyEqOrZeroIdxCC vec_find_any_eq_or_0_idx_cc] EqIdx vfaezbs vfaezhs vfaezfs }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorFindAnyNeOrZeroIdxCC<Other> {
+        type Result;
+        unsafe fn vec_find_any_ne_or_0_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
+    }
+
+    impl_vfae! { [idx_cc VectorFindAnyNeOrZeroIdxCC vec_find_any_ne_or_0_idx_cc] NeIdx vfaezbs vfaezhs vfaezfs }
 }
 
 /// Vector element-wise addition.
@@ -2647,72 +2625,54 @@ pub unsafe fn vec_splat_u64<const IMM: i16>() -> vector_unsigned_long_long {
     vector_unsigned_long_long([IMM as u64; 2])
 }
 
-#[inline]
-#[target_feature(enable = "vector")]
-#[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_find_any_eq<T, U>(a: T, b: U) -> <T as sealed::VectorFindAnyEq<U>>::Result
-where
-    T: sealed::VectorFindAnyEq<U>,
-{
-    a.vec_find_any_eq(b)
+macro_rules! vec_find_any {
+    ($($Trait:ident $fun:ident)*) => {
+        $(
+            #[inline]
+            #[target_feature(enable = "vector")]
+            #[unstable(feature = "stdarch_s390x", issue = "135681")]
+            pub unsafe fn $fun<T, U>(a: T, b: U) -> <T as sealed::$Trait<U>>::Result
+            where
+                T: sealed::$Trait<U>,
+            {
+                a.$fun(b)
+            }
+        )*
+    }
 }
 
-#[inline]
-#[target_feature(enable = "vector")]
-#[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_find_any_ne<T, U>(a: T, b: U) -> <T as sealed::VectorFindAnyNe<U>>::Result
-where
-    T: sealed::VectorFindAnyNe<U>,
-{
-    a.vec_find_any_ne(b)
+vec_find_any! {
+    VectorFindAnyEq vec_find_any_eq
+    VectorFindAnyNe vec_find_any_ne
+    VectorFindAnyEqIdx vec_find_any_eq_idx
+    VectorFindAnyNeIdx vec_find_any_ne_idx
+    VectorFindAnyEqOrZeroIdx vec_find_any_eq_or_0_idx
+    VectorFindAnyNeOrZeroIdx vec_find_any_ne_or_0_idx
 }
 
-#[inline]
-#[target_feature(enable = "vector")]
-#[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_find_any_eq_idx<T, U>(a: T, b: U) -> <T as sealed::VectorFindAnyEqIdx<U>>::Result
-where
-    T: sealed::VectorFindAnyEqIdx<U>,
-{
-    a.vec_find_any_eq_idx(b)
+macro_rules! vec_find_any_cc {
+    ($($Trait:ident $fun:ident)*) => {
+        $(
+            #[inline]
+            #[target_feature(enable = "vector")]
+            #[unstable(feature = "stdarch_s390x", issue = "135681")]
+            pub unsafe fn $fun<T, U>(a: T, b: U, c: *mut i32) -> <T as sealed::$Trait<U>>::Result
+            where
+                T: sealed::$Trait<U>,
+            {
+                a.$fun(b, c)
+            }
+        )*
+    }
 }
 
-#[inline]
-#[target_feature(enable = "vector")]
-#[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_find_any_ne_idx<T, U>(a: T, b: U) -> <T as sealed::VectorFindAnyNeIdx<U>>::Result
-where
-    T: sealed::VectorFindAnyNeIdx<U>,
-{
-    a.vec_find_any_ne_idx(b)
-}
-
-#[inline]
-#[target_feature(enable = "vector")]
-#[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_find_any_eq_cc<T, U>(
-    a: T,
-    b: U,
-    c: *mut i32,
-) -> <T as sealed::VectorFindAnyEqCC<U>>::Result
-where
-    T: sealed::VectorFindAnyEqCC<U>,
-{
-    a.vec_find_any_eq_cc(b, c)
-}
-
-#[inline]
-#[target_feature(enable = "vector")]
-#[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_find_any_ne_cc<T, U>(
-    a: T,
-    b: U,
-    c: *mut i32,
-) -> <T as sealed::VectorFindAnyNeCC<U>>::Result
-where
-    T: sealed::VectorFindAnyNeCC<U>,
-{
-    a.vec_find_any_ne_cc(b, c)
+vec_find_any_cc! {
+    VectorFindAnyEqCC vec_find_any_eq_cc
+    VectorFindAnyNeCC vec_find_any_ne_cc
+    VectorFindAnyEqIdxCC vec_find_any_eq_idx_cc
+    VectorFindAnyNeIdxCC vec_find_any_ne_idx_cc
+    VectorFindAnyEqOrZeroIdxCC vec_find_any_eq_or_0_idx_cc
+    VectorFindAnyNeOrZeroIdxCC vec_find_any_ne_or_0_idx_cc
 }
 
 #[cfg(test)]
@@ -3270,6 +3230,17 @@ mod tests {
         [0, 16, 0, 0]
     }
 
+    test_vec_2! { test_vec_find_any_eq_or_0_idx_1, vec_find_any_eq_or_0_idx, i32x4, i32x4 -> u32x4,
+        [1, 2, 0, 4],
+        [5, 6, 7, 8],
+        [0, 8, 0, 0]
+    }
+    test_vec_2! { test_vec_find_any_ne_or_0_idx_1, vec_find_any_ne_or_0_idx, i32x4, i32x4 -> u32x4,
+        [1, 2, 0, 4],
+        [1, 2, 3, 4],
+        [0, 8, 0, 0]
+    }
+
     #[simd_test(enable = "vector")]
     fn test_vec_find_any_eq_cc() {
         let mut c = 0i32;
@@ -3304,5 +3275,107 @@ mod tests {
         let d = unsafe { vec_find_any_ne_cc(a, b, &mut c) };
         assert_eq!(c, 3);
         assert_eq!(d.as_array(), &[0, 0, 0, 0]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_find_any_eq_idx_cc() {
+        let mut c = 0i32;
+
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 3, 7, 8]);
+
+        let d = unsafe { vec_find_any_eq_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 1);
+        assert_eq!(d.as_array(), &[0, 8, 0, 0]);
+
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 6, 7, 8]);
+        let d = unsafe { vec_find_any_eq_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 3);
+        assert_eq!(d.as_array(), &[0, 16, 0, 0]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_find_any_ne_idx_cc() {
+        let mut c = 0i32;
+
+        let a = vector_unsigned_int([5, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 3, 7, 8]);
+
+        let d = unsafe { vec_find_any_ne_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 1);
+        assert_eq!(d.as_array(), &[0, 4, 0, 0]);
+
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([1, 2, 3, 4]);
+        let d = unsafe { vec_find_any_ne_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 3);
+        assert_eq!(d.as_array(), &[0, 16, 0, 0]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_find_any_eq_or_0_idx_cc() {
+        let mut c = 0i32;
+
+        // if no element of a matches any element of b with an equal value, and there is at least one element from a with a value of 0
+        let a = vector_unsigned_int([0, 1, 2, 3]);
+        let b = vector_unsigned_int([4, 5, 6, 7]);
+        let d = unsafe { vec_find_any_eq_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 0);
+        assert_eq!(d.as_array(), &[0, 0, 0, 0]);
+
+        // if at least one element of a matches any element of b with an equal value, and no elements of a with a value of 0
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 2, 3, 4]);
+        let d = unsafe { vec_find_any_eq_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 1);
+        assert_eq!(d.as_array(), &[0, 4, 0, 0]);
+
+        // if at least one element of a matches any element of b with an equal value, and there is at least one element from a has a value of 0
+        let a = vector_unsigned_int([1, 2, 3, 0]);
+        let b = vector_unsigned_int([1, 2, 3, 4]);
+        let d = unsafe { vec_find_any_eq_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 2);
+        assert_eq!(d.as_array(), &[0, 0, 0, 0]);
+
+        // if no element of a matches any element of b with an equal value, and there is no element from a with a value of 0.
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 6, 7, 8]);
+        let d = unsafe { vec_find_any_eq_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 3);
+        assert_eq!(d.as_array(), &[0, 16, 0, 0]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_find_any_ne_or_0_idx_cc() {
+        let mut c = 0i32;
+
+        // if no element of a matches any element of b with a not equal value, and there is at least one element from a with a value of 0.
+        let a = vector_unsigned_int([0, 1, 2, 3]);
+        let b = vector_unsigned_int([4, 1, 2, 3]);
+        let d = unsafe { vec_find_any_ne_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 0);
+        assert_eq!(d.as_array(), &[0, 0, 0, 0]);
+
+        // if at least one element of a matches any element of b with a not equal value, and no elements of a with a value of 0.
+        let a = vector_unsigned_int([4, 2, 3, 4]);
+        let b = vector_unsigned_int([4, 5, 6, 7]);
+        let d = unsafe { vec_find_any_ne_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 1);
+        assert_eq!(d.as_array(), &[0, 4, 0, 0]);
+
+        // if at least one element of a matches any element of b with a not equal value, and there is at least one element from a has a value of 0.
+        let a = vector_unsigned_int([1, 0, 1, 1]);
+        let b = vector_unsigned_int([4, 5, 6, 7]);
+        let d = unsafe { vec_find_any_ne_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 2);
+        assert_eq!(d.as_array(), &[0, 0, 0, 0]);
+
+        // if no element of a matches any element of b with a not equal value, and there is no element from a with a value of 0.
+        let a = vector_unsigned_int([4, 4, 4, 4]);
+        let b = vector_unsigned_int([4, 5, 6, 7]);
+        let d = unsafe { vec_find_any_ne_or_0_idx_cc(a, b, &mut c) };
+        assert_eq!(c, 3);
+        assert_eq!(d.as_array(), &[0, 16, 0, 0]);
     }
 }

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -1444,6 +1444,17 @@ mod sealed {
     impl_vec_trait! {[VectorSubc vec_subc] vec_vscbih (vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_short }
     impl_vec_trait! {[VectorSubc vec_subc] vec_vscbif (vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_int }
     impl_vec_trait! {[VectorSubc vec_subc] vec_vscbig (vector_unsigned_long_long, vector_unsigned_long_long) -> vector_unsigned_long_long }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorSqrt {
+        unsafe fn vec_sqrt(self) -> Self;
+    }
+
+    test_impl! { vec_sqrt_f32 (v: vector_float) -> vector_float [ simd_fsqrt, "vector-enhancements-1" vfsqsb ] }
+    test_impl! { vec_sqrt_f64 (v: vector_double) -> vector_double [ simd_fsqrt, vfsqdb ] }
+
+    impl_vec_trait! { [VectorSqrt vec_sqrt] vec_sqrt_f32 (vector_float) }
+    impl_vec_trait! { [VectorSqrt vec_sqrt] vec_sqrt_f64 (vector_double) }
 }
 
 /// Vector element-wise addition.
@@ -1562,6 +1573,17 @@ where
     T: sealed::VectorNabs,
 {
     a.vec_nabs()
+}
+
+/// Vector square root.
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_sqrt<T>(a: T) -> T
+where
+    T: sealed::VectorSqrt,
+{
+    a.vec_sqrt()
 }
 
 /// Vector splats.
@@ -2651,4 +2673,8 @@ mod tests {
     [0x00, 0x01, 0x02, 0x03, 0x10, 0x11, 0x12, 0x13,
      0x04, 0x05, 0x06, 0x07, 0x14, 0x15, 0x16, 0x17],
     [0.0, 1.0, 1.0, 1.1]}
+
+    test_vec_1! { test_vec_sqrt, vec_sqrt, f32x4,
+    [core::f32::consts::PI, 1.0, 25.0, 2.0],
+    [core::f32::consts::PI.sqrt(), 1.0, 5.0, core::f32::consts::SQRT_2] }
 }

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -532,6 +532,72 @@ mod sealed {
     impl_vec_trait! { [VectorNabs vec_nabs] vec_nabs_f64 (vector_double) }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorSplat {
+        unsafe fn vec_splat<const IMM: u32>(self) -> Self;
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    #[cfg_attr(test, assert_instr(vrepb, IMM2 = 1))]
+    unsafe fn vrepb<const IMM2: u32>(a: vector_signed_char) -> vector_signed_char {
+        static_assert_uimm_bits!(IMM2, 4);
+        simd_shuffle(a, a, const { u32x16::from_array([IMM2; 16]) })
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    #[cfg_attr(test, assert_instr(vreph, IMM2 = 1))]
+    unsafe fn vreph<const IMM2: u32>(a: vector_signed_short) -> vector_signed_short {
+        static_assert_uimm_bits!(IMM2, 3);
+        simd_shuffle(a, a, const { u32x8::from_array([IMM2; 8]) })
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    #[cfg_attr(test, assert_instr(vrepf, IMM2 = 1))]
+    unsafe fn vrepf<const IMM2: u32>(a: vector_signed_int) -> vector_signed_int {
+        static_assert_uimm_bits!(IMM2, 2);
+        simd_shuffle(a, a, const { u32x4::from_array([IMM2; 4]) })
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    #[cfg_attr(test, assert_instr(vrepg, IMM2 = 1))]
+    unsafe fn vrepg<const IMM2: u32>(a: vector_signed_long_long) -> vector_signed_long_long {
+        static_assert_uimm_bits!(IMM2, 1);
+        simd_shuffle(a, a, const { u32x2::from_array([IMM2; 2]) })
+    }
+
+    macro_rules! impl_vec_splat {
+        ($ty:ty, $fun:ident) => {
+            #[unstable(feature = "stdarch_s390x", issue = "135681")]
+            impl VectorSplat for $ty {
+                #[inline]
+                #[target_feature(enable = "vector")]
+                unsafe fn vec_splat<const IMM: u32>(self) -> Self {
+                    transmute($fun::<IMM>(transmute(self)))
+                }
+            }
+        };
+    }
+
+    impl_vec_splat! { vector_signed_char, vrepb }
+    impl_vec_splat! { vector_unsigned_char, vrepb }
+    impl_vec_splat! { vector_bool_char, vrepb }
+    impl_vec_splat! { vector_signed_short, vreph }
+    impl_vec_splat! { vector_unsigned_short, vreph }
+    impl_vec_splat! { vector_bool_short, vreph }
+    impl_vec_splat! { vector_signed_int, vrepf }
+    impl_vec_splat! { vector_unsigned_int, vrepf }
+    impl_vec_splat! { vector_bool_int, vrepf }
+    impl_vec_splat! { vector_signed_long_long, vrepg }
+    impl_vec_splat! { vector_unsigned_long_long, vrepg }
+    impl_vec_splat! { vector_bool_long_long, vrepg }
+
+    impl_vec_splat! { vector_float, vrepf }
+    impl_vec_splat! { vector_double, vrepg }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorSplats<Output> {
         unsafe fn vec_splats(self) -> Output;
     }
@@ -1586,6 +1652,17 @@ where
     a.vec_sqrt()
 }
 
+/// Vector Splat
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_splat<T, const IMM: u32>(a: T) -> T
+where
+    T: sealed::VectorSplat,
+{
+    a.vec_splat::<IMM>()
+}
+
 /// Vector splats.
 #[inline]
 #[target_feature(enable = "vector")]
@@ -2155,6 +2232,78 @@ pub unsafe fn vec_subec_u128(
     c: vector_unsigned_char,
 ) -> vector_unsigned_char {
     transmute(vsbcbiq(transmute(a), transmute(b), transmute(c)))
+}
+
+/// Vector Splat Signed Byte
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepib, IMM = 42))]
+pub unsafe fn vec_splat_i8<const IMM: i8>() -> vector_signed_char {
+    vector_signed_char([IMM; 16])
+}
+
+/// Vector Splat Signed Halfword
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepih, IMM = 42))]
+pub unsafe fn vec_splat_i16<const IMM: i16>() -> vector_signed_short {
+    vector_signed_short([IMM as i16; 8])
+}
+
+/// Vector Splat Signed Word
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepif, IMM = 42))]
+pub unsafe fn vec_splat_i32<const IMM: i16>() -> vector_signed_int {
+    vector_signed_int([IMM as i32; 4])
+}
+
+/// Vector Splat Signed Doubleword
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepig, IMM = 42))]
+pub unsafe fn vec_splat_i64<const IMM: i16>() -> vector_signed_long_long {
+    vector_signed_long_long([IMM as i64; 2])
+}
+
+/// Vector Splat Unsigned Byte
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepib, IMM = 42))]
+pub unsafe fn vec_splat_u8<const IMM: u8>() -> vector_unsigned_char {
+    vector_unsigned_char([IMM; 16])
+}
+
+/// Vector Splat Unsigned Halfword
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepih, IMM = 42))]
+pub unsafe fn vec_splat_u16<const IMM: i16>() -> vector_unsigned_short {
+    vector_unsigned_short([IMM as u16; 8])
+}
+
+/// Vector Splat Unsigned Word
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepif, IMM = 42))]
+pub unsafe fn vec_splat_u32<const IMM: i16>() -> vector_unsigned_int {
+    vector_unsigned_int([IMM as u32; 4])
+}
+
+/// Vector Splat Unsigned Doubleword
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+#[cfg_attr(test, assert_instr(vrepig, IMM = 42))]
+pub unsafe fn vec_splat_u64<const IMM: i16>() -> vector_unsigned_long_long {
+    vector_unsigned_long_long([IMM as u64; 2])
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -1083,6 +1083,43 @@ mod sealed {
             transmute(transmute::<_, vector_signed_long_long>(self).vec_reve())
         }
     }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorRevb {
+        unsafe fn vec_revb(self) -> Self;
+    }
+
+    test_impl! { bswapb (a: vector_signed_char) -> vector_signed_char [simd_bswap, _] }
+    test_impl! { bswaph (a: vector_signed_short) -> vector_signed_short [simd_bswap, vperm] }
+    test_impl! { bswapf (a: vector_signed_int) -> vector_signed_int [simd_bswap, vperm] }
+    test_impl! { bswapg (a: vector_signed_long_long) -> vector_signed_long_long [simd_bswap, vperm] }
+
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswapb (vector_unsigned_char) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswapb (vector_signed_char) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswaph (vector_unsigned_short) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswaph (vector_signed_short) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswapf (vector_unsigned_int) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswapf (vector_signed_int) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswapg (vector_unsigned_long_long) }
+    impl_vec_trait! { [VectorRevb vec_revb]+ bswapg (vector_signed_long_long) }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    impl VectorRevb for vector_float {
+        #[inline]
+        #[target_feature(enable = "vector")]
+        unsafe fn vec_revb(self) -> Self {
+            transmute(transmute::<_, vector_signed_int>(self).vec_revb())
+        }
+    }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    impl VectorRevb for vector_double {
+        #[inline]
+        #[target_feature(enable = "vector")]
+        unsafe fn vec_revb(self) -> Self {
+            transmute(transmute::<_, vector_signed_long_long>(self).vec_revb())
+        }
+    }
 }
 
 /// Vector element-wise addition.
@@ -1554,6 +1591,17 @@ where
     a.vec_reve()
 }
 
+/// Returns a vector where each vector element contains the corresponding byte-reversed vector element of the input vector.
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_revb<T>(a: T) -> T
+where
+    T: sealed::VectorRevb,
+{
+    a.vec_revb()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1913,5 +1961,10 @@ mod tests {
     test_vec_1! { test_vec_reve_f32, vec_reve, f32x4,
         [0.1, 0.5, 0.6, 0.9],
         [0.9, 0.6, 0.5, 0.1]
+    }
+
+    test_vec_1! { test_vec_revb_u32, vec_revb, u32x4,
+        [0xAABBCCDD, 0xEEFF0011, 0x22334455, 0x66778899],
+        [0xDDCCBBAA, 0x1100FFEE, 0x55443322, 0x99887766]
     }
 }

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -87,6 +87,10 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.s390.vsrl"] fn vsrl(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
     #[link_name = "llvm.s390.vsl"] fn vsl(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
 
+    #[link_name = "llvm.s390.vsrab"] fn vsrab(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
+    #[link_name = "llvm.s390.vsrlb"] fn vsrlb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
+    #[link_name = "llvm.s390.vslb"] fn vslb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
+
     #[link_name = "llvm.fshl.v16i8"] fn fshlb(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char) -> vector_unsigned_char;
     #[link_name = "llvm.fshl.v8i16"] fn fshlh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short;
     #[link_name = "llvm.fshl.v4i32"] fn fshlf(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int) -> vector_unsigned_int;
@@ -778,6 +782,55 @@ mod sealed {
 
     impl_vec_shift! { [VectorSra vec_sra] (vesravb, vesravh, vesravf, vesravg) }
 
+    macro_rules! impl_vec_shift_byte {
+        ([$trait:ident $m:ident] ($f:ident)) => {
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_char, vector_signed_char) -> vector_unsigned_char }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_char, vector_unsigned_char) -> vector_unsigned_char }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_char, vector_signed_char) -> vector_signed_char }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_char, vector_unsigned_char) -> vector_signed_char }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_short, vector_signed_short) -> vector_unsigned_short }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_short }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_short, vector_signed_short) -> vector_signed_short }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_short, vector_unsigned_short) -> vector_signed_short }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_int, vector_signed_int) -> vector_unsigned_int }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_int }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_int, vector_signed_int) -> vector_signed_int }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_int, vector_unsigned_int) -> vector_signed_int }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_long_long, vector_signed_long_long) -> vector_unsigned_long_long }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_long_long, vector_unsigned_long_long) -> vector_unsigned_long_long }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_long_long, vector_signed_long_long) -> vector_signed_long_long }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_signed_long_long, vector_unsigned_long_long) -> vector_signed_long_long }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_float, vector_signed_int) -> vector_float }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_float, vector_unsigned_int) -> vector_float }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_double, vector_signed_long_long) -> vector_double }
+            impl_vec_trait!{ [$trait $m]+ $f (vector_double, vector_unsigned_long_long) -> vector_double }
+        };
+    }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorSlb<Other> {
+        type Result;
+        unsafe fn vec_slb(self, b: Other) -> Self::Result;
+    }
+
+    impl_vec_shift_byte! { [VectorSlb vec_slb] (vslb) }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorSrab<Other> {
+        type Result;
+        unsafe fn vec_srab(self, b: Other) -> Self::Result;
+    }
+
+    impl_vec_shift_byte! { [VectorSrab vec_srab] (vsrab) }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorSrb<Other> {
+        type Result;
+        unsafe fn vec_srb(self, b: Other) -> Self::Result;
+    }
+
+    impl_vec_shift_byte! { [VectorSrb vec_srb] (vsrlb) }
+
     macro_rules! impl_vec_shift_long {
         ([$trait:ident $m:ident] ($f:ident)) => {
             impl_vec_trait!{ [$trait $m]+ $f (vector_unsigned_char, vector_unsigned_char) -> vector_unsigned_char }
@@ -1203,6 +1256,39 @@ where
     T: sealed::VectorSra<U>,
 {
     a.vec_sra(b)
+}
+
+/// Vector Shift Left by Byte
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_slb<T, U>(a: T, b: U) -> <T as sealed::VectorSlb<U>>::Result
+where
+    T: sealed::VectorSlb<U>,
+{
+    a.vec_slb(b)
+}
+
+/// Vector Shift Right by Byte
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_srb<T, U>(a: T, b: U) -> <T as sealed::VectorSrb<U>>::Result
+where
+    T: sealed::VectorSrb<U>,
+{
+    a.vec_srb(b)
+}
+
+/// Vector Shift Right Algebraic by Byte
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_srab<T, U>(a: T, b: U) -> <T as sealed::VectorSrab<U>>::Result
+where
+    T: sealed::VectorSrab<U>,
+{
+    a.vec_srab(b)
 }
 
 /// Vector Element Rotate Left


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/135681

I'm not really sure how big these PRs should/could be. The commits are all separate, so I could break it up if that's easier.

The `as_{mut_}array` methods were added in preparation for https://github.com/rust-lang/compiler-team/issues/838, and are currently only used in tests.