### PR TITLE
Stabilize runtime detection of VEX variants of avx512

### DIFF
--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -203,15 +203,15 @@ features! {
     /// AVX-512 P2INTERSECT
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512fp16: "avx512fp16";
     /// AVX-512 FP16 (FLOAT16 instructions)
-    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxifma: "avxifma";
+    @FEATURE: #[stable(feature = "avx512_target_feature", since = "1.88.0")] avxifma: "avxifma";
     /// AVX-IFMA (Integer Fused Multiply Add)
-    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxneconvert: "avxneconvert";
+    @FEATURE: #[stable(feature = "avx512_target_feature", since = "1.88.0")] avxneconvert: "avxneconvert";
     /// AVX-NE-CONVERT (Exceptionless Convert)
-    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxvnni: "avxvnni";
+    @FEATURE: #[stable(feature = "avx512_target_feature", since = "1.88.0")] avxvnni: "avxvnni";
     /// AVX-VNNI (Vector Neural Network Instructions)
-    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxvnniint16: "avxvnniint16";
+    @FEATURE: #[stable(feature = "avx512_target_feature", since = "1.88.0")] avxvnniint16: "avxvnniint16";
     /// AVX-VNNI_INT8 (VNNI with 16-bit Integers)
-    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "44839")] avxvnniint8: "avxvnniint8";
+    @FEATURE: #[stable(feature = "avx512_target_feature", since = "1.88.0")] avxvnniint8: "avxvnniint8";
     /// AVX-VNNI_INT16 (VNNI with 8-bit integers)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_tile: "amx-tile";
     /// AMX (Advanced Matrix Extensions) - Tile load/store


### PR DESCRIPTION
This PR stabilizes the runtime detection of the following target features
 - `avxvnni`
 - `avxifma`
 - `avxvnniint8`
 - `avxvnniint16`
 - `avxneconvert`