### PR TITLE
run `powerpc64le` `assert_instr` on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,6 @@ jobs:
         - target:
             tuple: powerpc64le-unknown-linux-gnu
             os: ubuntu-latest
-          disable_assert_instr: true
           test_everything: true
         - target:
             tuple: riscv64gc-unknown-linux-gnu

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -11,6 +11,11 @@ if [ $# -lt 1 ]; then
 fi
 
 run() {
+    # Set the linker that is used for the host (e.g. when compiling a build.rs)
+    # This overrides any configuration in e.g. `.cargo/config.toml`, which will
+    # probably not work within the docker container.
+    HOST_LINKER="CARGO_TARGET_$(rustc --print host-tuple | tr '[:lower:]-' '[:upper:]_')_LINKER"
+
     # Prevent `Read-only file system (os error 30)`.
     cargo generate-lockfile
 
@@ -25,6 +30,7 @@ run() {
       --env CARGO_HOME=/cargo \
       --env CARGO_TARGET_DIR=/checkout/target \
       --env TARGET="${1}" \
+      --env "${HOST_LINKER}"="cc" \
       --env STDARCH_TEST_EVERYTHING \
       --env STDARCH_DISABLE_ASSERT_INSTR \
       --env NOSTD \

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -11,6 +11,9 @@ if [ $# -lt 1 ]; then
 fi
 
 run() {
+    # Prevent `Read-only file system (os error 30)`.
+    cargo generate-lockfile
+
     echo "Building docker container for TARGET=${1}"
     docker build -t stdarch -f "ci/docker/${1}/Dockerfile" ci/
     mkdir -p target c_programs rust_programs

--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -1878,7 +1878,7 @@ mod sealed {
 
     #[inline]
     #[target_feature(enable = "altivec")]
-    #[cfg_attr(test, assert_instr(vmaddfp))]
+    #[cfg_attr(test, assert_instr(xvmaddasp))]
     pub unsafe fn vec_vmaddfp(a: vector_float, b: vector_float, c: vector_float) -> vector_float {
         simd_fma(a, b, c)
     }
@@ -3239,7 +3239,7 @@ mod sealed {
         unsafe fn vec_round(self) -> Self;
     }
 
-    test_impl! { vec_vrfin(a: vector_float) -> vector_float [vrfin, vrfin] }
+    test_impl! { vec_vrfin(a: vector_float) -> vector_float [vrfin, xvrspic] }
 
     #[unstable(feature = "stdarch_powerpc", issue = "111145")]
     impl VectorRound for vector_float {


### PR DESCRIPTION
Two changes to tests were needed

`vrfin -> xvrspic` (changed in https://github.com/rust-lang/stdarch/pull/1713) 

- with older cpu types, it generates the same instruction https://godbolt.org/z/v7fW1fcrW
- but with newer ones, the new instruction is emitted https://godbolt.org/z/sYf5cKax8

So I think that means that this is fine? At least on s390x the rounding mode is not even relevant, this might be the case for powerpc too?

`vmaddfp -> xvmaddasp` (changed in https://github.com/rust-lang/stdarch/pull/1734)

That is just what C generates too now https://godbolt.org/z/5M8oT6fox

cc @lu-zero 