### PR TITLE
Coding style modernization to deal with Clippy warnings

### DIFF
--- a/crates/intrinsic-test/src/arm/compile.rs
+++ b/crates/intrinsic-test/src/arm/compile.rs
@@ -2,7 +2,7 @@ use crate::common::compile_c::CompilationCommandBuilder;
 use crate::common::gen_c::compile_c_programs;
 
 pub fn compile_c_arm(
-    intrinsics_name_list: &Vec<String>,
+    intrinsics_name_list: &[String],
     compiler: &str,
     target: &str,
     cxx_toolchain_dir: Option<&str>,
@@ -56,7 +56,7 @@ pub fn compile_c_arm(
                 .clone()
                 .set_input_name(intrinsic_name)
                 .set_output_name(intrinsic_name)
-                .to_string()
+                .make_string()
         })
         .collect::<Vec<_>>();
 

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -54,7 +54,7 @@ struct JsonIntrinsic {
 
 pub fn get_neon_intrinsics(
     filename: &Path,
-    target: &String,
+    target: &str,
 ) -> Result<Vec<Intrinsic<ArmIntrinsicType>>, Box<dyn std::error::Error>> {
     let file = std::fs::File::open(filename)?;
     let reader = std::io::BufReader::new(file);
@@ -75,7 +75,7 @@ pub fn get_neon_intrinsics(
 
 fn json_to_intrinsic(
     mut intr: JsonIntrinsic,
-    target: &String,
+    target: &str,
 ) -> Result<Intrinsic<ArmIntrinsicType>, Box<dyn std::error::Error>> {
     let name = intr.name.replace(['[', ']'], "");
 

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -45,8 +45,8 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         intrinsics.dedup();
 
         Box::new(Self {
-            intrinsics: intrinsics,
-            cli_options: cli_options,
+            intrinsics,
+            cli_options,
         })
     }
 
@@ -71,9 +71,12 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
         match compiler {
             None => true,
-            Some(compiler) => {
-                compile_c_arm(&intrinsics_name_list, compiler, target, cxx_toolchain_dir)
-            }
+            Some(compiler) => compile_c_arm(
+                intrinsics_name_list.as_slice(),
+                compiler,
+                target,
+                cxx_toolchain_dir,
+            ),
         }
     }
 

--- a/crates/intrinsic-test/src/common/cli.rs
+++ b/crates/intrinsic-test/src/common/cli.rs
@@ -100,14 +100,14 @@ impl ProcessedCli {
         };
 
         Self {
-            toolchain: toolchain,
-            cpp_compiler: cpp_compiler,
-            c_runner: c_runner,
-            target: target,
-            linker: linker,
-            cxx_toolchain_dir: cxx_toolchain_dir,
-            skip: skip,
-            filename: filename,
+            toolchain,
+            cpp_compiler,
+            c_runner,
+            target,
+            linker,
+            cxx_toolchain_dir,
+            skip,
+            filename,
         }
     }
 }

--- a/crates/intrinsic-test/src/common/compile_c.rs
+++ b/crates/intrinsic-test/src/common/compile_c.rs
@@ -100,10 +100,10 @@ impl CompilationCommandBuilder {
 }
 
 impl CompilationCommandBuilder {
-    pub fn to_string(self) -> String {
+    pub fn make_string(self) -> String {
         let arch_flags = self.arch_flags.join("+");
         let flags = std::env::var("CPPFLAGS").unwrap_or("".into());
-        let project_root = self.project_root.unwrap_or(String::new());
+        let project_root = self.project_root.unwrap_or_default();
         let project_root_str = project_root.as_str();
         let mut output = self.output.clone();
         if self.linker.is_some() {

--- a/crates/intrinsic-test/src/common/gen_c.rs
+++ b/crates/intrinsic-test/src/common/gen_c.rs
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {{
             .map(|header| format!("#include <{header}>"))
             .collect::<Vec<_>>()
             .join("\n"),
-        arch_specific_definitions = arch_specific_definitions.into_iter().join("\n"),
+        arch_specific_definitions = arch_specific_definitions.join("\n"),
     )
 }
 

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -130,9 +130,9 @@ pub fn setup_rust_file_paths(identifiers: &Vec<String>) -> BTreeMap<&String, Str
     identifiers
         .par_iter()
         .map(|identifier| {
-            let rust_dir = format!(r#"rust_programs/{}"#, identifier);
+            let rust_dir = format!("rust_programs/{identifier}");
             let _ = std::fs::create_dir_all(&rust_dir);
-            let rust_filename = format!(r#"{rust_dir}/main.rs"#);
+            let rust_filename = format!("{rust_dir}/main.rs");
 
             (identifier, rust_filename)
         })

--- a/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -117,11 +117,11 @@ impl IntrinsicType {
     }
 
     pub fn num_lanes(&self) -> u32 {
-        if let Some(sl) = self.simd_len { sl } else { 1 }
+        self.simd_len.unwrap_or(1)
     }
 
     pub fn num_vectors(&self) -> u32 {
-        if let Some(vl) = self.vec_len { vl } else { 1 }
+        self.vec_len.unwrap_or(1)
     }
 
     pub fn is_simd(&self) -> bool {
@@ -266,7 +266,7 @@ impl IntrinsicType {
 
     pub fn as_call_param_c(&self, name: &String) -> String {
         if self.ptr {
-            format!("&{}", name)
+            format!("&{name}")
         } else {
             name.clone()
         }
@@ -282,7 +282,7 @@ pub trait IntrinsicTypeDefinition: Deref<Target = IntrinsicType> {
     fn get_lane_function(&self) -> String;
 
     /// can be implemented in an `impl` block
-    fn from_c(_s: &str, _target: &String) -> Result<Box<Self>, String>;
+    fn from_c(_s: &str, _target: &str) -> Result<Box<Self>, String>;
 
     /// Gets a string containing the typename for this type in C format.
     /// can be directly defined in `impl` blocks

--- a/crates/intrinsic-test/src/common/write_file.rs
+++ b/crates/intrinsic-test/src/common/write_file.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::Write;
 
 pub fn write_file(filename: &String, code: String) {
-    let mut file = File::create(&filename).unwrap();
+    let mut file = File::create(filename).unwrap();
     file.write_all(code.into_bytes().as_slice()).unwrap();
 }
 
@@ -34,9 +34,8 @@ pub fn write_c_testfiles<T: IntrinsicTypeDefinition + Sized>(
             notice,
             arch_specific_definitions,
         );
-        match filename_mapping.get(&i.name()) {
-            Some(filename) => write_file(filename, c_code),
-            None => {}
+        if let Some(filename) = filename_mapping.get(&i.name()) {
+            write_file(filename, c_code)
         };
     });
 
@@ -58,9 +57,8 @@ pub fn write_rust_testfiles<T: IntrinsicTypeDefinition>(
 
     intrinsics.iter().for_each(|&i| {
         let rust_code = create_rust_test_program(i, rust_target, notice, definitions, cfg);
-        match filename_mapping.get(&i.name()) {
-            Some(filename) => write_file(filename, rust_code),
-            None => {}
+        if let Some(filename) = filename_mapping.get(&i.name()) {
+            write_file(filename, rust_code)
         }
     });
 

--- a/crates/stdarch-gen-arm/src/big_endian.rs
+++ b/crates/stdarch-gen-arm/src/big_endian.rs
@@ -38,7 +38,7 @@ fn create_array(lanes: u32) -> Option<String> {
         4 => Some("[3, 2, 1, 0]".to_string()),
         8 => Some("[7, 6, 5, 4, 3, 2, 1, 0]".to_string()),
         16 => Some("[15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]".to_string()),
-        _ => panic!("Incorrect vector number of vector lanes: {}", lanes),
+        _ => panic!("Incorrect vector number of vector lanes: {lanes}"),
     }
 }
 
@@ -78,12 +78,7 @@ pub fn type_has_tuple(type_kind: &TypeKind) -> bool {
 }
 
 pub fn make_variable_mutable(variable_name: &str, type_kind: &TypeKind) -> Expression {
-    let mut_variable = format!(
-        "let mut {}: {} = {}",
-        variable_name,
-        type_kind.to_string(),
-        variable_name
-    );
+    let mut_variable = format!("let mut {variable_name}: {type_kind} = {variable_name}");
     let identifier_name = create_single_wild_string(&mut_variable);
     Expression::Identifier(identifier_name, IdentifierType::Symbol)
 }
@@ -114,9 +109,7 @@ fn create_shuffle_internal(
     };
 
     let lane_count = vector_type.lanes();
-    let Some(array_lanes) = create_array(lane_count) else {
-        return None;
-    };
+    let array_lanes = create_array(lane_count)?;
 
     let tuple_count = vector_type.tuple_size().map_or_else(|| 0, |t| t.to_int());
 
@@ -144,10 +137,7 @@ fn create_assigned_tuple_shuffle_call_fmt(
     array_lanes: &String,
 ) -> String {
     format!(
-        "{variable_name}.{idx} = unsafe {{ simd_shuffle!({variable_name}.{idx}, {variable_name}.{idx}, {array_lanes}) }};\n",
-        variable_name = variable_name,
-        idx = idx,
-        array_lanes = array_lanes
+        "{variable_name}.{idx} = unsafe {{ simd_shuffle!({variable_name}.{idx}, {variable_name}.{idx}, {array_lanes}) }};\n"
     )
 }
 
@@ -157,10 +147,7 @@ fn create_assigned_shuffle_call_fmt(
     array_lanes: &String,
 ) -> String {
     format!(
-        "let {variable_name}: {type_kind} = unsafe {{ simd_shuffle!({variable_name}, {variable_name}, {array_lanes}) }}",
-        type_kind = type_kind.to_string(),
-        variable_name = variable_name,
-        array_lanes = array_lanes
+        "let {variable_name}: {type_kind} = unsafe {{ simd_shuffle!({variable_name}, {variable_name}, {array_lanes}) }}"
     )
 }
 
@@ -169,11 +156,7 @@ fn create_shuffle_call_fmt(
     _type_kind: &TypeKind,
     array_lanes: &String,
 ) -> String {
-    format!(
-        "simd_shuffle!({variable_name}, {variable_name}, {array_lanes})",
-        variable_name = variable_name,
-        array_lanes = array_lanes
-    )
+    format!("simd_shuffle!({variable_name}, {variable_name}, {array_lanes})")
 }
 
 /// Create a `simd_shuffle!(<...>, [...])` call, where the output is stored

--- a/crates/stdarch-gen-arm/src/context.rs
+++ b/crates/stdarch-gen-arm/src/context.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, usize};
+use std::collections::HashMap;
 
 use crate::{
     expression::Expression,
@@ -165,11 +165,12 @@ impl LocalContext {
                 .map_or_else(err, |ty| Ok((ty.size().parse::<i32>().unwrap()-1).to_string())),
             Wildcard::SizeInBytesLog2(idx) => self.input.typekind(*idx)
                 .map_or_else(err, |ty| Ok(ty.size_in_bytes_log2())),
-            Wildcard::NVariant if self.substitutions.get(wildcard).is_none() => Ok(String::new()),
+            Wildcard::NVariant if !self.substitutions.contains_key(wildcard) => Ok(String::new()),
             Wildcard::TypeKind(idx, opts) => {
                 self.input.typekind(*idx)
                     .map_or_else(err, |ty| {
                         let literal = if let Some(opts) = opts {
+                            #[allow(clippy::obfuscated_if_else)]
                             opts.contains(ty.base_type().map(|bt| *bt.kind()).ok_or_else(|| {
                                 format!("cannot retrieve a type literal out of {ty}")
                             })?)

--- a/crates/stdarch-gen-arm/src/load_store_tests.rs
+++ b/crates/stdarch-gen-arm/src/load_store_tests.rs
@@ -129,6 +129,7 @@ fn generate_single_test(
     let chars = LdIntrCharacteristics::new(&load)?;
     let fn_name = load.signature.fn_name().to_string();
 
+    #[allow(clippy::collapsible_if)]
     if let Some(ty) = &chars.gather_bases_type {
         if ty.base_type().unwrap().get_size() == Ok(32)
             && chars.gather_index_type.is_none()
@@ -372,7 +373,7 @@ fn generate_single_test(
             let create = format_ident!("svcreate{tuple_len}_{acle_type}");
             quote!(#create(#(#expecteds),*))
         };
-        let input = store.input.types.get(0).unwrap().get(0).unwrap();
+        let input = store.input.types.first().unwrap().get(0).unwrap();
         let store_type = input
             .get(store.test.get_typeset_index().unwrap())
             .and_then(InputType::typekind)
@@ -579,7 +580,7 @@ struct LdIntrCharacteristics {
 
 impl LdIntrCharacteristics {
     fn new(intr: &Intrinsic) -> Result<LdIntrCharacteristics, String> {
-        let input = intr.input.types.get(0).unwrap().get(0).unwrap();
+        let input = intr.input.types.first().unwrap().get(0).unwrap();
         let load_type = input
             .get(intr.test.get_typeset_index().unwrap())
             .and_then(InputType::typekind)

--- a/crates/stdarch-gen-arm/src/main.rs
+++ b/crates/stdarch-gen-arm/src/main.rs
@@ -164,11 +164,11 @@ use stdarch_test::assert_instr;
 use super::*;{uses_neon}
 
 "#,
-        uses_neon = generated_input
-            .ctx
-            .uses_neon_types
-            .then_some("\nuse crate::core_arch::arch::aarch64::*;")
-            .unwrap_or_default(),
+        uses_neon = if generated_input.ctx.uses_neon_types {
+            "\nuse crate::core_arch::arch::aarch64::*;"
+        } else {
+            ""
+        },
     )?;
     let intrinsics = generated_input.intrinsics;
     format_code(out, quote! { #(#intrinsics)* })?;
@@ -198,7 +198,7 @@ pub fn format_code(
 /// Panics if the resulting name is empty, or if file_name() is not UTF-8.
 fn make_output_filepath(in_filepath: &Path, out_dirpath: &Path) -> PathBuf {
     make_filepath(in_filepath, out_dirpath, |_name: &str| {
-        format!("generated.rs")
+        "generated.rs".to_owned()
     })
 }
 

--- a/crates/stdarch-gen-arm/src/typekinds.rs
+++ b/crates/stdarch-gen-arm/src/typekinds.rs
@@ -135,7 +135,7 @@ pub enum VectorTupleSize {
 }
 
 impl VectorTupleSize {
-    pub fn to_int(&self) -> u32 {
+    pub fn to_int(self) -> u32 {
         match self {
             Self::Two => 2,
             Self::Three => 3,
@@ -453,6 +453,7 @@ impl VectorType {
         is_scalable: bool,
         tuple_size: Option<VectorTupleSize>,
     ) -> VectorType {
+        #[allow(clippy::collapsible_if)]
         if is_scalable {
             if let BaseType::Sized(BaseTypeKind::Bool, size) = base_ty {
                 return Self::make_predicate_from_bitsize(size);
@@ -521,13 +522,12 @@ impl FromStr for VectorType {
                 .transpose()
                 .unwrap();
 
-            let v = Ok(VectorType {
+            Ok(VectorType {
                 base_type,
                 is_scalable: c.name("sv_ty").is_some(),
                 lanes,
                 tuple_size,
-            });
-            return v;
+            })
         } else {
             Err(format!("invalid vector type {s:#?} given"))
         }

--- a/crates/stdarch-gen-arm/src/wildstring.rs
+++ b/crates/stdarch-gen-arm/src/wildstring.rs
@@ -66,7 +66,7 @@ impl WildString {
         self.0.is_empty()
     }
 
-    pub fn replace<'a, P>(&'a self, from: P, to: &str) -> WildString
+    pub fn replace<P>(&self, from: P, to: &str) -> WildString
     where
         P: Pattern + Copy,
     {

--- a/crates/stdarch-gen-loongarch/src/main.rs
+++ b/crates/stdarch-gen-loongarch/src/main.rs
@@ -74,7 +74,7 @@ impl TargetFeature {
     }
 
     /// Generate a target_feature attribute
-    fn to_target_feature_attr(&self, ins: &str) -> Lines {
+    fn to_target_feature_attr(self, ins: &str) -> Lines {
         Lines::single(Self::attr(
             "target_feature",
             self.as_target_feature_arg(ins),

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -71,7 +71,7 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
     //eprintln!("  function: {:?}", function);
 
     let mut instrs = &function.instrs[..];
-    while instrs.last().map_or(false, |s| s == "nop" || s == "int3") {
+    while instrs.last().is_some_and(|s| s == "nop" || s == "int3") {
         instrs = &instrs[..instrs.len() - 1];
     }
 

--- a/crates/stdarch-verify/src/lib.rs
+++ b/crates/stdarch-verify/src/lib.rs
@@ -498,6 +498,7 @@ fn find_target_feature(attrs: &[syn::Attribute]) -> Option<syn::Lit> {
     attrs
         .iter()
         .flat_map(|a| {
+            #[allow(clippy::collapsible_if)]
             if let syn::Meta::List(ref l) = a.meta {
                 if l.path.is_ident("target_feature") {
                     if let Ok(l) =
@@ -526,6 +527,7 @@ fn find_doc(attrs: &[syn::Attribute]) -> String {
     attrs
         .iter()
         .filter_map(|a| {
+            #[allow(clippy::collapsible_if)]
             if let syn::Meta::NameValue(ref l) = a.meta {
                 if l.path.is_ident("doc") {
                     if let syn::Expr::Lit(syn::ExprLit {

--- a/examples/connect5.rs
+++ b/examples/connect5.rs
@@ -229,8 +229,7 @@ const MAPMOVEIDX: [[i32; 239]; 4] = [ [// Direction 0
 /// The first dimension is color: Black, White and Empty.\
 /// The second and third one are 2 x 512-bit. Direction 0 and 2 use the first 512-bit. Direction 1 and
 /// 3 use the second 512-bit.\
-/// Each 512-bit is a 32-bit x 16 array. Direction 0 and 1 store at bit 31-16 and Direction 2 and 3 store at bit 15-0.  
-
+/// Each 512-bit is a 32-bit x 16 array. Direction 0 and 1 store at bit 31-16 and Direction 2 and 3 store at bit 15-0.
 pub struct Pos {
     // position
     state: [Color; SQUARE_SIZE as usize],
@@ -473,6 +472,7 @@ fn gen_moves(list: &mut List, pos: &Pos) {
 }
 
 /// AI: use Minimax search with alpha-beta pruning
+#[allow(clippy::manual_range_contains)]
 fn search(pos: &Pos, alpha: i32, beta: i32, depth: i32, _ply: i32) -> i32 {
     assert!(-EVAL_INF <= alpha && alpha < beta && beta <= EVAL_INF);
     // leaf?
@@ -724,12 +724,12 @@ fn check_pattern5(pos: &Pos, sd: Side) -> bool {
         for fl in 0..FILE_SIZE {
             let sq: Square = square_make(fl, rk);
 
-            for pat in 0..4 {
+            for direction in &DIRECTION {
                 let idx0 = sq;
-                let idx1 = sq + DIRECTION[pat][0];
-                let idx2 = sq + DIRECTION[pat][1];
-                let idx3 = sq + DIRECTION[pat][2];
-                let idx4 = sq + DIRECTION[pat][3];
+                let idx1 = sq + direction[0];
+                let idx2 = sq + direction[1];
+                let idx3 = sq + direction[2];
+                let idx4 = sq + direction[3];
 
                 let val0 = pos.state[idx0 as usize];
                 let val1 = pos.state[idx1 as usize];
@@ -754,13 +754,13 @@ fn check_patternlive4(pos: &Pos, sd: Side) -> bool {
         for fl in 0..FILE_SIZE {
             let sq: Square = square_make(fl, rk);
 
-            for pat in 0..4 {
+            for direction in &DIRECTION {
                 let idx0 = sq;
-                let idx1 = sq + DIRECTION[pat][0];
-                let idx2 = sq + DIRECTION[pat][1];
-                let idx3 = sq + DIRECTION[pat][2];
-                let idx4 = sq + DIRECTION[pat][3];
-                let idx5 = sq + DIRECTION[pat][4];
+                let idx1 = sq + direction[0];
+                let idx2 = sq + direction[1];
+                let idx3 = sq + direction[2];
+                let idx4 = sq + direction[3];
+                let idx5 = sq + direction[4];
 
                 let val0 = pos.state[idx0 as usize];
                 let val1 = pos.state[idx1 as usize];
@@ -786,12 +786,12 @@ fn check_patterndead4(pos: &Pos, sd: Side) -> i32 {
         for fl in 0..FILE_SIZE {
             let sq: Square = square_make(fl, rk);
 
-            for dir in 0..4 {
+            for direction in &DIRECTION {
                 let idx0 = sq;
-                let idx1 = sq + DIRECTION[dir][0];
-                let idx2 = sq + DIRECTION[dir][1];
-                let idx3 = sq + DIRECTION[dir][2];
-                let idx4 = sq + DIRECTION[dir][3];
+                let idx1 = sq + direction[0];
+                let idx2 = sq + direction[1];
+                let idx3 = sq + direction[2];
+                let idx4 = sq + direction[3];
 
                 let val0 = pos.state[idx0 as usize];
                 let val1 = pos.state[idx1 as usize];
@@ -824,13 +824,13 @@ fn check_patternlive3(pos: &Pos, sd: Side) -> i32 {
         for fl in 0..FILE_SIZE {
             let sq: Square = square_make(fl, rk);
 
-            for dir in 0..4 {
+            for direction in &DIRECTION {
                 let idx0 = sq;
-                let idx1 = sq + DIRECTION[dir][0];
-                let idx2 = sq + DIRECTION[dir][1];
-                let idx3 = sq + DIRECTION[dir][2];
-                let idx4 = sq + DIRECTION[dir][3];
-                let idx5 = sq + DIRECTION[dir][4];
+                let idx1 = sq + direction[0];
+                let idx2 = sq + direction[1];
+                let idx3 = sq + direction[2];
+                let idx4 = sq + direction[3];
+                let idx5 = sq + direction[4];
 
                 let val0 = pos.state[idx0 as usize];
                 let val1 = pos.state[idx1 as usize];


### PR DESCRIPTION
In the development of `stdarch`, we encounter many warnings (mainly from Clippy; currently 133 as counted by Rust Analyzer and 132 as counted by `cargo clippy`) and hid real warnings we need to take care of.

However, the author found that source of such changes are mainly from old Rust code (which does not know newer coding styles) and decided to deal with it by this PR.

# Policy

I allowed `clippy::collapsible_if` for now (to be reviewed) because it's just nested `if`s.
I allowed `clippy::obfuscated_if_else` because a candidate to fix this issue looked more complex than before.
I allowed `clippy::manual_range_contains` (as suggested by @Amanieu) because *fixing* the warning will complicate the code.

Other than that, I mostly used suggestions generated by Clippy.

# Further Simplification

In `crates/stdarch-gen-arm/src/fn_suffix.rs`, I also simplified the code (use a new variable to deal with Clippy warnings and use `format!()` macro) where no warnings are generated.  It makes the code more simple and easier to maintain.