### PR TITLE
Revert "std_detect: Do not use libc::getauxval on 32-bit Android"

### DIFF
--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -139,8 +139,7 @@ fn getauxval(key: usize) -> Result<usize, ()> {
                 target_os = "linux",
                 any(target_env = "gnu", target_env = "musl", target_env = "ohos"),
             )),
-            // TODO: libc crate currently doesn't provide getauxval on 32-bit Android.
-            not(all(target_os = "android", target_pointer_width = "64")),
+            not(target_os = "android"),
         ))] {
             let ffi_getauxval: F = unsafe {
                 let ptr = libc::dlsym(libc::RTLD_DEFAULT, c"getauxval".as_ptr());


### PR DESCRIPTION
This reverts commit 85572dc298f5222902c9b200cebf5d045e769a83.

This has been done in https://github.com/rust-lang/stdarch/pull/1421 due to libc issue that lacking getauxval on 32-bit Android, but libc issue has been fixed in libc 0.2.172 (https://github.com/rust-lang/libc/pull/4338).