### PR TITLE
RISC-V: `riscv_hwprobe`-based feature detection on Linux / Android

### DIFF
--- a/crates/std_detect/README.md
+++ b/crates/std_detect/README.md
@@ -56,11 +56,14 @@ crate from working on applications in which `std` is not available.
   [`cupid`](https://crates.io/crates/cupid) crate.
 
 * Linux/Android:
-  * `arm{32, 64}`, `mips{32,64}{,el}`, `powerpc{32,64}{,le}`, `riscv{32,64}`, `loongarch64`, `s390x`:
+  * `arm{32, 64}`, `mips{32,64}{,el}`, `powerpc{32,64}{,le}`, `loongarch64`, `s390x`:
     `std_detect` supports these on Linux by querying ELF auxiliary vectors (using `getauxval`
     when available), and if that fails, by querying `/proc/cpuinfo`.
   * `arm64`: partial support for doing run-time feature detection by directly
     querying `mrs` is implemented for Linux >= 4.11, but not enabled by default.
+  * `riscv{32,64}`:
+    `std_detect` supports these on Linux by querying `riscv_hwprobe`, and
+    by querying ELF auxiliary vectors (using `getauxval` when available).
 
 * FreeBSD:
   * `arm32`, `powerpc64`: `std_detect` supports these on FreeBSD by querying ELF

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -37,22 +37,39 @@ features! {
     ///   * Zbb: `"zbb"`
     ///   * Zbs: `"zbs"`
     /// * C: `"c"`
+    ///   * Zca: `"zca"`
+    ///   * Zcd: `"zcd"` (if D is enabled)
+    ///   * Zcf: `"zcf"` (if F is enabled on RV32)
     /// * D: `"d"`
     /// * F: `"f"`
     /// * M: `"m"`
     /// * Q: `"q"`
     /// * V: `"v"`
+    ///   * Zve32x: `"zve32x"`
+    ///   * Zve32f: `"zve32f"`
+    ///   * Zve64x: `"zve64x"`
+    ///   * Zve64f: `"zve64f"`
+    ///   * Zve64d: `"zve64d"`
+    /// * Zicboz: `"zicboz"`
     /// * Zicntr: `"zicntr"`
+    /// * Zicond: `"zicond"`
     /// * Zicsr: `"zicsr"`
     /// * Zifencei: `"zifencei"`
+    /// * Zihintntl: `"zihintntl"`
     /// * Zihintpause: `"zihintpause"`
     /// * Zihpm: `"zihpm"`
+    /// * Zimop: `"zimop"`
+    /// * Zacas: `"zacas"`
+    /// * Zawrs: `"zawrs"`
+    /// * Zfa: `"zfa"`
     /// * Zfh: `"zfh"`
     ///   * Zfhmin: `"zfhmin"`
     /// * Zfinx: `"zfinx"`
     /// * Zdinx: `"zdinx"`
     /// * Zhinx: `"zhinx"`
     ///   * Zhinxmin: `"zhinxmin"`
+    /// * Zcb: `"zcb"`
+    /// * Zcmop: `"zcmop"`
     /// * Zbc: `"zbc"`
     /// * Zbkb: `"zbkb"`
     /// * Zbkc: `"zbkc"`
@@ -67,6 +84,24 @@ features! {
     ///   * Zksed: `"zksed"`
     ///   * Zksh: `"zksh"`
     /// * Zkt: `"zkt"`
+    /// * Zvbb: `"zvbb"`
+    /// * Zvbc: `"zvbc"`
+    /// * Zvfh: `"zvfh"`
+    ///   * Zvfhmin: `"zvfhmin"`
+    /// * Zvkb: `"zvkb"`
+    /// * Zvkg: `"zvkg"`
+    /// * Zvkn: `"zvkn"`
+    ///   * Zvkned: `"zvkned"`
+    ///   * Zvknha: `"zvknha"`
+    ///   * Zvknhb: `"zvknhb"`
+    /// * Zvknc: `"zvknc"`
+    /// * Zvkng: `"zvkng"`
+    /// * Zvks: `"zvks"`
+    ///   * Zvksed: `"zvksed"`
+    ///   * Zvksh: `"zvksh"`
+    /// * Zvksc: `"zvksc"`
+    /// * Zvksg: `"zvksg"`
+    /// * Zvkt: `"zvkt"`
     /// * Ztso: `"ztso"`
     ///
     /// There's also bases and extensions marked as standard instruction set,
@@ -87,6 +122,15 @@ features! {
     /// * Svnapot: `"svnapot"`
     /// * Svpbmt: `"svpbmt"`
     /// * Svinval: `"svinval"`
+    ///
+    /// # Performance Hints
+    ///
+    /// The two features below define performance hints for unaligned
+    /// scalar/vector memory accesses, respectively.  If enabled, it denotes that
+    /// corresponding unaligned memory access is reasonably fast.
+    ///
+    /// * `"unaligned-scalar-mem"`
+    /// * `"unaligned-vector-mem"`
     #[stable(feature = "riscv_ratified", since = "1.78.0")]
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] rv32i: "rv32i";
@@ -102,6 +146,11 @@ features! {
     without cfg check: true;
     /// RV128I Base Integer Instruction Set
 
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] unaligned_scalar_mem: "unaligned-scalar-mem";
+    /// Has reasonably performant unaligned scalar
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] unaligned_vector_mem: "unaligned-vector-mem";
+    /// Has reasonably performant unaligned vector
+
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicsr: "zicsr";
     without cfg check: true;
     /// "Zicsr" Extension for Control and Status Register (CSR) Instructions
@@ -115,9 +164,21 @@ features! {
     without cfg check: true;
     /// "Zifencei" Extension for Instruction-Fetch Fence
 
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihintntl: "zihintntl";
+    without cfg check: true;
+    /// "Zihintntl" Extension for Non-Temporal Locality Hints
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihintpause: "zihintpause";
     without cfg check: true;
     /// "Zihintpause" Extension for Pause Hint
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zimop: "zimop";
+    without cfg check: true;
+    /// "Zimop" Extension for May-Be-Operations
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicboz: "zicboz";
+    without cfg check: true;
+    /// "Zicboz" Extension for Cache-Block Zero Instruction
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicond: "zicond";
+    without cfg check: true;
+    /// "Zicond" Extension for Integer Conditional Operations
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] m: "m";
     /// "M" Extension for Integer Multiplication and Division
@@ -128,6 +189,10 @@ features! {
     /// "Zalrsc" Extension for Load-Reserved/Store-Conditional Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zaamo: "zaamo";
     /// "Zaamo" Extension for Atomic Memory Operations
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zawrs: "zawrs";
+    /// "Zawrs" Extension for Wait-on-Reservation-Set Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zacas: "zacas";
+    /// "Zacas" Extension for Atomic Compare-and-Swap (CAS) Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zam: "zam";
     without cfg check: true;
     /// "Zam" Extension for Misaligned Atomics
@@ -146,6 +211,9 @@ features! {
     /// "Zfh" Extension for Half-Precision Floating-Point
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfhmin: "zfhmin";
     /// "Zfhmin" Extension for Minimal Half-Precision Floating-Point
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfa: "zfa";
+    without cfg check: true;
+    /// "Zfa" Extension for Additional Floating-Point Instructions
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfinx: "zfinx";
     /// "Zfinx" Extension for Single-Precision Floating-Point in Integer Registers
@@ -158,6 +226,21 @@ features! {
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] c: "c";
     /// "C" Extension for Compressed Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zca: "zca";
+    without cfg check: true;
+    /// "Zca" Compressed Instructions excluding Floating-Point Loads/Stores
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcf: "zcf";
+    without cfg check: true;
+    /// "Zcf" Compressed Instructions for Single-Precision Floating-Point Loads/Stores on RV32
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcd: "zcd";
+    without cfg check: true;
+    /// "Zcd" Compressed Instructions for Double-Precision Floating-Point Loads/Stores
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcb: "zcb";
+    without cfg check: true;
+    /// "Zcb" Simple Code-size Saving Compressed Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcmop: "zcmop";
+    without cfg check: true;
+    /// "Zcmop" Extension for Compressed May-Be-Operations
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] b: "b";
     without cfg check: true;
@@ -200,6 +283,53 @@ features! {
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] v: "v";
     /// "V" Extension for Vector Operations
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zve32x: "zve32x";
+    /// "Zve32x" Vector Extension for Embedded Processors (32-bit+; Integer)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zve32f: "zve32f";
+    /// "Zve32f" Vector Extension for Embedded Processors (32-bit+; with Single-Precision Floating-Point)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zve64x: "zve64x";
+    /// "Zve64x" Vector Extension for Embedded Processors (64-bit+; Integer)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zve64f: "zve64f";
+    /// "Zve64f" Vector Extension for Embedded Processors (64-bit+; with Single-Precision Floating-Point)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zve64d: "zve64d";
+    /// "Zve64d" Vector Extension for Embedded Processors (64-bit+; with Double-Precision Floating-Point)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvfh: "zvfh";
+    /// "Zvfh" Vector Extension for Half-Precision Floating-Point
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvfhmin: "zvfhmin";
+    /// "Zvfhmin" Vector Extension for Minimal Half-Precision Floating-Point
+
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvbb: "zvbb";
+    /// "Zvbb" Extension for Vector Basic Bit-Manipulation
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvbc: "zvbc";
+    /// "Zvbc" Extension for Vector Carryless Multiplication
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkb: "zvkb";
+    /// "Zvkb" Extension for Vector Cryptography Bit-Manipulation
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkg: "zvkg";
+    /// "Zvkg" Cryptography Extension for Vector GCM/GMAC
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkned: "zvkned";
+    /// "Zvkned" Cryptography Extension for NIST Suite: Vector AES Block Cipher
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvknha: "zvknha";
+    /// "Zvknha" Cryptography Extension for Vector SHA-2 Secure Hash (SHA-256)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvknhb: "zvknhb";
+    /// "Zvknhb" Cryptography Extension for Vector SHA-2 Secure Hash (SHA-256/512)
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksed: "zvksed";
+    /// "Zvksed" Cryptography Extension for ShangMi Suite: Vector SM4 Block Cipher
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksh: "zvksh";
+    /// "Zvksh" Cryptography Extension for ShangMi Suite: Vector SM3 Secure Hash
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkn: "zvkn";
+    /// "Zvkn" Cryptography Extension for NIST Algorithm Suite
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvknc: "zvknc";
+    /// "Zvknc" Cryptography Extension for NIST Algorithm Suite with Carryless Multiply
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkng: "zvkng";
+    /// "Zvkng" Cryptography Extension for NIST Algorithm Suite with GCM
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvks: "zvks";
+    /// "Zvks" Cryptography Extension for ShangMi Algorithm Suite
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksc: "zvksc";
+    /// "Zvksc" Cryptography Extension for ShangMi Algorithm Suite with Carryless Multiply
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvksg: "zvksg";
+    /// "Zvksg" Cryptography Extension for ShangMi Algorithm Suite with GCM
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkt: "zvkt";
+    /// "Zvkt" Extension for Vector Data-Independent Execution Latency
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] svnapot: "svnapot";
     without cfg check: true;

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -32,10 +32,9 @@ features! {
     /// * A: `"a"`
     ///   * Zaamo: `"zaamo"`
     ///   * Zalrsc: `"zalrsc"`
-    /// * Bit-Manipulation Extensions:
+    /// * B: `"b"`
     ///   * Zba: `"zba"`
     ///   * Zbb: `"zbb"`
-    ///   * Zbc: `"zbc"`
     ///   * Zbs: `"zbs"`
     /// * C: `"c"`
     /// * D: `"d"`
@@ -54,6 +53,7 @@ features! {
     /// * Zdinx: `"zdinx"`
     /// * Zhinx: `"zhinx"`
     ///   * Zhinxmin: `"zhinxmin"`
+    /// * Zbc: `"zbc"`
     /// * Zbkb: `"zbkb"`
     /// * Zbkc: `"zbkc"`
     /// * Zbkx: `"zbkx"`
@@ -159,6 +159,9 @@ features! {
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] c: "c";
     /// "C" Extension for Compressed Instructions
 
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] b: "b";
+    without cfg check: true;
+    /// "B" Extension for Bit Manipulation
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zba: "zba";
     /// "Zba" Extension for Address Generation
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zbb: "zbb";

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -30,6 +30,8 @@ features! {
     /// * RV32I: `"rv32i"`
     /// * RV64I: `"rv64i"`
     /// * A: `"a"`
+    ///   * Zaamo: `"zaamo"`
+    ///   * Zalrsc: `"zalrsc"`
     /// * Bit-Manipulation Extensions:
     ///   * Zba: `"zba"`
     ///   * Zbb: `"zbb"`
@@ -122,6 +124,10 @@ features! {
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] a: "a";
     /// "A" Extension for Atomic Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zalrsc: "zalrsc";
+    /// "Zalrsc" Extension for Load-Reserved/Store-Conditional Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zaamo: "zaamo";
+    /// "Zaamo" Extension for Atomic Memory Operations
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zam: "zam";
     without cfg check: true;
     /// "Zam" Extension for Misaligned Atomics

--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -115,14 +115,6 @@ features! {
     /// * P: `"p"`
     /// * Zam: `"zam"`
     ///
-    /// Defined by Privileged Specification:
-    ///
-    /// * *Supervisor-Level ISA* (not "S" extension): `"s"`
-    /// * H (hypervisor): `"h"`
-    /// * Svnapot: `"svnapot"`
-    /// * Svpbmt: `"svpbmt"`
-    /// * Svinval: `"svinval"`
-    ///
     /// # Performance Hints
     ///
     /// The two features below define performance hints for unaligned
@@ -331,22 +323,6 @@ features! {
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvkt: "zvkt";
     /// "Zvkt" Extension for Vector Data-Independent Execution Latency
 
-    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] svnapot: "svnapot";
-    without cfg check: true;
-    /// "Svnapot" Extension for NAPOT Translation Contiguity
-    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] svpbmt: "svpbmt";
-    without cfg check: true;
-    /// "Svpbmt" Extension for Page-Based Memory Types
-    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] svinval: "svinval";
-    without cfg check: true;
-    /// "Svinval" Extension for Fine-Grained Address-Translation Cache Invalidation
-    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] h: "h";
-    without cfg check: true;
-    /// "H" Extension for Hypervisor Support
-
-    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] s: "s";
-    without cfg check: true;
-    /// Supervisor-Level ISA
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] j: "j";
     without cfg check: true;
     /// "J" Extension for Dynamically Translated Languages

--- a/crates/std_detect/src/detect/cache.rs
+++ b/crates/std_detect/src/detect/cache.rs
@@ -31,7 +31,7 @@ const CACHE_CAPACITY: u32 = 93;
 /// This type is used to initialize the cache
 // The derived `Default` implementation will initialize the field to zero,
 // which is what we want.
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub(crate) struct Initializer(u128);
 
 // NOTE: the `debug_assert!` would catch that we do not add more Features than

--- a/crates/std_detect/src/detect/mod.rs
+++ b/crates/std_detect/src/detect/mod.rs
@@ -49,6 +49,9 @@ cfg_if! {
         #[path = "os/x86.rs"]
         mod os;
     } else if #[cfg(all(any(target_os = "linux", target_os = "android"), feature = "libc"))] {
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+        #[path = "os/riscv.rs"]
+        mod riscv;
         #[path = "os/linux/mod.rs"]
         mod os;
     } else if #[cfg(all(target_os = "freebsd", feature = "libc"))] {

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -6,16 +6,9 @@ use crate::detect::{Feature, bit, cache};
 /// Read list of supported features from the auxiliary vector.
 pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
-    let enable_feature = |value: &mut cache::Initializer, feature, enable| {
+    let mut enable_feature = |feature, enable| {
         if enable {
             value.set(feature as u32);
-        }
-    };
-    let enable_features = |value: &mut cache::Initializer, feature_slice: &[Feature], enable| {
-        if enable {
-            for feature in feature_slice {
-                value.set(*feature as u32);
-            }
         }
     };
 
@@ -25,51 +18,26 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.14
     let auxv = auxvec::auxv().expect("read auxvec"); // should not fail on RISC-V platform
     #[allow(clippy::eq_op)]
-    enable_feature(
-        &mut value,
-        Feature::a,
-        bit::test(auxv.hwcap, (b'a' - b'a').into()),
-    );
-    enable_feature(
-        &mut value,
-        Feature::c,
-        bit::test(auxv.hwcap, (b'c' - b'a').into()),
-    );
-    enable_features(
-        &mut value,
-        &[Feature::d, Feature::f, Feature::zicsr],
-        bit::test(auxv.hwcap, (b'd' - b'a').into()),
-    );
-    enable_features(
-        &mut value,
-        &[Feature::f, Feature::zicsr],
-        bit::test(auxv.hwcap, (b'f' - b'a').into()),
-    );
-    enable_feature(
-        &mut value,
-        Feature::h,
-        bit::test(auxv.hwcap, (b'h' - b'a').into()),
-    );
-    enable_feature(
-        &mut value,
-        Feature::m,
-        bit::test(auxv.hwcap, (b'm' - b'a').into()),
-    );
+    enable_feature(Feature::a, bit::test(auxv.hwcap, (b'a' - b'a').into()));
+    enable_feature(Feature::c, bit::test(auxv.hwcap, (b'c' - b'a').into()));
+    let has_d = bit::test(auxv.hwcap, (b'd' - b'a').into());
+    let has_f = bit::test(auxv.hwcap, (b'f' - b'a').into());
+    enable_feature(Feature::d, has_d);
+    enable_feature(Feature::f, has_d | has_f);
+    enable_feature(Feature::zicsr, has_d | has_f);
+    enable_feature(Feature::h, bit::test(auxv.hwcap, (b'h' - b'a').into()));
+    enable_feature(Feature::m, bit::test(auxv.hwcap, (b'm' - b'a').into()));
 
     // Handle base ISA.
     let has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
     // If future RV128I is supported, implement with `enable_feature` here
     #[cfg(target_pointer_width = "64")]
-    enable_feature(&mut value, Feature::rv64i, has_i);
+    enable_feature(Feature::rv64i, has_i);
     #[cfg(target_pointer_width = "32")]
-    enable_feature(&mut value, Feature::rv32i, has_i);
+    enable_feature(Feature::rv32i, has_i);
     // FIXME: e is not exposed in any of asm/hwcap.h, uapi/asm/hwcap.h, uapi/asm/hwprobe.h
     #[cfg(target_pointer_width = "32")]
-    enable_feature(
-        &mut value,
-        Feature::rv32e,
-        bit::test(auxv.hwcap, (b'e' - b'a').into()),
-    );
+    enable_feature(Feature::rv32e, bit::test(auxv.hwcap, (b'e' - b'a').into()));
 
     // FIXME: Auxvec does not show supervisor feature support, but this mode may be useful
     // to detect when Rust is used to write Linux kernel modules.

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -21,7 +21,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
     // The values are part of the platform-specific [asm/hwcap.h][hwcap]
     //
-    // [hwcap]: https://github.com/torvalds/linux/blob/master/arch/riscv/include/asm/hwcap.h
+    // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.14
     let auxv = auxvec::auxv().expect("read auxvec"); // should not fail on RISC-V platform
     #[allow(clippy::eq_op)]
     enable_feature(

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -19,6 +19,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
         }
     };
 
+    // Use auxiliary vector to enable single-letter ISA extensions and Zicsr.
     // The values are part of the platform-specific [asm/hwcap.h][hwcap]
     //
     // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.14

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -1,10 +1,127 @@
 //! Run-time feature detection for RISC-V on Linux.
+//!
+//! On RISC-V, detection using auxv only supports single-letter extensions.
+//! So, we use riscv_hwprobe that supports multi-letter extensions if available.
+//! <https://www.kernel.org/doc/html/latest/arch/riscv/hwprobe.html>
+
+use core::ptr;
 
 use super::super::riscv::imply_features;
 use super::auxvec;
 use crate::detect::{Feature, bit, cache};
 
-/// Read list of supported features from the auxiliary vector.
+// See <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/prctl.h?h=v6.14>
+// for runtime status query constants.
+const PR_RISCV_V_GET_CONTROL: libc::c_int = 70;
+const PR_RISCV_V_VSTATE_CTRL_ON: libc::c_int = 2;
+const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: libc::c_int = 3;
+
+// See <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwprobe.h?h=v6.14>
+// for riscv_hwprobe struct and hardware probing constants.
+
+#[repr(C)]
+struct riscv_hwprobe {
+    key: i64,
+    value: u64,
+}
+
+#[allow(non_upper_case_globals)]
+const __NR_riscv_hwprobe: libc::c_long = 258;
+
+const RISCV_HWPROBE_KEY_BASE_BEHAVIOR: i64 = 3;
+const RISCV_HWPROBE_BASE_BEHAVIOR_IMA: u64 = 1 << 0;
+
+const RISCV_HWPROBE_KEY_IMA_EXT_0: i64 = 4;
+const RISCV_HWPROBE_IMA_FD: u64 = 1 << 0;
+const RISCV_HWPROBE_IMA_C: u64 = 1 << 1;
+const RISCV_HWPROBE_IMA_V: u64 = 1 << 2;
+const RISCV_HWPROBE_EXT_ZBA: u64 = 1 << 3;
+const RISCV_HWPROBE_EXT_ZBB: u64 = 1 << 4;
+const RISCV_HWPROBE_EXT_ZBS: u64 = 1 << 5;
+const RISCV_HWPROBE_EXT_ZICBOZ: u64 = 1 << 6;
+const RISCV_HWPROBE_EXT_ZBC: u64 = 1 << 7;
+const RISCV_HWPROBE_EXT_ZBKB: u64 = 1 << 8;
+const RISCV_HWPROBE_EXT_ZBKC: u64 = 1 << 9;
+const RISCV_HWPROBE_EXT_ZBKX: u64 = 1 << 10;
+const RISCV_HWPROBE_EXT_ZKND: u64 = 1 << 11;
+const RISCV_HWPROBE_EXT_ZKNE: u64 = 1 << 12;
+const RISCV_HWPROBE_EXT_ZKNH: u64 = 1 << 13;
+const RISCV_HWPROBE_EXT_ZKSED: u64 = 1 << 14;
+const RISCV_HWPROBE_EXT_ZKSH: u64 = 1 << 15;
+const RISCV_HWPROBE_EXT_ZKT: u64 = 1 << 16;
+const RISCV_HWPROBE_EXT_ZVBB: u64 = 1 << 17;
+const RISCV_HWPROBE_EXT_ZVBC: u64 = 1 << 18;
+const RISCV_HWPROBE_EXT_ZVKB: u64 = 1 << 19;
+const RISCV_HWPROBE_EXT_ZVKG: u64 = 1 << 20;
+const RISCV_HWPROBE_EXT_ZVKNED: u64 = 1 << 21;
+const RISCV_HWPROBE_EXT_ZVKNHA: u64 = 1 << 22;
+const RISCV_HWPROBE_EXT_ZVKNHB: u64 = 1 << 23;
+const RISCV_HWPROBE_EXT_ZVKSED: u64 = 1 << 24;
+const RISCV_HWPROBE_EXT_ZVKSH: u64 = 1 << 25;
+const RISCV_HWPROBE_EXT_ZVKT: u64 = 1 << 26;
+const RISCV_HWPROBE_EXT_ZFH: u64 = 1 << 27;
+const RISCV_HWPROBE_EXT_ZFHMIN: u64 = 1 << 28;
+const RISCV_HWPROBE_EXT_ZIHINTNTL: u64 = 1 << 29;
+const RISCV_HWPROBE_EXT_ZVFH: u64 = 1 << 30;
+const RISCV_HWPROBE_EXT_ZVFHMIN: u64 = 1 << 31;
+const RISCV_HWPROBE_EXT_ZFA: u64 = 1 << 32;
+const RISCV_HWPROBE_EXT_ZTSO: u64 = 1 << 33;
+const RISCV_HWPROBE_EXT_ZACAS: u64 = 1 << 34;
+const RISCV_HWPROBE_EXT_ZICOND: u64 = 1 << 35;
+const RISCV_HWPROBE_EXT_ZIHINTPAUSE: u64 = 1 << 36;
+const RISCV_HWPROBE_EXT_ZVE32X: u64 = 1 << 37;
+const RISCV_HWPROBE_EXT_ZVE32F: u64 = 1 << 38;
+const RISCV_HWPROBE_EXT_ZVE64X: u64 = 1 << 39;
+const RISCV_HWPROBE_EXT_ZVE64F: u64 = 1 << 40;
+const RISCV_HWPROBE_EXT_ZVE64D: u64 = 1 << 41;
+const RISCV_HWPROBE_EXT_ZIMOP: u64 = 1 << 42;
+const RISCV_HWPROBE_EXT_ZCA: u64 = 1 << 43;
+const RISCV_HWPROBE_EXT_ZCB: u64 = 1 << 44;
+const RISCV_HWPROBE_EXT_ZCD: u64 = 1 << 45;
+const RISCV_HWPROBE_EXT_ZCF: u64 = 1 << 46;
+const RISCV_HWPROBE_EXT_ZCMOP: u64 = 1 << 47;
+const RISCV_HWPROBE_EXT_ZAWRS: u64 = 1 << 48;
+// Excluded because it only reports the existence of `prctl`-based pointer masking control.
+// const RISCV_HWPROBE_EXT_SUPM: u64 = 1 << 49;
+
+const RISCV_HWPROBE_KEY_CPUPERF_0: i64 = 5;
+const RISCV_HWPROBE_MISALIGNED_FAST: u64 = 3;
+const RISCV_HWPROBE_MISALIGNED_MASK: u64 = 7;
+
+const RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF: i64 = 9;
+const RISCV_HWPROBE_MISALIGNED_SCALAR_FAST: u64 = 3;
+
+const RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF: i64 = 10;
+const RISCV_HWPROBE_MISALIGNED_VECTOR_FAST: u64 = 3;
+
+// syscall returns an unsupported error if riscv_hwprobe is not supported,
+// so we can safely use this function on older versions of Linux.
+fn _riscv_hwprobe(out: &mut [riscv_hwprobe]) -> bool {
+    unsafe fn __riscv_hwprobe(
+        pairs: *mut riscv_hwprobe,
+        pair_count: libc::size_t,
+        cpu_set_size: libc::size_t,
+        cpus: *mut libc::c_ulong,
+        flags: libc::c_uint,
+    ) -> libc::c_long {
+        unsafe {
+            libc::syscall(
+                __NR_riscv_hwprobe,
+                pairs,
+                pair_count,
+                cpu_set_size,
+                cpus,
+                flags,
+            )
+        }
+    }
+
+    let len = out.len();
+    unsafe { __riscv_hwprobe(out.as_mut_ptr(), len, 0, ptr::null_mut(), 0) == 0 }
+}
+
+/// Read list of supported features from (1) the auxiliary vector
+/// and (2) the results of `riscv_hwprobe` and `prctl` system calls.
 pub(crate) fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
     let mut enable_feature = |feature, enable| {
@@ -18,6 +135,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     //
     // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.14
     let auxv = auxvec::auxv().expect("read auxvec"); // should not fail on RISC-V platform
+    let mut has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
     #[allow(clippy::eq_op)]
     enable_feature(Feature::a, bit::test(auxv.hwcap, (b'a' - b'a').into()));
     enable_feature(Feature::c, bit::test(auxv.hwcap, (b'c' - b'a').into()));
@@ -25,9 +143,167 @@ pub(crate) fn detect_features() -> cache::Initializer {
     enable_feature(Feature::f, bit::test(auxv.hwcap, (b'f' - b'a').into()));
     enable_feature(Feature::h, bit::test(auxv.hwcap, (b'h' - b'a').into()));
     enable_feature(Feature::m, bit::test(auxv.hwcap, (b'm' - b'a').into()));
+    let has_v = bit::test(auxv.hwcap, (b'v' - b'a').into());
+    let mut is_v_set = false;
+
+    // Use riscv_hwprobe syscall to query more extensions and
+    // performance-related capabilities.
+    'hwprobe: {
+        let mut out = [
+            riscv_hwprobe {
+                key: RISCV_HWPROBE_KEY_BASE_BEHAVIOR,
+                value: 0,
+            },
+            riscv_hwprobe {
+                key: RISCV_HWPROBE_KEY_IMA_EXT_0,
+                value: 0,
+            },
+            riscv_hwprobe {
+                key: RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF,
+                value: 0,
+            },
+            riscv_hwprobe {
+                key: RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF,
+                value: 0,
+            },
+            riscv_hwprobe {
+                key: RISCV_HWPROBE_KEY_CPUPERF_0,
+                value: 0,
+            },
+        ];
+        if !_riscv_hwprobe(&mut out) {
+            break 'hwprobe;
+        }
+
+        // Query scalar/vector misaligned behavior.
+        if out[2].key != -1 {
+            enable_feature(
+                Feature::unaligned_scalar_mem,
+                out[2].value == RISCV_HWPROBE_MISALIGNED_SCALAR_FAST,
+            );
+        } else if out[4].key != -1 {
+            // Deprecated method for fallback
+            enable_feature(
+                Feature::unaligned_scalar_mem,
+                out[4].value & RISCV_HWPROBE_MISALIGNED_MASK == RISCV_HWPROBE_MISALIGNED_FAST,
+            );
+        }
+        if out[3].key != -1 {
+            enable_feature(
+                Feature::unaligned_vector_mem,
+                out[3].value == RISCV_HWPROBE_MISALIGNED_VECTOR_FAST,
+            );
+        }
+
+        // Query whether "I" base and extensions "M" and "A" (as in the ISA
+        // manual version 2.2) are enabled.  "I" base at that time corresponds
+        // to "I", "Zicsr", "Zicntr" and "Zifencei" (as in the ISA manual version
+        // 20240411) and we chose to imply "Zicsr" and "Zifencei" (not "Zicntr")
+        // because there will be a separate RISCV_HWPROBE_EXT_ZICNTR constant to
+        // determine existence of the "Zicntr" extension in Linux 6.15 (as of rc1).
+        // "fence.i" ("Zifencei") is conditionally valid on the Linux userland
+        // (when CMODX is enabled).
+        // This is a requirement of `RISCV_HWPROBE_KEY_IMA_EXT_0`-based tests.
+        let has_ima = (out[0].key != -1) && (out[0].value & RISCV_HWPROBE_BASE_BEHAVIOR_IMA != 0);
+        if !has_ima {
+            break 'hwprobe;
+        }
+        has_i |= has_ima;
+        enable_feature(Feature::zicsr, has_ima);
+        enable_feature(Feature::zifencei, has_ima);
+        enable_feature(Feature::m, has_ima);
+        enable_feature(Feature::a, has_ima);
+
+        // Enable features based on `RISCV_HWPROBE_KEY_IMA_EXT_0`.
+        if out[1].key == -1 {
+            break 'hwprobe;
+        }
+        let ima_ext_0 = out[1].value;
+        let test = |mask| (ima_ext_0 & mask) != 0;
+
+        enable_feature(Feature::d, test(RISCV_HWPROBE_IMA_FD)); // F is implied.
+        enable_feature(Feature::c, test(RISCV_HWPROBE_IMA_C));
+
+        enable_feature(Feature::zihintntl, test(RISCV_HWPROBE_EXT_ZIHINTNTL));
+        enable_feature(Feature::zihintpause, test(RISCV_HWPROBE_EXT_ZIHINTPAUSE));
+        enable_feature(Feature::zimop, test(RISCV_HWPROBE_EXT_ZIMOP));
+        enable_feature(Feature::zicboz, test(RISCV_HWPROBE_EXT_ZICBOZ));
+        enable_feature(Feature::zicond, test(RISCV_HWPROBE_EXT_ZICOND));
+
+        enable_feature(Feature::zawrs, test(RISCV_HWPROBE_EXT_ZAWRS));
+        enable_feature(Feature::zacas, test(RISCV_HWPROBE_EXT_ZACAS));
+        enable_feature(Feature::ztso, test(RISCV_HWPROBE_EXT_ZTSO));
+
+        enable_feature(Feature::zba, test(RISCV_HWPROBE_EXT_ZBA));
+        enable_feature(Feature::zbb, test(RISCV_HWPROBE_EXT_ZBB));
+        enable_feature(Feature::zbs, test(RISCV_HWPROBE_EXT_ZBS));
+        enable_feature(Feature::zbc, test(RISCV_HWPROBE_EXT_ZBC));
+
+        enable_feature(Feature::zbkb, test(RISCV_HWPROBE_EXT_ZBKB));
+        enable_feature(Feature::zbkc, test(RISCV_HWPROBE_EXT_ZBKC));
+        enable_feature(Feature::zbkx, test(RISCV_HWPROBE_EXT_ZBKX));
+        enable_feature(Feature::zknd, test(RISCV_HWPROBE_EXT_ZKND));
+        enable_feature(Feature::zkne, test(RISCV_HWPROBE_EXT_ZKNE));
+        enable_feature(Feature::zknh, test(RISCV_HWPROBE_EXT_ZKNH));
+        enable_feature(Feature::zksed, test(RISCV_HWPROBE_EXT_ZKSED));
+        enable_feature(Feature::zksh, test(RISCV_HWPROBE_EXT_ZKSH));
+        enable_feature(Feature::zkt, test(RISCV_HWPROBE_EXT_ZKT));
+
+        enable_feature(Feature::zcmop, test(RISCV_HWPROBE_EXT_ZCMOP));
+        enable_feature(Feature::zca, test(RISCV_HWPROBE_EXT_ZCA));
+        enable_feature(Feature::zcf, test(RISCV_HWPROBE_EXT_ZCF));
+        enable_feature(Feature::zcd, test(RISCV_HWPROBE_EXT_ZCD));
+        enable_feature(Feature::zcb, test(RISCV_HWPROBE_EXT_ZCB));
+
+        enable_feature(Feature::zfh, test(RISCV_HWPROBE_EXT_ZFH));
+        enable_feature(Feature::zfhmin, test(RISCV_HWPROBE_EXT_ZFHMIN));
+        enable_feature(Feature::zfa, test(RISCV_HWPROBE_EXT_ZFA));
+
+        // Use prctl (if any) to determine whether the vector extension
+        // is enabled on the current thread (assuming the entire process
+        // share the same status).  If prctl fails (e.g. QEMU userland emulator
+        // as of version 9.2.3), use auxiliary vector to retrieve the default
+        // vector status on the process startup.
+        let has_vectors = {
+            let v_status = unsafe { libc::prctl(PR_RISCV_V_GET_CONTROL) };
+            if v_status >= 0 {
+                (v_status & PR_RISCV_V_VSTATE_CTRL_CUR_MASK) == PR_RISCV_V_VSTATE_CTRL_ON
+            } else {
+                has_v
+            }
+        };
+        if has_vectors {
+            enable_feature(Feature::v, test(RISCV_HWPROBE_IMA_V));
+            enable_feature(Feature::zve32x, test(RISCV_HWPROBE_EXT_ZVE32X));
+            enable_feature(Feature::zve32f, test(RISCV_HWPROBE_EXT_ZVE32F));
+            enable_feature(Feature::zve64x, test(RISCV_HWPROBE_EXT_ZVE64X));
+            enable_feature(Feature::zve64f, test(RISCV_HWPROBE_EXT_ZVE64F));
+            enable_feature(Feature::zve64d, test(RISCV_HWPROBE_EXT_ZVE64D));
+
+            enable_feature(Feature::zvbb, test(RISCV_HWPROBE_EXT_ZVBB));
+            enable_feature(Feature::zvbc, test(RISCV_HWPROBE_EXT_ZVBC));
+            enable_feature(Feature::zvkb, test(RISCV_HWPROBE_EXT_ZVKB));
+            enable_feature(Feature::zvkg, test(RISCV_HWPROBE_EXT_ZVKG));
+            enable_feature(Feature::zvkned, test(RISCV_HWPROBE_EXT_ZVKNED));
+            enable_feature(Feature::zvknha, test(RISCV_HWPROBE_EXT_ZVKNHA));
+            enable_feature(Feature::zvknhb, test(RISCV_HWPROBE_EXT_ZVKNHB));
+            enable_feature(Feature::zvksed, test(RISCV_HWPROBE_EXT_ZVKSED));
+            enable_feature(Feature::zvksh, test(RISCV_HWPROBE_EXT_ZVKSH));
+            enable_feature(Feature::zvkt, test(RISCV_HWPROBE_EXT_ZVKT));
+
+            enable_feature(Feature::zvfh, test(RISCV_HWPROBE_EXT_ZVFH));
+            enable_feature(Feature::zvfhmin, test(RISCV_HWPROBE_EXT_ZVFHMIN));
+        }
+        is_v_set = true;
+    };
+
+    // Set V purely depending on the auxiliary vector
+    // only if no fine-grained vector extension detection is available.
+    if !is_v_set {
+        enable_feature(Feature::v, has_v);
+    }
 
     // Handle base ISA.
-    let has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
     // If future RV128I is supported, implement with `enable_feature` here.
     // Note that we should use `target_arch` instead of `target_pointer_width`
     // to avoid misdetection caused by experimental ABIs such as RV64ILP32.

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -44,18 +44,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
         &[Feature::f, Feature::zicsr],
         bit::test(auxv.hwcap, (b'f' - b'a').into()),
     );
-    let has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
-    // If future RV128I is supported, implement with `enable_feature` here
-    #[cfg(target_pointer_width = "64")]
-    enable_feature(&mut value, Feature::rv64i, has_i);
-    #[cfg(target_pointer_width = "32")]
-    enable_feature(&mut value, Feature::rv32i, has_i);
-    #[cfg(target_pointer_width = "32")]
-    enable_feature(
-        &mut value,
-        Feature::rv32e,
-        bit::test(auxv.hwcap, (b'e' - b'a').into()),
-    );
     enable_feature(
         &mut value,
         Feature::h,
@@ -66,6 +54,22 @@ pub(crate) fn detect_features() -> cache::Initializer {
         Feature::m,
         bit::test(auxv.hwcap, (b'm' - b'a').into()),
     );
+
+    // Handle base ISA.
+    let has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
+    // If future RV128I is supported, implement with `enable_feature` here
+    #[cfg(target_pointer_width = "64")]
+    enable_feature(&mut value, Feature::rv64i, has_i);
+    #[cfg(target_pointer_width = "32")]
+    enable_feature(&mut value, Feature::rv32i, has_i);
+    // FIXME: e is not exposed in any of asm/hwcap.h, uapi/asm/hwcap.h, uapi/asm/hwprobe.h
+    #[cfg(target_pointer_width = "32")]
+    enable_feature(
+        &mut value,
+        Feature::rv32e,
+        bit::test(auxv.hwcap, (b'e' - b'a').into()),
+    );
+
     // FIXME: Auxvec does not show supervisor feature support, but this mode may be useful
     // to detect when Rust is used to write Linux kernel modules.
     // These should be more than Auxvec way to detect supervisor features.

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -30,13 +30,15 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
     // Handle base ISA.
     let has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
-    // If future RV128I is supported, implement with `enable_feature` here
-    #[cfg(target_pointer_width = "64")]
+    // If future RV128I is supported, implement with `enable_feature` here.
+    // Note that we should use `target_arch` instead of `target_pointer_width`
+    // to avoid misdetection caused by experimental ABIs such as RV64ILP32.
+    #[cfg(target_arch = "riscv64")]
     enable_feature(Feature::rv64i, has_i);
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(target_arch = "riscv32")]
     enable_feature(Feature::rv32i, has_i);
     // FIXME: e is not exposed in any of asm/hwcap.h, uapi/asm/hwcap.h, uapi/asm/hwprobe.h
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(target_arch = "riscv32")]
     enable_feature(Feature::rv32e, bit::test(auxv.hwcap, (b'e' - b'a').into()));
 
     // FIXME: Auxvec does not show supervisor feature support, but this mode may be useful

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -18,7 +18,10 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.14
     let auxv = auxvec::auxv().expect("read auxvec"); // should not fail on RISC-V platform
     #[allow(clippy::eq_op)]
-    enable_feature(Feature::a, bit::test(auxv.hwcap, (b'a' - b'a').into()));
+    let has_a = bit::test(auxv.hwcap, (b'a' - b'a').into());
+    enable_feature(Feature::a, has_a);
+    enable_feature(Feature::zalrsc, has_a);
+    enable_feature(Feature::zaamo, has_a);
     enable_feature(Feature::c, bit::test(auxv.hwcap, (b'c' - b'a').into()));
     let has_d = bit::test(auxv.hwcap, (b'd' - b'a').into());
     let has_f = bit::test(auxv.hwcap, (b'f' - b'a').into());

--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -141,7 +141,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
     enable_feature(Feature::c, bit::test(auxv.hwcap, (b'c' - b'a').into()));
     enable_feature(Feature::d, bit::test(auxv.hwcap, (b'd' - b'a').into()));
     enable_feature(Feature::f, bit::test(auxv.hwcap, (b'f' - b'a').into()));
-    enable_feature(Feature::h, bit::test(auxv.hwcap, (b'h' - b'a').into()));
     enable_feature(Feature::m, bit::test(auxv.hwcap, (b'm' - b'a').into()));
     let has_v = bit::test(auxv.hwcap, (b'v' - b'a').into());
     let mut is_v_set = false;
@@ -314,10 +313,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // FIXME: e is not exposed in any of asm/hwcap.h, uapi/asm/hwcap.h, uapi/asm/hwprobe.h
     #[cfg(target_arch = "riscv32")]
     enable_feature(Feature::rv32e, bit::test(auxv.hwcap, (b'e' - b'a').into()));
-
-    // FIXME: Auxvec does not show supervisor feature support, but this mode may be useful
-    // to detect when Rust is used to write Linux kernel modules.
-    // These should be more than Auxvec way to detect supervisor features.
 
     imply_features(value)
 }

--- a/crates/std_detect/src/detect/os/riscv.rs
+++ b/crates/std_detect/src/detect/os/riscv.rs
@@ -123,7 +123,6 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
         imply!(c & f => zcf);
 
         imply!(zicntr | zihpm | f | zfinx | zve32x => zicsr);
-        imply!(s | h => zicsr);
 
         // Loop until the feature flags converge.
         if prev == value {

--- a/crates/std_detect/src/detect/os/riscv.rs
+++ b/crates/std_detect/src/detect/os/riscv.rs
@@ -1,0 +1,148 @@
+//! Run-time feature detection utility for RISC-V.
+//!
+//! On RISC-V, full feature detection needs a help of one or more
+//! feature detection mechanisms (usually provided by the operating system).
+//!
+//! RISC-V architecture defines many extensions and some have dependency to others.
+//! More importantly, some of them cannot be enabled without resolving such
+//! dependencies due to limited set of features that such mechanisms provide.
+//!
+//! This module provides an OS-independent utility to process such relations
+//! between RISC-V extensions.
+
+use crate::detect::{Feature, cache};
+
+/// Imply features by the given set of enabled features.
+///
+/// Note that it does not perform any consistency checks including existence of
+/// conflicting extensions and/or complicated requirements.  Eliminating such
+/// inconsistencies is the responsibility of the feature detection logic and
+/// its provider(s).
+pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initializer {
+    loop {
+        // Check convergence of the feature flags later.
+        let prev = value;
+
+        // Expect that the optimizer turns repeated operations into
+        // a fewer number of bit-manipulation operations.
+        macro_rules! imply {
+            // Regular implication:
+            // A1 => (B1[, B2...]), A2 => (B1[, B2...]) and so on.
+            ($($from: ident)|+ => $($to: ident)&+) => {
+                if [$(Feature::$from as u32),+].iter().any(|&x| value.test(x)) {
+                    $(
+                        value.set(Feature::$to as u32);
+                    )+
+                }
+            };
+            // Implication with multiple requirements:
+            // A1 && A2 ... => (B1[, B2...]).
+            ($($from: ident)&+ => $($to: ident)&+) => {
+                if [$(Feature::$from as u32),+].iter().all(|&x| value.test(x)) {
+                    $(
+                        value.set(Feature::$to as u32);
+                    )+
+                }
+            };
+        }
+        macro_rules! group {
+            ($group: ident == $($member: ident)&+) => {
+                // Forward implication as defined in the specifications.
+                imply!($group => $($member)&+);
+                // Reverse implication to "group extension" from its members.
+                // This is not a part of specifications but convenient for
+                // feature detection and implemented in e.g. LLVM.
+                imply!($($member)&+ => $group);
+            };
+        }
+
+        /*
+            If a dependency/implication is not explicitly stated in the
+            specification, it is denoted as a comment as follows:
+            "defined as subset":
+                The latter extension is described as a subset of the former
+                (but the evidence is weak).
+        */
+
+        imply!(zbc => zbkc); // defined as subset
+        group!(zkn == zbkb & zbkc & zbkx & zkne & zknd & zknh);
+        group!(zks == zbkb & zbkc & zbkx & zksed & zksh);
+        group!(zk == zkn & zkr & zkt);
+
+        group!(a == zalrsc & zaamo);
+
+        group!(b == zba & zbb & zbs);
+
+        imply!(zhinx => zhinxmin);
+        imply!(zdinx | zhinxmin => zfinx);
+
+        imply!(zfh => zfhmin);
+        imply!(q => d);
+        imply!(d | zfhmin => f);
+
+        imply!(zicntr | zihpm | f | zfinx => zicsr);
+        imply!(s | h => zicsr);
+
+        // Loop until the feature flags converge.
+        if prev == value {
+            return value;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_direct() {
+        let mut value = cache::Initializer::default();
+        value.set(Feature::f as u32);
+        // F (and other extensions with CSRs) -> Zicsr
+        assert!(imply_features(value).test(Feature::zicsr as u32));
+    }
+
+    #[test]
+    fn simple_indirect() {
+        let mut value = cache::Initializer::default();
+        value.set(Feature::q as u32);
+        // Q -> D, D -> F, F -> Zicsr
+        assert!(imply_features(value).test(Feature::zicsr as u32));
+    }
+
+    #[test]
+    fn group_simple_forward() {
+        let mut value = cache::Initializer::default();
+        // A -> Zalrsc & Zaamo (forward implication)
+        value.set(Feature::a as u32);
+        let value = imply_features(value);
+        assert!(value.test(Feature::zalrsc as u32));
+        assert!(value.test(Feature::zaamo as u32));
+    }
+
+    #[test]
+    fn group_simple_backward() {
+        let mut value = cache::Initializer::default();
+        // Zalrsc & Zaamo -> A (reverse implication)
+        value.set(Feature::zalrsc as u32);
+        value.set(Feature::zaamo as u32);
+        assert!(imply_features(value).test(Feature::a as u32));
+    }
+
+    #[test]
+    fn group_complex_convergence() {
+        let mut value = cache::Initializer::default();
+        // Needs 2 iterations to converge
+        // (and 3rd iteration for convergence checking):
+        // 1.  [Zk] -> Zkn & Zkr & Zkt
+        // 2.  Zkn -> {Zbkb} & {Zbkc} & {Zbkx} & {Zkne} & {Zknd} & {Zknh}
+        value.set(Feature::zk as u32);
+        let value = imply_features(value);
+        assert!(value.test(Feature::zbkb as u32));
+        assert!(value.test(Feature::zbkc as u32));
+        assert!(value.test(Feature::zbkx as u32));
+        assert!(value.test(Feature::zkne as u32));
+        assert!(value.test(Feature::zknd as u32));
+        assert!(value.test(Feature::zknh as u32));
+    }
+}

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -5,6 +5,10 @@
     any(target_arch = "aarch64", target_arch = "arm64ec"),
     feature(stdarch_aarch64_feature_detection)
 )]
+#![cfg_attr(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    feature(stdarch_riscv_feature_detection)
+)]
 #![cfg_attr(target_arch = "powerpc", feature(stdarch_powerpc_feature_detection))]
 #![cfg_attr(target_arch = "powerpc64", feature(stdarch_powerpc_feature_detection))]
 #![cfg_attr(target_arch = "s390x", feature(stdarch_s390x_feature_detection))]
@@ -15,6 +19,8 @@
         target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "arm64ec",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
         target_arch = "powerpc",
         target_arch = "powerpc64",
         target_arch = "s390x",
@@ -218,6 +224,65 @@ fn aarch64_darwin() {
     println!("aes: {:?}", is_aarch64_feature_detected!("aes"));
     println!("sha2: {:?}", is_aarch64_feature_detected!("sha2"));
     println!("sha3: {:?}", is_aarch64_feature_detected!("sha3"));
+}
+
+#[test]
+#[cfg(all(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    any(target_os = "linux", target_os = "android")
+))]
+fn riscv_linux() {
+    println!("rv32i: {}", is_riscv_feature_detected!("rv32i"));
+    println!("rv32e: {}", is_riscv_feature_detected!("rv32e"));
+    println!("rv64i: {}", is_riscv_feature_detected!("rv64i"));
+    println!("rv128i: {}", is_riscv_feature_detected!("rv128i"));
+    println!("zicsr: {}", is_riscv_feature_detected!("zicsr"));
+    println!("zicntr: {}", is_riscv_feature_detected!("zicntr"));
+    println!("zihpm: {}", is_riscv_feature_detected!("zihpm"));
+    println!("zifencei: {}", is_riscv_feature_detected!("zifencei"));
+    println!("zihintpause: {}", is_riscv_feature_detected!("zihintpause"));
+    println!("m: {}", is_riscv_feature_detected!("m"));
+    println!("a: {}", is_riscv_feature_detected!("a"));
+    println!("zalrsc: {}", is_riscv_feature_detected!("zalrsc"));
+    println!("zaamo: {}", is_riscv_feature_detected!("zaamo"));
+    println!("zam: {}", is_riscv_feature_detected!("zam"));
+    println!("ztso: {}", is_riscv_feature_detected!("ztso"));
+    println!("f: {}", is_riscv_feature_detected!("f"));
+    println!("d: {}", is_riscv_feature_detected!("d"));
+    println!("q: {}", is_riscv_feature_detected!("q"));
+    println!("zfh: {}", is_riscv_feature_detected!("zfh"));
+    println!("zfhmin: {}", is_riscv_feature_detected!("zfhmin"));
+    println!("zfinx: {}", is_riscv_feature_detected!("zfinx"));
+    println!("zdinx: {}", is_riscv_feature_detected!("zdinx"));
+    println!("zhinx: {}", is_riscv_feature_detected!("zhinx"));
+    println!("zhinxmin: {}", is_riscv_feature_detected!("zhinxmin"));
+    println!("c: {}", is_riscv_feature_detected!("c"));
+    println!("b: {}", is_riscv_feature_detected!("b"));
+    println!("zba: {}", is_riscv_feature_detected!("zba"));
+    println!("zbb: {}", is_riscv_feature_detected!("zbb"));
+    println!("zbc: {}", is_riscv_feature_detected!("zbc"));
+    println!("zbs: {}", is_riscv_feature_detected!("zbs"));
+    println!("zbkb: {}", is_riscv_feature_detected!("zbkb"));
+    println!("zbkc: {}", is_riscv_feature_detected!("zbkc"));
+    println!("zbkx: {}", is_riscv_feature_detected!("zbkx"));
+    println!("zknd: {}", is_riscv_feature_detected!("zknd"));
+    println!("zkne: {}", is_riscv_feature_detected!("zkne"));
+    println!("zknh: {}", is_riscv_feature_detected!("zknh"));
+    println!("zksed: {}", is_riscv_feature_detected!("zksed"));
+    println!("zksh: {}", is_riscv_feature_detected!("zksh"));
+    println!("zkr: {}", is_riscv_feature_detected!("zkr"));
+    println!("zkn: {}", is_riscv_feature_detected!("zkn"));
+    println!("zks: {}", is_riscv_feature_detected!("zks"));
+    println!("zk: {}", is_riscv_feature_detected!("zk"));
+    println!("zkt: {}", is_riscv_feature_detected!("zkt"));
+    println!("v: {}", is_riscv_feature_detected!("v"));
+    println!("svnapot: {}", is_riscv_feature_detected!("svnapot"));
+    println!("svpbmt: {}", is_riscv_feature_detected!("svpbmt"));
+    println!("svinval: {}", is_riscv_feature_detected!("svinval"));
+    println!("h: {}", is_riscv_feature_detected!("h"));
+    println!("s: {}", is_riscv_feature_detected!("s"));
+    println!("j: {}", is_riscv_feature_detected!("j"));
+    println!("p: {}", is_riscv_feature_detected!("p"));
 }
 
 #[test]

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -236,15 +236,29 @@ fn riscv_linux() {
     println!("rv32e: {}", is_riscv_feature_detected!("rv32e"));
     println!("rv64i: {}", is_riscv_feature_detected!("rv64i"));
     println!("rv128i: {}", is_riscv_feature_detected!("rv128i"));
+    println!(
+        "unaligned-scalar-mem: {}",
+        is_riscv_feature_detected!("unaligned-scalar-mem")
+    );
+    println!(
+        "unaligned-vector-mem: {}",
+        is_riscv_feature_detected!("unaligned-vector-mem")
+    );
     println!("zicsr: {}", is_riscv_feature_detected!("zicsr"));
     println!("zicntr: {}", is_riscv_feature_detected!("zicntr"));
     println!("zihpm: {}", is_riscv_feature_detected!("zihpm"));
     println!("zifencei: {}", is_riscv_feature_detected!("zifencei"));
+    println!("zihintntl: {}", is_riscv_feature_detected!("zihintntl"));
     println!("zihintpause: {}", is_riscv_feature_detected!("zihintpause"));
+    println!("zimop: {}", is_riscv_feature_detected!("zimop"));
+    println!("zicboz: {}", is_riscv_feature_detected!("zicboz"));
+    println!("zicond: {}", is_riscv_feature_detected!("zicond"));
     println!("m: {}", is_riscv_feature_detected!("m"));
     println!("a: {}", is_riscv_feature_detected!("a"));
     println!("zalrsc: {}", is_riscv_feature_detected!("zalrsc"));
     println!("zaamo: {}", is_riscv_feature_detected!("zaamo"));
+    println!("zawrs: {}", is_riscv_feature_detected!("zawrs"));
+    println!("zacas: {}", is_riscv_feature_detected!("zacas"));
     println!("zam: {}", is_riscv_feature_detected!("zam"));
     println!("ztso: {}", is_riscv_feature_detected!("ztso"));
     println!("f: {}", is_riscv_feature_detected!("f"));
@@ -252,11 +266,17 @@ fn riscv_linux() {
     println!("q: {}", is_riscv_feature_detected!("q"));
     println!("zfh: {}", is_riscv_feature_detected!("zfh"));
     println!("zfhmin: {}", is_riscv_feature_detected!("zfhmin"));
+    println!("zfa: {}", is_riscv_feature_detected!("zfa"));
     println!("zfinx: {}", is_riscv_feature_detected!("zfinx"));
     println!("zdinx: {}", is_riscv_feature_detected!("zdinx"));
     println!("zhinx: {}", is_riscv_feature_detected!("zhinx"));
     println!("zhinxmin: {}", is_riscv_feature_detected!("zhinxmin"));
     println!("c: {}", is_riscv_feature_detected!("c"));
+    println!("zca: {}", is_riscv_feature_detected!("zca"));
+    println!("zcf: {}", is_riscv_feature_detected!("zcf"));
+    println!("zcd: {}", is_riscv_feature_detected!("zcd"));
+    println!("zcb: {}", is_riscv_feature_detected!("zcb"));
+    println!("zcmop: {}", is_riscv_feature_detected!("zcmop"));
     println!("b: {}", is_riscv_feature_detected!("b"));
     println!("zba: {}", is_riscv_feature_detected!("zba"));
     println!("zbb: {}", is_riscv_feature_detected!("zbb"));
@@ -276,6 +296,29 @@ fn riscv_linux() {
     println!("zk: {}", is_riscv_feature_detected!("zk"));
     println!("zkt: {}", is_riscv_feature_detected!("zkt"));
     println!("v: {}", is_riscv_feature_detected!("v"));
+    println!("zve32x: {}", is_riscv_feature_detected!("zve32x"));
+    println!("zve32f: {}", is_riscv_feature_detected!("zve32f"));
+    println!("zve64x: {}", is_riscv_feature_detected!("zve64x"));
+    println!("zve64f: {}", is_riscv_feature_detected!("zve64f"));
+    println!("zve64d: {}", is_riscv_feature_detected!("zve64d"));
+    println!("zvfh: {}", is_riscv_feature_detected!("zvfh"));
+    println!("zvfhmin: {}", is_riscv_feature_detected!("zvfhmin"));
+    println!("zvbb: {}", is_riscv_feature_detected!("zvbb"));
+    println!("zvbc: {}", is_riscv_feature_detected!("zvbc"));
+    println!("zvkb: {}", is_riscv_feature_detected!("zvkb"));
+    println!("zvkg: {}", is_riscv_feature_detected!("zvkg"));
+    println!("zvkned: {}", is_riscv_feature_detected!("zvkned"));
+    println!("zvknha: {}", is_riscv_feature_detected!("zvknha"));
+    println!("zvknhb: {}", is_riscv_feature_detected!("zvknhb"));
+    println!("zvksed: {}", is_riscv_feature_detected!("zvksed"));
+    println!("zvksh: {}", is_riscv_feature_detected!("zvksh"));
+    println!("zvkn: {}", is_riscv_feature_detected!("zvkn"));
+    println!("zvknc: {}", is_riscv_feature_detected!("zvknc"));
+    println!("zvkng: {}", is_riscv_feature_detected!("zvkng"));
+    println!("zvks: {}", is_riscv_feature_detected!("zvks"));
+    println!("zvksc: {}", is_riscv_feature_detected!("zvksc"));
+    println!("zvksg: {}", is_riscv_feature_detected!("zvksg"));
+    println!("zvkt: {}", is_riscv_feature_detected!("zvkt"));
     println!("svnapot: {}", is_riscv_feature_detected!("svnapot"));
     println!("svpbmt: {}", is_riscv_feature_detected!("svpbmt"));
     println!("svinval: {}", is_riscv_feature_detected!("svinval"));

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -319,11 +319,6 @@ fn riscv_linux() {
     println!("zvksc: {}", is_riscv_feature_detected!("zvksc"));
     println!("zvksg: {}", is_riscv_feature_detected!("zvksg"));
     println!("zvkt: {}", is_riscv_feature_detected!("zvkt"));
-    println!("svnapot: {}", is_riscv_feature_detected!("svnapot"));
-    println!("svpbmt: {}", is_riscv_feature_detected!("svpbmt"));
-    println!("svinval: {}", is_riscv_feature_detected!("svinval"));
-    println!("h: {}", is_riscv_feature_detected!("h"));
-    println!("s: {}", is_riscv_feature_detected!("s"));
     println!("j: {}", is_riscv_feature_detected!("j"));
     println!("p: {}", is_riscv_feature_detected!("p"));
 }


### PR DESCRIPTION
This PR implements full `riscv_hwprobe`-based feature detection on newer Linux kernel and implements OS-independent extension implication logic to make extension handling easier.

This PR is a superset of #1769.

This PR is based on #1762 by @taiki-e.  Commits with @taiki-e's code (with or without modification) are marked by `Co-Authored-By`.

While the OS-independent logic in this PR uses iterators, I confirmed that LLVM is smart enough to optimize them into a series of bit-manipulation operations (multi-feature masking then multi-feature enablement).

# RFC: Where to Put `imply_features()`?

The only reason why I originally made this PR as a draft is, I was not sure where to put new OS-independent RISC-V extension implication logic (`imply_features()`).

## Responses

@taiki-e: suggested the path like `src/detect/os/riscv.rs`.

## Decision

@taiki-e's suggestion is adopted here (on PR version 7).

# RFC: Automatic Loops?

Is it allowed to derive `Eq` for `cache::Initializer`?  Using this way, we can continue implication until the feature flags converge (will loop 2 times on normal cases, up to 4 times on mostly adversarial cases).

If it's not allowed, [I proved that (in the current state)](https://gist.github.com/a4lg/e6d5049118958afad8f646944f3e5676), looping `group!` definitions of `Zvk*` 3 times and `group!` definitions of `Zk*` 2 times is sufficient to ensure convergence (I tentatively introduced manual loops in the PR v4).

## Decision

For now, I assume that it is okay to do that (on PR version 6).

# Main Differences between #1762

1.  Use key `RISCV_HWPROBE_KEY_IMA_EXT_0` after checking that `RISCV_HWPROBE_BASE_BEHAVIOR_IMA` is set on the key `RISCV_HWPROBE_KEY_BASE_BEHAVIOR`.
    Because `RISCV_HWPROBE_KEY_IMA_EXT_0` lists extensions compatible to `RISCV_HWPROBE_BASE_BEHAVIOR_IMA`, it must be checked (current Linux requires `RV[32|64]IMA` + some extra features but this difference makes the resulting code much robust when Linux kernel decided to lower its requirements),
2.  Use key `RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF`, not just `RISCV_HWPROBE_KEY_CPUPERF_0`.
    @taiki-e's proposal only uses `RISCV_HWPROBE_KEY_CPUPERF_0` but this key is considered deprecated (because it is incorrectly implemented as a bitmask).
    Considering the fact that some versions of the Linux kernel do not support `RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF`, `RISCV_HWPROBE_KEY_CPUPERF_0`-based unaligned scalar memory access performance checking is kept as a fallback.
3.  Attempt to enable vectors only once and use the most up to date information  
    This PR first uses `prctl` with `PR_RISCV_V_GET_CONTROL` (whether vector is enabled on the current thread when a runtime feature detection is requested) and falls back to the auxiliary vector (whether a vector extension, `V`, is enabled on the program starts) for workaround for userland emulation of QEMU (as of version 9.2.3).
    This PR attempts to use the latest (up to date) information for vector enablement and makes two differences when the program is ran on the real Linux kernel:
    1.  When the program starts with vectors disabled and later enabled, this difference is properly handled (or vice versa; unlikely but possible when the crate is compiled as a Rust-based library).
    2.  When only vector extension subset(s) are supported, this PR accurately reports their existence.

    And this PR won't try to use the auxiliary vector for `V` enablement once `riscv_hwprobe` is confirmed that capable of checking vector extensions (to ensure that we only test the vector status on *one timing* (either program startup or on the first feature detection), not two (program startup and on the first feature detection)).
4.  Simplify feature enablement including uses of `enable_feature` through:
    1.  Removal of `enable_features` and the `value` argument,
    2.  Addition of the OS-independent RISC-V extension implication logic and
    3.  More common closure for feature enablement (`test` which tests the value of `RISCV_HWPROBE_KEY_IMA_EXT_0`).

    Macros `imply!` and `group!` inside new implication function makes writing extension implication pretty easy and making implication a separate function (`imply_features`) will make computing various flags on the feature detection logic unnecessary.  It'll make the logic hard to break when multiple feature detection logic is used (see code snippet 1).
    Complex implication logic also works as expected as in code snippet 2.
5.  Imply `I`, `M`, `A`, `Zicsr` and `Zifencei` when we find the `IMA` base using `riscv_hwprobe`.  
    Due to historical reasons, the `I` extension does not preserve backward compatibility but rather in reverse.  The `I` extension in the ISA manual version 2.2 (RV32I/RV64I version 2.0) is splitted as three extensions `I` (RV32I/RV64I version 2.1), `Zicsr`, `Zifencei` and one non-extension "Counters" (with a few amendants) in the ISA manual version 20190608 and "Counters" are ratified as two extensions `Zicntr` (originally a part of the `I` extension) and `Zihpm` (amended parts in the non-extension "Counters") as in the ISA manual version 20240411.
    The thing is, Linux's base behavior defines that the `I` extension of the `IMA` base is of the ISA manual version 2.2 (later splitted to various extensions).  If `riscv_hwprobe` succeeds and has the `IMA` base, the author chose to enable not just `I` but also `Zicsr` and `Zifencei`.
    1.  `Zifencei` was *initially* excluded because [the Linux documentation states that `fence.i` is not expected to be run on the user mode](https://docs.kernel.org/arch/riscv/hwprobe.html).  [Although no traps will be generated, its effect is unreliable unless SMP is disabled](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/kernel/sys_riscv.c?h=v6.14#n46).
        However, this is only the normal path.  If [Concurrent Modification and Execution of Instructions (CMODX)](https://docs.kernel.org/arch/riscv/cmodx.html) is enabled, `fence.i` can be valid on the Linux userland, making this implication useful on certain cases.  So, it is now implied on the PR version 9.
    2.  `Zihpm` is excluded for not being a part of the original `I` extension as in the ISA manual version 2.2).
    3.  `Zicntr` is excluded (on the PR version 2 or later) while it seems safe to imply that but Linux 6.15 will include (as of rc1) the separate constant `RISCV_HWPROBE_EXT_ZICNTR` to detect the existence of the `Zicntr` extension.  So, the author chose more pessimistic assumption.
    4.  `Zicsr` should be safe (so implied) because Linux depends on the privileged architecture, which depends on the `Zicsr` extension.  If no other extensions with CSRs are enabled, it is almost equivalent to not having the `Zicsr` extension.

# Same as #1762

1.  Temporally remove privileged extensions
2.  Add test

# Code Snippets

## 1. From #1762: Multiple manual feature enablement

```rust
enable_features(
    &mut value,
    &[
        Feature::v,
        Feature::zve32f,
        Feature::zve32x,
        Feature::zve64d,
        Feature::zve64f,
        Feature::zve64x,
    ],
    has_v,
);
```

It enables `V` and its subsets.  If this is alone, that would be okay but:

```rust
// Standard Vector Extensions
// v and zve{32,64}* extensions are detected by hwcap.
// enable_feature(Feature::v, ima_ext_0 & RISCV_HWPROBE_IMA_V != 0);
enable_feature(Feature::zvfh, ima_ext_0 & RISCV_HWPROBE_EXT_ZVFH != 0);
enable_feature(Feature::zvfhmin, ima_ext_0 & RISCV_HWPROBE_EXT_ZVFHMIN != 0);
// enable_feature(Feature::zve32x, ima_ext_0 & RISCV_HWPROBE_EXT_ZVE32X != 0);
// enable_feature(Feature::zve32f, ima_ext_0 & RISCV_HWPROBE_EXT_ZVE32F != 0);
// enable_feature(Feature::zve64x, ima_ext_0 & RISCV_HWPROBE_EXT_ZVE64X != 0);
// enable_feature(Feature::zve64f, ima_ext_0 & RISCV_HWPROBE_EXT_ZVE64F != 0);
// enable_feature(Feature::zve64d, ima_ext_0 & RISCV_HWPROBE_EXT_ZVE64D != 0);
```

Despite that commented out in #1762 (which is okay), handling separate vector subsets will need additional logic.  Just removing comments here makes the code partially incorrect (depending on how `has_v` is computed) for being `Zicsr` not implied by `Zve32x`.

This PR removes the needs to write extension implication logic for multiple times.

## 2. From this PR: Complex implication

```rust
imply!(zcf => zca & f);
imply!(zcd => zca & d);
// ... omitted for being irrelevant ...
// Relatively complex implication rules from the "C" extension.
imply!(c => zca);
imply!(c & d => zcd);
#[cfg(target_arch = "riscv32")]
imply!(c & f => zcf);
```

It accurately represents what features to enable depending on the situation.

# History

## Version 1 (2025-04-11)

The first proposal.

## Version 2 (2025-04-11)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v1..a4lg:stdarch:old/riscv-hwprobe-linux-v2)

*   Use more pessimistic assumption about the Linux's `IMA` base.  
    Excluded the `Zicntr` extension from implication.
*   Renamed `has_v` inside fine-grained detection logic using `riscv_hwprobe` to `has_vectors`  
    `is_vectors_enabled` is more accurate name but it should be sufficient (denoting whether the vector extension *or its subset(s)* are enabled).
*   Minor fix and clarification in comments.  
    It sets `V` purely depending on the auxiliary vector only if no fine-grained vector extension detection is available (PR v1 stated that this occurs when `riscv_hwprobe` is unavailable but that was incorrect).

## Version 3 (2025-04-11)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v2..a4lg:stdarch:old/riscv-hwprobe-linux-v3)

*   Comment clarification
*   An attempt to ensure convergence of feature flags (insufficient)

There's still a case where implying without a loop won't converge.  We need to loop a portion several times.

## Version 4 (2025-04-11)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v3..a4lg:stdarch:old/riscv-hwprobe-linux-v4)

*   Ensure convergence of feature flags ([formally proven](https://gist.github.com/a4lg/e6d5049118958afad8f646944f3e5676))  
    But *this is a tentative change*.  If I'm allowed to derive `Eq` for `cache::Initializer`, OS-independent RISC-V extension implication logic will get a lot simpler (loop over until it converges; termination is guaranteed because we are never removing features).
*   Reflect a change suggested by @taiki-e (Thanks for reviewing!)

## Version 5 (2025-04-12)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v4..a4lg:stdarch:old/riscv-hwprobe-linux-v5)

*   Rebase
*   Tentative version with the `Supm` extension removed (to be too OS-dependent; thanks @Amanieu!).

## Version 6 (2025-04-12)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v5..a4lg:stdarch:old/riscv-hwprobe-linux-v6)

*   A clarification in a comment.  
    `I` as in the ISA manual version 2.2 is not the `I` extension with version 2.2 (actually, the ISA manual version 2.2 defines version 2.0 of RV32I and RV64I and splitted `I` base indicates version 2.1 of RV32I and RV64I).
*   Ensure convergence of feature flags through use of the loop.  
    Normally, it loops twice.  Termination of the loop (in finite time) can be easily proved (from two facts: (1) we have finite number of feature flags and (2) we never unset any feature flags) and in fact, even on the worst case (including the case where the feature flags are completely broken), the maximum loop count is currently 4 (formally proven).
    To implement this, the author added automatic derive of `PartialEq` and `Eq` to `cache::Initializer`.

## Version 7 (2025-04-12)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v6..a4lg:stdarch:old/riscv-hwprobe-linux-v7)

*   Various adjustments in the commit message.
*   Improve documentation of performance hints (`unaligned-scalar-mem` and `unaligned-vector-mem`).
*   Minor fix to a comment.
*   Move `imply_features` to a separate module as suggested by @taiki-e.  
    Now, it's an official proposal (leaving from the draft status).

## Version 8 (2025-04-12)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v7..a4lg:stdarch:old/riscv-hwprobe-linux-v8)

*   Add double quotes around documentation of `unaligned-scalar-mem` and `unaligned-vector-mem`
    (make them `"unaligned-scalar-mem"` and `"unaligned-vector-mem"` for consistency).

## Version 9 (2025-04-12)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v8..a4lg:stdarch:old/riscv-hwprobe-linux-v9)

*   Imply the `Zifencei` extension from the Linux `IMA` base.  
    The author initially excluded this because `fence.i` of the `Zifencei` instruction is *normally* invalid on Linux ABI but found this is only *normally* true.  If [Concurrent Modification and Execution of Instructions (CMODX)](https://docs.kernel.org/arch/riscv/cmodx.html) is enabled, `fence.i` can be valid on the Linux userland.  Even if CMODX is not enabled, it will not cause any traps so "use at your risk" policy should work (`fence.i` is generally unreliable on SMP-enabled systems with preemptive multi-threading, not just Linux).

## Version 10 (2025-04-12)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v9-rebased..a4lg:stdarch:old/riscv-hwprobe-linux-v10)

*   **Bug Fix:** Add missing implication: `Zvfh` → `Zfhmin`
*   Doc: Improve capitalization consistency (fix description of the `Zawrs` extension)
*   Add functional implications:
    *   `Zvknhb` → `Zvknha`
    *   `Zbc` → `Zbkc`
*   If a dependency / implication is not explicitly stated in the specification but adding implication is useful for feature discovery (and does not form an extension group with "reverse implication"), such an implication is commented with a brief reason.
    *   `Zvbb` → `Zvkb` (from PR v1; comment removed in PR v11 as there's a strong evidence now)
    *   `Zvknhb` → `Zvknha` (from PR v10)
    *   `Zbc` → `Zbkc` (from PR v10)
    *   `Zvfh` → `Zvfhmin` (from PR v1)
    *   `Zkr` → `Zicsr` (from PR v1)

## Version 11 (2025-04-13)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v10..a4lg:stdarch:old/riscv-hwprobe-linux-v11)

This is functionally equivalent to the version 10 but incorporates minor changes.

*   Tidying: Found a strong evidence to support `Zvbb` → `Zvkb` (remove "defined as subset" comment which have denoted that there was a weak evidence only).
*   Tidying: Various comments (grammar and clarification).
*   Tidying: Move `Zvknhb` → `Zvknha` implication after group definitions inside `imply_features`.  
    It makes the worst iteration count minimum.
    Although the big loop inside this function is designed to be ordering-free (not introducing a bug when we move `imply!` and `group!` macro uses and it's free to add implications in any order),
    at least my contribution is designed also to minimize iteration count.

## Version 12 (2025-04-13)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v11..a4lg:stdarch:old/riscv-hwprobe-linux-v12)

Oh no... How can I miss that section for years!?

*   **Bug Fix:** Remove excess implication: `Zkr` → `Zicsr` (considered *not* an errata)  
    Although the `seed` CSR must be accessed through CSR instructions, originally defined in the `Zicsr` extension, scalar cryptography spec defines its own `seed` CSR access instruction (a subset of `Zicsr`).
    I (somehow) did not catch this for years.

## Version 13 (2025-04-15)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v12..a4lg:stdarch:old/riscv-hwprobe-linux-v13)

Despite that this is functionally equivalent to the version 12, *it is now tested*.

*   Add tests.
    *   Simple direct / indirect cases.
    *   Complex case.
    *   Whether the extension group is working as expected (2 tests).
    *   Mostly adversarial case which maximizes the iteration count in the current design.

## Version 14 (2025-04-16)

[See diff](https://github.com/a4lg/stdarch/compare/old/riscv-hwprobe-linux-v13..a4lg:stdarch:old/riscv-hwprobe-linux-v14)

*   Reflected a change suggested by @Amanieu (thanks!).