### PR TITLE
[RFC] std_detect: RISC-V platform guide documentation

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -22,87 +22,121 @@ features! {
     ///
     /// [ISA manual]: https://riscv.org/specifications/ratified/
     ///
+    /// # Platform-specific behavior and Availability
+    ///
+    /// Runtime detection depends on the platform-specific feature detection
+    /// facility and its availability per feature is
+    /// highly platform/version-specific.
+    ///
+    /// Still, a best-effort attempt is performed to enable subset/dependent
+    /// features if a superset feature is enabled regardless of the platform.
+    /// For instance, if the A extension (`"a"`) is enabled, its subsets (the
+    /// Zalrsc and Zaamo extensions; `"zalrsc"` and `"zaamo"`) are also enabled.
+    /// Likewise, if the F extension (`"f"`) is enabled, one of its dependencies
+    /// (the Zicsr extension `"zicsr"`) is also enabled.
+    ///
     /// # Unprivileged Specification
     ///
-    /// The supported ratified RISC-V instruction sets are as follows:
+    /// The supported ratified RISC-V instruction sets are as follows (OS
+    /// columns denote runtime feature detection support with or without minimum
+    /// kernel version; "No" by default):
     ///
-    /// * RV32E: `"rv32e"`
-    /// * RV32I: `"rv32i"`
-    /// * RV64I: `"rv64i"`
-    /// * A: `"a"`
-    ///   * Zaamo: `"zaamo"`
-    ///   * Zalrsc: `"zalrsc"`
-    /// * B: `"b"`
-    ///   * Zba: `"zba"`
-    ///   * Zbb: `"zbb"`
-    ///   * Zbs: `"zbs"`
-    /// * C: `"c"`
-    ///   * Zca: `"zca"`
-    ///   * Zcd: `"zcd"` (if D is enabled)
-    ///   * Zcf: `"zcf"` (if F is enabled on RV32)
-    /// * D: `"d"`
-    /// * F: `"f"`
-    /// * M: `"m"`
-    /// * Q: `"q"`
-    /// * V: `"v"`
-    ///   * Zve32x: `"zve32x"`
-    ///   * Zve32f: `"zve32f"`
-    ///   * Zve64x: `"zve64x"`
-    ///   * Zve64f: `"zve64f"`
-    ///   * Zve64d: `"zve64d"`
-    /// * Zicboz: `"zicboz"`
-    /// * Zicntr: `"zicntr"`
-    /// * Zicond: `"zicond"`
-    /// * Zicsr: `"zicsr"`
-    /// * Zifencei: `"zifencei"`
-    /// * Zihintntl: `"zihintntl"`
-    /// * Zihintpause: `"zihintpause"`
-    /// * Zihpm: `"zihpm"`
-    /// * Zimop: `"zimop"`
-    /// * Zacas: `"zacas"`
-    /// * Zawrs: `"zawrs"`
-    /// * Zfa: `"zfa"`
-    /// * Zfh: `"zfh"`
-    ///   * Zfhmin: `"zfhmin"`
-    /// * Zfinx: `"zfinx"`
-    /// * Zdinx: `"zdinx"`
-    /// * Zhinx: `"zhinx"`
-    ///   * Zhinxmin: `"zhinxmin"`
-    /// * Zcb: `"zcb"`
-    /// * Zcmop: `"zcmop"`
-    /// * Zbc: `"zbc"`
-    /// * Zbkb: `"zbkb"`
-    /// * Zbkc: `"zbkc"`
-    /// * Zbkx: `"zbkx"`
-    /// * Zk: `"zk"`
-    /// * Zkn: `"zkn"`
-    ///   * Zknd: `"zknd"`
-    ///   * Zkne: `"zkne"`
-    ///   * Zknh: `"zknh"`
-    /// * Zkr: `"zkr"`
-    /// * Zks: `"zks"`
-    ///   * Zksed: `"zksed"`
-    ///   * Zksh: `"zksh"`
-    /// * Zkt: `"zkt"`
-    /// * Zvbb: `"zvbb"`
-    /// * Zvbc: `"zvbc"`
-    /// * Zvfh: `"zvfh"`
-    ///   * Zvfhmin: `"zvfhmin"`
-    /// * Zvkb: `"zvkb"`
-    /// * Zvkg: `"zvkg"`
-    /// * Zvkn: `"zvkn"`
-    ///   * Zvkned: `"zvkned"`
-    ///   * Zvknha: `"zvknha"`
-    ///   * Zvknhb: `"zvknhb"`
-    /// * Zvknc: `"zvknc"`
-    /// * Zvkng: `"zvkng"`
-    /// * Zvks: `"zvks"`
-    ///   * Zvksed: `"zvksed"`
-    ///   * Zvksh: `"zvksh"`
-    /// * Zvksc: `"zvksc"`
-    /// * Zvksg: `"zvksg"`
-    /// * Zvkt: `"zvkt"`
-    /// * Ztso: `"ztso"`
+    /// | Literal    | Base    | Linux      |
+    /// |:---------- |:------- |:---------- |
+    /// | `"rv32e"`  | RV32E   |            |
+    /// | `"rv32i"`  | RV32I   | Yes [^ima] |
+    /// | `"rv64i"`  | RV64I   | Yes [^ima] |
+    ///
+    /// | Literal         | Extension   | Linux              |
+    /// |:--------------- |:----------- |:------------------ |
+    /// | `"a"`           | A           | Yes [^ima]         |
+    /// | `"b"`           | B           | 6.5                |
+    /// | `"c"`           | C           | Yes                |
+    /// | `"d"`           | D           | Yes                |
+    /// | `"f"`           | F           | Yes                |
+    /// | `"m"`           | M           | Yes [^ima]         |
+    /// | `"q"`           | Q           |                    |
+    /// | `"v"`           | V           | 6.5                |
+    /// | `"zaamo"`       | Zaamo       | No [^ima] [^dep]   |
+    /// | `"zacas"`       | Zacas       | 6.8                |
+    /// | `"zalrsc"`      | Zalrsc      | No [^ima] [^dep]   |
+    /// | `"zawrs"`       | Zawrs       | 6.11               |
+    /// | `"zba"`         | Zba         | 6.5                |
+    /// | `"zbb"`         | Zbb         | 6.5                |
+    /// | `"zbc"`         | Zbc         | 6.8                |
+    /// | `"zbkb"`        | Zbkb        | 6.8                |
+    /// | `"zbkc"`        | Zbkc        | 6.8                |
+    /// | `"zbkx"`        | Zbkx        | 6.8                |
+    /// | `"zbs"`         | Zbs         | 6.5                |
+    /// | `"zca"`         | Zca         | 6.11 [^dep]        |
+    /// | `"zcb"`         | Zcb         | 6.11 [^dep]        |
+    /// | `"zcd"`         | Zcd         | 6.11 [^dep]        |
+    /// | `"zcf"`         | Zcf         | 6.11 [^dep]        |
+    /// | `"zcmop"`       | Zcmop       | 6.11               |
+    /// | `"zdinx"`       | Zdinx       |                    |
+    /// | `"zfa"`         | Zfa         | 6.8                |
+    /// | `"zfh"`         | Zfh         | 6.8                |
+    /// | `"zfhmin"`      | Zfhmin      | 6.8                |
+    /// | `"zfinx"`       | Zfinx       |                    |
+    /// | `"zhinx"`       | Zhinx       |                    |
+    /// | `"zhinxmin"`    | Zhinxmin    |                    |
+    /// | `"zicboz"`      | Zicboz      | 6.7                |
+    /// | `"zicond"`      | Zicond      | 6.8                |
+    /// | `"zicntr"`      | Zicntr      |                    |
+    /// | `"zicsr"`       | Zicsr       | No [^ima] [^dep]   |
+    /// | `"zifencei"`    | Zifencei    | No [^ima]          |
+    /// | `"zihintntl"`   | Zihintntl   | 6.8                |
+    /// | `"zihintpause"` | Zihintpause | 6.10               |
+    /// | `"zihpm"`       | Zihpm       |                    |
+    /// | `"zimop"`       | Zimop       | 6.11               |
+    /// | `"zk"`          | Zk          | No [^zkr]          |
+    /// | `"zkn"`         | Zkn         | 6.8                |
+    /// | `"zknd"`        | Zknd        | 6.8                |
+    /// | `"zkne"`        | Zkne        | 6.8                |
+    /// | `"zknh"`        | Zknh        | 6.8                |
+    /// | `"zkr"`         | Zkr         | No [^zkr]          |
+    /// | `"zks"`         | Zks         | 6.8                |
+    /// | `"zksed"`       | Zksed       | 6.8                |
+    /// | `"zksh"`        | Zksh        | 6.8                |
+    /// | `"zkt"`         | Zkt         | 6.8                |
+    /// | `"ztso"`        | Ztso        | 6.8                |
+    /// | `"zvbb"`        | Zvbb        | 6.8                |
+    /// | `"zvbc"`        | Zvbc        | 6.8                |
+    /// | `"zve32f"`      | Zve32f      | 6.11 [^dep]        |
+    /// | `"zve32x"`      | Zve32x      | 6.11 [^dep]        |
+    /// | `"zve64d"`      | Zve64d      | 6.11 [^dep]        |
+    /// | `"zve64f"`      | Zve64f      | 6.11 [^dep]        |
+    /// | `"zve64x"`      | Zve64x      | 6.11 [^dep]        |
+    /// | `"zvfh"`        | Zvfh        | 6.8                |
+    /// | `"zvfhmin"`     | Zvfhmin     | 6.8                |
+    /// | `"zvkb"`        | Zvkb        | 6.8                |
+    /// | `"zvkg"`        | Zvkg        | 6.8                |
+    /// | `"zvkn"`        | Zvkn        | 6.8                |
+    /// | `"zvknc"`       | Zvknc       | 6.8                |
+    /// | `"zvkned"`      | Zvkned      | 6.8                |
+    /// | `"zvkng"`       | Zvkng       | 6.8                |
+    /// | `"zvknha"`      | Zvknha      | 6.8                |
+    /// | `"zvknhb"`      | Zvknhb      | 6.8                |
+    /// | `"zvks"`        | Zvks        | 6.8                |
+    /// | `"zvksc"`       | Zvksc       | 6.8                |
+    /// | `"zvksed"`      | Zvksed      | 6.8                |
+    /// | `"zvksg"`       | Zvksg       | 6.8                |
+    /// | `"zvksh"`       | Zvksh       | 6.8                |
+    /// | `"zvkt"`        | Zvkt        | 6.8                |
+    ///
+    /// [^ima]: Or enabled when the IMA base behavior is enabled on the Linux
+    /// kernel version 6.4 or later (for bases, the only matching one -- either
+    /// `"rv32i"` or `"rv64i"` -- is enabled).
+    ///
+    /// [^dep]: Or enabled as a dependency of another extension (a superset)
+    /// even if runtime detection of this feature itself is not supported (as
+    /// long as the runtime detection of the superset is supported).
+    ///
+    /// [^zkr]: Linux does not report existence of this extension even if
+    /// supported by the hardware mainly because the `seed` CSR is normally not
+    /// exposed to the user mode.
+    /// For the Zk extension features except this CSR, check existence of both
+    /// `"zkn"` and `"zkt"` features instead.
     ///
     /// There's also bases and extensions marked as standard instruction set,
     /// but they are in frozen or draft state. These instruction sets are also
@@ -121,8 +155,10 @@ features! {
     /// scalar/vector memory accesses, respectively.  If enabled, it denotes that
     /// corresponding unaligned memory access is reasonably fast.
     ///
-    /// * `"unaligned-scalar-mem"`
-    /// * `"unaligned-vector-mem"`
+    /// * `"unaligned-scalar-mem"`  
+    ///   Runtime detection requires Linux version 6.4 or later.
+    /// * `"unaligned-vector-mem"`  
+    ///   Runtime detection requires Linux version 6.13 or later.
     #[stable(feature = "riscv_ratified", since = "1.78.0")]
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] rv32i: "rv32i";


### PR DESCRIPTION
To help users make a decision for feature checking on a RISC-V system:

1.  Whether to use this runtime detection macro (or prefer to use static feature enablement with `-Ctarget-feature` compiler option) and
2.  Determine the platform and versions to support,

This commit adds a platform guide with minimum supported platform versions.

# Screenshot

Because I could not make a single HTML version of the resulting documentation, I will paste a screenshot (slightly modified for readability) here.

Image: [screenshot-is_riscv_feature_detected.png](https://github.com/user-attachments/assets/7f021c9d-3d56-4ae1-938a-08e2aac27311)

# Background / Problem

## Absence of Architectural Runtime Feature Detection on RISC-V

Unlike x86 architectures with an unprivileged `CPUID` instruction and Arm/AArch64 architectures [with a series of system registers](https://github.com/rust-lang/stdarch/blob/d8785a32e63090e98243c0b4b5d6d2f5f8518b5a/crates/std_detect/src/detect/os/aarch64.rs) (available to the operating system level (EL1) but some operating systems chose to expose them to the user mode (EL0) through instruction emulation), RISC-V does not provide any fine-grained feature detection facility itself.

The only standard RISC-V architectural thing provided is the `misa` CSR but it is only available to the firmware level (M-mode, even higher than the S-mode which the operating system normally runs on, and the firmware normally does not provide the contents of the `misa` CSR to lower modes). Even if this CSR is accessible, it's very coarse (only provides existence of single-letter extensions).

As a result, runtime feature detection on RISC-V entirely depends on the platform-specific facility which heavily depends on the platform and its version *per feature* (e.g. the main source of the runtime feature detection on Linux is the Devicetree (optionally, command line arguments and boot time benchmark) and the kernel exports a subset through the auxiliary vector and the `riscv_hwprobe` system call but note that this filtering is performed on the kernel which means only features *supported* by the kernel are exposed to the user mode; the word *support* means just the given extension is on the allow list in the kernel and even some *unsupported* extensions work without explicit kernel support).

This is a mess and the author considers just providing the list of features supported by the macro is insufficient for users who *actually* wants to use runtime feature detection.

## Existence of a Supported but Not Useful Feature: `"zkr"` (and `"zk"`)

The problem is not just the platform and the version.  For instance, there is an example of `"zkr"` (the Zkr extension) which is supported by this macro but unlikely to return `true` by a result of true runtime feature detection because the `seed` CSR provided by this extension is normally inaccessible from the user-mode.
For instance, OpenSBI ― a reference RISC-V firmware implementation ― changes the `mseccfg` CSR so that the `seed` CSR is accessible from the S-mode (OS) but not from the U-mode (user) by default. Worse than that, this behavior is not even configurable from the OS.

It also affects the Zk extension `"zk"` (fully-featured scalar cryptography) which contains the Zkr extension.

# Proposal

This commit makes the large portion of the supported feature list table-based to show platform support (with minimum supported versions) *per feature* and a few footnotes.

Tables are basically sorted (purely) alphabetically to make finding an extension easier but this change makes relations between extensions less obvious.  The author still prefers this format because the user will find an extension to use with the ISA manual  (which describes relations between extensions anyway).

It also adds some notes as a RISC-V platform guide.

## Note: About Reverse Implication (Extension Groups)

It intentionally omits the description of the reverse implication related to *extension groups* (such like implication of `B` *from* its members: `Zba`, `Zbb` and `Zbs` extensions) because it currently does not synchronize well with the `-Ctarget-feature` compiler option (due to missing reverse implication checks using `cfg` and due to constraints of the current Rust's feature handling).

Instead, it only describes forward implications (like `D` implying `F`) due to the fact that it relatively synchronizes well between Rust and `stdarch` for this kind of feature handling (not fully synchronized though).

# Request for Comments

Although this PR *can* be a regular PR right now, I first request comments because the change is very significant.

## Is this Guide to be Here?

Because this kind of change is large and the resulting documentation is far more verbose than the rest (runtime feature detection macro on other architectures), I'm not sure whether this kind of the guide is suitable here.

Even if this kind of the guide is helpful for users, it may not be the right place.

What do you think?

## Are Version Numbers Required in the Extension Table?

The author prefers to include version numbers (also due to the fact that there are large gaps of runtime feature detection on the Linux kernel version 6.4 and later) but if that's too much, the author considers just showing Yes/No (with footnotes) will be still helpful for users (far better than nothing).

## Formatting: Trailing Spaces

Changes in the "Performance Hints" section are the first examples in `stdarch` that utilize *a new line by two trailing spaces*.
Though it is not prohibited per coding rules, this is unusual as a Rust source code (and may need to ask whether this is okay).