### PR TITLE
Feat - Aarch64 FEAT_FAMINMAX

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -821,6 +821,114 @@ pub fn vaddvq_u64(a: uint64x2_t) -> u64 {
     }
     unsafe { _vaddvq_u64(a) }
 }
+#[doc = "Multi-vector floating-point absolute maximum"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamax_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon instrinsic unsafe"]
+#[inline]
+#[target_feature(enable = "neon,faminmax")]
+#[cfg_attr(test, assert_instr(famax))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.neon.famax.v2f32"
+        )]
+        fn _vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
+    }
+    _vamax_f32(a, b)
+}
+#[doc = "Multi-vector floating-point absolute maximum"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamaxq_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon instrinsic unsafe"]
+#[inline]
+#[target_feature(enable = "neon,faminmax")]
+#[cfg_attr(test, assert_instr(famax))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.neon.famax.v4f32"
+        )]
+        fn _vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t;
+    }
+    _vamaxq_f32(a, b)
+}
+#[doc = "Multi-vector floating-point absolute maximum"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamaxq_f64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon instrinsic unsafe"]
+#[inline]
+#[target_feature(enable = "neon,faminmax")]
+#[cfg_attr(test, assert_instr(famax))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.neon.famax.v2f64"
+        )]
+        fn _vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t;
+    }
+    _vamaxq_f64(a, b)
+}
+#[doc = "Multi-vector floating-point absolute minimum"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamin_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon instrinsic unsafe"]
+#[inline]
+#[target_feature(enable = "neon,faminmax")]
+#[cfg_attr(test, assert_instr(famin))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.neon.famin.v2f32"
+        )]
+        fn _vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
+    }
+    _vamin_f32(a, b)
+}
+#[doc = "Multi-vector floating-point absolute minimum"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaminq_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon instrinsic unsafe"]
+#[inline]
+#[target_feature(enable = "neon,faminmax")]
+#[cfg_attr(test, assert_instr(famin))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.neon.famin.v4f32"
+        )]
+        fn _vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t;
+    }
+    _vaminq_f32(a, b)
+}
+#[doc = "Multi-vector floating-point absolute minimum"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaminq_f64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon instrinsic unsafe"]
+#[inline]
+#[target_feature(enable = "neon,faminmax")]
+#[cfg_attr(test, assert_instr(famin))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.neon.famin.v2f64"
+        )]
+        fn _vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t;
+    }
+    _vaminq_f64(a, b)
+}
 #[doc = "Bit clear and exclusive OR"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vbcaxq_s8)"]
 #[inline]

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -827,7 +827,7 @@ pub fn vaddvq_u64(a: uint64x2_t) -> u64 {
 #[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
-#[cfg_attr(test, assert_instr(famax))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
@@ -845,7 +845,7 @@ pub unsafe fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
-#[cfg_attr(test, assert_instr(famax))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
@@ -863,7 +863,7 @@ pub unsafe fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
-#[cfg_attr(test, assert_instr(famax))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     unsafe extern "unadjusted" {
@@ -881,7 +881,7 @@ pub unsafe fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
-#[cfg_attr(test, assert_instr(famin))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
@@ -899,7 +899,7 @@ pub unsafe fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
-#[cfg_attr(test, assert_instr(famin))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
@@ -917,7 +917,7 @@ pub unsafe fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
-#[cfg_attr(test, assert_instr(famin))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     unsafe extern "unadjusted" {

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -823,13 +823,11 @@ pub fn vaddvq_u64(a: uint64x2_t) -> u64 {
 }
 #[doc = "Multi-vector floating-point absolute maximum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamax_f32)"]
-#[doc = "## Safety"]
-#[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-pub unsafe fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
+pub fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
@@ -837,17 +835,15 @@ pub unsafe fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
         )]
         fn _vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
     }
-    _vamax_f32(a, b)
+    unsafe { _vamax_f32(a, b) }
 }
 #[doc = "Multi-vector floating-point absolute maximum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamaxq_f32)"]
-#[doc = "## Safety"]
-#[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-pub unsafe fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+pub fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
@@ -855,17 +851,15 @@ pub unsafe fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
         )]
         fn _vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t;
     }
-    _vamaxq_f32(a, b)
+    unsafe { _vamaxq_f32(a, b) }
 }
 #[doc = "Multi-vector floating-point absolute maximum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamaxq_f64)"]
-#[doc = "## Safety"]
-#[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-pub unsafe fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+pub fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
@@ -873,17 +867,15 @@ pub unsafe fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
         )]
         fn _vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t;
     }
-    _vamaxq_f64(a, b)
+    unsafe { _vamaxq_f64(a, b) }
 }
 #[doc = "Multi-vector floating-point absolute minimum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamin_f32)"]
-#[doc = "## Safety"]
-#[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-pub unsafe fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
+pub fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
@@ -891,17 +883,15 @@ pub unsafe fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
         )]
         fn _vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
     }
-    _vamin_f32(a, b)
+    unsafe { _vamin_f32(a, b) }
 }
 #[doc = "Multi-vector floating-point absolute minimum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaminq_f32)"]
-#[doc = "## Safety"]
-#[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-pub unsafe fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+pub fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
@@ -909,17 +899,15 @@ pub unsafe fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
         )]
         fn _vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t;
     }
-    _vaminq_f32(a, b)
+    unsafe { _vaminq_f32(a, b) }
 }
 #[doc = "Multi-vector floating-point absolute minimum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaminq_f64)"]
-#[doc = "## Safety"]
-#[doc = "  * Neon instrinsic unsafe"]
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-pub unsafe fn vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+pub fn vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
@@ -927,7 +915,7 @@ pub unsafe fn vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
         )]
         fn _vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t;
     }
-    _vaminq_f64(a, b)
+    unsafe { _vaminq_f64(a, b) }
 }
 #[doc = "Bit clear and exclusive OR"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vbcaxq_s8)"]

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -826,7 +826,7 @@ pub fn vaddvq_u64(a: uint64x2_t) -> u64 {
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[unstable(feature = "faminmax", issue = "137933")]
 pub fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
@@ -842,7 +842,7 @@ pub fn vamax_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[unstable(feature = "faminmax", issue = "137933")]
 pub fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
@@ -858,7 +858,7 @@ pub fn vamaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[unstable(feature = "faminmax", issue = "137933")]
 pub fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
@@ -874,7 +874,7 @@ pub fn vamaxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[unstable(feature = "faminmax", issue = "137933")]
 pub fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
@@ -890,7 +890,7 @@ pub fn vamin_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[unstable(feature = "faminmax", issue = "137933")]
 pub fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
@@ -906,7 +906,7 @@ pub fn vaminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 #[inline]
 #[target_feature(enable = "neon,faminmax")]
 #[cfg_attr(test, assert_instr(nop))]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[unstable(feature = "faminmax", issue = "137933")]
 pub fn vaminq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -37,7 +37,8 @@
     sha512_sm_x86,
     x86_amx_intrinsics,
     f16,
-    keylocker_x86
+    keylocker_x86,
+    aarch64_unstable_target_feature
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]
 #![deny(clippy::missing_inline_in_public_items)]

--- a/crates/intrinsic-test/missing_aarch64.txt
+++ b/crates/intrinsic-test/missing_aarch64.txt
@@ -19,6 +19,12 @@ vrnd32xq_f64
 vrnd32zq_f64
 vrnd64xq_f64
 vrnd64zq_f64
+vamin_f32
+vaminq_f32
+vaminq_f64
+vamax_f32
+vamaxq_f32
+vamaxq_f64
 # LLVM select error, and missing in Clang.
 vrnd32x_f64
 vrnd32z_f64

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -241,7 +241,6 @@ fn compile_c(
         "-march=armv8.6-a+crypto+crc+dotprod+fp16"
     } else {
         "-march=armv8.6-a+crypto+sha3+crc+dotprod+fp16+faminmax"
-    } else {
     };
 
     let intrinsic_name = &intrinsic.name;

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -240,7 +240,8 @@ fn compile_c(
     let arch_flags = if target.contains("v7") {
         "-march=armv8.6-a+crypto+crc+dotprod+fp16"
     } else {
-        "-march=armv8.6-a+crypto+sha3+crc+dotprod+fp16"
+        "-march=armv8.6-a+crypto+sha3+crc+dotprod+fp16+faminmax"
+    } else {
     };
 
     let intrinsic_name = &intrinsic.name;

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13973,3 +13973,45 @@ intrinsics:
           - - r
             - a
             - FnCall: ["vdup{neon_type[1].N}", [{FnCall: [simd_extract!, [b, 'LANE as u32']]}]]
+
+  - name: "vamax{neon_type.no}"
+    doc: "Multi-vector floating-point absolute maximum"
+    arguments: ["a: {neon_type}", "b: {neon_type}"]
+    return_type: "{neon_type}"
+    attr:
+      - FnCall: [target_feature, ['enable = "neon,faminmax"']]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [famax]]}]]
+      - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
+    safety:
+      unsafe: [neon]
+    types:
+      - float32x2_t
+      - float32x4_t
+      - float64x2_t
+    compose:
+      - LLVMLink:
+          name: "_vamax{neon_type.no}"
+          links:
+            - link: "llvm.aarch64.neon.famax.{neon_type}"
+              arch: aarch64,arm64ec
+
+  - name: "vamin{neon_type.no}"
+    doc: "Multi-vector floating-point absolute minimum"
+    arguments: ["a: {neon_type}", "b: {neon_type}"]
+    return_type: "{neon_type}"
+    attr:
+      - FnCall: [target_feature, ['enable = "neon,faminmax"']]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [famin]]}]]
+      - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
+    safety:
+      unsafe: [neon]
+    types:
+      - float32x2_t
+      - float32x4_t
+      - float64x2_t
+    compose:
+      - LLVMLink:
+          name: "_vamin{neon_type.no}"
+          links:
+            - link: "llvm.aarch64.neon.famin.{neon_type}"
+              arch: aarch64,arm64ec

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13982,8 +13982,7 @@ intrinsics:
       - FnCall: [target_feature, ['enable = "neon,faminmax"']]
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
-    safety:
-      unsafe: [neon]
+    safety: safe
     types:
       - float32x2_t
       - float32x4_t
@@ -14003,8 +14002,7 @@ intrinsics:
       - FnCall: [target_feature, ['enable = "neon,faminmax"']]
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
-    safety:
-      unsafe: [neon]
+    safety: safe
     types:
       - float32x2_t
       - float32x4_t

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13980,7 +13980,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - FnCall: [target_feature, ['enable = "neon,faminmax"']]
-      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [famax]]}]]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
     safety:
       unsafe: [neon]
@@ -14001,7 +14001,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - FnCall: [target_feature, ['enable = "neon,faminmax"']]
-      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [famin]]}]]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
     safety:
       unsafe: [neon]

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13981,7 +13981,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "neon,faminmax"']]
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [nop]]}]]
-      - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
+      - FnCall: [unstable, ['feature = "faminmax"', 'issue = "137933"']]
     safety: safe
     types:
       - float32x2_t
@@ -14001,7 +14001,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "neon,faminmax"']]
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [nop]]}]]
-      - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
+      - FnCall: [unstable, ['feature = "faminmax"', 'issue = "137933"']]
     safety: safe
     types:
       - float32x2_t

--- a/intrinsics_data/arm_intrinsics.json
+++ b/intrinsics_data/arm_intrinsics.json
@@ -118681,5 +118681,167 @@
         "ZIP2"
       ]
     ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "vamin_f32",
+    "arguments": [
+      "float32x2_t a",
+      "float32x2_t b"
+    ],
+    "return_type": {
+      "value": "float32x2_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Vn.2S"
+      },
+      "b": {
+        "register": "Vm.2S"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FAMIN"
+      ]
+    ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "vaminq_f32",
+    "arguments": [
+      "float32x4_t a",
+      "float32x4_t b"
+    ],
+    "return_type": {
+      "value": "float32x4_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Vn.4S"
+      },
+      "b": {
+        "register": "Vm.4S"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FAMIN"
+      ]
+    ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "vaminq_f64",
+    "arguments": [
+      "float64x2_t a",
+      "float64x2_t b"
+    ],
+    "return_type": {
+      "value": "float64x2_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Vn.2D"
+      },
+      "b": {
+        "register": "Vm.2D"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FAMIN"
+      ]
+    ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "vamax_f32",
+    "arguments": [
+      "float32x2_t a",
+      "float32x2_t b"
+    ],
+    "return_type": {
+      "value": "float32x2_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Vn.2S"
+      },
+      "b": {
+        "register": "Vm.2S"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FAMAX"
+      ]
+    ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "vamaxq_f32",
+    "arguments": [
+      "float32x4_t a",
+      "float32x4_t b"
+    ],
+    "return_type": {
+      "value": "float32x4_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Vn.4S"
+      },
+      "b": {
+        "register": "Vm.4S"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FAMAX"
+      ]
+    ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "vamaxq_f64",
+    "arguments": [
+      "float64x2_t a",
+      "float64x2_t b"
+    ],
+    "return_type": {
+      "value": "float64x2_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Vn.2D"
+      },
+      "b": {
+        "register": "Vm.2D"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FAMAX"
+      ]
+    ]
   }
 ]


### PR DESCRIPTION
These intrinsics have been excluded from the tests because they require a Clang version with LLVM 20, and QEMU does not yet support the famax or famin instructions.