### PR TITLE
silence `clippy::eq_op` while checking

### DIFF
--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -23,6 +23,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     //
     // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/riscv/include/asm/hwcap.h
     let auxv = auxvec::auxv().expect("read auxvec"); // should not fail on RISC-V platform
+    #[allow(clippy::eq_op)]
     enable_feature(
         &mut value,
         Feature::a,


### PR DESCRIPTION
This error occurs when the RISC-V "A" Extension is being tested.

```rust
(b'a' - b'a')
```

This expression is detected as an error.