### PR TITLE
RISC-V: Tidying (batch 2025-04-11)

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -20,6 +20,8 @@ features! {
     /// ISA prefix X. These sets are highly platform specific and should be
     /// detected with their own platform support crates.
     ///
+    /// [ISA manual]: https://riscv.org/specifications/ratified/
+    ///
     /// # Unprivileged Specification
     ///
     /// The supported ratified RISC-V instruction sets are as follows:
@@ -83,8 +85,6 @@ features! {
     /// * Svnapot: `"svnapot"`
     /// * Svpbmt: `"svpbmt"`
     /// * Svinval: `"svinval"`
-    ///
-    /// [ISA manual]: https://github.com/riscv/riscv-isa-manual/
     #[stable(feature = "riscv_ratified", since = "1.78.0")]
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] rv32i: "rv32i";

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -109,10 +109,10 @@ features! {
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihpm: "zihpm";
     without cfg check: true;
     /// "Zihpm" Extension for Hardware Performance Counters
-
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zifencei: "zifencei";
     without cfg check: true;
     /// "Zifencei" Extension for Instruction-Fetch Fence
+
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihintpause: "zihintpause";
     without cfg check: true;
     /// "Zihintpause" Extension for Pause Hint

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -44,33 +44,30 @@ features! {
     /// * Zifencei: `"zifencei"`
     /// * Zihintpause: `"zihintpause"`
     /// * Zihpm: `"zihpm"`
+    /// * Zfh: `"zfh"`
+    ///   * Zfhmin: `"zfhmin"`
+    /// * Zfinx: `"zfinx"`
+    /// * Zdinx: `"zdinx"`
+    /// * Zhinx: `"zhinx"`
+    ///   * Zhinxmin: `"zhinxmin"`
+    /// * Zbkb: `"zbkb"`
+    /// * Zbkc: `"zbkc"`
+    /// * Zbkx: `"zbkx"`
     /// * Zk: `"zk"`
-    ///   * Zbkb: `"zbkb"`
-    ///   * Zbkc: `"zbkc"`
-    ///   * Zbkx: `"zbkx"`
-    ///   * Zkn: `"zkn"`
-    ///     * Zknd: `"zknd"`
-    ///     * Zkne: `"zkne"`
-    ///     * Zknh: `"zknh"`
-    ///   * Zkr: `"zkr"`
-    ///   * Zks: `"zks"`
-    ///     * Zksed: `"zksed"`
-    ///     * Zksh: `"zksh"`
-    ///   * Zkt: `"zkt"`
+    /// * Zkn: `"zkn"`
+    ///   * Zknd: `"zknd"`
+    ///   * Zkne: `"zkne"`
+    ///   * Zknh: `"zknh"`
+    /// * Zkr: `"zkr"`
+    /// * Zks: `"zks"`
+    ///   * Zksed: `"zksed"`
+    ///   * Zksh: `"zksh"`
+    /// * Zkt: `"zkt"`
+    /// * Ztso: `"ztso"`
     ///
     /// There's also bases and extensions marked as standard instruction set,
     /// but they are in frozen or draft state. These instruction sets are also
     /// reserved by this macro and can be detected in the future platforms.
-    ///
-    /// Frozen RISC-V instruction sets:
-    ///
-    /// * Zfh: `"zfh"`
-    /// * Zfhmin: `"zfhmin"`
-    /// * Zfinx: `"zfinx"`
-    /// * Zdinx: `"zdinx"`
-    /// * Zhinx: `"zhinx"`
-    /// * Zhinxmin: `"zhinxmin"`
-    /// * Ztso: `"ztso"`
     ///
     /// Draft RISC-V instruction sets:
     ///
@@ -81,11 +78,11 @@ features! {
     ///
     /// Defined by Privileged Specification:
     ///
-    /// * Supervisor: `"s"`
+    /// * *Supervisor-Level ISA* (not "S" extension): `"s"`
+    /// * H (hypervisor): `"h"`
     /// * Svnapot: `"svnapot"`
     /// * Svpbmt: `"svpbmt"`
     /// * Svinval: `"svinval"`
-    /// * Hypervisor: `"h"`
     ///
     /// [ISA manual]: https://github.com/riscv/riscv-isa-manual/
     #[stable(feature = "riscv_ratified", since = "1.78.0")]

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -163,14 +163,14 @@ features! {
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbc: "zbc";
     /// "Zbc" Extension for Carry-less Multiplication
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbs: "zbs";
-    /// "Zbs" Extension for Single-Bit instructions
+    /// "Zbs" Extension for Single-Bit Instructions
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbkb: "zbkb";
-    /// "Zbkb" Extension for Bit-manipulation for Cryptography
+    /// "Zbkb" Extension for Bit-Manipulation for Cryptography
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbkc: "zbkc";
-    /// "Zbkc" Extension for Carry-less multiplication for Cryptography
+    /// "Zbkc" Extension for Carry-less Multiplication for Cryptography
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbkx: "zbkx";
-    /// "Zbkx" Extension for Crossbar permutations
+    /// "Zbkx" Extension for Crossbar Permutations
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zknd: "zknd";
     /// "Zknd" Cryptography Extension for NIST Suite: AES Decryption
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkne: "zkne";
@@ -188,7 +188,7 @@ features! {
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zks: "zks";
     /// "Zks" Cryptography Extension for ShangMi Algorithm Suite
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zk: "zk";
-    /// "Zk" Cryptography Extension for Standard scalar cryptography
+    /// "Zk" Cryptography Extension for Standard Scalar Cryptography
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zkt: "zkt";
     /// "Zkt" Cryptography Extension for Data Independent Execution Latency
 


### PR DESCRIPTION
This PR updates the RISC-V definition file (`arch/riscv.rs`; mainly its documentation) for various parts (better links, indentation, more consistency on the extension naming and its capitalization).

This is a subset of upcoming PR but separate for being:

1. independent from the rest and
2. probably unarguable.

This PR consists of four commits:

1. Improve extension consistency (capitalization)
2. Move ratified extensions and make some clarification changes (by sorting or raising / lowering indentation)
3. Changing the ISA manual link ([before](https://github.com/riscv/riscv-isa-manual/) / [after](https://riscv.org/specifications/ratified/))  
   while GitHub is a good place to browse the latest draft, it's hard to determine which is the ratified specification.  So, I think a page in RISC-V International would be better.
4. Fix minor section separation issue