### PR TITLE
attempt to `#[allow(unnecessary_transmutes)]` in neon

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -43,7 +43,6 @@
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]
 #![deny(clippy::missing_inline_in_public_items)]
-#![allow(unknown_lints, unnecessary_transmutes)]
 #![allow(
     clippy::identity_op,
     clippy::inline_always,

--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -1,5 +1,7 @@
 //! `core_arch`
 
+#![allow(unknown_lints, unnecessary_transmutes)]
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
im not sure why the `#![allow]` in `lib.rs` doesnt take effect, but for some reason it doesnt: https://github.com/rust-lang/rust/pull/136083#issuecomment-2804984503

this might fix that? im not sure