### PR TITLE
std_detect: Remove RV32E support attempt on Linux (RISC-V)

### DIFF
--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -310,9 +310,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
     enable_feature(Feature::rv64i, has_i);
     #[cfg(target_arch = "riscv32")]
     enable_feature(Feature::rv32i, has_i);
-    // FIXME: e is not exposed in any of asm/hwcap.h, uapi/asm/hwcap.h, uapi/asm/hwprobe.h
-    #[cfg(target_arch = "riscv32")]
-    enable_feature(Feature::rv32e, bit::test(auxv.hwcap, (b'e' - b'a').into()));
 
     imply_features(value)
 }


### PR DESCRIPTION
Because the current lowest requirements to run the Linux kernel on RISC-V is RV{32,64}IMA (with 32 general purpose registers) plus some features, RV32E (with only 16 GPRs) is not currently supported.

Since it's not sure whether current implemented method will work for future Linux versions even if the minimum requirements are lowered, the support for RV32E (to be more specific, an attempt to do that) is removed for now.

Since Rust doesn't have any RV32E + Linux targets, it should be safe to do that and we can safely revert this:
*   If the method removed by this commit is confirmed working when the minimum requirements of the Linux kernel are lowered and is a preferred method for feature detection and
*   When an RV32E(something) + Linux target is going to be added to Rust.