### PR TITLE
Fix: stabilized version of RISC-V feature macro

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -88,7 +88,7 @@ features! {
     /// * Hypervisor: `"h"`
     ///
     /// [ISA manual]: https://github.com/riscv/riscv-isa-manual/
-    #[stable(feature = "riscv_ratified", since = "1.76.0")]
+    #[stable(feature = "riscv_ratified", since = "1.78.0")]
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] rv32i: "rv32i";
     without cfg check: true;
     /// RV32I Base Integer Instruction Set
@@ -101,9 +101,9 @@ features! {
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] rv64i: "rv64i";
     without cfg check: true;
     /// RV64I Base Integer Instruction Set
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] m: "m";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] m: "m";
     /// "M" Standard Extension for Integer Multiplication and Division
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] a: "a";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] a: "a";
     /// "A" Standard Extension for Atomic Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicsr: "zicsr";
     without cfg check: true;
@@ -121,7 +121,7 @@ features! {
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] q: "q";
     without cfg check: true;
     /// "Q" Standard Extension for Quad-Precision Floating-Point
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] c: "c";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] c: "c";
     /// "C" Standard Extension for Compressed Instructions
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfinx: "zfinx";
@@ -174,39 +174,39 @@ features! {
     without cfg check: true;
     /// Hypervisor Extension
 
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zba: "zba";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zba: "zba";
     /// "Zba" Standard Extension for Address Generation Instructions
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zbb: "zbb";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbb: "zbb";
     /// "Zbb" Standard Extension for Basic Bit-Manipulation
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zbc: "zbc";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbc: "zbc";
     /// "Zbc" Standard Extension for Carry-less Multiplication
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zbs: "zbs";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbs: "zbs";
     /// "Zbs" Standard Extension for Single-Bit instructions
 
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zbkb: "zbkb";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbkb: "zbkb";
     /// "Zbkb" Standard Extension for Bitmanip instructions for Cryptography
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zbkc: "zbkc";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbkc: "zbkc";
     /// "Zbkc" Standard Extension for Carry-less multiply instructions
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zbkx: "zbkx";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbkx: "zbkx";
     /// "Zbkx" Standard Extension for Crossbar permutation instructions
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zknd: "zknd";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zknd: "zknd";
     /// "Zknd" Standard Extension for NIST Suite: AES Decryption
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zkne: "zkne";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkne: "zkne";
     /// "Zkne" Standard Extension for NIST Suite: AES Encryption
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zknh: "zknh";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zknh: "zknh";
     /// "Zknh" Standard Extension for NIST Suite: Hash Function Instructions
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zksed: "zksed";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zksed: "zksed";
     /// "Zksed" Standard Extension for ShangMi Suite: SM4 Block Cipher Instructions
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zksh: "zksh";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zksh: "zksh";
     /// "Zksh" Standard Extension for ShangMi Suite: SM3 Hash Function Instructions
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zkr: "zkr";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkr: "zkr";
     /// "Zkr" Standard Extension for Entropy Source Extension
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zkn: "zkn";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkn: "zkn";
     /// "Zkn" Standard Extension for NIST Algorithm Suite
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zks: "zks";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zks: "zks";
     /// "Zks" Standard Extension for ShangMi Algorithm Suite
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zk: "zk";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zk: "zk";
     /// "Zk" Standard Extension for Standard scalar cryptography extension
-    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.76.0")] zkt: "zkt";
+    @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkt: "zkt";
     /// "Zkt" Standard Extension for Data Independent Execution Latency
 }


### PR DESCRIPTION
RISC-V runtime feature detection macro (`std::arch::is_riscv_feature_detected`) is stabilized on [Rust 1.78.0](https://doc.rust-lang.org/1.78.0/std/arch/macro.is_riscv_feature_detected.html), not [Rust 1.76.0](https://doc.rust-lang.org/1.76.0/std/arch/macro.is_riscv_feature_detected.html).