### PR TITLE
Minor correction to __m512d documentation.

### DIFF
--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -340,7 +340,7 @@ types! {
     ///
     /// Note that unlike `__m512i`, the integer version of the 512-bit
     /// registers, this `__m512d` type has *one* interpretation. Each instance
-    /// of `__m512d` always corresponds to `f64x4`, or eight `f64` types packed
+    /// of `__m512d` always corresponds to `f64x8`, or eight `f64` types packed
     /// together.
     ///
     /// The in-memory representation of this type is the same as the one of an


### PR DESCRIPTION
A 512-bit register is f64x8, not f64x4. Likely a copy-paste error from the _m256d documentation, which seems correct.