### PR TITLE
RISC-V: Remove footnote from the `Zcb` extension

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -69,7 +69,7 @@ features! {
     /// | `"zbkx"`        | Zbkx        | 6.8                |
     /// | `"zbs"`         | Zbs         | 6.5                |
     /// | `"zca"`         | Zca         | 6.11 [^dep]        |
-    /// | `"zcb"`         | Zcb         | 6.11 [^dep]        |
+    /// | `"zcb"`         | Zcb         | 6.11               |
     /// | `"zcd"`         | Zcd         | 6.11 [^dep]        |
     /// | `"zcf"`         | Zcf         | 6.11 [^dep]        |
     /// | `"zcmop"`       | Zcmop       | 6.11               |


### PR DESCRIPTION
This commit removes excess footnote caused by sloppy copy-and-paste of other `Zc*` extension lines (the footnote is true for other currently supported `Zc?` extensions but not `Zcb`).