### PR TITLE
Stabilize `sha512`, `sm3` and `sm4` intrinsics and runtime detection

### DIFF
--- a/crates/core_arch/src/x86/sha.rs
+++ b/crates/core_arch/src/x86/sha.rs
@@ -146,7 +146,7 @@ pub fn _mm_sha256rnds2_epu32(a: __m128i, b: __m128i, k: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sha512,avx")]
 #[cfg_attr(test, assert_instr(vsha512msg1))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm256_sha512msg1_epi64(a: __m256i, b: __m128i) -> __m256i {
     unsafe { transmute(vsha512msg1(a.as_i64x4(), b.as_i64x2())) }
 }
@@ -159,7 +159,7 @@ pub fn _mm256_sha512msg1_epi64(a: __m256i, b: __m128i) -> __m256i {
 #[inline]
 #[target_feature(enable = "sha512,avx")]
 #[cfg_attr(test, assert_instr(vsha512msg2))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm256_sha512msg2_epi64(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(vsha512msg2(a.as_i64x4(), b.as_i64x4())) }
 }
@@ -175,7 +175,7 @@ pub fn _mm256_sha512msg2_epi64(a: __m256i, b: __m256i) -> __m256i {
 #[inline]
 #[target_feature(enable = "sha512,avx")]
 #[cfg_attr(test, assert_instr(vsha512rnds2))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm256_sha512rnds2_epi64(a: __m256i, b: __m256i, k: __m128i) -> __m256i {
     unsafe { transmute(vsha512rnds2(a.as_i64x4(), b.as_i64x4(), k.as_i64x2())) }
 }
@@ -188,7 +188,7 @@ pub fn _mm256_sha512rnds2_epi64(a: __m256i, b: __m256i, k: __m128i) -> __m256i {
 #[inline]
 #[target_feature(enable = "sm3,avx")]
 #[cfg_attr(test, assert_instr(vsm3msg1))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm_sm3msg1_epi32(a: __m128i, b: __m128i, c: __m128i) -> __m128i {
     unsafe { transmute(vsm3msg1(a.as_i32x4(), b.as_i32x4(), c.as_i32x4())) }
 }
@@ -201,7 +201,7 @@ pub fn _mm_sm3msg1_epi32(a: __m128i, b: __m128i, c: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sm3,avx")]
 #[cfg_attr(test, assert_instr(vsm3msg2))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm_sm3msg2_epi32(a: __m128i, b: __m128i, c: __m128i) -> __m128i {
     unsafe { transmute(vsm3msg2(a.as_i32x4(), b.as_i32x4(), c.as_i32x4())) }
 }
@@ -219,7 +219,7 @@ pub fn _mm_sm3msg2_epi32(a: __m128i, b: __m128i, c: __m128i) -> __m128i {
 #[target_feature(enable = "sm3,avx")]
 #[cfg_attr(test, assert_instr(vsm3rnds2, IMM8 = 0))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm_sm3rnds2_epi32<const IMM8: i32>(a: __m128i, b: __m128i, c: __m128i) -> __m128i {
     static_assert!(
         IMM8 == (IMM8 & 0x3e),
@@ -235,7 +235,7 @@ pub fn _mm_sm3rnds2_epi32<const IMM8: i32>(a: __m128i, b: __m128i, c: __m128i) -
 #[inline]
 #[target_feature(enable = "sm4,avx")]
 #[cfg_attr(test, assert_instr(vsm4key4))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm_sm4key4_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(vsm4key4128(a.as_i32x4(), b.as_i32x4())) }
 }
@@ -247,7 +247,7 @@ pub fn _mm_sm4key4_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sm4,avx")]
 #[cfg_attr(test, assert_instr(vsm4key4))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm256_sm4key4_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(vsm4key4256(a.as_i32x8(), b.as_i32x8())) }
 }
@@ -259,7 +259,7 @@ pub fn _mm256_sm4key4_epi32(a: __m256i, b: __m256i) -> __m256i {
 #[inline]
 #[target_feature(enable = "sm4,avx")]
 #[cfg_attr(test, assert_instr(vsm4rnds4))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm_sm4rnds4_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(vsm4rnds4128(a.as_i32x4(), b.as_i32x4())) }
 }
@@ -271,7 +271,7 @@ pub fn _mm_sm4rnds4_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "sm4,avx")]
 #[cfg_attr(test, assert_instr(vsm4rnds4))]
-#[unstable(feature = "sha512_sm_x86", issue = "126624")]
+#[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")]
 pub fn _mm256_sm4rnds4_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(vsm4rnds4256(a.as_i32x8(), b.as_i32x8())) }
 }

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -157,11 +157,11 @@ features! {
     /// AVX (Advanced Vector Extensions)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx2: "avx2";
     /// AVX2 (Advanced Vector Extensions 2)
-    @FEATURE: #[unstable(feature = "sha512_sm_x86", issue = "126624")] sha512: "sha512";
+    @FEATURE: #[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")] sha512: "sha512";
     /// SHA512
-    @FEATURE: #[unstable(feature = "sha512_sm_x86", issue = "126624")] sm3: "sm3";
+    @FEATURE: #[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")] sm3: "sm3";
     /// SM3
-    @FEATURE: #[unstable(feature = "sha512_sm_x86", issue = "126624")] sm4: "sm4";
+    @FEATURE: #[stable(feature = "sha512_sm_x86", since = "CURRENT_RUSTC_VERSION")] sm4: "sm4";
     /// SM4
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] avx512f: "avx512f" ;
     /// AVX-512 F (Foundation)


### PR DESCRIPTION
parent: rust-lang/rust#126624

related: rust-lang/rust#140767

currently draft because this requires the rustc PR to merge