### PR TITLE
std_detect: Support detecting more features on aarch64 Windows

### DIFF
--- a/crates/std_detect/src/detect/os/windows/aarch64.rs
+++ b/crates/std_detect/src/detect/os/windows/aarch64.rs
@@ -19,9 +19,23 @@ pub(crate) fn detect_features() -> cache::Initializer {
     const PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE: u32 = 43;
     const PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE: u32 = 44;
     const PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE: u32 = 45;
+    const PF_ARM_SVE_INSTRUCTIONS_AVAILABLE: u32 = 46;
+    const PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE: u32 = 47;
+    const PF_ARM_SVE2_1_INSTRUCTIONS_AVAILABLE: u32 = 48;
+    const PF_ARM_SVE_AES_INSTRUCTIONS_AVAILABLE: u32 = 49;
+    const PF_ARM_SVE_PMULL128_INSTRUCTIONS_AVAILABLE: u32 = 50;
+    const PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE: u32 = 51;
+    // const PF_ARM_SVE_BF16_INSTRUCTIONS_AVAILABLE: u32 = 52;
+    // const PF_ARM_SVE_EBF16_INSTRUCTIONS_AVAILABLE: u32 = 53;
+    const PF_ARM_SVE_B16B16_INSTRUCTIONS_AVAILABLE: u32 = 54;
+    const PF_ARM_SVE_SHA3_INSTRUCTIONS_AVAILABLE: u32 = 55;
+    const PF_ARM_SVE_SM4_INSTRUCTIONS_AVAILABLE: u32 = 56;
+    // const PF_ARM_SVE_I8MM_INSTRUCTIONS_AVAILABLE: u32 = 57;
+    // const PF_ARM_SVE_F32MM_INSTRUCTIONS_AVAILABLE: u32 = 58;
+    // const PF_ARM_SVE_F64MM_INSTRUCTIONS_AVAILABLE: u32 = 59;
 
     unsafe extern "system" {
-        pub fn IsProcessorFeaturePresent(ProcessorFeature: DWORD) -> BOOL;
+        fn IsProcessorFeaturePresent(ProcessorFeature: DWORD) -> BOOL;
     }
 
     let mut value = cache::Initializer::default();
@@ -63,6 +77,40 @@ pub(crate) fn detect_features() -> cache::Initializer {
             enable_feature(
                 Feature::rcpc,
                 IsProcessorFeaturePresent(PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve,
+                IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve2,
+                IsProcessorFeaturePresent(PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve2p1,
+                IsProcessorFeaturePresent(PF_ARM_SVE2_1_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve2_aes,
+                IsProcessorFeaturePresent(PF_ARM_SVE_AES_INSTRUCTIONS_AVAILABLE) != FALSE
+                    && IsProcessorFeaturePresent(PF_ARM_SVE_PMULL128_INSTRUCTIONS_AVAILABLE)
+                        != FALSE,
+            );
+            enable_feature(
+                Feature::sve2_bitperm,
+                IsProcessorFeaturePresent(PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve_b16b16,
+                IsProcessorFeaturePresent(PF_ARM_SVE_B16B16_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve2_sha3,
+                IsProcessorFeaturePresent(PF_ARM_SVE_SHA3_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::sve2_sm4,
+                IsProcessorFeaturePresent(PF_ARM_SVE_SM4_INSTRUCTIONS_AVAILABLE) != FALSE,
             );
             // PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE means aes, sha1, sha2 and
             // pmull support


### PR DESCRIPTION
Windows now supports detecting SVE-related features.

Windows SDK:

<img width="530" alt="winnt-26100" src="https://github.com/user-attachments/assets/0945aa54-ce8a-4b80-973e-e475451cdd69" />

mingw-w64:
https://github.com/mingw-w64/mingw-w64/commit/f97814b9602d62cec180aae9e0a0bb5198e7289d
