### PR TITLE
s390x: final batch of intrinsics

### DIFF
--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -396,6 +396,9 @@ macro_rules! t_b {
     (vector_bool_int) => {
         vector_bool_int
     };
+    (vector_bool_long_long) => {
+        vector_bool_long_long
+    };
     (vector_signed_char) => {
         vector_bool_char
     };

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -250,6 +250,19 @@ macro_rules! l_t_t {
         u8
     };
 
+    (vector_bool_long_long ) => {
+        u64
+    };
+    (vector_bool_int ) => {
+        u32
+    };
+    (vector_bool_short ) => {
+        u16
+    };
+    (vector_bool_char ) => {
+        u8
+    };
+
     (vector_float) => {
         f32
     };
@@ -337,6 +350,9 @@ macro_rules! t_u {
     };
     (vector_bool_int) => {
         vector_unsigned_int
+    };
+    (vector_bool_long_long) => {
+        vector_unsigned_long_long
     };
     (vector_unsigned_char) => {
         vector_unsigned_char

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -1929,10 +1929,9 @@ mod sealed {
                     type Result = $r;
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn $m(self, b: Self, c: *mut i32) -> Self::Result {
+                    unsafe fn $m(self, b: Self) -> (Self::Result, i32) {
                         let PackedTuple { x, y } = $fun::<{ FindImm::$imm as i32 }>(transmute(self), transmute(b));
-                        c.write(y);
-                        transmute(x)
+                        (transmute(x), y)
                     }
                 }
             )*
@@ -1959,10 +1958,9 @@ mod sealed {
                     type Result = t_b!($ty);
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn $m(self, b: Self, c: *mut i32) -> Self::Result {
+                    unsafe fn $m(self, b: Self) -> (Self::Result, i32) {
                         let PackedTuple { x, y } = $fun::<{ FindImm::$imm as i32 }>(transmute(self), transmute(b));
-                        c.write(y);
-                        transmute(x)
+                        (transmute(x), y)
                     }
                 }
             )*
@@ -2126,7 +2124,7 @@ mod sealed {
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyEqCC<Other> {
         type Result;
-        unsafe fn vec_find_any_eq_cc(self, other: Other, c: *mut i32) -> Self::Result;
+        unsafe fn vec_find_any_eq_cc(self, other: Other) -> (Self::Result, i32);
     }
 
     impl_vfae! { [cc VectorFindAnyEqCC vec_find_any_eq_cc] Eq vfaebs vfaehs vfaefs }
@@ -2134,7 +2132,7 @@ mod sealed {
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNeCC<Other> {
         type Result;
-        unsafe fn vec_find_any_ne_cc(self, other: Other, c: *mut i32) -> Self::Result;
+        unsafe fn vec_find_any_ne_cc(self, other: Other) -> (Self::Result, i32);
     }
 
     impl_vfae! { [cc VectorFindAnyNeCC vec_find_any_ne_cc] Ne vfaebs vfaehs vfaefs }
@@ -2142,7 +2140,7 @@ mod sealed {
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyEqIdxCC<Other> {
         type Result;
-        unsafe fn vec_find_any_eq_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
+        unsafe fn vec_find_any_eq_idx_cc(self, other: Other) -> (Self::Result, i32);
     }
 
     impl_vfae! { [idx_cc VectorFindAnyEqIdxCC vec_find_any_eq_idx_cc] EqIdx vfaebs vfaehs vfaefs }
@@ -2150,7 +2148,7 @@ mod sealed {
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNeIdxCC<Other> {
         type Result;
-        unsafe fn vec_find_any_ne_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
+        unsafe fn vec_find_any_ne_idx_cc(self, other: Other) -> (Self::Result, i32);
     }
 
     impl_vfae! { [idx_cc VectorFindAnyNeIdxCC vec_find_any_ne_idx_cc] NeIdx vfaebs vfaehs vfaefs }
@@ -2158,7 +2156,7 @@ mod sealed {
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyEqOrZeroIdxCC<Other> {
         type Result;
-        unsafe fn vec_find_any_eq_or_0_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
+        unsafe fn vec_find_any_eq_or_0_idx_cc(self, other: Other) -> (Self::Result, i32);
     }
 
     impl_vfae! { [idx_cc VectorFindAnyEqOrZeroIdxCC vec_find_any_eq_or_0_idx_cc] EqIdx vfaezbs vfaezhs vfaezfs }
@@ -2166,7 +2164,7 @@ mod sealed {
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorFindAnyNeOrZeroIdxCC<Other> {
         type Result;
-        unsafe fn vec_find_any_ne_or_0_idx_cc(self, other: Other, c: *mut i32) -> Self::Result;
+        unsafe fn vec_find_any_ne_or_0_idx_cc(self, other: Other) -> (Self::Result, i32);
     }
 
     impl_vfae! { [idx_cc VectorFindAnyNeOrZeroIdxCC vec_find_any_ne_or_0_idx_cc] NeIdx vfaezbs vfaezhs vfaezfs }
@@ -2423,11 +2421,9 @@ mod sealed {
                 unsafe fn $intr(
                     a: $ty,
                     b: $ty,
-                    c: *mut i32,
-                ) -> $outty {
+                ) -> ($outty, i32) {
                     let PackedTuple { x, y } = super::$intr(a, b);
-                    c.write(y);
-                    x
+                    (x, y)
                 }
 
                 #[unstable(feature = "stdarch_s390x", issue = "135681")]
@@ -2436,8 +2432,8 @@ mod sealed {
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_packs_cc(self, b: Self, c: *mut i32) -> Self::Result {
-                        $intr(self, b, c)
+                    unsafe fn vec_packs_cc(self, b: Self) -> (Self::Result, i32) {
+                        $intr(self, b)
                     }
                 }
             )*
@@ -2447,7 +2443,7 @@ mod sealed {
     #[unstable(feature = "stdarch_powerpc", issue = "111145")]
     pub trait VectorPacksCC {
         type Result;
-        unsafe fn vec_packs_cc(self, b: Self, c: *mut i32) -> Self::Result;
+        unsafe fn vec_packs_cc(self, b: Self) -> (Self::Result, i32);
     }
 
     impl_vector_packs_cc! {
@@ -2468,8 +2464,8 @@ mod sealed {
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_packsu_cc(self, b: Self, c: *mut i32) -> Self::Result {
-                        $intr(self, b, c)
+                    unsafe fn vec_packsu_cc(self, b: Self) -> (Self::Result, i32) {
+                        $intr(self, b)
                     }
                 }
             )*
@@ -2479,7 +2475,7 @@ mod sealed {
     #[unstable(feature = "stdarch_powerpc", issue = "111145")]
     pub trait VectorPacksuCC {
         type Result;
-        unsafe fn vec_packsu_cc(self, b: Self, c: *mut i32) -> Self::Result;
+        unsafe fn vec_packsu_cc(self, b: Self) -> (Self::Result, i32);
     }
 
     impl_vector_packsu_cc! {
@@ -3187,15 +3183,13 @@ mod sealed {
             self,
             b: Self,
             c: vector_unsigned_char,
-            d: *mut i32,
-        ) -> vector_unsigned_char;
+        ) -> (vector_unsigned_char, i32);
 
         unsafe fn vec_search_string_until_zero_cc(
             self,
             b: Self,
             c: vector_unsigned_char,
-            d: *mut i32,
-        ) -> vector_unsigned_char;
+        ) -> (vector_unsigned_char, i32);
     }
 
     macro_rules! impl_vec_search_string{
@@ -3205,18 +3199,16 @@ mod sealed {
                 impl VectorSearchString for $ty {
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_search_string_cc(self, b: Self, c: vector_unsigned_char, d: *mut i32) -> vector_unsigned_char {
+                    unsafe fn vec_search_string_cc(self, b: Self, c: vector_unsigned_char) -> (vector_unsigned_char, i32) {
                         let PackedTuple { x,y } = $intr_s(transmute(self), transmute(b), c);
-                        d.write(y);
-                        x
+                        (x, y)
                     }
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_search_string_until_zero_cc(self, b: Self, c: vector_unsigned_char, d: *mut i32) -> vector_unsigned_char {
+                    unsafe fn vec_search_string_until_zero_cc(self, b: Self, c: vector_unsigned_char) -> (vector_unsigned_char, i32) {
                         let PackedTuple { x,y } = $intr_sz(transmute(self), transmute(b), c);
-                        d.write(y);
-                        x
+                        (x, y)
                     }
                 }
 
@@ -3435,8 +3427,8 @@ mod sealed {
     impl_vec_trait! { [VectorCopyUntilZero vec_cp_until_zero]+ vec_vistrf (vector_unsigned_int) }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
-    pub trait VectorCopyUntilZeroCC {
-        unsafe fn vec_cp_until_zero_cc(self, cc: *mut i32) -> Self;
+    pub trait VectorCopyUntilZeroCC: Sized {
+        unsafe fn vec_cp_until_zero_cc(self) -> (Self, i32);
     }
 
     test_impl! { vec_vistrbs (a: vector_unsigned_char) -> PackedTuple<vector_unsigned_char, i32> [vistrbs, vistrbs] }
@@ -3450,10 +3442,9 @@ mod sealed {
                 impl VectorCopyUntilZeroCC for $ty {
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_cp_until_zero_cc(self, cc: *mut i32) -> Self {
+                    unsafe fn vec_cp_until_zero_cc(self) -> (Self, i32) {
                         let PackedTuple { x,y } = $intr(transmute(self));
-                        cc.write(y);
-                        transmute(x)
+                        (transmute(x), y)
                     }
                 }
 
@@ -3729,14 +3720,14 @@ mod sealed {
         unsafe fn vec_cmpeq_idx(self, other: Self) -> Self::Result;
         unsafe fn vec_cmpne_idx(self, other: Self) -> Self::Result;
 
-        unsafe fn vec_cmpeq_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
-        unsafe fn vec_cmpne_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
+        unsafe fn vec_cmpeq_idx_cc(self, other: Self) -> (Self::Result, i32);
+        unsafe fn vec_cmpne_idx_cc(self, other: Self) -> (Self::Result, i32);
 
         unsafe fn vec_cmpeq_or_0_idx(self, other: Self) -> Self::Result;
         unsafe fn vec_cmpne_or_0_idx(self, other: Self) -> Self::Result;
 
-        unsafe fn vec_cmpeq_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
-        unsafe fn vec_cmpne_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
+        unsafe fn vec_cmpeq_or_0_idx_cc(self, other: Self) -> (Self::Result, i32);
+        unsafe fn vec_cmpne_or_0_idx_cc(self, other: Self) -> (Self::Result, i32);
     }
 
     macro_rules! impl_compare_equality_idx {
@@ -3777,34 +3768,30 @@ mod sealed {
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_cmpeq_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                    unsafe fn vec_cmpeq_idx_cc(self, other: Self) -> (Self::Result, i32) {
                         let PackedTuple { x, y } = $cmpeq_cc(transmute(self), transmute(other));
-                        *cc = y;
-                        transmute(x)
+                        (transmute(x), y)
                     }
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_cmpne_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                    unsafe fn vec_cmpne_idx_cc(self, other: Self) -> (Self::Result, i32) {
                         let PackedTuple { x, y } = $cmpne_cc(transmute(self), transmute(other));
-                        *cc = y;
-                        transmute(x)
+                        (transmute(x),y)
                     }
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_cmpeq_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                    unsafe fn vec_cmpeq_or_0_idx_cc(self, other: Self) -> (Self::Result, i32) {
                         let PackedTuple { x, y } = $cmpeq_or_0_cc(transmute(self), transmute(other));
-                        *cc = y;
-                        transmute(x)
+                        (transmute(x), y)
                     }
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_cmpne_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                    unsafe fn vec_cmpne_or_0_idx_cc(self, other: Self) -> (Self::Result, i32) {
                         let PackedTuple { x, y } = $cmpne_or_0_cc(transmute(self), transmute(other));
-                        *cc = y;
-                        transmute(x)
+                        (transmute(x),y)
                     }
                 }
             )*
@@ -4279,7 +4266,9 @@ pub unsafe fn vec_packs<T: sealed::VectorPacks<U>, U>(a: T, b: U) -> T::Result {
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 pub unsafe fn vec_packs_cc<T: sealed::VectorPacksCC>(a: T, b: T, c: *mut i32) -> T::Result {
-    a.vec_packs_cc(b, c)
+    let (x, y) = a.vec_packs_cc(b);
+    unsafe { c.write(y) };
+    x
 }
 
 /// Vector Pack Saturated Unsigned
@@ -4295,7 +4284,9 @@ pub unsafe fn vec_packsu<T: sealed::VectorPacksu<U>, U>(a: T, b: U) -> T::Result
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 pub unsafe fn vec_packsu_cc<T: sealed::VectorPacksuCC>(a: T, b: T, c: *mut i32) -> T::Result {
-    a.vec_packsu_cc(b, c)
+    let (x, y) = a.vec_packsu_cc(b);
+    unsafe { c.write(y) };
+    x
 }
 
 /// Vector Unpack High
@@ -4668,7 +4659,9 @@ macro_rules! vec_find_any_cc {
             #[target_feature(enable = "vector")]
             #[unstable(feature = "stdarch_s390x", issue = "135681")]
             pub unsafe fn $fun<T: sealed::$Trait<U>, U>(a: T, b: U, c: *mut i32) -> T::Result {
-                a.$fun(b, c)
+                let (x, y) = a.$fun(b);
+                unsafe { c.write(y) };
+                x
             }
         )*
     }
@@ -5021,7 +5014,9 @@ pub unsafe fn vec_search_string_cc<T: sealed::VectorSearchString>(
     c: vector_unsigned_char,
     d: *mut i32,
 ) -> vector_unsigned_char {
-    a.vec_search_string_cc(b, c, d)
+    let (x, y) = a.vec_search_string_cc(b, c);
+    unsafe { d.write(y) };
+    x
 }
 
 /// Vector Search String Until Zero
@@ -5034,7 +5029,9 @@ pub unsafe fn vec_search_string_until_zero_cc<T: sealed::VectorSearchString>(
     c: vector_unsigned_char,
     d: *mut i32,
 ) -> vector_unsigned_char {
-    a.vec_search_string_until_zero_cc(b, c, d)
+    let (x, y) = a.vec_search_string_until_zero_cc(b, c);
+    unsafe { d.write(y) };
+    x
 }
 
 /// Vector Convert from float (even elements) to double
@@ -5116,7 +5113,9 @@ pub unsafe fn vec_cp_until_zero<T: sealed::VectorCopyUntilZero>(a: T) -> T {
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 pub unsafe fn vec_cp_until_zero_cc<T: sealed::VectorCopyUntilZeroCC>(a: T, cc: *mut i32) -> T {
-    a.vec_cp_until_zero_cc(cc)
+    let (x, y) = a.vec_cp_until_zero_cc();
+    unsafe { cc.write(y) };
+    x
 }
 
 /// Vector Multiply Sum Logical
@@ -5384,7 +5383,9 @@ pub unsafe fn vec_cmpeq_idx_cc<T: sealed::VectorEqualityIdx>(
     b: T,
     cc: *mut i32,
 ) -> T::Result {
-    a.vec_cmpeq_idx_cc(b, cc)
+    let (x, y) = a.vec_cmpeq_idx_cc(b);
+    unsafe { cc.write(y) };
+    x
 }
 /// Vector Compare Not Equal Index with Condition Code
 #[inline]
@@ -5395,7 +5396,9 @@ pub unsafe fn vec_cmpne_idx_cc<T: sealed::VectorEqualityIdx>(
     b: T,
     cc: *mut i32,
 ) -> T::Result {
-    a.vec_cmpne_idx_cc(b, cc)
+    let (x, y) = a.vec_cmpne_idx_cc(b);
+    unsafe { cc.write(y) };
+    x
 }
 /// Vector Compare Equal or Zero Index
 #[inline]
@@ -5420,7 +5423,9 @@ pub unsafe fn vec_cmpeq_or_0_idx_cc<T: sealed::VectorEqualityIdx>(
     b: T,
     cc: *mut i32,
 ) -> T::Result {
-    a.vec_cmpeq_or_0_idx_cc(b, cc)
+    let (x, y) = a.vec_cmpeq_or_0_idx_cc(b);
+    unsafe { cc.write(y) };
+    x
 }
 /// Vector Compare Not Equal or Zero Index with Condition Code
 #[inline]
@@ -5431,7 +5436,9 @@ pub unsafe fn vec_cmpne_or_0_idx_cc<T: sealed::VectorEqualityIdx>(
     b: T,
     cc: *mut i32,
 ) -> T::Result {
-    a.vec_cmpne_or_0_idx_cc(b, cc)
+    let (x, y) = a.vec_cmpne_or_0_idx_cc(b);
+    unsafe { cc.write(y) };
+    x
 }
 
 /// All Elements Equal

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -251,6 +251,38 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.s390.vstrczbs"] fn vstrczbs(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char, d: u32) -> PackedTuple<vector_bool_char, i32>;
     #[link_name = "llvm.s390.vstrczhs"] fn vstrczhs(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short, d: u32) -> PackedTuple<vector_bool_short, i32>;
     #[link_name = "llvm.s390.vstrczfs"] fn vstrczfs(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int, d: u32) -> PackedTuple<vector_bool_int, i32>;
+
+    #[link_name = "llvm.s390.vfeeb"] fn vfeeb(a: i8x16, b: i8x16) -> i8x16;
+    #[link_name = "llvm.s390.vfeeh"] fn vfeeh(a: i16x8, b: i16x8) -> i16x8;
+    #[link_name = "llvm.s390.vfeef"] fn vfeef(a: i32x4, b: i32x4) -> i32x4;
+
+    #[link_name = "llvm.s390.vfeezb"] fn vfeezb(a: i8x16, b: i8x16) -> i8x16;
+    #[link_name = "llvm.s390.vfeezh"] fn vfeezh(a: i16x8, b: i16x8) -> i16x8;
+    #[link_name = "llvm.s390.vfeezf"] fn vfeezf(a: i32x4, b: i32x4) -> i32x4;
+
+    #[link_name = "llvm.s390.vfeebs"] fn vfeebs(a: i8x16, b: i8x16) -> PackedTuple<i8x16, i32>;
+    #[link_name = "llvm.s390.vfeehs"] fn vfeehs(a: i16x8, b: i16x8) -> PackedTuple<i16x8, i32>;
+    #[link_name = "llvm.s390.vfeefs"] fn vfeefs(a: i32x4, b: i32x4) -> PackedTuple<i32x4, i32>;
+
+    #[link_name = "llvm.s390.vfeezbs"] fn vfeezbs(a: i8x16, b: i8x16) -> PackedTuple<i8x16, i32>;
+    #[link_name = "llvm.s390.vfeezhs"] fn vfeezhs(a: i16x8, b: i16x8) -> PackedTuple<i16x8, i32>;
+    #[link_name = "llvm.s390.vfeezfs"] fn vfeezfs(a: i32x4, b: i32x4) -> PackedTuple<i32x4, i32>;
+
+    #[link_name = "llvm.s390.vfeneb"] fn vfeneb(a: i8x16, b: i8x16) -> i8x16;
+    #[link_name = "llvm.s390.vfeneh"] fn vfeneh(a: i16x8, b: i16x8) -> i16x8;
+    #[link_name = "llvm.s390.vfenef"] fn vfenef(a: i32x4, b: i32x4) -> i32x4;
+
+    #[link_name = "llvm.s390.vfenezb"] fn vfenezb(a: i8x16, b: i8x16) -> i8x16;
+    #[link_name = "llvm.s390.vfenezh"] fn vfenezh(a: i16x8, b: i16x8) -> i16x8;
+    #[link_name = "llvm.s390.vfenezf"] fn vfenezf(a: i32x4, b: i32x4) -> i32x4;
+
+    #[link_name = "llvm.s390.vfenebs"] fn vfenebs(a: i8x16, b: i8x16) -> PackedTuple<i8x16, i32>;
+    #[link_name = "llvm.s390.vfenehs"] fn vfenehs(a: i16x8, b: i16x8) -> PackedTuple<i16x8, i32>;
+    #[link_name = "llvm.s390.vfenefs"] fn vfenefs(a: i32x4, b: i32x4) -> PackedTuple<i32x4, i32>;
+
+    #[link_name = "llvm.s390.vfenezbs"] fn vfenezbs(a: i8x16, b: i8x16) -> PackedTuple<i8x16, i32>;
+    #[link_name = "llvm.s390.vfenezhs"] fn vfenezhs(a: i16x8, b: i16x8) -> PackedTuple<i16x8, i32>;
+    #[link_name = "llvm.s390.vfenezfs"] fn vfenezfs(a: i32x4, b: i32x4) -> PackedTuple<i32x4, i32>;
 }
 
 impl_from! { i8x16, u8x16,  i16x8, u16x8, i32x4, u32x4, i64x2, u64x2, f32x4, f64x2 }
@@ -3437,6 +3469,107 @@ mod sealed {
         vector_unsigned_long_long
         vector_double
     }
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorEqualityIdx: Sized {
+        type Result;
+
+        unsafe fn vec_cmpeq_idx(self, other: Self) -> Self::Result;
+        unsafe fn vec_cmpne_idx(self, other: Self) -> Self::Result;
+
+        unsafe fn vec_cmpeq_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
+        unsafe fn vec_cmpne_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
+
+        unsafe fn vec_cmpeq_or_0_idx(self, other: Self) -> Self::Result;
+        unsafe fn vec_cmpne_or_0_idx(self, other: Self) -> Self::Result;
+
+        unsafe fn vec_cmpeq_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
+        unsafe fn vec_cmpne_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result;
+    }
+
+    macro_rules! impl_compare_equality_idx {
+        ($($ty:ident $ret:ident
+                $cmpeq:ident $cmpne:ident
+                $cmpeq_or_0:ident $cmpne_or_0:ident
+                $cmpeq_cc:ident $cmpne_cc:ident
+                $cmpeq_or_0_cc:ident $cmpne_or_0_cc:ident
+        )*) => {
+            $(
+                #[unstable(feature = "stdarch_s390x", issue = "135681")]
+                impl VectorEqualityIdx for $ty {
+                    type Result = $ret;
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpeq_idx(self, other: Self) -> Self::Result {
+                        transmute($cmpeq(transmute(self), transmute(other)))
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpne_idx(self, other: Self) -> Self::Result {
+                        transmute($cmpne(transmute(self), transmute(other)))
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpeq_or_0_idx(self, other: Self) -> Self::Result {
+                        transmute($cmpeq_or_0(transmute(self), transmute(other)))
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpne_or_0_idx(self, other: Self) -> Self::Result {
+                        transmute($cmpne_or_0(transmute(self), transmute(other)))
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpeq_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                        let PackedTuple { x, y } = $cmpeq_cc(transmute(self), transmute(other));
+                        *cc = y;
+                        transmute(x)
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpne_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                        let PackedTuple { x, y } = $cmpne_cc(transmute(self), transmute(other));
+                        *cc = y;
+                        transmute(x)
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpeq_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                        let PackedTuple { x, y } = $cmpeq_or_0_cc(transmute(self), transmute(other));
+                        *cc = y;
+                        transmute(x)
+                    }
+
+                    #[inline]
+                    #[target_feature(enable = "vector")]
+                    unsafe fn vec_cmpne_or_0_idx_cc(self, other: Self, cc: *mut i32) -> Self::Result {
+                        let PackedTuple { x, y } = $cmpne_or_0_cc(transmute(self), transmute(other));
+                        *cc = y;
+                        transmute(x)
+                    }
+                }
+            )*
+        }
+    }
+
+    impl_compare_equality_idx! {
+        vector_signed_char vector_signed_char               vfeeb vfeneb vfeezb vfenezb vfeebs vfenebs vfeezbs vfenezbs
+        vector_bool_char vector_unsigned_char               vfeeb vfeneb vfeezb vfenezb vfeebs vfenebs vfeezbs vfenezbs
+        vector_unsigned_char vector_unsigned_char           vfeeb vfeneb vfeezb vfenezb vfeebs vfenebs vfeezbs vfenezbs
+        vector_signed_short vector_signed_short             vfeeh vfeneh vfeezh vfenezh vfeehs vfenehs vfeezhs vfenezhs
+        vector_bool_short  vector_unsigned_short            vfeeh vfeneh vfeezh vfenezh vfeehs vfenehs vfeezhs vfenezhs
+        vector_unsigned_short vector_unsigned_short         vfeeh vfeneh vfeezh vfenezh vfeehs vfenehs vfeezhs vfenezhs
+        vector_signed_int vector_signed_int                 vfeef vfenef vfeezf vfenezf vfeefs vfenefs vfeezfs vfenezfs
+        vector_bool_int  vector_unsigned_int                vfeef vfenef vfeezf vfenezf vfeefs vfenefs vfeezfs vfenezfs
+        vector_unsigned_int vector_unsigned_int             vfeef vfenef vfeezf vfenezf vfeefs vfenefs vfeezfs vfenezfs
+    }
 }
 
 /// Load Count to Block Boundary
@@ -5028,6 +5161,79 @@ pub unsafe fn vec_cmplt<T: sealed::VectorComparePredicate>(a: T, b: T) -> T::Res
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 pub unsafe fn vec_cmple<T: sealed::VectorComparePredicate>(a: T, b: T) -> T::Result {
     a.vec_cmple(b)
+}
+
+/// Vector Compare Equal Index
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpeq_idx<T: sealed::VectorEqualityIdx>(a: T, b: T) -> T::Result {
+    a.vec_cmpeq_idx(b)
+}
+/// Vector Compare Not Equal Index
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpne_idx<T: sealed::VectorEqualityIdx>(a: T, b: T) -> T::Result {
+    a.vec_cmpne_idx(b)
+}
+/// Vector Compare Equal Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpeq_idx_cc<T: sealed::VectorEqualityIdx>(
+    a: T,
+    b: T,
+    cc: *mut i32,
+) -> T::Result {
+    a.vec_cmpeq_idx_cc(b, cc)
+}
+/// Vector Compare Not Equal Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpne_idx_cc<T: sealed::VectorEqualityIdx>(
+    a: T,
+    b: T,
+    cc: *mut i32,
+) -> T::Result {
+    a.vec_cmpne_idx_cc(b, cc)
+}
+/// Vector Compare Equal or Zero Index
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpeq_or_0_idx<T: sealed::VectorEqualityIdx>(a: T, b: T) -> T::Result {
+    a.vec_cmpeq_or_0_idx(b)
+}
+/// Vector Compare Not Equal or Zero Index
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpne_or_0_idx<T: sealed::VectorEqualityIdx>(a: T, b: T) -> T::Result {
+    a.vec_cmpne_or_0_idx(b)
+}
+/// Vector Compare Equal or Zero Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpeq_or_0_idx_cc<T: sealed::VectorEqualityIdx>(
+    a: T,
+    b: T,
+    cc: *mut i32,
+) -> T::Result {
+    a.vec_cmpeq_or_0_idx_cc(b, cc)
+}
+/// Vector Compare Not Equal or Zero Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpne_or_0_idx_cc<T: sealed::VectorEqualityIdx>(
+    a: T,
+    b: T,
+    cc: *mut i32,
+) -> T::Result {
+    a.vec_cmpne_or_0_idx_cc(b, cc)
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -3837,10 +3837,7 @@ unsafe fn __lcbb<const BLOCK_BOUNDARY: u16>(ptr: *const u8) -> u32 {
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_add<T, U>(a: T, b: U) -> <T as sealed::VectorAdd<U>>::Result
-where
-    T: sealed::VectorAdd<U>,
-{
+pub unsafe fn vec_add<T: sealed::VectorAdd<U>, U>(a: T, b: U) -> T::Result {
     a.vec_add(b)
 }
 
@@ -3848,10 +3845,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_sub<T, U>(a: T, b: U) -> <T as sealed::VectorSub<U>>::Result
-where
-    T: sealed::VectorSub<U>,
-{
+pub unsafe fn vec_sub<T: sealed::VectorSub<U>, U>(a: T, b: U) -> T::Result {
     a.vec_sub(b)
 }
 
@@ -3865,10 +3859,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_mul<T>(a: T, b: T) -> T
-where
-    T: sealed::VectorMul,
-{
+pub unsafe fn vec_mul<T: sealed::VectorMul>(a: T, b: T) -> T {
     a.vec_mul(b)
 }
 
@@ -3876,10 +3867,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_cntlz<T>(a: T) -> <T as sealed::CountBits>::Result
-where
-    T: sealed::CountBits,
-{
+pub unsafe fn vec_cntlz<T: sealed::CountBits>(a: T) -> T::Result {
     a.vec_cntlz()
 }
 
@@ -3887,10 +3875,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_cnttz<T>(a: T) -> <T as sealed::CountBits>::Result
-where
-    T: sealed::CountBits,
-{
+pub unsafe fn vec_cnttz<T: sealed::CountBits>(a: T) -> T::Result {
     a.vec_cnttz()
 }
 
@@ -3900,10 +3885,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_popcnt<T>(a: T) -> <T as sealed::CountBits>::Result
-where
-    T: sealed::CountBits,
-{
+pub unsafe fn vec_popcnt<T: sealed::CountBits>(a: T) -> T::Result {
     a.vec_popcnt()
 }
 
@@ -3911,10 +3893,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_max<T, U>(a: T, b: U) -> <T as sealed::VectorMax<U>>::Result
-where
-    T: sealed::VectorMax<U>,
-{
+pub unsafe fn vec_max<T: sealed::VectorMax<U>, U>(a: T, b: U) -> T::Result {
     a.vec_max(b)
 }
 
@@ -3922,10 +3901,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_min<T, U>(a: T, b: U) -> <T as sealed::VectorMin<U>>::Result
-where
-    T: sealed::VectorMin<U>,
-{
+pub unsafe fn vec_min<T: sealed::VectorMin<U>, U>(a: T, b: U) -> T::Result {
     a.vec_min(b)
 }
 
@@ -3933,10 +3909,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_abs<T>(a: T) -> T
-where
-    T: sealed::VectorAbs,
-{
+pub unsafe fn vec_abs<T: sealed::VectorAbs>(a: T) -> T {
     a.vec_abs()
 }
 
@@ -3968,10 +3941,7 @@ pub unsafe fn vec_nmsub<T: sealed::VectorNmsub>(a: T, b: T, c: T) -> T {
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_sqrt<T>(a: T) -> T
-where
-    T: sealed::VectorSqrt,
-{
+pub unsafe fn vec_sqrt<T: sealed::VectorSqrt>(a: T) -> T {
     a.vec_sqrt()
 }
 
@@ -3979,10 +3949,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_splat<T, const IMM: u32>(a: T) -> T
-where
-    T: sealed::VectorSplat,
-{
+pub unsafe fn vec_splat<T: sealed::VectorSplat, const IMM: u32>(a: T) -> T {
     a.vec_splat::<IMM>()
 }
 
@@ -3990,10 +3957,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_splats<T, U>(a: T) -> U
-where
-    T: sealed::VectorSplats<U>,
-{
+pub unsafe fn vec_splats<T: sealed::VectorSplats<U>, U>(a: T) -> U {
     a.vec_splats()
 }
 
@@ -4001,10 +3965,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_and<T, U>(a: T, b: U) -> <T as sealed::VectorAnd<U>>::Result
-where
-    T: sealed::VectorAnd<U>,
-{
+pub unsafe fn vec_and<T: sealed::VectorAnd<U>, U>(a: T, b: U) -> T::Result {
     a.vec_and(b)
 }
 
@@ -4012,10 +3973,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_or<T, U>(a: T, b: U) -> <T as sealed::VectorOr<U>>::Result
-where
-    T: sealed::VectorOr<U>,
-{
+pub unsafe fn vec_or<T: sealed::VectorOr<U>, U>(a: T, b: U) -> T::Result {
     a.vec_or(b)
 }
 
@@ -4023,10 +3981,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_xor<T, U>(a: T, b: U) -> <T as sealed::VectorXor<U>>::Result
-where
-    T: sealed::VectorXor<U>,
-{
+pub unsafe fn vec_xor<T: sealed::VectorXor<U>, U>(a: T, b: U) -> T::Result {
     a.vec_xor(b)
 }
 
@@ -4034,10 +3989,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_nor<T, U>(a: T, b: U) -> <T as sealed::VectorNor<U>>::Result
-where
-    T: sealed::VectorNor<U>,
-{
+pub unsafe fn vec_nor<T: sealed::VectorNor<U>, U>(a: T, b: U) -> T::Result {
     a.vec_nor(b)
 }
 
@@ -4045,10 +3997,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_nand<T, U>(a: T, b: U) -> <T as sealed::VectorNand<U>>::Result
-where
-    T: sealed::VectorNand<U>,
-{
+pub unsafe fn vec_nand<T: sealed::VectorNand<U>, U>(a: T, b: U) -> T::Result {
     a.vec_nand(b)
 }
 
@@ -4056,10 +4005,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_eqv<T, U>(a: T, b: U) -> <T as sealed::VectorEqv<U>>::Result
-where
-    T: sealed::VectorEqv<U>,
-{
+pub unsafe fn vec_eqv<T: sealed::VectorEqv<U>, U>(a: T, b: U) -> T::Result {
     a.vec_eqv(b)
 }
 
@@ -4067,10 +4013,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_andc<T, U>(a: T, b: U) -> <T as sealed::VectorAndc<U>>::Result
-where
-    T: sealed::VectorAndc<U>,
-{
+pub unsafe fn vec_andc<T: sealed::VectorAndc<U>, U>(a: T, b: U) -> T::Result {
     a.vec_andc(b)
 }
 
@@ -4084,10 +4027,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_orc<T, U>(a: T, b: U) -> <T as sealed::VectorOrc<U>>::Result
-where
-    T: sealed::VectorOrc<U>,
-{
+pub unsafe fn vec_orc<T: sealed::VectorOrc<U>, U>(a: T, b: U) -> T::Result {
     a.vec_orc(b)
 }
 
@@ -4095,10 +4035,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_floor<T>(a: T) -> T
-where
-    T: sealed::VectorFloor,
-{
+pub unsafe fn vec_floor<T: sealed::VectorFloor>(a: T) -> T {
     a.vec_floor()
 }
 
@@ -4106,10 +4043,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_ceil<T>(a: T) -> T
-where
-    T: sealed::VectorCeil,
-{
+pub unsafe fn vec_ceil<T: sealed::VectorCeil>(a: T) -> T {
     a.vec_ceil()
 }
 
@@ -4118,10 +4052,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_trunc<T>(a: T) -> T
-where
-    T: sealed::VectorTrunc,
-{
+pub unsafe fn vec_trunc<T: sealed::VectorTrunc>(a: T) -> T {
     a.vec_trunc()
 }
 
@@ -4130,10 +4061,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_round<T>(a: T) -> T
-where
-    T: sealed::VectorRound,
-{
+pub unsafe fn vec_round<T: sealed::VectorRound>(a: T) -> T {
     a.vec_round()
 }
 
@@ -4142,10 +4070,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_roundc<T>(a: T) -> T
-where
-    T: sealed::VectorRoundc,
-{
+pub unsafe fn vec_roundc<T: sealed::VectorRoundc>(a: T) -> T {
     a.vec_roundc()
 }
 
@@ -4154,10 +4079,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_roundm<T>(a: T) -> T
-where
-    T: sealed::VectorFloor,
-{
+pub unsafe fn vec_roundm<T: sealed::VectorFloor>(a: T) -> T {
     // the IBM docs note
     //
     // > vec_roundm provides the same functionality as vec_floor, except that vec_roundz would not trigger the IEEE-inexact exception.
@@ -4171,10 +4093,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_roundp<T>(a: T) -> T
-where
-    T: sealed::VectorCeil,
-{
+pub unsafe fn vec_roundp<T: sealed::VectorCeil>(a: T) -> T {
     // the IBM docs note
     //
     // > vec_roundp provides the same functionality as vec_ceil, except that vec_roundz would not trigger the IEEE-inexact exception.
@@ -4188,10 +4107,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_roundz<T>(a: T) -> T
-where
-    T: sealed::VectorTrunc,
-{
+pub unsafe fn vec_roundz<T: sealed::VectorTrunc>(a: T) -> T {
     // the IBM docs note
     //
     // > vec_roundz provides the same functionality as vec_trunc, except that vec_roundz would not trigger the IEEE-inexact exception.
@@ -4204,10 +4120,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_rint<T>(a: T) -> T
-where
-    T: sealed::VectorRint,
-{
+pub unsafe fn vec_rint<T: sealed::VectorRint>(a: T) -> T {
     a.vec_rint()
 }
 
@@ -4223,10 +4136,7 @@ pub unsafe fn vec_avg<T: sealed::VectorAvg<U>, U>(a: T, b: U) -> T::Result {
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_sl<T, U>(a: T, b: U) -> <T as sealed::VectorSl<U>>::Result
-where
-    T: sealed::VectorSl<U>,
-{
+pub unsafe fn vec_sl<T: sealed::VectorSl<U>, U>(a: T, b: U) -> T::Result {
     a.vec_sl(b)
 }
 
@@ -4234,10 +4144,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_sr<T, U>(a: T, b: U) -> <T as sealed::VectorSr<U>>::Result
-where
-    T: sealed::VectorSr<U>,
-{
+pub unsafe fn vec_sr<T: sealed::VectorSr<U>, U>(a: T, b: U) -> T::Result {
     a.vec_sr(b)
 }
 
@@ -4245,10 +4152,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_sra<T, U>(a: T, b: U) -> <T as sealed::VectorSra<U>>::Result
-where
-    T: sealed::VectorSra<U>,
-{
+pub unsafe fn vec_sra<T: sealed::VectorSra<U>, U>(a: T, b: U) -> T::Result {
     a.vec_sra(b)
 }
 
@@ -4256,10 +4160,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_slb<T, U>(a: T, b: U) -> <T as sealed::VectorSlb<U>>::Result
-where
-    T: sealed::VectorSlb<U>,
-{
+pub unsafe fn vec_slb<T: sealed::VectorSlb<U>, U>(a: T, b: U) -> T::Result {
     a.vec_slb(b)
 }
 
@@ -4267,10 +4168,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_srb<T, U>(a: T, b: U) -> <T as sealed::VectorSrb<U>>::Result
-where
-    T: sealed::VectorSrb<U>,
-{
+pub unsafe fn vec_srb<T: sealed::VectorSrb<U>, U>(a: T, b: U) -> T::Result {
     a.vec_srb(b)
 }
 
@@ -4278,10 +4176,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_srab<T, U>(a: T, b: U) -> <T as sealed::VectorSrab<U>>::Result
-where
-    T: sealed::VectorSrab<U>,
-{
+pub unsafe fn vec_srab<T: sealed::VectorSrab<U>, U>(a: T, b: U) -> T::Result {
     a.vec_srab(b)
 }
 
@@ -4289,10 +4184,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_rl<T, U>(a: T, b: U) -> <T as sealed::VectorRl<U>>::Result
-where
-    T: sealed::VectorRl<U>,
-{
+pub unsafe fn vec_rl<T: sealed::VectorRl<U>, U>(a: T, b: U) -> T::Result {
     a.vec_rl(b)
 }
 
@@ -4338,10 +4230,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_rli<T>(a: T, bits: core::ffi::c_ulong) -> T
-where
-    T: sealed::VectorRli,
-{
+pub unsafe fn vec_rli<T: sealed::VectorRli>(a: T, bits: core::ffi::c_ulong) -> T {
     a.vec_rli(bits)
 }
 
@@ -4349,10 +4238,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_reve<T>(a: T) -> T
-where
-    T: sealed::VectorReve,
-{
+pub unsafe fn vec_reve<T: sealed::VectorReve>(a: T) -> T {
     a.vec_reve()
 }
 
@@ -4360,10 +4246,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_revb<T>(a: T) -> T
-where
-    T: sealed::VectorRevb,
-{
+pub unsafe fn vec_revb<T: sealed::VectorRevb>(a: T) -> T {
     a.vec_revb()
 }
 
@@ -4371,10 +4254,7 @@ where
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_mergeh<T>(a: T, b: T) -> T
-where
-    T: sealed::VectorMergeh,
-{
+pub unsafe fn vec_mergeh<T: sealed::VectorMergeh>(a: T, b: T) -> T {
     a.vec_mergeh(b)
 }
 
@@ -4438,10 +4318,7 @@ pub unsafe fn vec_unpackl<T: sealed::VectorUnpackl>(a: T) -> <T as sealed::Vecto
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_mergel<T>(a: T, b: T) -> T
-where
-    T: sealed::VectorMergel,
-{
+pub unsafe fn vec_mergel<T: sealed::VectorMergel>(a: T, b: T) -> T {
     a.vec_mergel(b)
 }
 
@@ -4579,10 +4456,7 @@ pub unsafe fn vec_sub_u128(
 #[inline]
 #[target_feature(enable = "vector")]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
-pub unsafe fn vec_subc<T, U>(a: T, b: U) -> <T as sealed::VectorSubc<U>>::Result
-where
-    T: sealed::VectorSubc<U>,
-{
+pub unsafe fn vec_subc<T: sealed::VectorSubc<U>, U>(a: T, b: U) -> T::Result {
     a.vec_subc(b)
 }
 
@@ -4771,10 +4645,7 @@ macro_rules! vec_find_any {
             #[inline]
             #[target_feature(enable = "vector")]
             #[unstable(feature = "stdarch_s390x", issue = "135681")]
-            pub unsafe fn $fun<T, U>(a: T, b: U) -> <T as sealed::$Trait<U>>::Result
-            where
-                T: sealed::$Trait<U>,
-            {
+            pub unsafe fn $fun<T: sealed::$Trait<U>, U>(a: T, b: U) -> T::Result {
                 a.$fun(b)
             }
         )*
@@ -4796,10 +4667,7 @@ macro_rules! vec_find_any_cc {
             #[inline]
             #[target_feature(enable = "vector")]
             #[unstable(feature = "stdarch_s390x", issue = "135681")]
-            pub unsafe fn $fun<T, U>(a: T, b: U, c: *mut i32) -> <T as sealed::$Trait<U>>::Result
-            where
-                T: sealed::$Trait<U>,
-            {
+            pub unsafe fn $fun<T: sealed::$Trait<U>, U>(a: T, b: U, c: *mut i32) -> T::Result {
                 a.$fun(b, c)
             }
         )*

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -4752,6 +4752,46 @@ pub unsafe fn vec_cmpnrg_idx<T: sealed::VectorCompareRange>(a: T, b: T, c: T) ->
     a.vstrc::<{ FindImm::NeIdx as u32 }>(b, c)
 }
 
+/// Vector Compare Ranges with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmprg_cc<T: sealed::VectorCompareRange>(a: T, b: T, c: T, d: *mut i32) -> T::Result {
+    let (x,y) = a.vstrcs::<{ FindImm::Eq as u32 }>(b, c);
+    d.write(y);
+    x
+}
+
+/// Vector Compare Not in Ranges with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpnrg_cc<T: sealed::VectorCompareRange>(a: T, b: T, c: T, d: *mut i32) -> T::Result {
+    let (x,y) = a.vstrcs::<{ FindImm::Ne as u32 }>(b, c);
+    d.write(y);
+    x
+}
+
+/// Vector Compare Ranges Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmprg_idx_cc<T: sealed::VectorCompareRange>(a: T, b: T, c: T, d: *mut i32) -> T::Result {
+    let (x,y) = a.vstrcs::<{ FindImm::EqIdx as u32 }>(b, c);
+    d.write(y);
+    x
+}
+
+/// Vector Compare Not in Ranges Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpnrg_idx_cc<T: sealed::VectorCompareRange>(a: T, b: T, c: T, d: *mut i32) -> T::Result {
+    let (x,y) = a.vstrcs::<{ FindImm::NeIdx as u32 }>(b, c);
+    d.write(y);
+    x
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -217,6 +217,38 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.s390.vmlhh"] fn vmlhh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_short;
     #[link_name = "llvm.s390.vmlhf"] fn vmlhf(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_int;
 
+    #[link_name = "llvm.s390.vmaeb"] fn vmaeb(a: vector_signed_char, b: vector_signed_char, c: vector_signed_short) -> vector_signed_short;
+    #[link_name = "llvm.s390.vmaeh"] fn vmaeh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_int) -> vector_signed_int;
+    #[link_name = "llvm.s390.vmaef"] fn vmaef(a: vector_signed_int, b: vector_signed_int, c: vector_signed_long_long) -> vector_signed_long_long;
+
+    #[link_name = "llvm.s390.vmaleb"] fn vmaleb(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_short) -> vector_unsigned_short;
+    #[link_name = "llvm.s390.vmaleh"] fn vmaleh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_int) -> vector_unsigned_int;
+    #[link_name = "llvm.s390.vmalef"] fn vmalef(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_long_long) -> vector_unsigned_long_long;
+
+    #[link_name = "llvm.s390.vmaob"] fn vmaob(a: vector_signed_char, b: vector_signed_char, c: vector_signed_short) -> vector_signed_short;
+    #[link_name = "llvm.s390.vmaoh"] fn vmaoh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_int) -> vector_signed_int;
+    #[link_name = "llvm.s390.vmaof"] fn vmaof(a: vector_signed_int, b: vector_signed_int, c: vector_signed_long_long) -> vector_signed_long_long;
+
+    #[link_name = "llvm.s390.vmalob"] fn vmalob(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_short) -> vector_unsigned_short;
+    #[link_name = "llvm.s390.vmaloh"] fn vmaloh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_int) -> vector_unsigned_int;
+    #[link_name = "llvm.s390.vmalof"] fn vmalof(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_long_long) -> vector_unsigned_long_long;
+
+    #[link_name = "llvm.s390.vmahb"] fn vmahb(a: vector_signed_char, b: vector_signed_char, c: vector_signed_char) -> vector_signed_char;
+    #[link_name = "llvm.s390.vmahh"] fn vmahh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_short) -> vector_signed_short;
+    #[link_name = "llvm.s390.vmahf"] fn vmahf(a: vector_signed_int, b: vector_signed_int, c: vector_signed_int) -> vector_signed_int;
+
+    #[link_name = "llvm.s390.vmalhb"] fn vmalhb(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char) -> vector_unsigned_char;
+    #[link_name = "llvm.s390.vmalhh"] fn vmalhh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short;
+    #[link_name = "llvm.s390.vmalhf"] fn vmalhf(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int) -> vector_unsigned_int;
+
+    #[link_name = "llvm.s390.vmalb"] fn vmalb(a: vector_signed_char, b: vector_signed_char, c: vector_signed_char) -> vector_signed_char;
+    #[link_name = "llvm.s390.vmalh"] fn vmalh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_short) -> vector_signed_short;
+    #[link_name = "llvm.s390.vmalf"] fn vmalf(a: vector_signed_int, b: vector_signed_int, c: vector_signed_int) -> vector_signed_int;
+
+    #[link_name = "llvm.s390.vmallb"] fn vmallb(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char) -> vector_unsigned_char;
+    #[link_name = "llvm.s390.vmallh"] fn vmallh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short;
+    #[link_name = "llvm.s390.vmallf"] fn vmallf(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int) -> vector_unsigned_int;
+
     #[link_name = "llvm.s390.vgfmb"] fn vgfmb(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_short;
     #[link_name = "llvm.s390.vgfmh"] fn vgfmh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int;
     #[link_name = "llvm.s390.vgfmf"] fn vgfmf(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_long_long;
@@ -2594,6 +2626,17 @@ mod sealed {
                 }
             }
         };
+        ([$Trait:ident $m:ident] $fun:ident ($a:ty, $b:ty, $c:ty) -> $r:ty) => {
+            #[unstable(feature = "stdarch_s390x", issue = "135681")]
+            impl $Trait for $a {
+                type Result = $r;
+                #[inline]
+                #[target_feature(enable = "vector")]
+                unsafe fn $m(self, b: $b, c: $c) -> $r {
+                    $fun(self, b, c)
+                }
+            }
+        };
     }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
@@ -2677,6 +2720,100 @@ mod sealed {
     impl_mul!([VectorMulh vec_mulh] vec_vmlhb (vector_unsigned_char, vector_unsigned_char) -> vector_unsigned_char);
     impl_mul!([VectorMulh vec_mulh] vec_vmlhh (vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_short);
     impl_mul!([VectorMulh vec_mulh] vec_vmlhf (vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_int);
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorMeadd {
+        type Result;
+        unsafe fn vec_meadd(self, b: Self, c: Self::Result) -> Self::Result;
+    }
+
+    test_impl! { vec_vmaeb(a: vector_signed_char, b: vector_signed_char, c: vector_signed_short) -> vector_signed_short [ vmaeb, vmaeb ] }
+    test_impl! { vec_vmaeh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_int) -> vector_signed_int[ vmaeh, vmaeh ] }
+    test_impl! { vec_vmaef(a: vector_signed_int, b: vector_signed_int, c: vector_signed_long_long) -> vector_signed_long_long [ vmaef, vmaef ] }
+
+    test_impl! { vec_vmaleb(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_short) -> vector_unsigned_short [ vmaleb, vmaleb ] }
+    test_impl! { vec_vmaleh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_int) -> vector_unsigned_int[ vmaleh, vmaleh ] }
+    test_impl! { vec_vmalef(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_long_long) -> vector_unsigned_long_long [ vmalef, vmalef ] }
+
+    impl_mul!([VectorMeadd vec_meadd] vec_vmaeb (vector_signed_char, vector_signed_char, vector_signed_short) -> vector_signed_short );
+    impl_mul!([VectorMeadd vec_meadd] vec_vmaeh (vector_signed_short, vector_signed_short, vector_signed_int) -> vector_signed_int);
+    impl_mul!([VectorMeadd vec_meadd] vec_vmaef (vector_signed_int, vector_signed_int, vector_signed_long_long) -> vector_signed_long_long );
+
+    impl_mul!([VectorMeadd vec_meadd] vec_vmaleb (vector_unsigned_char, vector_unsigned_char, vector_unsigned_short) -> vector_unsigned_short );
+    impl_mul!([VectorMeadd vec_meadd] vec_vmaleh (vector_unsigned_short, vector_unsigned_short, vector_unsigned_int) -> vector_unsigned_int);
+    impl_mul!([VectorMeadd vec_meadd] vec_vmalef (vector_unsigned_int, vector_unsigned_int, vector_unsigned_long_long) -> vector_unsigned_long_long );
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorMoadd {
+        type Result;
+        unsafe fn vec_moadd(self, b: Self, c: Self::Result) -> Self::Result;
+    }
+
+    test_impl! { vec_vmaob(a: vector_signed_char, b: vector_signed_char, c: vector_signed_short) -> vector_signed_short [ vmaob, vmaob ] }
+    test_impl! { vec_vmaoh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_int) -> vector_signed_int[ vmaoh, vmaoh ] }
+    test_impl! { vec_vmaof(a: vector_signed_int, b: vector_signed_int, c: vector_signed_long_long) -> vector_signed_long_long [ vmaof, vmaof ] }
+
+    test_impl! { vec_vmalob(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_short) -> vector_unsigned_short [ vmalob, vmalob ] }
+    test_impl! { vec_vmaloh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_int) -> vector_unsigned_int[ vmaloh, vmaloh ] }
+    test_impl! { vec_vmalof(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_long_long) -> vector_unsigned_long_long [ vmalof, vmalof ] }
+
+    impl_mul!([VectorMoadd vec_moadd] vec_vmaob (vector_signed_char, vector_signed_char, vector_signed_short) -> vector_signed_short );
+    impl_mul!([VectorMoadd vec_moadd] vec_vmaoh (vector_signed_short, vector_signed_short, vector_signed_int) -> vector_signed_int);
+    impl_mul!([VectorMoadd vec_moadd] vec_vmaof (vector_signed_int, vector_signed_int, vector_signed_long_long) -> vector_signed_long_long );
+
+    impl_mul!([VectorMoadd vec_moadd] vec_vmalob (vector_unsigned_char, vector_unsigned_char, vector_unsigned_short) -> vector_unsigned_short );
+    impl_mul!([VectorMoadd vec_moadd] vec_vmaloh (vector_unsigned_short, vector_unsigned_short, vector_unsigned_int) -> vector_unsigned_int);
+    impl_mul!([VectorMoadd vec_moadd] vec_vmalof (vector_unsigned_int, vector_unsigned_int, vector_unsigned_long_long) -> vector_unsigned_long_long );
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorMhadd {
+        type Result;
+        unsafe fn vec_mhadd(self, b: Self, c: Self::Result) -> Self::Result;
+    }
+
+    test_impl! { vec_vmahb(a: vector_signed_char, b: vector_signed_char, c: vector_signed_char) -> vector_signed_char [ vmahb, vmahb ] }
+    test_impl! { vec_vmahh(a: vector_signed_short, b: vector_signed_short, c: vector_signed_short) -> vector_signed_short[ vmahh, vmahh ] }
+    test_impl! { vec_vmahf(a: vector_signed_int, b: vector_signed_int, c: vector_signed_int) -> vector_signed_int [ vmahf, vmahf ] }
+
+    test_impl! { vec_vmalhb(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char) -> vector_unsigned_char [ vmalhb, vmalhb ] }
+    test_impl! { vec_vmalhh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short[ vmalhh, vmalhh ] }
+    test_impl! { vec_vmalhf(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int) -> vector_unsigned_int [ vmalhf, vmalhf ] }
+
+    impl_mul!([VectorMhadd vec_mhadd] vec_vmahb (vector_signed_char, vector_signed_char, vector_signed_char) -> vector_signed_char );
+    impl_mul!([VectorMhadd vec_mhadd] vec_vmahh (vector_signed_short, vector_signed_short, vector_signed_short) -> vector_signed_short);
+    impl_mul!([VectorMhadd vec_mhadd] vec_vmahf (vector_signed_int, vector_signed_int, vector_signed_int) -> vector_signed_int );
+
+    impl_mul!([VectorMhadd vec_mhadd] vec_vmalhb (vector_unsigned_char, vector_unsigned_char, vector_unsigned_char) -> vector_unsigned_char );
+    impl_mul!([VectorMhadd vec_mhadd] vec_vmalhh (vector_unsigned_short, vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_short);
+    impl_mul!([VectorMhadd vec_mhadd] vec_vmalhf (vector_unsigned_int, vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_int );
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorMladd {
+        type Result;
+        unsafe fn vec_mladd(self, b: Self, c: Self::Result) -> Self::Result;
+    }
+
+    #[inline]
+    #[target_feature(enable = "vector")]
+    unsafe fn simd_mladd<T>(a: T, b: T, c: T) -> T {
+        simd_add(simd_mul(a, b), c)
+    }
+
+    test_impl! { vec_vmal_ib(a: vector_signed_char, b: vector_signed_char, c: vector_signed_char) -> vector_signed_char [simd_mladd, vmalb ] }
+    test_impl! { vec_vmal_ih(a: vector_signed_short, b: vector_signed_short, c: vector_signed_short) -> vector_signed_short[simd_mladd, vmalh ] }
+    test_impl! { vec_vmal_if(a: vector_signed_int, b: vector_signed_int, c: vector_signed_int) -> vector_signed_int [simd_mladd, vmalf ] }
+
+    test_impl! { vec_vmal_ub(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char) -> vector_unsigned_char [simd_mladd, vmalb ] }
+    test_impl! { vec_vmal_uh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short[simd_mladd, vmalh ] }
+    test_impl! { vec_vmal_uf(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int) -> vector_unsigned_int [simd_mladd, vmalf ] }
+
+    impl_mul!([VectorMladd vec_mladd] vec_vmal_ib (vector_signed_char, vector_signed_char, vector_signed_char) -> vector_signed_char );
+    impl_mul!([VectorMladd vec_mladd] vec_vmal_ih (vector_signed_short, vector_signed_short, vector_signed_short) -> vector_signed_short);
+    impl_mul!([VectorMladd vec_mladd] vec_vmal_if (vector_signed_int, vector_signed_int, vector_signed_int) -> vector_signed_int );
+
+    impl_mul!([VectorMladd vec_mladd] vec_vmal_ub (vector_unsigned_char, vector_unsigned_char, vector_unsigned_char) -> vector_unsigned_char );
+    impl_mul!([VectorMladd vec_mladd] vec_vmal_uh (vector_unsigned_short, vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_short);
+    impl_mul!([VectorMladd vec_mladd] vec_vmal_uf (vector_unsigned_int, vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_int );
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorGfmsum<Result> {
@@ -4767,6 +4904,38 @@ pub unsafe fn vec_madd<T: sealed::VectorMadd>(a: T, b: T, c: T) -> T {
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 pub unsafe fn vec_msub<T: sealed::VectorMadd>(a: T, b: T, c: T) -> T {
     a.vec_msub(b, c)
+}
+
+/// Vector Multiply and Add Even
+#[inline]
+#[target_feature(enable = "vector-packed-decimal")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_meadd<T: sealed::VectorMeadd>(a: T, b: T, c: T::Result) -> T::Result {
+    a.vec_meadd(b, c)
+}
+
+/// Vector Multiply and Add Odd
+#[inline]
+#[target_feature(enable = "vector-packed-decimal")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_moadd<T: sealed::VectorMoadd>(a: T, b: T, c: T::Result) -> T::Result {
+    a.vec_moadd(b, c)
+}
+
+/// Vector Multiply and Add High
+#[inline]
+#[target_feature(enable = "vector-packed-decimal")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_mhadd<T: sealed::VectorMhadd>(a: T, b: T, c: T::Result) -> T::Result {
+    a.vec_mhadd(b, c)
+}
+
+/// Vector Multiply and Add Low
+#[inline]
+#[target_feature(enable = "vector-packed-decimal")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_mladd<T: sealed::VectorMladd>(a: T, b: T, c: T::Result) -> T::Result {
+    a.vec_mladd(b, c)
 }
 
 /// Vector Checksum
@@ -7031,5 +7200,73 @@ mod tests {
         [1.0, f32::NAN, f32::NAN, 2.0],
         [1.0, f32::NAN, 5.0, 3.14],
         [0, !0, !0, !0]
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_meadd() {
+        let a = vector_unsigned_short([1, 0, 2, 0, 3, 0, 4, 0]);
+        let b = vector_unsigned_short([5, 0, 6, 0, 7, 0, 8, 0]);
+        let c = vector_unsigned_int([2, 2, 2, 2]);
+
+        let d = unsafe { vec_meadd(a, b, c) };
+        assert_eq!(d.as_array(), &[7, 14, 23, 34]);
+
+        let a = vector_signed_short([1, 0, 2, 0, 3, 0, 4, 0]);
+        let b = vector_signed_short([5, 0, 6, 0, 7, 0, 8, 0]);
+        let c = vector_signed_int([2, -2, 2, -2]);
+
+        let d = unsafe { vec_meadd(a, b, c) };
+        assert_eq!(d.as_array(), &[7, 10, 23, 30]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_moadd() {
+        let a = vector_unsigned_short([0, 1, 0, 2, 0, 3, 0, 4]);
+        let b = vector_unsigned_short([0, 5, 0, 6, 0, 7, 0, 8]);
+        let c = vector_unsigned_int([2, 2, 2, 2]);
+
+        let d = unsafe { vec_moadd(a, b, c) };
+        assert_eq!(d.as_array(), &[7, 14, 23, 34]);
+
+        let a = vector_signed_short([0, 1, 0, 2, 0, 3, 0, 4]);
+        let b = vector_signed_short([0, 5, 0, 6, 0, 7, 0, 8]);
+        let c = vector_signed_int([2, -2, 2, -2]);
+
+        let d = unsafe { vec_moadd(a, b, c) };
+        assert_eq!(d.as_array(), &[7, 10, 23, 30]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_mhadd() {
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 6, 7, 8]);
+        let c = vector_unsigned_int([u32::MAX; 4]);
+
+        let d = unsafe { vec_mhadd(a, b, c) };
+        assert_eq!(d.as_array(), &[1, 1, 1, 1]);
+
+        let a = vector_signed_int([-1, -2, -3, -4]);
+        let b = vector_signed_int([5, 6, 7, 8]);
+        let c = vector_signed_int([i32::MIN; 4]);
+
+        let d = unsafe { vec_mhadd(a, b, c) };
+        assert_eq!(d.as_array(), &[-1, -1, -1, -1]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_mladd() {
+        let a = vector_unsigned_int([1, 2, 3, 4]);
+        let b = vector_unsigned_int([5, 6, 7, 8]);
+        let c = vector_unsigned_int([2, 2, 2, 2]);
+
+        let d = unsafe { vec_mladd(a, b, c) };
+        assert_eq!(d.as_array(), &[7, 14, 23, 34]);
+
+        let a = vector_signed_int([-1, -2, -3, -4]);
+        let b = vector_signed_int([5, 6, 7, 8]);
+        let c = vector_signed_int([2, 2, 2, 2]);
+
+        let d = unsafe { vec_mladd(a, b, c) };
+        assert_eq!(d.as_array(), &[-3, -10, -19, -30]);
     }
 }

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -2903,14 +2903,14 @@ mod sealed {
             self,
             b: Self,
             c: vector_unsigned_char,
-            d: &mut i32,
+            d: *mut i32,
         ) -> vector_unsigned_char;
 
         unsafe fn vec_search_string_until_zero_cc(
             self,
             b: Self,
             c: vector_unsigned_char,
-            d: &mut i32,
+            d: *mut i32,
         ) -> vector_unsigned_char;
     }
 
@@ -2921,17 +2921,17 @@ mod sealed {
                 impl VectorSearchString for $ty {
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_search_string_cc(self, b: Self, c: vector_unsigned_char, d: &mut i32) -> vector_unsigned_char {
+                    unsafe fn vec_search_string_cc(self, b: Self, c: vector_unsigned_char, d: *mut i32) -> vector_unsigned_char {
                         let PackedTuple { x,y } = $intr_s(transmute(self), transmute(b), c);
-                        *d = y;
+                        d.write(y);
                         x
                     }
 
                     #[inline]
                     #[target_feature(enable = "vector")]
-                    unsafe fn vec_search_string_until_zero_cc(self, b: Self, c: vector_unsigned_char, d: &mut i32) -> vector_unsigned_char {
+                    unsafe fn vec_search_string_until_zero_cc(self, b: Self, c: vector_unsigned_char, d: *mut i32) -> vector_unsigned_char {
                         let PackedTuple { x,y } = $intr_sz(transmute(self), transmute(b), c);
-                        *d = y;
+                        d.write(y);
                         x
                     }
                 }
@@ -4584,7 +4584,7 @@ pub unsafe fn vec_search_string_cc<T: sealed::VectorSearchString>(
     a: T,
     b: T,
     c: vector_unsigned_char,
-    d: &mut i32,
+    d: *mut i32,
 ) -> vector_unsigned_char {
     a.vec_search_string_cc(b, c, d)
 }
@@ -4597,7 +4597,7 @@ pub unsafe fn vec_search_string_until_zero_cc<T: sealed::VectorSearchString>(
     a: T,
     b: T,
     c: vector_unsigned_char,
-    d: &mut i32,
+    d: *mut i32,
 ) -> vector_unsigned_char {
     a.vec_search_string_until_zero_cc(b, c, d)
 }

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -201,6 +201,14 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.s390.vmleh"] fn vmleh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int;
     #[link_name = "llvm.s390.vmlef"] fn vmlef(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_long_long;
 
+    #[link_name = "llvm.s390.vmob"] fn vmob(a: vector_signed_char, b: vector_signed_char) -> vector_signed_short;
+    #[link_name = "llvm.s390.vmoh"] fn vmoh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_int;
+    #[link_name = "llvm.s390.vmof"] fn vmof(a: vector_signed_int, b: vector_signed_int) -> vector_signed_long_long;
+
+    #[link_name = "llvm.s390.vmlob"] fn vmlob(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_short;
+    #[link_name = "llvm.s390.vmloh"] fn vmloh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int;
+    #[link_name = "llvm.s390.vmlof"] fn vmlof(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_long_long;
+
     #[link_name = "llvm.s390.vgfmb"] fn vgfmb(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_short;
     #[link_name = "llvm.s390.vgfmh"] fn vgfmh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int;
     #[link_name = "llvm.s390.vgfmf"] fn vgfmf(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_long_long;
@@ -2621,6 +2629,27 @@ mod sealed {
     impl_mul!([VectorMule vec_mule] vec_vmlef (vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_long_long );
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
+    pub trait VectorMulo<Result> {
+        unsafe fn vec_mulo(self, b: Self) -> Result;
+    }
+
+    test_impl! { vec_vmob(a: vector_signed_char, b: vector_signed_char) -> vector_signed_short [ vmob, vmob ] }
+    test_impl! { vec_vmoh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_int[ vmoh, vmoh ] }
+    test_impl! { vec_vmof(a: vector_signed_int, b: vector_signed_int) -> vector_signed_long_long [ vmof, vmof ] }
+
+    test_impl! { vec_vmlob(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_short [ vmlob, vmlob ] }
+    test_impl! { vec_vmloh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int[ vmloh, vmloh ] }
+    test_impl! { vec_vmlof(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_long_long [ vmlof, vmlof ] }
+
+    impl_mul!([VectorMulo vec_mulo] vec_vmob (vector_signed_char, vector_signed_char) -> vector_signed_short );
+    impl_mul!([VectorMulo vec_mulo] vec_vmoh (vector_signed_short, vector_signed_short) -> vector_signed_int);
+    impl_mul!([VectorMulo vec_mulo] vec_vmof (vector_signed_int, vector_signed_int) -> vector_signed_long_long );
+
+    impl_mul!([VectorMulo vec_mulo] vec_vmlob (vector_unsigned_char, vector_unsigned_char) -> vector_unsigned_short );
+    impl_mul!([VectorMulo vec_mulo] vec_vmloh (vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_int);
+    impl_mul!([VectorMulo vec_mulo] vec_vmlof (vector_unsigned_int, vector_unsigned_int) -> vector_unsigned_long_long );
+
+    #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorGfmsum<Result> {
         unsafe fn vec_gfmsum(self, b: Self) -> Result;
     }
@@ -4728,6 +4757,14 @@ pub unsafe fn vec_mule<T: sealed::VectorMule<U>, U>(a: T, b: T) -> U {
     a.vec_mule(b)
 }
 
+/// Vector Multiply Odd
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_mulo<T: sealed::VectorMulo<U>, U>(a: T, b: T) -> U {
+    a.vec_mulo(b)
+}
+
 /// Vector Galois Field Multiply Sum
 #[inline]
 #[target_feature(enable = "vector")]
@@ -6391,6 +6428,18 @@ mod tests {
     test_vec_2! { test_vec_mule_i, vec_mule, i16x8, i16x8 -> i32x4,
         [i16::MIN, 0, -2, 0, 2, 0, 1, 0],
         [i16::MIN, 0, 4, 0, i16::MAX, 0, 2, 0],
+        [0x4000_0000, -8, 0xFFFE, 2]
+    }
+
+    test_vec_2! { test_vec_mulo_u, vec_mulo, u16x8, u16x8 -> u32x4,
+        [0, 0xFFFF, 0, 2, 0, 2, 0, 1],
+        [0, 0xFFFF, 0, 4, 0, 0xFFFF, 0, 2],
+        [0xFFFE_0001, 8, 0x0001_FFFE, 2]
+    }
+
+    test_vec_2! { test_vec_mulo_i, vec_mulo, i16x8, i16x8 -> i32x4,
+        [0, i16::MIN, 0, -2, 0, 2, 0, 1],
+        [0, i16::MIN, 0, 4, 0, i16::MAX, 0, 2],
         [0x4000_0000, -8, 0xFFFE, 2]
     }
 

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -4848,6 +4848,36 @@ pub unsafe fn vec_cmpnrg_or_0_idx<T: sealed::VectorCompareRange>(a: T, b: T, c: 
     a.vstrcz::<{ FindImm::NeIdx as u32 }>(b, c)
 }
 
+/// Vector Compare Ranges or Zero Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmprg_or_0_idx_cc<T: sealed::VectorCompareRange>(
+    a: T,
+    b: T,
+    c: T,
+    d: *mut i32,
+) -> T::Result {
+    let (x, y) = a.vstrczs::<{ FindImm::EqIdx as u32 }>(b, c);
+    d.write(y);
+    x
+}
+
+/// Vector Compare Not in Ranges or Zero Index with Condition Code
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpnrg_or_0_idx_cc<T: sealed::VectorCompareRange>(
+    a: T,
+    b: T,
+    c: T,
+    d: *mut i32,
+) -> T::Result {
+    let (x, y) = a.vstrczs::<{ FindImm::NeIdx as u32 }>(b, c);
+    d.write(y);
+    x
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -4736,6 +4736,22 @@ pub unsafe fn vec_cmpnrg<T: sealed::VectorCompareRange>(a: T, b: T, c: T) -> T::
     a.vstrc::<{ FindImm::Ne as u32 }>(b, c)
 }
 
+/// Vector Compare Ranges Index
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmprg_idx<T: sealed::VectorCompareRange>(a: T, b: T, c: T) -> T::Result {
+    a.vstrc::<{ FindImm::EqIdx as u32 }>(b, c)
+}
+
+/// Vector Compare Not in Ranges Index
+#[inline]
+#[target_feature(enable = "vector")]
+#[unstable(feature = "stdarch_s390x", issue = "135681")]
+pub unsafe fn vec_cmpnrg_idx<T: sealed::VectorCompareRange>(a: T, b: T, c: T) -> T::Result {
+    a.vstrc::<{ FindImm::NeIdx as u32 }>(b, c)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6058,5 +6074,25 @@ mod tests {
         let c = vector_unsigned_int([GT, LT, EQ, EQ]);
         let d = unsafe { vec_cmpnrg(a, b, c) };
         assert_eq!(d.as_array(), &[0, !0, !0, 0]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_cmprg_idx() {
+        let a = vector_unsigned_int([1, 11, 22, 33]);
+        let b = vector_unsigned_int([10, 20, 30, 40]);
+
+        let c = vector_unsigned_int([GT, LT, GT, LT]);
+        let d = unsafe { vec_cmprg_idx(a, b, c) };
+        assert_eq!(d.as_array(), &[0, 4, 0, 0]);
+    }
+
+    #[simd_test(enable = "vector")]
+    fn test_vec_cmpnrg_idx() {
+        let a = vector_unsigned_int([1, 11, 22, 33]);
+        let b = vector_unsigned_int([10, 20, 30, 40]);
+
+        let c = vector_unsigned_int([GT, LT, GT, LT]);
+        let d = unsafe { vec_cmpnrg_idx(a, b, c) };
+        assert_eq!(d.as_array(), &[0, 0, 0, 0]);
     }
 }


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/135681

well, final for now. I'm waiting on some changes to the `intrinsics::simd` insert and extract functions for some of the final intrinsics, and there are a couple very new intrinsics that even qemu will not run yet, so those will come when the tooling is there.

A bunch of optimization improvements to s390x have just been merged into LLVM, so when those are available (with the llvm 21 upgrade I assume) we should revisit some of the llvm comments and add/enable more instruction test cases.