### PR TITLE
make _mm256_zero{upper,all} safe

### DIFF
--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1053,8 +1053,8 @@ pub fn _mm256_cvtsi256_si32(a: __m256i) -> i32 {
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vzeroall))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_zeroall() {
-    vzeroall()
+pub fn _mm256_zeroall() {
+    unsafe { vzeroall() }
 }
 
 /// Zeroes the upper 128 bits of all YMM registers;
@@ -1065,8 +1065,8 @@ pub unsafe fn _mm256_zeroall() {
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vzeroupper))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_zeroupper() {
-    vzeroupper()
+pub fn _mm256_zeroupper() {
+    unsafe { vzeroupper() }
 }
 
 /// Shuffles single-precision (32-bit) floating-point elements in `a`


### PR DESCRIPTION
These intrinsics were implemented as a NOP in Miri with the explanation:
```
                // These functions are purely a performance hint for the CPU.
                // Any registers currently in use will be saved beforehand by the
                // compiler, making these functions no-ops.
```
So, if that is true then they can be marked as safe. (If it is not true then the function should document its safety contract).