### PR TITLE
allow unnecessary transmutes in core_arch

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -43,6 +43,7 @@
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]
 #![deny(clippy::missing_inline_in_public_items)]
+#![allow(unknown_lints, unnecessary_transmutes)]
 #![allow(
     clippy::identity_op,
     clippy::inline_always,


### PR DESCRIPTION
allows [unnecessary transmutes](https://github.com/rust-lang/rust/pull/136083) for `core_arch` to fix the issue in https://github.com/rust-lang/rust/pull/139009#issuecomment-2756647289
continuation of #1711 