### PR TITLE
Remove the workarounds for some resolved issues

### DIFF
--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -25,9 +25,7 @@ dox() {
 if [ -z "$1" ]; then
   dox i686-unknown-linux-gnu
   dox x86_64-unknown-linux-gnu
-  # Disabled temporarily,
-  # See https://github.com/rust-lang/rust/issues/134511
-  #dox armv7-unknown-linux-gnueabihf
+  dox armv7-unknown-linux-gnueabihf
   dox aarch64-unknown-linux-gnu
   dox powerpc-unknown-linux-gnu
   dox powerpc64le-unknown-linux-gnu

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -4563,9 +4563,13 @@ pub fn _mm_maskz_fmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let a = transmute(a);
-        let r = vfmaddcsh_maskz(a, transmute(b), transmute(c), k, ROUNDING);
-        transmute(_mm_move_ss(a, r)) // FIXME: If `k == 0`, then LLVM optimized `vfmaddcsh_maskz` to output an all-zero vector, which is incorrect
+        transmute(vfmaddcsh_maskz(
+            transmute(a),
+            transmute(b),
+            transmute(c),
+            k,
+            ROUNDING,
+        ))
     }
 }
 
@@ -5108,9 +5112,13 @@ pub fn _mm_maskz_fcmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let a = transmute(a);
-        let r = vfcmaddcsh_maskz(a, transmute(b), transmute(c), k, ROUNDING);
-        transmute(_mm_move_ss(a, r)) // FIXME: If `k == 0`, then LLVM optimized `vfcmaddcsh_maskz` to output an all-zero vector, which is incorrect
+        transmute(vfcmaddcsh_maskz(
+            transmute(a),
+            transmute(b),
+            transmute(c),
+            k,
+            ROUNDING,
+        ))
     }
 }
 


### PR DESCRIPTION
 - Re-enable `dox` CI for `armv7-unknown-linux-gnueabihf`
 - Remove workarounds for llvm/llvm-project#98306