### PR TITLE
Add RISCV32 to CI, and use `windows-11-arm` runners for `aarch64-msvc` run

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,10 @@ task:
   name: x86_64-unknown-freebsd
   freebsd_instance:
     image_family: freebsd-13-4
+  env:
+    # FIXME(freebsd): FreeBSD has a segfault when `RUST_BACKTRACE` is set
+    # https://github.com/rust-lang/rust/issues/132185
+    RUST_BACKTRACE: "0"
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain nightly -y

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
         - tuple: i686-pc-windows-msvc
           os: windows-2025
         - tuple: aarch64-pc-windows-msvc
-          os: windows-2025
+          os: windows-11-arm
         - tuple: x86_64-pc-windows-gnu
           os: windows-2025
         # - tuple: i686-pc-windows-gnu
@@ -199,10 +199,6 @@ jobs:
             tuple: aarch64-apple-ios-macabi
             os: macos-15
           norun: true # https://github.com/rust-lang/stdarch/issues/1206
-        - target:
-            tuple: aarch64-pc-windows-msvc
-            os: windows-2025
-          norun: true
 
     steps:
     - uses: actions/checkout@v4
@@ -210,13 +206,24 @@ jobs:
       run: |
         rustup update nightly --no-self-update
         rustup default nightly
+      shell: bash
+      if: matrix.target.os != 'windows-11-arm'
+    - name: Install Rust for `windows-11-arm` runners
+      # The arm runners don't have Rust pre-installed (https://github.com/actions/partner-runner-images/issues/77)
+      run: |
+        curl https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      shell: bash
+      if: matrix.target.os == 'windows-11-arm'
+
     - run: rustup target add ${{ matrix.target.tuple }}
+      shell: bash
       if: matrix.build_std == ''
     - run: |
         rustup component add rust-src
         echo "CARGO_UNSTABLE_BUILD_STD=std" >> $GITHUB_ENV
+      shell: bash
       if: matrix.build_std != ''
-    - run: cargo generate-lockfile
 
     # Configure some env vars based on matrix configuration
     - run: echo "PROFILE=--profile=${{matrix.profile}}" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
           os: ubuntu-latest
         - tuple: aarch64_be-unknown-linux-gnu
           os: ubuntu-latest
+        - tuple: riscv32gc-unknown-linux-gnu
+          os: ubuntu-latest
         - tuple: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
         - tuple: powerpc-unknown-linux-gnu
@@ -155,6 +157,11 @@ jobs:
             os: ubuntu-latest
           test_everything: true
         - target:
+            tuple: riscv32gc-unknown-linux-gnu
+            os: ubuntu-latest
+          test_everything: true
+          build_std: true
+        - target:
             tuple: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
           test_everything: true
@@ -237,7 +244,7 @@ jobs:
     # ... while Linux goes to `run-docker.sh`
     - run: ./ci/run-docker.sh ${{ matrix.target.tuple }}
       shell: bash
-      if: "matrix.target.os == 'ubuntu-latest' && !startsWith(matrix.target.tuple, 'thumb')"
+      if: matrix.target.os == 'ubuntu-latest' && !startsWith(matrix.target.tuple, 'thumb')
       env:
         TARGET: ${{ matrix.target.tuple }}
 

--- a/ci/docker/riscv32gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv32gc-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:25.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc libc6-dev qemu-user ca-certificates \
+        wget xz-utils make file llvm
+
+ENV VERSION=2025.01.20
+
+RUN wget "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${VERSION}/riscv32-glibc-ubuntu-24.04-gcc-nightly-${VERSION}-nightly.tar.xz" \
+    -O riscv-toolchain.tar.xz
+RUN tar -xJf riscv-toolchain.tar.xz
+
+ENV CARGO_TARGET_RISCV32GC_UNKNOWN_LINUX_GNU_LINKER=/riscv/bin/riscv32-unknown-linux-gnu-gcc \
+    CARGO_TARGET_RISCV32GC_UNKNOWN_LINUX_GNU_RUNNER="qemu-riscv32 -cpu max -L /riscv/sysroot" \
+    OBJDUMP=llvm-objdump

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -44,9 +44,8 @@ case ${TARGET} in
         ;;
     # Some of our test dependencies use the deprecated `gcc` crates which
     # doesn't detect RISC-V compilers automatically, so do it manually here.
-    riscv64*)
+    riscv*)
         export RUSTFLAGS="${RUSTFLAGS} -Ctarget-feature=+zk,+zks,+zbb,+zbc"
-        export TARGET_CC="riscv64-linux-gnu-gcc"
         ;;
 esac
 

--- a/crates/core_arch/src/aarch64/mte.rs
+++ b/crates/core_arch/src/aarch64/mte.rs
@@ -127,42 +127,42 @@ mod test {
     use super::*;
     use stdarch_test::assert_instr;
 
-    #[cfg_attr(test, assert_instr(irg))]
+    #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(irg))] // FIXME: MSVC  `dumpbin` doesn't support MTE
     #[allow(dead_code)]
     #[target_feature(enable = "mte")]
     unsafe fn test_arm_mte_create_random_tag(src: *const (), mask: u64) -> *const () {
         __arm_mte_create_random_tag(src, mask)
     }
 
-    #[cfg_attr(test, assert_instr(addg))]
+    #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(addg))]
     #[allow(dead_code)]
     #[target_feature(enable = "mte")]
     unsafe fn test_arm_mte_increment_tag(src: *const ()) -> *const () {
         __arm_mte_increment_tag::<1, _>(src)
     }
 
-    #[cfg_attr(test, assert_instr(gmi))]
+    #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(gmi))]
     #[allow(dead_code)]
     #[target_feature(enable = "mte")]
     unsafe fn test_arm_mte_exclude_tag(src: *const (), excluded: u64) -> u64 {
         __arm_mte_exclude_tag(src, excluded)
     }
 
-    #[cfg_attr(test, assert_instr(stg))]
+    #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stg))]
     #[allow(dead_code)]
     #[target_feature(enable = "mte")]
     unsafe fn test_arm_mte_set_tag(src: *const ()) {
         __arm_mte_set_tag(src)
     }
 
-    #[cfg_attr(test, assert_instr(ldg))]
+    #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(ldg))]
     #[allow(dead_code)]
     #[target_feature(enable = "mte")]
     unsafe fn test_arm_mte_get_tag(src: *const ()) -> *const () {
         __arm_mte_get_tag(src)
     }
 
-    #[cfg_attr(test, assert_instr(subp))]
+    #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(subp))]
     #[allow(dead_code)]
     #[target_feature(enable = "mte")]
     unsafe fn test_arm_mte_ptrdiff(a: *const (), b: *const ()) -> i64 {

--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -422,8 +422,7 @@ pub fn vmovq_n_f64(value: f64) -> float64x2_t {
 /// Duplicate vector element to vector or scalar
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(mov))]
-#[cfg_attr(all(test, target_env = "msvc"), assert_instr(dup))]
+#[cfg_attr(test, assert_instr(nop))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vget_high_f64(a: float64x2_t) -> float64x1_t {
     unsafe { float64x1_t([simd_extract!(a, 1)]) }

--- a/crates/std_detect/tests/macro_trailing_commas.rs
+++ b/crates/std_detect/tests/macro_trailing_commas.rs
@@ -9,15 +9,30 @@
         target_arch = "powerpc",
         target_arch = "powerpc64",
         target_arch = "s390x",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
     ),
     feature(stdarch_internal)
 )]
 #![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
-#![cfg_attr(target_arch = "aarch64", feature(stdarch_aarch64_feature_detection))]
-#![cfg_attr(target_arch = "powerpc", feature(stdarch_powerpc_feature_detection))]
-#![cfg_attr(target_arch = "powerpc64", feature(stdarch_powerpc_feature_detection))]
+#![cfg_attr(
+    any(target_arch = "aarch64", target_arch = "arm64ec"),
+    feature(stdarch_aarch64_feature_detection)
+)]
+#![cfg_attr(
+    any(target_arch = "powerpc", target_arch = "powerpc64"),
+    feature(stdarch_powerpc_feature_detection)
+)]
 #![cfg_attr(target_arch = "s390x", feature(stdarch_s390x_feature_detection))]
-#![allow(clippy::unwrap_used, clippy::use_debug, clippy::print_stdout)]
+#![cfg_attr(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    feature(stdarch_riscv_feature_detection)
+)]
+#![cfg_attr(
+    target_arch = "loongarch64",
+    feature(stdarch_loongarch_feature_detection)
+)]
 
 #[cfg(any(
     target_arch = "arm",
@@ -28,51 +43,65 @@
     target_arch = "powerpc",
     target_arch = "powerpc64",
     target_arch = "s390x",
+    target_arch = "riscv32",
+    target_arch = "riscv64",
+    target_arch = "loongarch64"
 ))]
 #[macro_use]
 extern crate std_detect;
 
 #[test]
-#[cfg(all(target_arch = "arm", any(target_os = "linux", target_os = "android")))]
-fn arm_linux() {
+#[cfg(target_arch = "arm")]
+fn arm() {
     let _ = is_arm_feature_detected!("neon");
     let _ = is_arm_feature_detected!("neon",);
 }
 
 #[test]
-#[cfg(all(
-    target_arch = "aarch64",
-    any(target_os = "linux", target_os = "android")
-))]
-fn aarch64_linux() {
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+fn aarch64() {
     let _ = is_aarch64_feature_detected!("fp");
     let _ = is_aarch64_feature_detected!("fp",);
 }
 
 #[test]
-#[cfg(all(target_arch = "powerpc", target_os = "linux"))]
-fn powerpc_linux() {
+#[cfg(target_arch = "loongarch64")]
+fn loongarch64() {
+    let _ = is_loongarch_feature_detected!("lsx");
+    let _ = is_loongarch_feature_detected!("lsx",);
+}
+
+#[test]
+#[cfg(target_arch = "powerpc")]
+fn powerpc() {
     let _ = is_powerpc_feature_detected!("altivec");
     let _ = is_powerpc_feature_detected!("altivec",);
 }
 
 #[test]
-#[cfg(all(target_arch = "powerpc64", target_os = "linux"))]
-fn powerpc64_linux() {
+#[cfg(target_arch = "powerpc64")]
+fn powerpc64() {
     let _ = is_powerpc64_feature_detected!("altivec");
     let _ = is_powerpc64_feature_detected!("altivec",);
 }
 
 #[test]
-#[cfg(all(target_arch = "s390x", target_os = "linux"))]
-fn s390x_linux() {
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+fn riscv() {
+    let _ = is_riscv_feature_detected!("zk");
+    let _ = is_riscv_feature_detected!("zk",);
+}
+
+#[test]
+#[cfg(target_arch = "s390x")]
+fn s390x() {
     let _ = is_s390x_feature_detected!("vector");
     let _ = is_s390x_feature_detected!("vector",);
 }
 
 #[test]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn x86_all() {
+fn x86() {
     let _ = is_x86_feature_detected!("sse");
     let _ = is_x86_feature_detected!("sse",);
 }

--- a/crates/stdarch-test/src/disassembly.rs
+++ b/crates/stdarch-test/src/disassembly.rs
@@ -77,7 +77,7 @@ pub(crate) fn disassemble_myself() -> HashSet<Function> {
     let add_args = if cfg!(target_vendor = "apple") && cfg!(target_arch = "aarch64") {
         // Target features need to be enabled for LLVM objdump on Darwin ARM64
         vec!["--mattr=+v8.6a,+crypto,+tme"]
-    } else if cfg!(target_arch = "riscv64") {
+    } else if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
         vec!["--mattr=+zk,+zks,+zbc,+zbb"]
     } else {
         vec![]


### PR DESCRIPTION
This PR adds CI support `riscv32gc-unknown-linux-gnu`

Fixes spurious segfaults in Cirrus CI

Adds support for running the `aarch64-pc-windows-msvc` runners in the new `windows-11-arm` runners