### PR TITLE
Fix intrinsic-test for debug test suites

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -30,6 +30,7 @@ run() {
       --env NORUN \
       --env RUSTFLAGS \
       --env STDARCH_TEST_NORUN \
+      --env PROFILE \
       --volume "${HOME}/.cargo":/cargo \
       --volume "$(rustc --print sysroot)":/rust:ro \
       --volume "$(pwd)":/checkout:ro \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -171,24 +171,26 @@ esac
 case "${TARGET}" in
     aarch64-unknown-linux-gnu*|armv7-unknown-linux-gnueabihf*)
         CPPFLAGS="${TEST_CPPFLAGS}" RUSTFLAGS="${HOST_RUSTFLAGS}" RUST_LOG=warn \
-            cargo run "${INTRINSIC_TEST}" "${PROFILE}" \
+            cargo run "${INTRINSIC_TEST}" --release \
             --bin intrinsic-test -- intrinsics_data/arm_intrinsics.json \
             --runner "${TEST_RUNNER}" \
             --cppcompiler "${TEST_CXX_COMPILER}" \
             --skip "${TEST_SKIP_INTRINSICS}" \
-            --target "${TARGET}"
+            --target "${TARGET}" \
+            "${PROFILE}"
         ;;
 
     aarch64_be-unknown-linux-gnu*)
         CPPFLAGS="${TEST_CPPFLAGS}" RUSTFLAGS="${HOST_RUSTFLAGS}" RUST_LOG=warn \
-            cargo run "${INTRINSIC_TEST}" "${PROFILE}"  \
+            cargo run "${INTRINSIC_TEST}" --release \
             --bin intrinsic-test -- intrinsics_data/arm_intrinsics.json \
             --runner "${TEST_RUNNER}" \
             --cppcompiler "${TEST_CXX_COMPILER}" \
             --skip "${TEST_SKIP_INTRINSICS}" \
             --target "${TARGET}" \
             --linker "${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER}" \
-            --cxx-toolchain-dir "${AARCH64_BE_TOOLCHAIN}"
+            --cxx-toolchain-dir "${AARCH64_BE_TOOLCHAIN}" \
+            "${PROFILE}"
         ;;
      *)
         ;;


### PR DESCRIPTION
The intrinsic-test tool itself was being built in dev/release profiles but the test programs it generates were all being tested in release mode. This PR pipes the GitHub Actions profile into the tool through a command line argument.