### PR TITLE
Update SDE mirror to ci-mirrors.rust-lang.org

### DIFF
--- a/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
@@ -8,8 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   xz-utils
 
-RUN wget https://downloadmirror.intel.com/843185/sde-external-9.48.0-2024-11-25-lin.tar.xz
-RUN tar -xJf sde-external-9.48.0-2024-11-25-lin.tar.xz
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/sde-external-9.48.0-2024-11-25-lin/sde64 \
+RUN wget http://ci-mirrors.rust-lang.org/stdarch/sde-external-9.48.0-2024-11-25-lin.tar.xz -O sde.tar.xz
+RUN mkdir intel-sde
+RUN tar -xJf sde.tar.xz --strip-components=1 -C intel-sde
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/intel-sde/sde64 \
             -cpuid-in /checkout/ci/docker/x86_64-unknown-linux-gnu-emulated/cpuid.def \
             -rtm-mode full -tsx --"


### PR DESCRIPTION
This is to combat the spurious CI failures in emulated run. Also helps with updatability and compatibility - it will work even if Intel changes the link