### PR TITLE
use 'unadjusted' ABI for wasm LLVM intrinsics

### DIFF
--- a/crates/core_arch/src/wasm32/atomic.rs
+++ b/crates/core_arch/src/wasm32/atomic.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.wasm.memory.atomic.wait32"]
     fn llvm_atomic_wait_i32(ptr: *mut i32, exp: i32, timeout: i64) -> i32;
     #[link_name = "llvm.wasm.memory.atomic.wait64"]

--- a/crates/core_arch/src/wasm32/memory.rs
+++ b/crates/core_arch/src/wasm32/memory.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.wasm.memory.grow"]
     fn llvm_memory_grow(mem: u32, pages: usize) -> usize;
     #[link_name = "llvm.wasm.memory.size"]

--- a/crates/core_arch/src/wasm32/relaxed_simd.rs
+++ b/crates/core_arch/src/wasm32/relaxed_simd.rs
@@ -5,7 +5,7 @@ use crate::core_arch::simd;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.wasm.relaxed.swizzle"]
     fn llvm_relaxed_swizzle(a: simd::i8x16, b: simd::i8x16) -> simd::i8x16;
     #[link_name = "llvm.wasm.relaxed.trunc.signed"]

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -73,7 +73,7 @@ conversions! {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.wasm.swizzle"]
     fn llvm_swizzle(a: simd::i8x16, b: simd::i8x16) -> simd::i8x16;
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/139809 for context.

Currently this crate uses a mix of "C" and "unadjusted", sometimes even for the same target -- no idea why. I would assume it should be "unadjusted" everywhere when importing an LLVM intrinsic? I don't want to make any sweeping changes in this PR though so this only touches wasm.

Cc @alexcrichton 