### PR TITLE
Fix doctests failing due to unused_unsafe

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -47,6 +47,7 @@ types! {
     ///
     /// # fn main() {
     /// # #[target_feature(enable = "sse2")]
+    /// # #[allow(unused_unsafe)] // temporary, to unstick CI
     /// # unsafe fn foo() { unsafe {
     /// let all_bytes_zero = _mm_setzero_si128();
     /// let all_bytes_one = _mm_set1_epi8(1);
@@ -89,6 +90,7 @@ types! {
     ///
     /// # fn main() {
     /// # #[target_feature(enable = "sse")]
+    /// # #[allow(unused_unsafe)] // temporary, to unstick CI
     /// # unsafe fn foo() { unsafe {
     /// let four_zeros = _mm_setzero_ps();
     /// let four_ones = _mm_set1_ps(1.0);
@@ -131,6 +133,7 @@ types! {
     ///
     /// # fn main() {
     /// # #[target_feature(enable = "sse2")]
+    /// # #[allow(unused_unsafe)] // temporary, to unstick CI
     /// # unsafe fn foo() { unsafe {
     /// let two_zeros = _mm_setzero_pd();
     /// let two_ones = _mm_set1_pd(1.0);
@@ -177,6 +180,7 @@ types! {
     ///
     /// # fn main() {
     /// # #[target_feature(enable = "avx")]
+    /// # #[allow(unused_unsafe)] // temporary, to unstick CI
     /// # unsafe fn foo() { unsafe {
     /// let all_bytes_zero = _mm256_setzero_si256();
     /// let all_bytes_one = _mm256_set1_epi8(1);
@@ -219,6 +223,7 @@ types! {
     ///
     /// # fn main() {
     /// # #[target_feature(enable = "avx")]
+    /// # #[allow(unused_unsafe)] // temporary, to unstick CI
     /// # unsafe fn foo() { unsafe {
     /// let eight_zeros = _mm256_setzero_ps();
     /// let eight_ones = _mm256_set1_ps(1.0);
@@ -261,6 +266,7 @@ types! {
     ///
     /// # fn main() {
     /// # #[target_feature(enable = "avx")]
+    /// # #[allow(unused_unsafe)] // temporary, to unstick CI
     /// # unsafe fn foo() { unsafe {
     /// let four_zeros = _mm256_setzero_pd();
     /// let four_ones = _mm256_set1_pd(1.0);


### PR DESCRIPTION
The function calls in these doctests were switched to safe in https://github.com/rust-lang/stdarch/pull/1714 which broke these tests. This unblocks updating upstream.