### PR TITLE
Fix Neon f16 stability

### DIFF
--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -3851,14 +3851,7 @@ pub fn vbicq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(bsl)
 )]
-#[cfg_attr(
-    not(target_arch = "arm"),
-    stable(feature = "neon_intrinsics", since = "1.59.0")
-)]
-#[cfg_attr(
-    target_arch = "arm",
-    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
-)]
+#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vbsl_f16(a: uint16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     let not = int16x4_t::splat(-1);
     unsafe {
@@ -3878,14 +3871,7 @@ pub fn vbsl_f16(a: uint16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(bsl)
 )]
-#[cfg_attr(
-    not(target_arch = "arm"),
-    stable(feature = "neon_intrinsics", since = "1.59.0")
-)]
-#[cfg_attr(
-    target_arch = "arm",
-    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
-)]
+#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vbslq_f16(a: uint16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
     let not = int16x8_t::splat(-1);
     unsafe {

--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -62,8 +62,6 @@ types! {
     pub struct int16x4_t(4 x pub(crate) i16);
     /// Arm-specific 64-bit wide vector of four packed `u16`.
     pub struct uint16x4_t(4 x pub(crate) u16);
-    //  Arm-specific 64-bit wide vector of four packed `f16`.
-    pub struct float16x4_t(4 x pub(crate) f16);
     /// Arm-specific 64-bit wide vector of four packed `p16`.
     pub struct poly16x4_t(4 x pub(crate) p16);
     /// Arm-specific 64-bit wide vector of two packed `i32`.
@@ -89,8 +87,6 @@ types! {
     pub struct int16x8_t(8 x pub(crate) i16);
     /// Arm-specific 128-bit wide vector of eight packed `u16`.
     pub struct uint16x8_t(8 x pub(crate) u16);
-    //  Arm-specific 128-bit wide vector of eight packed `f16`.
-    pub struct float16x8_t(8 x pub(crate) f16);
     /// Arm-specific 128-bit wide vector of eight packed `p16`.
     pub struct poly16x8_t(8 x pub(crate) p16);
     /// Arm-specific 128-bit wide vector of four packed `i32`.
@@ -105,6 +101,15 @@ types! {
     pub struct uint64x2_t(2 x pub(crate) u64);
     /// Arm-specific 128-bit wide vector of two packed `p64`.
     pub struct poly64x2_t(2 x pub(crate) p64);
+}
+
+types! {
+    #![unstable(feature = "stdarch_neon_f16", issue = "136306")]
+
+    /// Arm-specific 64-bit wide vector of four packed `f16`.
+    pub struct float16x4_t(4 x pub(crate) f16);
+    /// Arm-specific 128-bit wide vector of eight packed `f16`.
+    pub struct float16x8_t(8 x pub(crate) f16);
 }
 
 /// Arm-specific type containing two `int8x8_t` vectors.

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -14644,8 +14644,7 @@ intrinsics:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, { FnCall: [assert_instr, ['vbsl']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, ['bsl']]}]]
-      - *neon-not-arm-stable
-      - *neon-cfg-arm-unstable
+      - *neon-unstable-f16
     safety: safe
     types:
       - ['vbslq_f16', 'uint16x8_t', 'float16x8_t', 'int16x8_t::splat(-1)']


### PR DESCRIPTION
In https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/is.20.60arch.3A.3Aaarch64.3A.3Afloat16x8_t.60.20supposed.20to.20be.20stable.3F/with/520762685 it was noted that some f16 Neon types were incorrectly stable when introduced and that some f16 Neon intrinsics were incorrectly changed from unstable to stable recently.

The latter is a regression from stable to beta and could be nominated for a beta backport, but I couldn't find any process or precedent for doing this on stdarch.