### PR TITLE
RISC-V: check `cfg` (batch 1)

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -104,20 +104,15 @@ features! {
     /// RV128I Base Integer Instruction Set
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicsr: "zicsr";
-    without cfg check: true;
     /// "Zicsr" Extension for Control and Status Register (CSR) Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicntr: "zicntr";
-    without cfg check: true;
     /// "Zicntr" Extension for Base Counters and Timers
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihpm: "zihpm";
-    without cfg check: true;
     /// "Zihpm" Extension for Hardware Performance Counters
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zifencei: "zifencei";
-    without cfg check: true;
     /// "Zifencei" Extension for Instruction-Fetch Fence
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihintpause: "zihintpause";
-    without cfg check: true;
     /// "Zihintpause" Extension for Pause Hint
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] m: "m";


### PR DESCRIPTION
rust-lang/rust#138823 added five new extensions as compiler target features.
This commit reflects that fact and now checks static target features on `std::arch::is_riscv_feature_detected!` as well.

*   `Zicsr`
*   `Zicntr`
*   `Zihpm`
*   `Zifencei`
*   `Zihintpause`