### PR TITLE
RISC-V: Linux 6.15 `riscv_hwprobe` support

### DIFF
--- a/crates/std_detect/src/detect/arch/riscv.rs
+++ b/crates/std_detect/src/detect/arch/riscv.rs
@@ -63,6 +63,7 @@ features! {
     ///   * Zve64x: `"zve64x"`
     ///   * Zve64f: `"zve64f"`
     ///   * Zve64d: `"zve64d"`
+    /// * Zicbom: `"zicbom"`
     /// * Zicboz: `"zicboz"`
     /// * Zicntr: `"zicntr"`
     /// * Zicond: `"zicond"`
@@ -75,6 +76,7 @@ features! {
     /// * Zacas: `"zacas"`
     /// * Zawrs: `"zawrs"`
     /// * Zfa: `"zfa"`
+    /// * Zfbfmin: `"zfbfmin"`
     /// * Zfh: `"zfh"`
     ///   * Zfhmin: `"zfhmin"`
     /// * Zfinx: `"zfinx"`
@@ -99,6 +101,8 @@ features! {
     /// * Zkt: `"zkt"`
     /// * Zvbb: `"zvbb"`
     /// * Zvbc: `"zvbc"`
+    /// * Zvfbfmin: `"zvfbfmin"`
+    /// * Zvfbfwma: `"zvfbfwma"`
     /// * Zvfh: `"zvfh"`
     ///   * Zvfhmin: `"zvfhmin"`
     /// * Zvkb: `"zvkb"`
@@ -173,6 +177,8 @@ features! {
     /// "Zihintpause" Extension for Pause Hint
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zimop: "zimop";
     /// "Zimop" Extension for May-Be-Operations
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicbom: "zicbom";
+    /// "Zicbom" Extension for Cache-Block Management Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicboz: "zicboz";
     /// "Zicboz" Extension for Cache-Block Zero Instruction
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zicond: "zicond";
@@ -210,6 +216,8 @@ features! {
     /// "Zfhmin" Extension for Minimal Half-Precision Floating-Point
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfa: "zfa";
     /// "Zfa" Extension for Additional Floating-Point Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfbfmin: "zfbfmin";
+    /// "Zfbfmin" Extension for Scalar BF16 Converts
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zfinx: "zfinx";
     /// "Zfinx" Extension for Single-Precision Floating-Point in Integer Registers
@@ -289,6 +297,10 @@ features! {
     /// "Zvfh" Vector Extension for Half-Precision Floating-Point
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvfhmin: "zvfhmin";
     /// "Zvfhmin" Vector Extension for Minimal Half-Precision Floating-Point
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvfbfmin: "zvfbfmin";
+    /// "Zvfbfmin" Vector Extension for BF16 Converts
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvfbfwma: "zvfbfwma";
+    /// "Zvfbfwma" Vector Extension for BF16 Widening Multiply-Add
 
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zvbb: "zvbb";
     /// "Zvbb" Extension for Vector Basic Bit-Manipulation

--- a/crates/std_detect/src/detect/os/riscv.rs
+++ b/crates/std_detect/src/detect/os/riscv.rs
@@ -105,6 +105,8 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
         imply!(zvfh => zvfhmin); // functional
         imply!(zvfh => zve32f & zfhmin);
         imply!(zvfhmin => zve32f);
+        imply!(zvfbfwma => zvfbfmin & zfbfmin);
+        imply!(zvfbfmin => zve32f);
 
         imply!(v => zve64d);
         imply!(zve64d => zve64f & d);
@@ -115,6 +117,7 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
         imply!(zfh => zfhmin);
         imply!(q => d);
         imply!(d | zfhmin | zfa => f);
+        imply!(zfbfmin => f); // and some of (not all) "Zfh" instructions.
 
         // Relatively complex implication rules from the "C" extension.
         imply!(c => zca);

--- a/crates/std_detect/tests/cpu-detection.rs
+++ b/crates/std_detect/tests/cpu-detection.rs
@@ -251,6 +251,7 @@ fn riscv_linux() {
     println!("zihintntl: {}", is_riscv_feature_detected!("zihintntl"));
     println!("zihintpause: {}", is_riscv_feature_detected!("zihintpause"));
     println!("zimop: {}", is_riscv_feature_detected!("zimop"));
+    println!("zicbom: {}", is_riscv_feature_detected!("zicbom"));
     println!("zicboz: {}", is_riscv_feature_detected!("zicboz"));
     println!("zicond: {}", is_riscv_feature_detected!("zicond"));
     println!("m: {}", is_riscv_feature_detected!("m"));
@@ -267,6 +268,7 @@ fn riscv_linux() {
     println!("zfh: {}", is_riscv_feature_detected!("zfh"));
     println!("zfhmin: {}", is_riscv_feature_detected!("zfhmin"));
     println!("zfa: {}", is_riscv_feature_detected!("zfa"));
+    println!("zfbfmin: {}", is_riscv_feature_detected!("zfbfmin"));
     println!("zfinx: {}", is_riscv_feature_detected!("zfinx"));
     println!("zdinx: {}", is_riscv_feature_detected!("zdinx"));
     println!("zhinx: {}", is_riscv_feature_detected!("zhinx"));
@@ -303,6 +305,8 @@ fn riscv_linux() {
     println!("zve64d: {}", is_riscv_feature_detected!("zve64d"));
     println!("zvfh: {}", is_riscv_feature_detected!("zvfh"));
     println!("zvfhmin: {}", is_riscv_feature_detected!("zvfhmin"));
+    println!("zvfbfmin: {}", is_riscv_feature_detected!("zvfbfmin"));
+    println!("zvfbfwma: {}", is_riscv_feature_detected!("zvfbfwma"));
     println!("zvbb: {}", is_riscv_feature_detected!("zvbb"));
     println!("zvbc: {}", is_riscv_feature_detected!("zvbc"));
     println!("zvkb: {}", is_riscv_feature_detected!("zvkb"));


### PR DESCRIPTION
This commit adds support for `riscv_hwprobe` on the Linux kernel 6.15. It adds feature detection of 8 extensions (4 of them are new in this).

Existing RISC-V Extensions:

1.  `Zicntr`
2.  `Zihpm`
3.  `Zalrsc`
4.  `Zaamo`

New RISC-V Extensions:

5.  `Zicbom`
6.  `Zfbfmin`
7.  `Zvfbfmin`
8.  `Zvfbfwma`

Note: four new extensions are already added to beta (cf. rust-lang/rust#140507) and checking `cfg` should be okay.