### PR TITLE
Temporary fix: change the feature gate of VEX variants

### DIFF
--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -197,15 +197,15 @@ features! {
     /// AVX-512 P2INTERSECT
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512fp16: "avx512fp16";
     /// AVX-512 FP16 (FLOAT16 instructions)
-    @FEATURE: #[unstable(feature = "avx512_target_feature", issue = "44839")] avxifma: "avxifma";
+    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxifma: "avxifma";
     /// AVX-IFMA (Integer Fused Multiply Add)
-    @FEATURE: #[unstable(feature = "avx512_target_feature", issue = "44839")] avxneconvert: "avxneconvert";
+    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxneconvert: "avxneconvert";
     /// AVX-NE-CONVERT (Exceptionless Convert)
-    @FEATURE: #[unstable(feature = "avx512_target_feature", issue = "44839")] avxvnni: "avxvnni";
+    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxvnni: "avxvnni";
     /// AVX-VNNI (Vector Neural Network Instructions)
-    @FEATURE: #[unstable(feature = "avx512_target_feature", issue = "44839")] avxvnniint16: "avxvnniint16";
+    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxvnniint16: "avxvnniint16";
     /// AVX-VNNI_INT8 (VNNI with 16-bit Integers)
-    @FEATURE: #[unstable(feature = "avx512_target_feature", issue = "44839")] avxvnniint8: "avxvnniint8";
+    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxvnniint8: "avxvnniint8";
     /// AVX-VNNI_INT16 (VNNI with 8-bit integers)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_tile: "amx-tile";
     /// AMX (Advanced Matrix Extensions) - Tile load/store


### PR DESCRIPTION
These were causing compilation failures while stabilizing avx512, will be FCP'd soon, together with the rest of AVX512. So for a little while, any feature gate (except for `avx512_target_feature`) works