### PR TITLE
std_detect: Add target features for LoongArch v1.1

### DIFF
--- a/crates/std_detect/src/detect/arch/loongarch.rs
+++ b/crates/std_detect/src/detect/arch/loongarch.rs
@@ -11,8 +11,13 @@ features! {
     /// * `"f"`
     /// * `"d"`
     /// * `"frecipe"`
+    /// * `"div32"`
     /// * `"lsx"`
     /// * `"lasx"`
+    /// * `"lam-bh"`
+    /// * `"lamcas"`
+    /// * `"ld-seq-sa"`
+    /// * `"scq"`
     /// * `"lbt"`
     /// * `"lvz"`
     /// * `"ual"`
@@ -23,10 +28,20 @@ features! {
     /// D
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] frecipe: "frecipe";
     /// Frecipe
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] div32: "div32";
+    /// Div32
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lsx: "lsx";
     /// LSX
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lasx: "lasx";
     /// LASX
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lam_bh: "lam-bh";
+    /// LAM-BH
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lamcas: "lamcas";
+    /// LAM-CAS
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] ld_seq_sa: "ld-seq-sa";
+    /// LD-SEQ-SA
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] scq: "scq";
+    /// SCQ
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lbt: "lbt";
     /// LBT
     @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lvz: "lvz";

--- a/crates/std_detect/src/detect/os/linux/loongarch.rs
+++ b/crates/std_detect/src/detect/os/linux/loongarch.rs
@@ -24,7 +24,20 @@ pub(crate) fn detect_features() -> cache::Initializer {
             options(pure, nomem, preserves_flags, nostack)
         );
     }
+    let cpucfg3: usize;
+    unsafe {
+        asm!(
+            "cpucfg {}, {}",
+            out(reg) cpucfg3, in(reg) 3,
+            options(pure, nomem, preserves_flags, nostack)
+        );
+    }
     enable_feature(&mut value, Feature::frecipe, bit::test(cpucfg2, 25));
+    enable_feature(&mut value, Feature::div32, bit::test(cpucfg2, 26));
+    enable_feature(&mut value, Feature::lam_bh, bit::test(cpucfg2, 27));
+    enable_feature(&mut value, Feature::lamcas, bit::test(cpucfg2, 28));
+    enable_feature(&mut value, Feature::scq, bit::test(cpucfg2, 30));
+    enable_feature(&mut value, Feature::ld_seq_sa, bit::test(cpucfg3, 23));
 
     // The values are part of the platform-specific [asm/hwcap.h][hwcap]
     //


### PR DESCRIPTION
This patch adds new target features for LoongArch v1.1:

* div32
* lam-bh
* lamcas
* ld-seq-sa
* scq