### PR TITLE
powerpc: use `llvm.fshl` for `vec_rl`

### DIFF
--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -362,12 +362,24 @@ unsafe extern "C" {
     #[link_name = "llvm.ppc.altivec.srv"]
     fn vsrv(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_char;
 
-    #[link_name = "llvm.ppc.altivec.vrlb"]
-    fn vrlb(a: vector_signed_char, b: vector_unsigned_char) -> vector_signed_char;
-    #[link_name = "llvm.ppc.altivec.vrlh"]
-    fn vrlh(a: vector_signed_short, b: vector_unsigned_short) -> vector_signed_short;
-    #[link_name = "llvm.ppc.altivec.vrlw"]
-    fn vrlw(a: vector_signed_int, c: vector_unsigned_int) -> vector_signed_int;
+    #[link_name = "llvm.fshl.v16i8"]
+    fn fshlb(
+        a: vector_unsigned_char,
+        b: vector_unsigned_char,
+        c: vector_unsigned_char,
+    ) -> vector_unsigned_char;
+    #[link_name = "llvm.fshl.v8i16"]
+    fn fshlh(
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
+        c: vector_unsigned_short,
+    ) -> vector_unsigned_short;
+    #[link_name = "llvm.fshl.v4i32"]
+    fn fshlw(
+        a: vector_unsigned_int,
+        b: vector_unsigned_int,
+        c: vector_unsigned_int,
+    ) -> vector_unsigned_int;
 
     #[link_name = "llvm.nearbyint.v4f32"]
     fn vrfin(a: vector_float) -> vector_float;
@@ -3182,6 +3194,21 @@ mod sealed {
     impl_vec_cntlz! { vec_vcntlzw(vector_signed_int) }
     impl_vec_cntlz! { vec_vcntlzw(vector_unsigned_int) }
 
+    macro_rules! impl_vrl {
+        ($fun:ident $intr:ident $ty:ident) => {
+            #[inline]
+            #[target_feature(enable = "altivec")]
+            #[cfg_attr(test, assert_instr($fun))]
+            unsafe fn $fun(a: t_t_l!($ty), b: t_t_l!($ty)) -> t_t_l!($ty) {
+                transmute($intr(transmute(a), transmute(a), transmute(b)))
+            }
+        };
+    }
+
+    impl_vrl! { vrlb fshlb u8 }
+    impl_vrl! { vrlh fshlh u16 }
+    impl_vrl! { vrlw fshlw u32 }
+
     #[unstable(feature = "stdarch_powerpc", issue = "111145")]
     pub trait VectorRl {
         type Shift;
@@ -3202,16 +3229,12 @@ mod sealed {
         };
     }
 
-    test_impl! { vec_vrlb(a: vector_signed_char, b: vector_unsigned_char) -> vector_signed_char [vrlb, vrlb] }
-    test_impl! { vec_vrlh(a: vector_signed_short, b: vector_unsigned_short) -> vector_signed_short [vrlh, vrlh] }
-    test_impl! { vec_vrlw(a: vector_signed_int, b: vector_unsigned_int) -> vector_signed_int [vrlw, vrlw] }
-
-    impl_vec_rl! { vec_vrlb(vector_signed_char) }
-    impl_vec_rl! { vec_vrlh(vector_signed_short) }
-    impl_vec_rl! { vec_vrlw(vector_signed_int) }
-    impl_vec_rl! { vec_vrlb(vector_unsigned_char) }
-    impl_vec_rl! { vec_vrlh(vector_unsigned_short) }
-    impl_vec_rl! { vec_vrlw(vector_unsigned_int) }
+    impl_vec_rl! { vrlb(vector_signed_char) }
+    impl_vec_rl! { vrlh(vector_signed_short) }
+    impl_vec_rl! { vrlw(vector_signed_int) }
+    impl_vec_rl! { vrlb(vector_unsigned_char) }
+    impl_vec_rl! { vrlh(vector_unsigned_short) }
+    impl_vec_rl! { vrlw(vector_unsigned_int) }
 
     #[unstable(feature = "stdarch_powerpc", issue = "111145")]
     pub trait VectorRound {
@@ -6661,5 +6684,11 @@ mod tests {
         assert_eq!(v2, v);
         assert_eq!(v4, v);
         assert_eq!(v8, v);
+    }
+
+    test_vec_2! { test_vec_rl, vec_rl, u32x4,
+        [0x12345678, 0x9ABCDEF0, 0x0F0F0F0F, 0x12345678],
+        [4, 8, 12, 68],
+        [0x23456781, 0xBCDEF09A, 0xF0F0F0F0, 0x23456781]
     }
 }


### PR DESCRIPTION
another place where the general LLVM implementation can be used instead of the target-specific one.

https://llvm.org/docs/LangRef.html#llvm-fshl-intrinsic

This is another candidate for inclusion in `intrinsics::simd`, although I don't see how we could have a fallback MIR implementation for this one so the backends would need to implement it.