### PR TITLE
Add back `std_detect_env_override`

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -37,6 +37,7 @@ run() {
       --env NORUN \
       --env RUSTFLAGS \
       --env CARGO_UNSTABLE_BUILD_STD \
+      --env RUST_STD_DETECT_UNSTABLE \
       --volume "${HOME}/.cargo":/cargo \
       --volume "$(rustc --print sysroot)":/rust:ro \
       --volume "$(pwd)":/checkout:ro \

--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -35,6 +35,7 @@ libc = { version = "0.2.0", optional = true, default-features = false }
 default = [ "std_detect_dlsym_getauxval", "std_detect_file_io" ]
 std_detect_file_io = [ "libc" ]
 std_detect_dlsym_getauxval = [ "libc" ]
+std_detect_env_override = [ "libc" ]
 rustc-dep-of-std = [
     "core",
     "compiler_builtins",

--- a/crates/std_detect/src/detect/cache.rs
+++ b/crates/std_detect/src/detect/cache.rs
@@ -121,12 +121,65 @@ impl Cache {
     }
 }
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std_detect_env_override")] {
+        #[inline]
+        fn disable_features(disable: &[u8], value: &mut Initializer) {
+            if let Ok(disable) = core::str::from_utf8(disable) {
+                for v in disable.split(" ") {
+                    let _ = super::Feature::from_str(v).map(|v| value.unset(v as u32));
+                }
+            }
+        }
+
+        #[inline]
+        fn initialize(mut value: Initializer) -> Initializer {
+            use core::ffi::CStr;
+            const RUST_STD_DETECT_UNSTABLE: &CStr = c"RUST_STD_DETECT_UNSTABLE";
+            cfg_if::cfg_if! {
+                if #[cfg(windows)] {
+                    use alloc::vec;
+                    #[link(name = "kernel32")]
+                    unsafe extern "system" {
+                        fn GetEnvironmentVariableA(name: *const u8, buffer: *mut u8, size: u32) -> u32;
+                    }
+                    let len = unsafe { GetEnvironmentVariableA(RUST_STD_DETECT_UNSTABLE.as_ptr().cast::<u8>(), core::ptr::null_mut(), 0) };
+                    if len > 0 {
+                        // +1 to include the null terminator.
+                        let mut env = vec![0; len as usize + 1];
+                        let len = unsafe { GetEnvironmentVariableA(RUST_STD_DETECT_UNSTABLE.as_ptr().cast::<u8>(), env.as_mut_ptr(), len + 1) };
+                        if len > 0 {
+                            disable_features(&env[..len as usize], &mut value);
+                        }
+                    }
+                } else {
+                    let env = unsafe {
+                        libc::getenv(RUST_STD_DETECT_UNSTABLE.as_ptr())
+                    };
+                    if !env.is_null() {
+                        let len = unsafe { libc::strlen(env) };
+                        let env = unsafe { core::slice::from_raw_parts(env as *const u8, len) };
+                        disable_features(env, &mut value);
+                    }
+                }
+            }
+            do_initialize(value);
+            value
+        }
+    } else {
+        #[inline]
+        fn initialize(value: Initializer) -> Initializer {
+            do_initialize(value);
+            value
+        }
+    }
+}
+
 #[inline]
-fn initialize(value: Initializer) -> Initializer {
+fn do_initialize(value: Initializer) {
     CACHE[0].initialize((value.0) as usize & Cache::MASK);
     CACHE[1].initialize((value.0 >> Cache::CAPACITY) as usize & Cache::MASK);
     CACHE[2].initialize((value.0 >> (2 * Cache::CAPACITY)) as usize & Cache::MASK);
-    value
 }
 
 // We only have to detect features once, and it's fairly costly, so hint to LLVM
@@ -151,6 +204,10 @@ fn detect_and_initialize() -> Initializer {
 ///
 /// It uses the `Feature` variant to index into this variable as a bitset. If
 /// the bit is set, the feature is enabled, and otherwise it is disabled.
+///
+/// If the feature `std_detect_env_override` is enabled looks for the env
+/// variable `RUST_STD_DETECT_UNSTABLE` and uses its content to disable
+/// Features that would had been otherwise detected.
 #[inline]
 pub(crate) fn test(bit: u32) -> bool {
     let (relative_bit, idx) = if bit < Cache::CAPACITY {

--- a/crates/std_detect/src/detect/macros.rs
+++ b/crates/std_detect/src/detect/macros.rs
@@ -168,6 +168,14 @@ macro_rules! features {
                     Feature::_last => unreachable!(),
                 }
             }
+
+            #[cfg(feature = "std_detect_env_override")]
+            pub(crate) fn from_str(s: &str) -> Result<Feature, ()> {
+                match s {
+                    $($feature_lit => Ok(Feature::$feature),)*
+                    _ => Err(())
+                }
+            }
         }
 
         /// Each function performs run-time feature detection for a single


### PR DESCRIPTION
#1776 removed the machinery to manually enable/disable target features at runtime. It was overlooked that this is actually useful for testing, so this pr adds it back (the `env_override_no_avx` CI run is not added back)

cc @lu-zero 