### PR TITLE
Check cfg on features that stage0 compiler support

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -159,32 +159,23 @@ features! {
     /// Has reasonably performant unaligned vector
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicsr: "zicsr";
-    without cfg check: true;
     /// "Zicsr" Extension for Control and Status Register (CSR) Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicntr: "zicntr";
-    without cfg check: true;
     /// "Zicntr" Extension for Base Counters and Timers
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihpm: "zihpm";
-    without cfg check: true;
     /// "Zihpm" Extension for Hardware Performance Counters
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zifencei: "zifencei";
-    without cfg check: true;
     /// "Zifencei" Extension for Instruction-Fetch Fence
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihintntl: "zihintntl";
-    without cfg check: true;
     /// "Zihintntl" Extension for Non-Temporal Locality Hints
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zihintpause: "zihintpause";
-    without cfg check: true;
     /// "Zihintpause" Extension for Pause Hint
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zimop: "zimop";
-    without cfg check: true;
     /// "Zimop" Extension for May-Be-Operations
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicboz: "zicboz";
-    without cfg check: true;
     /// "Zicboz" Extension for Cache-Block Zero Instruction
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicond: "zicond";
-    without cfg check: true;
     /// "Zicond" Extension for Integer Conditional Operations
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] m: "m";
@@ -204,7 +195,6 @@ features! {
     without cfg check: true;
     /// "Zam" Extension for Misaligned Atomics
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] ztso: "ztso";
-    without cfg check: true;
     /// "Ztso" Extension for Total Store Ordering
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] f: "f";
@@ -219,7 +209,6 @@ features! {
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfhmin: "zfhmin";
     /// "Zfhmin" Extension for Minimal Half-Precision Floating-Point
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfa: "zfa";
-    without cfg check: true;
     /// "Zfa" Extension for Additional Floating-Point Instructions
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfinx: "zfinx";
@@ -234,7 +223,6 @@ features! {
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] c: "c";
     /// "C" Extension for Compressed Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zca: "zca";
-    without cfg check: true;
     /// "Zca" Compressed Instructions excluding Floating-Point Loads/Stores
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcf: "zcf";
     without cfg check: true;
@@ -243,14 +231,11 @@ features! {
     without cfg check: true;
     /// "Zcd" Compressed Instructions for Double-Precision Floating-Point Loads/Stores
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcb: "zcb";
-    without cfg check: true;
     /// "Zcb" Simple Code-size Saving Compressed Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zcmop: "zcmop";
-    without cfg check: true;
     /// "Zcmop" Extension for Compressed May-Be-Operations
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] b: "b";
-    without cfg check: true;
     /// "B" Extension for Bit Manipulation
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] zba: "zba";
     /// "Zba" Extension for Address Generation

--- a/crates/std_detect/src/detect/arch/x86.rs
+++ b/crates/std_detect/src/detect/arch/x86.rs
@@ -224,19 +224,14 @@ features! {
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_complex: "amx-complex";
     /// AMX-COMPLEX (Complex number Operations)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_avx512: "amx-avx512";
-    without cfg check: true;
     /// AMX-AVX512 (AVX512 operations extended to matrices)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_fp8: "amx-fp8";
-    without cfg check: true;
     /// AMX-FP8 (Float8 Operations)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_movrs: "amx-movrs";
-    without cfg check: true;
     /// AMX-MOVRS (Matrix MOVERS operations)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_tf32: "amx-tf32";
-    without cfg check: true;
     /// AMX-TF32 (TensorFloat32 Operations)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_transpose: "amx-transpose";
-    without cfg check: true;
     /// AMX-TRANSPOSE (Matrix Transpose Operations)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] f16c: "f16c";
     /// F16C (Conversions between IEEE-754 `binary16` and `binary32` formats)


### PR DESCRIPTION
Since the bootstrap compiler of Rust is bumped to the commit rust-lang/rust@5dadfd5c417f0b66816cb7ca662859e2c8751fb3 (version 1.88.0-beta.3 2025-05-11), some features should be safe to enable `cfg` checks.

This is a superset of the revert of #1768.

RISC-V Features:

*   "zicsr"
*   "zicntr"
*   "zihpm"
*   "zifencei"
*   "zihintntl"
*   "zihintpause"
*   "zimop"
*   "zicboz"
*   "zicond"
*   "ztso"
*   "zfa"
*   "zca"
*   "zcb"
*   "zcmop"
*   "b"

x86 Features:

*   "amx-avx512"
*   "amx-fp8"
*   "amx-movrs"
*   "amx-tf32"
*   "amx-transpose"