### PR TITLE
Fix some more uses of LLVM intrinsics

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -10072,14 +10072,7 @@ pub fn vextq_p64<const N: i32>(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmadd))]
 pub fn vfma_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.v1f64"
-        )]
-        fn _vfma_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vfma_f64(b, c, a) }
+    unsafe { simd_fma(b, c, a) }
 }
 #[doc = "Floating-point fused multiply-add to accumulator"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfma_lane_f16)"]
@@ -10281,17 +10274,10 @@ pub fn vfma_n_f64(a: float64x1_t, b: float64x1_t, c: f64) -> float64x1_t {
 #[rustc_legacy_const_generics(3)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vfmad_lane_f64<const LANE: i32>(a: f64, b: f64, c: float64x1_t) -> f64 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.f64"
-        )]
-        fn _vfmad_lane_f64(a: f64, b: f64, c: f64) -> f64;
-    }
     static_assert!(LANE == 0);
     unsafe {
         let c: f64 = simd_extract!(c, LANE as u32);
-        _vfmad_lane_f64(b, c, a)
+        fmaf64(b, c, a)
     }
 }
 #[doc = "Floating-point fused multiply-add to accumulator"]
@@ -10301,14 +10287,7 @@ pub fn vfmad_lane_f64<const LANE: i32>(a: f64, b: f64, c: float64x1_t) -> f64 {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vfmah_f16(a: f16, b: f16, c: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.f16"
-        )]
-        fn _vfmah_f16(a: f16, b: f16, c: f16) -> f16;
-    }
-    unsafe { _vfmah_f16(b, c, a) }
+    unsafe { fmaf16(b, c, a) }
 }
 #[doc = "Floating-point fused multiply-add to accumulator"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfmah_lane_f16)"]
@@ -10345,14 +10324,7 @@ pub fn vfmah_laneq_f16<const LANE: i32>(a: f16, b: f16, v: float16x8_t) -> f16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmla))]
 pub fn vfmaq_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.v2f64"
-        )]
-        fn _vfmaq_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vfmaq_f64(b, c, a) }
+    unsafe { simd_fma(b, c, a) }
 }
 #[doc = "Floating-point fused multiply-add to accumulator"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfmaq_lane_f64)"]
@@ -10386,17 +10358,10 @@ pub fn vfmaq_n_f64(a: float64x2_t, b: float64x2_t, c: f64) -> float64x2_t {
 #[rustc_legacy_const_generics(3)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vfmas_lane_f32<const LANE: i32>(a: f32, b: f32, c: float32x2_t) -> f32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.f32"
-        )]
-        fn _vfmas_lane_f32(a: f32, b: f32, c: f32) -> f32;
-    }
     static_assert_uimm_bits!(LANE, 1);
     unsafe {
         let c: f32 = simd_extract!(c, LANE as u32);
-        _vfmas_lane_f32(b, c, a)
+        fmaf32(b, c, a)
     }
 }
 #[doc = "Floating-point fused multiply-add to accumulator"]
@@ -10407,17 +10372,10 @@ pub fn vfmas_lane_f32<const LANE: i32>(a: f32, b: f32, c: float32x2_t) -> f32 {
 #[rustc_legacy_const_generics(3)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vfmas_laneq_f32<const LANE: i32>(a: f32, b: f32, c: float32x4_t) -> f32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.f32"
-        )]
-        fn _vfmas_laneq_f32(a: f32, b: f32, c: f32) -> f32;
-    }
     static_assert_uimm_bits!(LANE, 2);
     unsafe {
         let c: f32 = simd_extract!(c, LANE as u32);
-        _vfmas_laneq_f32(b, c, a)
+        fmaf32(b, c, a)
     }
 }
 #[doc = "Floating-point fused multiply-add to accumulator"]
@@ -10428,17 +10386,10 @@ pub fn vfmas_laneq_f32<const LANE: i32>(a: f32, b: f32, c: float32x4_t) -> f32 {
 #[rustc_legacy_const_generics(3)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vfmad_laneq_f64<const LANE: i32>(a: f64, b: f64, c: float64x2_t) -> f64 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.fma.f64"
-        )]
-        fn _vfmad_laneq_f64(a: f64, b: f64, c: f64) -> f64;
-    }
     static_assert_uimm_bits!(LANE, 1);
     unsafe {
         let c: f64 = simd_extract!(c, LANE as u32);
-        _vfmad_laneq_f64(b, c, a)
+        fmaf64(b, c, a)
     }
 }
 #[doc = "Floating-point fused Multiply-Add Long to accumulator (vector)."]
@@ -23406,14 +23357,7 @@ pub fn vrnd64z_f64(a: float64x1_t) -> float64x1_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrnd_f16(a: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.v4f16"
-        )]
-        fn _vrnd_f16(a: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vrnd_f16(a) }
+    unsafe { simd_trunc(a) }
 }
 #[doc = "Floating-point round to integral, toward zero"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndq_f16)"]
@@ -23422,14 +23366,7 @@ pub fn vrnd_f16(a: float16x4_t) -> float16x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrndq_f16(a: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.v8f16"
-        )]
-        fn _vrndq_f16(a: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vrndq_f16(a) }
+    unsafe { simd_trunc(a) }
 }
 #[doc = "Floating-point round to integral, toward zero"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnd_f32)"]
@@ -23438,14 +23375,7 @@ pub fn vrndq_f16(a: float16x8_t) -> float16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrnd_f32(a: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.v2f32"
-        )]
-        fn _vrnd_f32(a: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vrnd_f32(a) }
+    unsafe { simd_trunc(a) }
 }
 #[doc = "Floating-point round to integral, toward zero"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndq_f32)"]
@@ -23454,14 +23384,7 @@ pub fn vrnd_f32(a: float32x2_t) -> float32x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrndq_f32(a: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.v4f32"
-        )]
-        fn _vrndq_f32(a: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vrndq_f32(a) }
+    unsafe { simd_trunc(a) }
 }
 #[doc = "Floating-point round to integral, toward zero"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnd_f64)"]
@@ -23470,14 +23393,7 @@ pub fn vrndq_f32(a: float32x4_t) -> float32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrnd_f64(a: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.v1f64"
-        )]
-        fn _vrnd_f64(a: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vrnd_f64(a) }
+    unsafe { simd_trunc(a) }
 }
 #[doc = "Floating-point round to integral, toward zero"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndq_f64)"]
@@ -23486,14 +23402,7 @@ pub fn vrnd_f64(a: float64x1_t) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrndq_f64(a: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.v2f64"
-        )]
-        fn _vrndq_f64(a: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vrndq_f64(a) }
+    unsafe { simd_trunc(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnda_f16)"]
@@ -23502,14 +23411,7 @@ pub fn vrndq_f64(a: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrnda_f16(a: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.v4f16"
-        )]
-        fn _vrnda_f16(a: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vrnda_f16(a) }
+    unsafe { simd_round(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndaq_f16)"]
@@ -23518,14 +23420,7 @@ pub fn vrnda_f16(a: float16x4_t) -> float16x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrndaq_f16(a: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.v8f16"
-        )]
-        fn _vrndaq_f16(a: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vrndaq_f16(a) }
+    unsafe { simd_round(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnda_f32)"]
@@ -23534,14 +23429,7 @@ pub fn vrndaq_f16(a: float16x8_t) -> float16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrnda_f32(a: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.v2f32"
-        )]
-        fn _vrnda_f32(a: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vrnda_f32(a) }
+    unsafe { simd_round(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndaq_f32)"]
@@ -23550,14 +23438,7 @@ pub fn vrnda_f32(a: float32x2_t) -> float32x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrndaq_f32(a: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.v4f32"
-        )]
-        fn _vrndaq_f32(a: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vrndaq_f32(a) }
+    unsafe { simd_round(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnda_f64)"]
@@ -23566,14 +23447,7 @@ pub fn vrndaq_f32(a: float32x4_t) -> float32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrnda_f64(a: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.v1f64"
-        )]
-        fn _vrnda_f64(a: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vrnda_f64(a) }
+    unsafe { simd_round(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndaq_f64)"]
@@ -23582,14 +23456,7 @@ pub fn vrnda_f64(a: float64x1_t) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrndaq_f64(a: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.v2f64"
-        )]
-        fn _vrndaq_f64(a: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vrndaq_f64(a) }
+    unsafe { simd_round(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndah_f16)"]
@@ -23598,14 +23465,7 @@ pub fn vrndaq_f64(a: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrndah_f16(a: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.round.f16"
-        )]
-        fn _vrndah_f16(a: f16) -> f16;
-    }
-    unsafe { _vrndah_f16(a) }
+    unsafe { roundf16(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to away"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndh_f16)"]
@@ -23614,14 +23474,7 @@ pub fn vrndah_f16(a: f16) -> f16 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrndh_f16(a: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.trunc.f16"
-        )]
-        fn _vrndh_f16(a: f16) -> f16;
-    }
-    unsafe { _vrndh_f16(a) }
+    unsafe { truncf16(a) }
 }
 #[doc = "Floating-point round to integral, using current rounding mode"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndi_f16)"]
@@ -23742,14 +23595,7 @@ pub fn vrndih_f16(a: f16) -> f16 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndm_f16(a: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.v4f16"
-        )]
-        fn _vrndm_f16(a: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vrndm_f16(a) }
+    unsafe { simd_floor(a) }
 }
 #[doc = "Floating-point round to integral, toward minus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndmq_f16)"]
@@ -23758,14 +23604,7 @@ pub fn vrndm_f16(a: float16x4_t) -> float16x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndmq_f16(a: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.v8f16"
-        )]
-        fn _vrndmq_f16(a: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vrndmq_f16(a) }
+    unsafe { simd_floor(a) }
 }
 #[doc = "Floating-point round to integral, toward minus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndm_f32)"]
@@ -23774,14 +23613,7 @@ pub fn vrndmq_f16(a: float16x8_t) -> float16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndm_f32(a: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.v2f32"
-        )]
-        fn _vrndm_f32(a: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vrndm_f32(a) }
+    unsafe { simd_floor(a) }
 }
 #[doc = "Floating-point round to integral, toward minus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndmq_f32)"]
@@ -23790,14 +23622,7 @@ pub fn vrndm_f32(a: float32x2_t) -> float32x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndmq_f32(a: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.v4f32"
-        )]
-        fn _vrndmq_f32(a: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vrndmq_f32(a) }
+    unsafe { simd_floor(a) }
 }
 #[doc = "Floating-point round to integral, toward minus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndm_f64)"]
@@ -23806,14 +23631,7 @@ pub fn vrndmq_f32(a: float32x4_t) -> float32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndm_f64(a: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.v1f64"
-        )]
-        fn _vrndm_f64(a: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vrndm_f64(a) }
+    unsafe { simd_floor(a) }
 }
 #[doc = "Floating-point round to integral, toward minus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndmq_f64)"]
@@ -23822,14 +23640,7 @@ pub fn vrndm_f64(a: float64x1_t) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndmq_f64(a: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.v2f64"
-        )]
-        fn _vrndmq_f64(a: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vrndmq_f64(a) }
+    unsafe { simd_floor(a) }
 }
 #[doc = "Floating-point round to integral, toward minus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndmh_f16)"]
@@ -23838,14 +23649,7 @@ pub fn vrndmq_f64(a: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndmh_f16(a: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.floor.f16"
-        )]
-        fn _vrndmh_f16(a: f16) -> f16;
-    }
-    unsafe { _vrndmh_f16(a) }
+    unsafe { floorf16(a) }
 }
 #[doc = "Floating-point round to integral, to nearest with ties to even"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndn_f64)"]
@@ -23918,14 +23722,7 @@ pub fn vrndns_f32(a: f32) -> f32 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndp_f16(a: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.v4f16"
-        )]
-        fn _vrndp_f16(a: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vrndp_f16(a) }
+    unsafe { simd_ceil(a) }
 }
 #[doc = "Floating-point round to integral, toward plus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndpq_f16)"]
@@ -23934,14 +23731,7 @@ pub fn vrndp_f16(a: float16x4_t) -> float16x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndpq_f16(a: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.v8f16"
-        )]
-        fn _vrndpq_f16(a: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vrndpq_f16(a) }
+    unsafe { simd_ceil(a) }
 }
 #[doc = "Floating-point round to integral, toward plus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndp_f32)"]
@@ -23950,14 +23740,7 @@ pub fn vrndpq_f16(a: float16x8_t) -> float16x8_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndp_f32(a: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.v2f32"
-        )]
-        fn _vrndp_f32(a: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vrndp_f32(a) }
+    unsafe { simd_ceil(a) }
 }
 #[doc = "Floating-point round to integral, toward plus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndpq_f32)"]
@@ -23966,14 +23749,7 @@ pub fn vrndp_f32(a: float32x2_t) -> float32x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndpq_f32(a: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.v4f32"
-        )]
-        fn _vrndpq_f32(a: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vrndpq_f32(a) }
+    unsafe { simd_ceil(a) }
 }
 #[doc = "Floating-point round to integral, toward plus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndp_f64)"]
@@ -23982,14 +23758,7 @@ pub fn vrndpq_f32(a: float32x4_t) -> float32x4_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndp_f64(a: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.v1f64"
-        )]
-        fn _vrndp_f64(a: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vrndp_f64(a) }
+    unsafe { simd_ceil(a) }
 }
 #[doc = "Floating-point round to integral, toward plus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndpq_f64)"]
@@ -23998,14 +23767,7 @@ pub fn vrndp_f64(a: float64x1_t) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndpq_f64(a: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.v2f64"
-        )]
-        fn _vrndpq_f64(a: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vrndpq_f64(a) }
+    unsafe { simd_ceil(a) }
 }
 #[doc = "Floating-point round to integral, toward plus infinity"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndph_f16)"]
@@ -24014,14 +23776,7 @@ pub fn vrndpq_f64(a: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndph_f16(a: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ceil.f16"
-        )]
-        fn _vrndph_f16(a: f16) -> f16;
-    }
-    unsafe { _vrndph_f16(a) }
+    unsafe { ceilf16(a) }
 }
 #[doc = "Floating-point round to integral exact, using current rounding mode"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndx_f16)"]
@@ -24126,14 +23881,7 @@ pub fn vrndxq_f64(a: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(frintx))]
 pub fn vrndxh_f16(a: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.rint.f16"
-        )]
-        fn _vrndxh_f16(a: f16) -> f16;
-    }
-    unsafe { _vrndxh_f16(a) }
+    round_ties_even_f16(a)
 }
 #[doc = "Signed rounding shift left"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrshld_s64)"]
@@ -25561,14 +25309,7 @@ pub fn vsqrtq_f64(a: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fsqrt))]
 pub fn vsqrth_f16(a: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.sqrt.f16"
-        )]
-        fn _vsqrth_f16(a: f16) -> f16;
-    }
-    unsafe { _vsqrth_f16(a) }
+    unsafe { sqrtf16(a) }
 }
 #[doc = "Shift Right and Insert (immediate)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsri_n_s8)"]

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -623,7 +623,7 @@ pub fn vaddv_s8(a: int8x8_t) -> i8 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i32.v8i8"
+            link_name = "llvm.aarch64.neon.saddv.i8.v8i8"
         )]
         fn _vaddv_s8(a: int8x8_t) -> i8;
     }
@@ -639,7 +639,7 @@ pub fn vaddvq_s8(a: int8x16_t) -> i8 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i32.v16i8"
+            link_name = "llvm.aarch64.neon.saddv.i8.v16i8"
         )]
         fn _vaddvq_s8(a: int8x16_t) -> i8;
     }
@@ -655,7 +655,7 @@ pub fn vaddv_s16(a: int16x4_t) -> i16 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i32.v4i16"
+            link_name = "llvm.aarch64.neon.saddv.i16.v4i16"
         )]
         fn _vaddv_s16(a: int16x4_t) -> i16;
     }
@@ -671,7 +671,7 @@ pub fn vaddvq_s16(a: int16x8_t) -> i16 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i32.v8i16"
+            link_name = "llvm.aarch64.neon.saddv.i16.v8i16"
         )]
         fn _vaddvq_s16(a: int16x8_t) -> i16;
     }
@@ -719,7 +719,7 @@ pub fn vaddv_u8(a: uint8x8_t) -> u8 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i32.v8i8"
+            link_name = "llvm.aarch64.neon.uaddv.i8.v8i8"
         )]
         fn _vaddv_u8(a: uint8x8_t) -> u8;
     }
@@ -735,7 +735,7 @@ pub fn vaddvq_u8(a: uint8x16_t) -> u8 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i32.v16i8"
+            link_name = "llvm.aarch64.neon.uaddv.i8.v16i8"
         )]
         fn _vaddvq_u8(a: uint8x16_t) -> u8;
     }
@@ -751,7 +751,7 @@ pub fn vaddv_u16(a: uint16x4_t) -> u16 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i32.v4i16"
+            link_name = "llvm.aarch64.neon.uaddv.i16.v4i16"
         )]
         fn _vaddv_u16(a: uint16x4_t) -> u16;
     }
@@ -767,7 +767,7 @@ pub fn vaddvq_u16(a: uint16x8_t) -> u16 {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i32.v8i16"
+            link_name = "llvm.aarch64.neon.uaddv.i16.v8i16"
         )]
         fn _vaddvq_u16(a: uint16x8_t) -> u16;
     }

--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -11421,7 +11421,7 @@ pub unsafe fn vld1_f64_x2(a: *const f64) -> float64x1x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x2.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld1x2.v1f64.p0"
         )]
         fn _vld1_f64_x2(a: *const f64) -> float64x1x2_t;
     }
@@ -11439,7 +11439,7 @@ pub unsafe fn vld1_f64_x3(a: *const f64) -> float64x1x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x3.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld1x3.v1f64.p0"
         )]
         fn _vld1_f64_x3(a: *const f64) -> float64x1x3_t;
     }
@@ -11457,7 +11457,7 @@ pub unsafe fn vld1_f64_x4(a: *const f64) -> float64x1x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x4.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld1x4.v1f64.p0"
         )]
         fn _vld1_f64_x4(a: *const f64) -> float64x1x4_t;
     }
@@ -11475,7 +11475,7 @@ pub unsafe fn vld1q_f64_x2(a: *const f64) -> float64x2x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x2.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld1x2.v2f64.p0"
         )]
         fn _vld1q_f64_x2(a: *const f64) -> float64x2x2_t;
     }
@@ -11493,7 +11493,7 @@ pub unsafe fn vld1q_f64_x3(a: *const f64) -> float64x2x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x3.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld1x3.v2f64.p0"
         )]
         fn _vld1q_f64_x3(a: *const f64) -> float64x2x3_t;
     }
@@ -11511,7 +11511,7 @@ pub unsafe fn vld1q_f64_x4(a: *const f64) -> float64x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x4.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld1x4.v2f64.p0"
         )]
         fn _vld1q_f64_x4(a: *const f64) -> float64x2x4_t;
     }
@@ -11529,7 +11529,7 @@ pub unsafe fn vld2_dup_f64(a: *const f64) -> float64x1x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2r.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld2r.v1f64.p0"
         )]
         fn _vld2_dup_f64(ptr: *const f64) -> float64x1x2_t;
     }
@@ -11547,7 +11547,7 @@ pub unsafe fn vld2q_dup_f64(a: *const f64) -> float64x2x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2r.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld2r.v2f64.p0"
         )]
         fn _vld2q_dup_f64(ptr: *const f64) -> float64x2x2_t;
     }
@@ -11565,7 +11565,7 @@ pub unsafe fn vld2q_dup_s64(a: *const i64) -> int64x2x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2r.v2i64.p0i64"
+            link_name = "llvm.aarch64.neon.ld2r.v2i64.p0"
         )]
         fn _vld2q_dup_s64(ptr: *const i64) -> int64x2x2_t;
     }
@@ -11583,7 +11583,7 @@ pub unsafe fn vld2_f64(a: *const f64) -> float64x1x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2.v1f64.p0v1f64"
+            link_name = "llvm.aarch64.neon.ld2.v1f64.p0"
         )]
         fn _vld2_f64(ptr: *const float64x1_t) -> float64x1x2_t;
     }
@@ -11603,7 +11603,7 @@ pub unsafe fn vld2_lane_f64<const LANE: i32>(a: *const f64, b: float64x1x2_t) ->
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2lane.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.ld2lane.v1f64.p0"
         )]
         fn _vld2_lane_f64(a: float64x1_t, b: float64x1_t, n: i64, ptr: *const i8) -> float64x1x2_t;
     }
@@ -11623,7 +11623,7 @@ pub unsafe fn vld2_lane_s64<const LANE: i32>(a: *const i64, b: int64x1x2_t) -> i
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2lane.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.ld2lane.v1i64.p0"
         )]
         fn _vld2_lane_s64(a: int64x1_t, b: int64x1_t, n: i64, ptr: *const i8) -> int64x1x2_t;
     }
@@ -11721,7 +11721,7 @@ pub unsafe fn vld2q_f64(a: *const f64) -> float64x2x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2.v2f64.p0v2f64"
+            link_name = "llvm.aarch64.neon.ld2.v2f64.p0"
         )]
         fn _vld2q_f64(ptr: *const float64x2_t) -> float64x2x2_t;
     }
@@ -11739,7 +11739,7 @@ pub unsafe fn vld2q_s64(a: *const i64) -> int64x2x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2.v2i64.p0v2i64"
+            link_name = "llvm.aarch64.neon.ld2.v2i64.p0"
         )]
         fn _vld2q_s64(ptr: *const int64x2_t) -> int64x2x2_t;
     }
@@ -11759,7 +11759,7 @@ pub unsafe fn vld2q_lane_f64<const LANE: i32>(a: *const f64, b: float64x2x2_t) -
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2lane.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.ld2lane.v2f64.p0"
         )]
         fn _vld2q_lane_f64(a: float64x2_t, b: float64x2_t, n: i64, ptr: *const i8)
             -> float64x2x2_t;
@@ -11780,7 +11780,7 @@ pub unsafe fn vld2q_lane_s8<const LANE: i32>(a: *const i8, b: int8x16x2_t) -> in
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2lane.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.ld2lane.v16i8.p0"
         )]
         fn _vld2q_lane_s8(a: int8x16_t, b: int8x16_t, n: i64, ptr: *const i8) -> int8x16x2_t;
     }
@@ -11800,7 +11800,7 @@ pub unsafe fn vld2q_lane_s64<const LANE: i32>(a: *const i64, b: int64x2x2_t) -> 
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2lane.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.ld2lane.v2i64.p0"
         )]
         fn _vld2q_lane_s64(a: int64x2_t, b: int64x2_t, n: i64, ptr: *const i8) -> int64x2x2_t;
     }
@@ -11924,7 +11924,7 @@ pub unsafe fn vld3_dup_f64(a: *const f64) -> float64x1x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3r.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld3r.v1f64.p0"
         )]
         fn _vld3_dup_f64(ptr: *const f64) -> float64x1x3_t;
     }
@@ -11942,7 +11942,7 @@ pub unsafe fn vld3q_dup_f64(a: *const f64) -> float64x2x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3r.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld3r.v2f64.p0"
         )]
         fn _vld3q_dup_f64(ptr: *const f64) -> float64x2x3_t;
     }
@@ -11960,7 +11960,7 @@ pub unsafe fn vld3q_dup_s64(a: *const i64) -> int64x2x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3r.v2i64.p0i64"
+            link_name = "llvm.aarch64.neon.ld3r.v2i64.p0"
         )]
         fn _vld3q_dup_s64(ptr: *const i64) -> int64x2x3_t;
     }
@@ -11978,7 +11978,7 @@ pub unsafe fn vld3_f64(a: *const f64) -> float64x1x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3.v1f64.p0v1f64"
+            link_name = "llvm.aarch64.neon.ld3.v1f64.p0"
         )]
         fn _vld3_f64(ptr: *const float64x1_t) -> float64x1x3_t;
     }
@@ -11998,7 +11998,7 @@ pub unsafe fn vld3_lane_f64<const LANE: i32>(a: *const f64, b: float64x1x3_t) ->
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3lane.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.ld3lane.v1f64.p0"
         )]
         fn _vld3_lane_f64(
             a: float64x1_t,
@@ -12037,7 +12037,7 @@ pub unsafe fn vld3_lane_s64<const LANE: i32>(a: *const i64, b: int64x1x3_t) -> i
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3lane.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.ld3lane.v1i64.p0"
         )]
         fn _vld3_lane_s64(
             a: int64x1_t,
@@ -12130,7 +12130,7 @@ pub unsafe fn vld3q_f64(a: *const f64) -> float64x2x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3.v2f64.p0v2f64"
+            link_name = "llvm.aarch64.neon.ld3.v2f64.p0"
         )]
         fn _vld3q_f64(ptr: *const float64x2_t) -> float64x2x3_t;
     }
@@ -12148,7 +12148,7 @@ pub unsafe fn vld3q_s64(a: *const i64) -> int64x2x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3.v2i64.p0v2i64"
+            link_name = "llvm.aarch64.neon.ld3.v2i64.p0"
         )]
         fn _vld3q_s64(ptr: *const int64x2_t) -> int64x2x3_t;
     }
@@ -12168,7 +12168,7 @@ pub unsafe fn vld3q_lane_f64<const LANE: i32>(a: *const f64, b: float64x2x3_t) -
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3lane.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.ld3lane.v2f64.p0"
         )]
         fn _vld3q_lane_f64(
             a: float64x2_t,
@@ -12207,7 +12207,7 @@ pub unsafe fn vld3q_lane_s8<const LANE: i32>(a: *const i8, b: int8x16x3_t) -> in
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3lane.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.ld3lane.v16i8.p0"
         )]
         fn _vld3q_lane_s8(
             a: int8x16_t,
@@ -12233,7 +12233,7 @@ pub unsafe fn vld3q_lane_s64<const LANE: i32>(a: *const i64, b: int64x2x3_t) -> 
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3lane.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.ld3lane.v2i64.p0"
         )]
         fn _vld3q_lane_s64(
             a: int64x2_t,
@@ -12352,7 +12352,7 @@ pub unsafe fn vld4_dup_f64(a: *const f64) -> float64x1x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld4r.v1f64.p0"
         )]
         fn _vld4_dup_f64(ptr: *const f64) -> float64x1x4_t;
     }
@@ -12370,7 +12370,7 @@ pub unsafe fn vld4q_dup_f64(a: *const f64) -> float64x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.ld4r.v2f64.p0"
         )]
         fn _vld4q_dup_f64(ptr: *const f64) -> float64x2x4_t;
     }
@@ -12388,7 +12388,7 @@ pub unsafe fn vld4q_dup_s64(a: *const i64) -> int64x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v2i64.p0i64"
+            link_name = "llvm.aarch64.neon.ld4r.v2i64.p0"
         )]
         fn _vld4q_dup_s64(ptr: *const i64) -> int64x2x4_t;
     }
@@ -12406,7 +12406,7 @@ pub unsafe fn vld4_f64(a: *const f64) -> float64x1x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4.v1f64.p0v1f64"
+            link_name = "llvm.aarch64.neon.ld4.v1f64.p0"
         )]
         fn _vld4_f64(ptr: *const float64x1_t) -> float64x1x4_t;
     }
@@ -12426,7 +12426,7 @@ pub unsafe fn vld4_lane_f64<const LANE: i32>(a: *const f64, b: float64x1x4_t) ->
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4lane.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.ld4lane.v1f64.p0"
         )]
         fn _vld4_lane_f64(
             a: float64x1_t,
@@ -12453,7 +12453,7 @@ pub unsafe fn vld4_lane_s64<const LANE: i32>(a: *const i64, b: int64x1x4_t) -> i
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4lane.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.ld4lane.v1i64.p0"
         )]
         fn _vld4_lane_s64(
             a: int64x1_t,
@@ -12562,7 +12562,7 @@ pub unsafe fn vld4q_f64(a: *const f64) -> float64x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4.v2f64.p0v2f64"
+            link_name = "llvm.aarch64.neon.ld4.v2f64.p0"
         )]
         fn _vld4q_f64(ptr: *const float64x2_t) -> float64x2x4_t;
     }
@@ -12580,7 +12580,7 @@ pub unsafe fn vld4q_s64(a: *const i64) -> int64x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4.v2i64.p0v2i64"
+            link_name = "llvm.aarch64.neon.ld4.v2i64.p0"
         )]
         fn _vld4q_s64(ptr: *const int64x2_t) -> int64x2x4_t;
     }
@@ -12600,7 +12600,7 @@ pub unsafe fn vld4q_lane_f64<const LANE: i32>(a: *const f64, b: float64x2x4_t) -
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4lane.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.ld4lane.v2f64.p0"
         )]
         fn _vld4q_lane_f64(
             a: float64x2_t,
@@ -12627,7 +12627,7 @@ pub unsafe fn vld4q_lane_s8<const LANE: i32>(a: *const i8, b: int8x16x4_t) -> in
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4lane.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.ld4lane.v16i8.p0"
         )]
         fn _vld4q_lane_s8(
             a: int8x16_t,
@@ -12654,7 +12654,7 @@ pub unsafe fn vld4q_lane_s64<const LANE: i32>(a: *const i64, b: int64x2x4_t) -> 
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4lane.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.ld4lane.v2i64.p0"
         )]
         fn _vld4q_lane_s64(
             a: int64x2_t,
@@ -25979,7 +25979,7 @@ pub unsafe fn vst1_f64_x2(a: *mut f64, b: float64x1x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.st1x2.v1f64.p0"
         )]
         fn _vst1_f64_x2(a: float64x1_t, b: float64x1_t, ptr: *mut f64);
     }
@@ -25997,7 +25997,7 @@ pub unsafe fn vst1q_f64_x2(a: *mut f64, b: float64x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.st1x2.v2f64.p0"
         )]
         fn _vst1q_f64_x2(a: float64x2_t, b: float64x2_t, ptr: *mut f64);
     }
@@ -26015,7 +26015,7 @@ pub unsafe fn vst1_f64_x3(a: *mut f64, b: float64x1x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.st1x3.v1f64.p0"
         )]
         fn _vst1_f64_x3(a: float64x1_t, b: float64x1_t, c: float64x1_t, ptr: *mut f64);
     }
@@ -26033,7 +26033,7 @@ pub unsafe fn vst1q_f64_x3(a: *mut f64, b: float64x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.st1x3.v2f64.p0"
         )]
         fn _vst1q_f64_x3(a: float64x2_t, b: float64x2_t, c: float64x2_t, ptr: *mut f64);
     }
@@ -26051,7 +26051,7 @@ pub unsafe fn vst1_f64_x4(a: *mut f64, b: float64x1x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v1f64.p0f64"
+            link_name = "llvm.aarch64.neon.st1x4.v1f64.p0"
         )]
         fn _vst1_f64_x4(
             a: float64x1_t,
@@ -26075,7 +26075,7 @@ pub unsafe fn vst1q_f64_x4(a: *mut f64, b: float64x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v2f64.p0f64"
+            link_name = "llvm.aarch64.neon.st1x4.v2f64.p0"
         )]
         fn _vst1q_f64_x4(
             a: float64x2_t,
@@ -26125,7 +26125,7 @@ pub unsafe fn vst2_f64(a: *mut f64, b: float64x1x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v1f64.p0"
         )]
         fn _vst2_f64(a: float64x1_t, b: float64x1_t, ptr: *mut i8);
     }
@@ -26145,7 +26145,7 @@ pub unsafe fn vst2_lane_f64<const LANE: i32>(a: *mut f64, b: float64x1x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v1f64.p0"
         )]
         fn _vst2_lane_f64(a: float64x1_t, b: float64x1_t, n: i64, ptr: *mut i8);
     }
@@ -26165,7 +26165,7 @@ pub unsafe fn vst2_lane_s64<const LANE: i32>(a: *mut i64, b: int64x1x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v1i64.p0"
         )]
         fn _vst2_lane_s64(a: int64x1_t, b: int64x1_t, n: i64, ptr: *mut i8);
     }
@@ -26209,7 +26209,7 @@ pub unsafe fn vst2q_f64(a: *mut f64, b: float64x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v2f64.p0"
         )]
         fn _vst2q_f64(a: float64x2_t, b: float64x2_t, ptr: *mut i8);
     }
@@ -26227,7 +26227,7 @@ pub unsafe fn vst2q_s64(a: *mut i64, b: int64x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v2i64.p0"
         )]
         fn _vst2q_s64(a: int64x2_t, b: int64x2_t, ptr: *mut i8);
     }
@@ -26247,7 +26247,7 @@ pub unsafe fn vst2q_lane_f64<const LANE: i32>(a: *mut f64, b: float64x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v2f64.p0"
         )]
         fn _vst2q_lane_f64(a: float64x2_t, b: float64x2_t, n: i64, ptr: *mut i8);
     }
@@ -26267,7 +26267,7 @@ pub unsafe fn vst2q_lane_s8<const LANE: i32>(a: *mut i8, b: int8x16x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v16i8.p0"
         )]
         fn _vst2q_lane_s8(a: int8x16_t, b: int8x16_t, n: i64, ptr: *mut i8);
     }
@@ -26287,7 +26287,7 @@ pub unsafe fn vst2q_lane_s64<const LANE: i32>(a: *mut i64, b: int64x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v2i64.p0"
         )]
         fn _vst2q_lane_s64(a: int64x2_t, b: int64x2_t, n: i64, ptr: *mut i8);
     }
@@ -26379,7 +26379,7 @@ pub unsafe fn vst3_f64(a: *mut f64, b: float64x1x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v1f64.p0"
         )]
         fn _vst3_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t, ptr: *mut i8);
     }
@@ -26399,7 +26399,7 @@ pub unsafe fn vst3_lane_f64<const LANE: i32>(a: *mut f64, b: float64x1x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v1f64.p0"
         )]
         fn _vst3_lane_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t, n: i64, ptr: *mut i8);
     }
@@ -26419,7 +26419,7 @@ pub unsafe fn vst3_lane_s64<const LANE: i32>(a: *mut i64, b: int64x1x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v1i64.p0"
         )]
         fn _vst3_lane_s64(a: int64x1_t, b: int64x1_t, c: int64x1_t, n: i64, ptr: *mut i8);
     }
@@ -26463,7 +26463,7 @@ pub unsafe fn vst3q_f64(a: *mut f64, b: float64x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v2f64.p0"
         )]
         fn _vst3q_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t, ptr: *mut i8);
     }
@@ -26481,7 +26481,7 @@ pub unsafe fn vst3q_s64(a: *mut i64, b: int64x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v2i64.p0"
         )]
         fn _vst3q_s64(a: int64x2_t, b: int64x2_t, c: int64x2_t, ptr: *mut i8);
     }
@@ -26501,7 +26501,7 @@ pub unsafe fn vst3q_lane_f64<const LANE: i32>(a: *mut f64, b: float64x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v2f64.p0"
         )]
         fn _vst3q_lane_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t, n: i64, ptr: *mut i8);
     }
@@ -26521,7 +26521,7 @@ pub unsafe fn vst3q_lane_s8<const LANE: i32>(a: *mut i8, b: int8x16x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v16i8.p0"
         )]
         fn _vst3q_lane_s8(a: int8x16_t, b: int8x16_t, c: int8x16_t, n: i64, ptr: *mut i8);
     }
@@ -26541,7 +26541,7 @@ pub unsafe fn vst3q_lane_s64<const LANE: i32>(a: *mut i64, b: int64x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v2i64.p0"
         )]
         fn _vst3q_lane_s64(a: int64x2_t, b: int64x2_t, c: int64x2_t, n: i64, ptr: *mut i8);
     }
@@ -26633,7 +26633,7 @@ pub unsafe fn vst4_f64(a: *mut f64, b: float64x1x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v1f64.p0"
         )]
         fn _vst4_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t, d: float64x1_t, ptr: *mut i8);
     }
@@ -26653,7 +26653,7 @@ pub unsafe fn vst4_lane_f64<const LANE: i32>(a: *mut f64, b: float64x1x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v1f64.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v1f64.p0"
         )]
         fn _vst4_lane_f64(
             a: float64x1_t,
@@ -26680,7 +26680,7 @@ pub unsafe fn vst4_lane_s64<const LANE: i32>(a: *mut i64, b: int64x1x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v1i64.p0"
         )]
         fn _vst4_lane_s64(
             a: int64x1_t,
@@ -26731,7 +26731,7 @@ pub unsafe fn vst4q_f64(a: *mut f64, b: float64x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v2f64.p0"
         )]
         fn _vst4q_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t, d: float64x2_t, ptr: *mut i8);
     }
@@ -26749,7 +26749,7 @@ pub unsafe fn vst4q_s64(a: *mut i64, b: int64x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v2i64.p0"
         )]
         fn _vst4q_s64(a: int64x2_t, b: int64x2_t, c: int64x2_t, d: int64x2_t, ptr: *mut i8);
     }
@@ -26769,7 +26769,7 @@ pub unsafe fn vst4q_lane_f64<const LANE: i32>(a: *mut f64, b: float64x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v2f64.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v2f64.p0"
         )]
         fn _vst4q_lane_f64(
             a: float64x2_t,
@@ -26796,7 +26796,7 @@ pub unsafe fn vst4q_lane_s8<const LANE: i32>(a: *mut i8, b: int8x16x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v16i8.p0"
         )]
         fn _vst4q_lane_s8(
             a: int8x16_t,
@@ -26823,7 +26823,7 @@ pub unsafe fn vst4q_lane_s64<const LANE: i32>(a: *mut i64, b: int64x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v2i64.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v2i64.p0"
         )]
         fn _vst4q_lane_s64(
             a: int64x2_t,

--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -13,7 +13,7 @@ pub use self::generated::*;
 use crate::{
     core_arch::{arm_shared::*, simd::*},
     hint::unreachable_unchecked,
-    intrinsics::simd::*,
+    intrinsics::{simd::*, *},
     mem::transmute,
 };
 #[cfg(test)]

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -14978,9 +14978,9 @@ pub unsafe fn vld1_f16_x2(a: *const f16) -> float16x4x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x2.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld1x2.v4f16.p0"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x2.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x2.v4f16.p0")]
         fn _vld1_f16_x2(a: *const f16) -> float16x4x2_t;
     }
     _vld1_f16_x2(a)
@@ -15002,9 +15002,9 @@ pub unsafe fn vld1_f16_x3(a: *const f16) -> float16x4x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x3.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld1x3.v4f16.p0"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x3.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x3.v4f16.p0")]
         fn _vld1_f16_x3(a: *const f16) -> float16x4x3_t;
     }
     _vld1_f16_x3(a)
@@ -15026,9 +15026,9 @@ pub unsafe fn vld1_f16_x4(a: *const f16) -> float16x4x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x4.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld1x4.v4f16.p0"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x4.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x4.v4f16.p0")]
         fn _vld1_f16_x4(a: *const f16) -> float16x4x4_t;
     }
     _vld1_f16_x4(a)
@@ -15050,9 +15050,9 @@ pub unsafe fn vld1q_f16_x2(a: *const f16) -> float16x8x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x2.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld1x2.v8f16.p0"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x2.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x2.v8f16.p0")]
         fn _vld1q_f16_x2(a: *const f16) -> float16x8x2_t;
     }
     _vld1q_f16_x2(a)
@@ -15074,9 +15074,9 @@ pub unsafe fn vld1q_f16_x3(a: *const f16) -> float16x8x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x3.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld1x3.v8f16.p0"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x3.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x3.v8f16.p0")]
         fn _vld1q_f16_x3(a: *const f16) -> float16x8x3_t;
     }
     _vld1q_f16_x3(a)
@@ -15098,9 +15098,9 @@ pub unsafe fn vld1q_f16_x4(a: *const f16) -> float16x8x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld1x4.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld1x4.v8f16.p0"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x4.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld1x4.v8f16.p0")]
         fn _vld1q_f16_x4(a: *const f16) -> float16x8x4_t;
     }
     _vld1q_f16_x4(a)
@@ -19608,7 +19608,7 @@ pub unsafe fn vld1q_dup_p64(ptr: *const p64) -> poly64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld2_dup_f16(a: *const f16) -> float16x4x2_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2dup.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2dup.v4f16.p0")]
         fn _vld2_dup_f16(ptr: *const f16, size: i32) -> float16x4x2_t;
     }
     _vld2_dup_f16(a as _, 2)
@@ -19625,7 +19625,7 @@ pub unsafe fn vld2_dup_f16(a: *const f16) -> float16x4x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld2q_dup_f16(a: *const f16) -> float16x8x2_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2dup.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2dup.v8f16.p0")]
         fn _vld2q_dup_f16(ptr: *const f16, size: i32) -> float16x8x2_t;
     }
     _vld2q_dup_f16(a as _, 2)
@@ -19646,7 +19646,7 @@ pub unsafe fn vld2_dup_f16(a: *const f16) -> float16x4x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2r.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld2r.v4f16.p0"
         )]
         fn _vld2_dup_f16(ptr: *const f16) -> float16x4x2_t;
     }
@@ -19668,7 +19668,7 @@ pub unsafe fn vld2q_dup_f16(a: *const f16) -> float16x8x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2r.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld2r.v8f16.p0"
         )]
         fn _vld2q_dup_f16(ptr: *const f16) -> float16x8x2_t;
     }
@@ -20581,7 +20581,7 @@ pub unsafe fn vld2q_dup_p16(a: *const p16) -> poly16x8x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld2_f16(a: *const f16) -> float16x4x2_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2.v4f16.p0")]
         fn _vld2_f16(ptr: *const f16, size: i32) -> float16x4x2_t;
     }
     _vld2_f16(a as _, 2)
@@ -20598,7 +20598,7 @@ pub unsafe fn vld2_f16(a: *const f16) -> float16x4x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld2q_f16(a: *const f16) -> float16x8x2_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld2.v8f16.p0")]
         fn _vld2q_f16(ptr: *const f16, size: i32) -> float16x8x2_t;
     }
     _vld2q_f16(a as _, 2)
@@ -20619,7 +20619,7 @@ pub unsafe fn vld2_f16(a: *const f16) -> float16x4x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld2.v4f16.p0"
         )]
         fn _vld2_f16(ptr: *const f16) -> float16x4x2_t;
     }
@@ -20641,7 +20641,7 @@ pub unsafe fn vld2q_f16(a: *const f16) -> float16x8x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld2.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld2.v8f16.p0"
         )]
         fn _vld2q_f16(ptr: *const f16) -> float16x8x2_t;
     }
@@ -22169,7 +22169,7 @@ pub unsafe fn vld2q_p16(a: *const p16) -> poly16x8x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld3_dup_f16(a: *const f16) -> float16x4x3_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3dup.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3dup.v4f16.p0")]
         fn _vld3_dup_f16(ptr: *const f16, size: i32) -> float16x4x3_t;
     }
     _vld3_dup_f16(a as _, 2)
@@ -22186,7 +22186,7 @@ pub unsafe fn vld3_dup_f16(a: *const f16) -> float16x4x3_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld3q_dup_f16(a: *const f16) -> float16x8x3_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3dup.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3dup.v8f16.p0")]
         fn _vld3q_dup_f16(ptr: *const f16, size: i32) -> float16x8x3_t;
     }
     _vld3q_dup_f16(a as _, 2)
@@ -22207,7 +22207,7 @@ pub unsafe fn vld3_dup_f16(a: *const f16) -> float16x4x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3r.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld3r.v4f16.p0"
         )]
         fn _vld3_dup_f16(ptr: *const f16) -> float16x4x3_t;
     }
@@ -22229,7 +22229,7 @@ pub unsafe fn vld3q_dup_f16(a: *const f16) -> float16x8x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3r.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld3r.v8f16.p0"
         )]
         fn _vld3q_dup_f16(ptr: *const f16) -> float16x8x3_t;
     }
@@ -23164,7 +23164,7 @@ pub unsafe fn vld3q_dup_p16(a: *const p16) -> poly16x8x3_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld3_f16(a: *const f16) -> float16x4x3_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3.v4f16.p0")]
         fn _vld3_f16(ptr: *const f16, size: i32) -> float16x4x3_t;
     }
     _vld3_f16(a as _, 2)
@@ -23181,7 +23181,7 @@ pub unsafe fn vld3_f16(a: *const f16) -> float16x4x3_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld3q_f16(a: *const f16) -> float16x8x3_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld3.v8f16.p0")]
         fn _vld3q_f16(ptr: *const f16, size: i32) -> float16x8x3_t;
     }
     _vld3q_f16(a as _, 2)
@@ -23202,7 +23202,7 @@ pub unsafe fn vld3_f16(a: *const f16) -> float16x4x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld3.v4f16.p0"
         )]
         fn _vld3_f16(ptr: *const f16) -> float16x4x3_t;
     }
@@ -23224,7 +23224,7 @@ pub unsafe fn vld3q_f16(a: *const f16) -> float16x8x3_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld3.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld3.v8f16.p0"
         )]
         fn _vld3q_f16(ptr: *const f16) -> float16x8x3_t;
     }
@@ -24835,7 +24835,7 @@ pub unsafe fn vld3q_lane_f32<const LANE: i32>(a: *const f32, b: float32x4x3_t) -
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld4_dup_f16(a: *const f16) -> float16x4x4_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4dup.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4dup.v4f16.p0")]
         fn _vld4_dup_f16(ptr: *const f16, size: i32) -> float16x4x4_t;
     }
     _vld4_dup_f16(a as _, 2)
@@ -24852,7 +24852,7 @@ pub unsafe fn vld4_dup_f16(a: *const f16) -> float16x4x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld4q_dup_f16(a: *const f16) -> float16x8x4_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4dup.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4dup.v8f16.p0")]
         fn _vld4q_dup_f16(ptr: *const f16, size: i32) -> float16x8x4_t;
     }
     _vld4q_dup_f16(a as _, 2)
@@ -24873,7 +24873,7 @@ pub unsafe fn vld4_dup_f16(a: *const f16) -> float16x4x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld4r.v4f16.p0"
         )]
         fn _vld4_dup_f16(ptr: *const f16) -> float16x4x4_t;
     }
@@ -24895,7 +24895,7 @@ pub unsafe fn vld4q_dup_f16(a: *const f16) -> float16x8x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld4r.v8f16.p0"
         )]
         fn _vld4q_dup_f16(ptr: *const f16) -> float16x8x4_t;
     }
@@ -25042,7 +25042,7 @@ pub unsafe fn vld4_dup_f32(a: *const f32) -> float32x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v2f32.p0f32.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v2f32.p0.p0"
         )]
         fn _vld4_dup_f32(ptr: *const f32) -> float32x2x4_t;
     }
@@ -25061,7 +25061,7 @@ pub unsafe fn vld4q_dup_f32(a: *const f32) -> float32x4x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v4f32.p0f32.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v4f32.p0.p0"
         )]
         fn _vld4q_dup_f32(ptr: *const f32) -> float32x4x4_t;
     }
@@ -25080,7 +25080,7 @@ pub unsafe fn vld4_dup_s8(a: *const i8) -> int8x8x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v8i8.p0i8.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v8i8.p0.p0"
         )]
         fn _vld4_dup_s8(ptr: *const i8) -> int8x8x4_t;
     }
@@ -25099,7 +25099,7 @@ pub unsafe fn vld4q_dup_s8(a: *const i8) -> int8x16x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v16i8.p0i8.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v16i8.p0.p0"
         )]
         fn _vld4q_dup_s8(ptr: *const i8) -> int8x16x4_t;
     }
@@ -25118,7 +25118,7 @@ pub unsafe fn vld4_dup_s16(a: *const i16) -> int16x4x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v4i16.p0i16.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v4i16.p0.p0"
         )]
         fn _vld4_dup_s16(ptr: *const i16) -> int16x4x4_t;
     }
@@ -25137,7 +25137,7 @@ pub unsafe fn vld4q_dup_s16(a: *const i16) -> int16x8x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v8i16.p0i16.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v8i16.p0.p0"
         )]
         fn _vld4q_dup_s16(ptr: *const i16) -> int16x8x4_t;
     }
@@ -25156,7 +25156,7 @@ pub unsafe fn vld4_dup_s32(a: *const i32) -> int32x2x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v2i32.p0i32.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v2i32.p0.p0"
         )]
         fn _vld4_dup_s32(ptr: *const i32) -> int32x2x4_t;
     }
@@ -25175,7 +25175,7 @@ pub unsafe fn vld4q_dup_s32(a: *const i32) -> int32x4x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v4i32.p0i32.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v4i32.p0.p0"
         )]
         fn _vld4q_dup_s32(ptr: *const i32) -> int32x4x4_t;
     }
@@ -25194,7 +25194,7 @@ pub unsafe fn vld4_dup_s64(a: *const i64) -> int64x1x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4r.v1i64.p0i64.p0"
+            link_name = "llvm.aarch64.neon.ld4r.v1i64.p0.p0"
         )]
         fn _vld4_dup_s64(ptr: *const i64) -> int64x1x4_t;
     }
@@ -25852,7 +25852,7 @@ pub unsafe fn vld4q_dup_p16(a: *const p16) -> poly16x8x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld4_f16(a: *const f16) -> float16x4x4_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4.v4f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4.v4f16.p0")]
         fn _vld4_f16(ptr: *const f16, size: i32) -> float16x4x4_t;
     }
     _vld4_f16(a as _, 2)
@@ -25869,7 +25869,7 @@ pub unsafe fn vld4_f16(a: *const f16) -> float16x4x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vld4q_f16(a: *const f16) -> float16x8x4_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4.v8f16.p0f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vld4.v8f16.p0")]
         fn _vld4q_f16(ptr: *const f16, size: i32) -> float16x8x4_t;
     }
     _vld4q_f16(a as _, 2)
@@ -25890,7 +25890,7 @@ pub unsafe fn vld4_f16(a: *const f16) -> float16x4x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld4.v4f16.p0"
         )]
         fn _vld4_f16(ptr: *const f16) -> float16x4x4_t;
     }
@@ -25912,7 +25912,7 @@ pub unsafe fn vld4q_f16(a: *const f16) -> float16x8x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.ld4.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.ld4.v8f16.p0"
         )]
         fn _vld4q_f16(ptr: *const f16) -> float16x8x4_t;
     }
@@ -64129,7 +64129,7 @@ pub unsafe fn vst1q_f16(ptr: *mut f16, a: float16x8_t) {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vst1_f16_x2(a: *mut f16, b: float16x4x2_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x2.p0f16.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x2.p0.v4f16")]
         fn _vst1_f16_x2(ptr: *mut f16, a: float16x4_t, b: float16x4_t);
     }
     _vst1_f16_x2(a, b.0, b.1)
@@ -64146,7 +64146,7 @@ pub unsafe fn vst1_f16_x2(a: *mut f16, b: float16x4x2_t) {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vst1q_f16_x2(a: *mut f16, b: float16x8x2_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x2.p0f16.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x2.p0.v8f16")]
         fn _vst1q_f16_x2(ptr: *mut f16, a: float16x8_t, b: float16x8_t);
     }
     _vst1q_f16_x2(a, b.0, b.1)
@@ -64164,7 +64164,7 @@ pub unsafe fn vst1_f16_x2(a: *mut f16, b: float16x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.st1x2.v4f16.p0"
         )]
         fn _vst1_f16_x2(a: float16x4_t, b: float16x4_t, ptr: *mut f16);
     }
@@ -64183,7 +64183,7 @@ pub unsafe fn vst1q_f16_x2(a: *mut f16, b: float16x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.st1x2.v8f16.p0"
         )]
         fn _vst1q_f16_x2(a: float16x8_t, b: float16x8_t, ptr: *mut f16);
     }
@@ -64201,7 +64201,7 @@ pub unsafe fn vst1q_f16_x2(a: *mut f16, b: float16x8x2_t) {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vst1_f16_x3(a: *mut f16, b: float16x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0f16.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v4f16")]
         fn _vst1_f16_x3(ptr: *mut f16, a: float16x4_t, b: float16x4_t, c: float16x4_t);
     }
     _vst1_f16_x3(a, b.0, b.1, b.2)
@@ -64218,7 +64218,7 @@ pub unsafe fn vst1_f16_x3(a: *mut f16, b: float16x4x3_t) {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub unsafe fn vst1q_f16_x3(a: *mut f16, b: float16x8x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0f16.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v8f16")]
         fn _vst1q_f16_x3(ptr: *mut f16, a: float16x8_t, b: float16x8_t, c: float16x8_t);
     }
     _vst1q_f16_x3(a, b.0, b.1, b.2)
@@ -64236,7 +64236,7 @@ pub unsafe fn vst1_f16_x3(a: *mut f16, b: float16x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.st1x3.v4f16.p0"
         )]
         fn _vst1_f16_x3(a: float16x4_t, b: float16x4_t, c: float16x4_t, ptr: *mut f16);
     }
@@ -64255,7 +64255,7 @@ pub unsafe fn vst1q_f16_x3(a: *mut f16, b: float16x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.st1x3.v8f16.p0"
         )]
         fn _vst1q_f16_x3(a: float16x8_t, b: float16x8_t, c: float16x8_t, ptr: *mut f16);
     }
@@ -64273,7 +64273,7 @@ pub unsafe fn vst1q_f16_x3(a: *mut f16, b: float16x8x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_f16_x4(a: *mut f16, b: float16x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0f16.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v4f16")]
         fn _vst1_f16_x4(
             ptr: *mut f16,
             a: float16x4_t,
@@ -64296,7 +64296,7 @@ pub unsafe fn vst1_f16_x4(a: *mut f16, b: float16x4x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_f16_x4(a: *mut f16, b: float16x8x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0f16.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v8f16")]
         fn _vst1q_f16_x4(
             ptr: *mut f16,
             a: float16x8_t,
@@ -64320,7 +64320,7 @@ pub unsafe fn vst1_f16_x4(a: *mut f16, b: float16x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v4f16.p0f16"
+            link_name = "llvm.aarch64.neon.st1x4.v4f16.p0"
         )]
         fn _vst1_f16_x4(
             a: float16x4_t,
@@ -64345,7 +64345,7 @@ pub unsafe fn vst1q_f16_x4(a: *mut f16, b: float16x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v8f16.p0f16"
+            link_name = "llvm.aarch64.neon.st1x4.v8f16.p0"
         )]
         fn _vst1q_f16_x4(
             a: float16x8_t,
@@ -64778,7 +64778,7 @@ pub unsafe fn vst1_f32_x2(a: *mut f32, b: float32x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v2f32.p0f32"
+            link_name = "llvm.aarch64.neon.st1x2.v2f32.p0"
         )]
         fn _vst1_f32_x2(a: float32x2_t, b: float32x2_t, ptr: *mut f32);
     }
@@ -64797,7 +64797,7 @@ pub unsafe fn vst1q_f32_x2(a: *mut f32, b: float32x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v4f32.p0f32"
+            link_name = "llvm.aarch64.neon.st1x2.v4f32.p0"
         )]
         fn _vst1q_f32_x2(a: float32x4_t, b: float32x4_t, ptr: *mut f32);
     }
@@ -64816,7 +64816,7 @@ pub unsafe fn vst1_f32_x3(a: *mut f32, b: float32x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v2f32.p0f32"
+            link_name = "llvm.aarch64.neon.st1x3.v2f32.p0"
         )]
         fn _vst1_f32_x3(a: float32x2_t, b: float32x2_t, c: float32x2_t, ptr: *mut f32);
     }
@@ -64835,7 +64835,7 @@ pub unsafe fn vst1q_f32_x3(a: *mut f32, b: float32x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v4f32.p0f32"
+            link_name = "llvm.aarch64.neon.st1x3.v4f32.p0"
         )]
         fn _vst1q_f32_x3(a: float32x4_t, b: float32x4_t, c: float32x4_t, ptr: *mut f32);
     }
@@ -64852,7 +64852,7 @@ pub unsafe fn vst1q_f32_x3(a: *mut f32, b: float32x4x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_f32_x4(a: *mut f32, b: float32x2x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0f32.v2f32.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v2f32.p0")]
         fn _vst1_f32_x4(
             ptr: *mut f32,
             a: float32x2_t,
@@ -64874,7 +64874,7 @@ pub unsafe fn vst1_f32_x4(a: *mut f32, b: float32x2x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_f32_x4(a: *mut f32, b: float32x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0f32.v4f32.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v4f32.p0")]
         fn _vst1q_f32_x4(
             ptr: *mut f32,
             a: float32x4_t,
@@ -64898,7 +64898,7 @@ pub unsafe fn vst1_f32_x4(a: *mut f32, b: float32x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v2f32.p0f32"
+            link_name = "llvm.aarch64.neon.st1x4.v2f32.p0"
         )]
         fn _vst1_f32_x4(
             a: float32x2_t,
@@ -64923,7 +64923,7 @@ pub unsafe fn vst1q_f32_x4(a: *mut f32, b: float32x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v4f32.p0f32"
+            link_name = "llvm.aarch64.neon.st1x4.v4f32.p0"
         )]
         fn _vst1q_f32_x4(
             a: float32x4_t,
@@ -65697,7 +65697,7 @@ pub unsafe fn vst1_s8_x2(a: *mut i8, b: int8x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st1x2.v8i8.p0"
         )]
         fn _vst1_s8_x2(a: int8x8_t, b: int8x8_t, ptr: *mut i8);
     }
@@ -65716,7 +65716,7 @@ pub unsafe fn vst1q_s8_x2(a: *mut i8, b: int8x16x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st1x2.v16i8.p0"
         )]
         fn _vst1q_s8_x2(a: int8x16_t, b: int8x16_t, ptr: *mut i8);
     }
@@ -65735,7 +65735,7 @@ pub unsafe fn vst1_s16_x2(a: *mut i16, b: int16x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v4i16.p0i16"
+            link_name = "llvm.aarch64.neon.st1x2.v4i16.p0"
         )]
         fn _vst1_s16_x2(a: int16x4_t, b: int16x4_t, ptr: *mut i16);
     }
@@ -65754,7 +65754,7 @@ pub unsafe fn vst1q_s16_x2(a: *mut i16, b: int16x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v8i16.p0i16"
+            link_name = "llvm.aarch64.neon.st1x2.v8i16.p0"
         )]
         fn _vst1q_s16_x2(a: int16x8_t, b: int16x8_t, ptr: *mut i16);
     }
@@ -65773,7 +65773,7 @@ pub unsafe fn vst1_s32_x2(a: *mut i32, b: int32x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v2i32.p0i32"
+            link_name = "llvm.aarch64.neon.st1x2.v2i32.p0"
         )]
         fn _vst1_s32_x2(a: int32x2_t, b: int32x2_t, ptr: *mut i32);
     }
@@ -65792,7 +65792,7 @@ pub unsafe fn vst1q_s32_x2(a: *mut i32, b: int32x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v4i32.p0i32"
+            link_name = "llvm.aarch64.neon.st1x2.v4i32.p0"
         )]
         fn _vst1q_s32_x2(a: int32x4_t, b: int32x4_t, ptr: *mut i32);
     }
@@ -65811,7 +65811,7 @@ pub unsafe fn vst1_s64_x2(a: *mut i64, b: int64x1x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v1i64.p0i64"
+            link_name = "llvm.aarch64.neon.st1x2.v1i64.p0"
         )]
         fn _vst1_s64_x2(a: int64x1_t, b: int64x1_t, ptr: *mut i64);
     }
@@ -65830,7 +65830,7 @@ pub unsafe fn vst1q_s64_x2(a: *mut i64, b: int64x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x2.v2i64.p0i64"
+            link_name = "llvm.aarch64.neon.st1x2.v2i64.p0"
         )]
         fn _vst1q_s64_x2(a: int64x2_t, b: int64x2_t, ptr: *mut i64);
     }
@@ -65977,7 +65977,7 @@ pub unsafe fn vst1_s8_x3(a: *mut i8, b: int8x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st1x3.v8i8.p0"
         )]
         fn _vst1_s8_x3(a: int8x8_t, b: int8x8_t, c: int8x8_t, ptr: *mut i8);
     }
@@ -65996,7 +65996,7 @@ pub unsafe fn vst1q_s8_x3(a: *mut i8, b: int8x16x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st1x3.v16i8.p0"
         )]
         fn _vst1q_s8_x3(a: int8x16_t, b: int8x16_t, c: int8x16_t, ptr: *mut i8);
     }
@@ -66015,7 +66015,7 @@ pub unsafe fn vst1_s16_x3(a: *mut i16, b: int16x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v4i16.p0i16"
+            link_name = "llvm.aarch64.neon.st1x3.v4i16.p0"
         )]
         fn _vst1_s16_x3(a: int16x4_t, b: int16x4_t, c: int16x4_t, ptr: *mut i16);
     }
@@ -66034,7 +66034,7 @@ pub unsafe fn vst1q_s16_x3(a: *mut i16, b: int16x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v8i16.p0i16"
+            link_name = "llvm.aarch64.neon.st1x3.v8i16.p0"
         )]
         fn _vst1q_s16_x3(a: int16x8_t, b: int16x8_t, c: int16x8_t, ptr: *mut i16);
     }
@@ -66053,7 +66053,7 @@ pub unsafe fn vst1_s32_x3(a: *mut i32, b: int32x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v2i32.p0i32"
+            link_name = "llvm.aarch64.neon.st1x3.v2i32.p0"
         )]
         fn _vst1_s32_x3(a: int32x2_t, b: int32x2_t, c: int32x2_t, ptr: *mut i32);
     }
@@ -66072,7 +66072,7 @@ pub unsafe fn vst1q_s32_x3(a: *mut i32, b: int32x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v4i32.p0i32"
+            link_name = "llvm.aarch64.neon.st1x3.v4i32.p0"
         )]
         fn _vst1q_s32_x3(a: int32x4_t, b: int32x4_t, c: int32x4_t, ptr: *mut i32);
     }
@@ -66091,7 +66091,7 @@ pub unsafe fn vst1_s64_x3(a: *mut i64, b: int64x1x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v1i64.p0i64"
+            link_name = "llvm.aarch64.neon.st1x3.v1i64.p0"
         )]
         fn _vst1_s64_x3(a: int64x1_t, b: int64x1_t, c: int64x1_t, ptr: *mut i64);
     }
@@ -66110,7 +66110,7 @@ pub unsafe fn vst1q_s64_x3(a: *mut i64, b: int64x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x3.v2i64.p0i64"
+            link_name = "llvm.aarch64.neon.st1x3.v2i64.p0"
         )]
         fn _vst1q_s64_x3(a: int64x2_t, b: int64x2_t, c: int64x2_t, ptr: *mut i64);
     }
@@ -66127,7 +66127,7 @@ pub unsafe fn vst1q_s64_x3(a: *mut i64, b: int64x2x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s8_x3(a: *mut i8, b: int8x8x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i8.v8i8.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v8i8.p0")]
         fn _vst1_s8_x3(ptr: *mut i8, a: int8x8_t, b: int8x8_t, c: int8x8_t);
     }
     _vst1_s8_x3(a, b.0, b.1, b.2)
@@ -66143,7 +66143,7 @@ pub unsafe fn vst1_s8_x3(a: *mut i8, b: int8x8x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s8_x3(a: *mut i8, b: int8x16x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i8.v16i8.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v16i8.p0")]
         fn _vst1q_s8_x3(ptr: *mut i8, a: int8x16_t, b: int8x16_t, c: int8x16_t);
     }
     _vst1q_s8_x3(a, b.0, b.1, b.2)
@@ -66159,7 +66159,7 @@ pub unsafe fn vst1q_s8_x3(a: *mut i8, b: int8x16x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s16_x3(a: *mut i16, b: int16x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i16.v4i16.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v4i16.p0")]
         fn _vst1_s16_x3(ptr: *mut i16, a: int16x4_t, b: int16x4_t, c: int16x4_t);
     }
     _vst1_s16_x3(a, b.0, b.1, b.2)
@@ -66175,7 +66175,7 @@ pub unsafe fn vst1_s16_x3(a: *mut i16, b: int16x4x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s16_x3(a: *mut i16, b: int16x8x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i16.v8i16.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v8i16.p0")]
         fn _vst1q_s16_x3(ptr: *mut i16, a: int16x8_t, b: int16x8_t, c: int16x8_t);
     }
     _vst1q_s16_x3(a, b.0, b.1, b.2)
@@ -66191,7 +66191,7 @@ pub unsafe fn vst1q_s16_x3(a: *mut i16, b: int16x8x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s32_x3(a: *mut i32, b: int32x2x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i32.v2i32.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v2i32.p0")]
         fn _vst1_s32_x3(ptr: *mut i32, a: int32x2_t, b: int32x2_t, c: int32x2_t);
     }
     _vst1_s32_x3(a, b.0, b.1, b.2)
@@ -66207,7 +66207,7 @@ pub unsafe fn vst1_s32_x3(a: *mut i32, b: int32x2x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s32_x3(a: *mut i32, b: int32x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i32.v4i32.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v4i32.p0")]
         fn _vst1q_s32_x3(ptr: *mut i32, a: int32x4_t, b: int32x4_t, c: int32x4_t);
     }
     _vst1q_s32_x3(a, b.0, b.1, b.2)
@@ -66223,7 +66223,7 @@ pub unsafe fn vst1q_s32_x3(a: *mut i32, b: int32x4x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s64_x3(a: *mut i64, b: int64x1x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i64.v1i64.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v1i64.p0")]
         fn _vst1_s64_x3(ptr: *mut i64, a: int64x1_t, b: int64x1_t, c: int64x1_t);
     }
     _vst1_s64_x3(a, b.0, b.1, b.2)
@@ -66239,7 +66239,7 @@ pub unsafe fn vst1_s64_x3(a: *mut i64, b: int64x1x3_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s64_x3(a: *mut i64, b: int64x2x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0i64.v2i64.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x3.p0.v2i64.p0")]
         fn _vst1q_s64_x3(ptr: *mut i64, a: int64x2_t, b: int64x2_t, c: int64x2_t);
     }
     _vst1q_s64_x3(a, b.0, b.1, b.2)
@@ -66257,7 +66257,7 @@ pub unsafe fn vst1_s8_x4(a: *mut i8, b: int8x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st1x4.v8i8.p0"
         )]
         fn _vst1_s8_x4(a: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t, ptr: *mut i8);
     }
@@ -66276,7 +66276,7 @@ pub unsafe fn vst1q_s8_x4(a: *mut i8, b: int8x16x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st1x4.v16i8.p0"
         )]
         fn _vst1q_s8_x4(a: int8x16_t, b: int8x16_t, c: int8x16_t, d: int8x16_t, ptr: *mut i8);
     }
@@ -66295,7 +66295,7 @@ pub unsafe fn vst1_s16_x4(a: *mut i16, b: int16x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v4i16.p0i16"
+            link_name = "llvm.aarch64.neon.st1x4.v4i16.p0"
         )]
         fn _vst1_s16_x4(a: int16x4_t, b: int16x4_t, c: int16x4_t, d: int16x4_t, ptr: *mut i16);
     }
@@ -66314,7 +66314,7 @@ pub unsafe fn vst1q_s16_x4(a: *mut i16, b: int16x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v8i16.p0i16"
+            link_name = "llvm.aarch64.neon.st1x4.v8i16.p0"
         )]
         fn _vst1q_s16_x4(a: int16x8_t, b: int16x8_t, c: int16x8_t, d: int16x8_t, ptr: *mut i16);
     }
@@ -66333,7 +66333,7 @@ pub unsafe fn vst1_s32_x4(a: *mut i32, b: int32x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v2i32.p0i32"
+            link_name = "llvm.aarch64.neon.st1x4.v2i32.p0"
         )]
         fn _vst1_s32_x4(a: int32x2_t, b: int32x2_t, c: int32x2_t, d: int32x2_t, ptr: *mut i32);
     }
@@ -66352,7 +66352,7 @@ pub unsafe fn vst1q_s32_x4(a: *mut i32, b: int32x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v4i32.p0i32"
+            link_name = "llvm.aarch64.neon.st1x4.v4i32.p0"
         )]
         fn _vst1q_s32_x4(a: int32x4_t, b: int32x4_t, c: int32x4_t, d: int32x4_t, ptr: *mut i32);
     }
@@ -66371,7 +66371,7 @@ pub unsafe fn vst1_s64_x4(a: *mut i64, b: int64x1x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v1i64.p0i64"
+            link_name = "llvm.aarch64.neon.st1x4.v1i64.p0"
         )]
         fn _vst1_s64_x4(a: int64x1_t, b: int64x1_t, c: int64x1_t, d: int64x1_t, ptr: *mut i64);
     }
@@ -66390,7 +66390,7 @@ pub unsafe fn vst1q_s64_x4(a: *mut i64, b: int64x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st1x4.v2i64.p0i64"
+            link_name = "llvm.aarch64.neon.st1x4.v2i64.p0"
         )]
         fn _vst1q_s64_x4(a: int64x2_t, b: int64x2_t, c: int64x2_t, d: int64x2_t, ptr: *mut i64);
     }
@@ -66407,7 +66407,7 @@ pub unsafe fn vst1q_s64_x4(a: *mut i64, b: int64x2x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s8_x4(a: *mut i8, b: int8x8x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i8.v8i8.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v8i8.p0")]
         fn _vst1_s8_x4(ptr: *mut i8, a: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t);
     }
     _vst1_s8_x4(a, b.0, b.1, b.2, b.3)
@@ -66423,7 +66423,7 @@ pub unsafe fn vst1_s8_x4(a: *mut i8, b: int8x8x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s8_x4(a: *mut i8, b: int8x16x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i8.v16i8.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v16i8.p0")]
         fn _vst1q_s8_x4(ptr: *mut i8, a: int8x16_t, b: int8x16_t, c: int8x16_t, d: int8x16_t);
     }
     _vst1q_s8_x4(a, b.0, b.1, b.2, b.3)
@@ -66439,7 +66439,7 @@ pub unsafe fn vst1q_s8_x4(a: *mut i8, b: int8x16x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s16_x4(a: *mut i16, b: int16x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i16.v4i16.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v4i16.p0")]
         fn _vst1_s16_x4(ptr: *mut i16, a: int16x4_t, b: int16x4_t, c: int16x4_t, d: int16x4_t);
     }
     _vst1_s16_x4(a, b.0, b.1, b.2, b.3)
@@ -66455,7 +66455,7 @@ pub unsafe fn vst1_s16_x4(a: *mut i16, b: int16x4x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s16_x4(a: *mut i16, b: int16x8x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i16.v8i16.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v8i16.p0")]
         fn _vst1q_s16_x4(ptr: *mut i16, a: int16x8_t, b: int16x8_t, c: int16x8_t, d: int16x8_t);
     }
     _vst1q_s16_x4(a, b.0, b.1, b.2, b.3)
@@ -66471,7 +66471,7 @@ pub unsafe fn vst1q_s16_x4(a: *mut i16, b: int16x8x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s32_x4(a: *mut i32, b: int32x2x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i32.v2i32.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v2i32.p0")]
         fn _vst1_s32_x4(ptr: *mut i32, a: int32x2_t, b: int32x2_t, c: int32x2_t, d: int32x2_t);
     }
     _vst1_s32_x4(a, b.0, b.1, b.2, b.3)
@@ -66487,7 +66487,7 @@ pub unsafe fn vst1_s32_x4(a: *mut i32, b: int32x2x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s32_x4(a: *mut i32, b: int32x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i32.v4i32.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v4i32.p0")]
         fn _vst1q_s32_x4(ptr: *mut i32, a: int32x4_t, b: int32x4_t, c: int32x4_t, d: int32x4_t);
     }
     _vst1q_s32_x4(a, b.0, b.1, b.2, b.3)
@@ -66503,7 +66503,7 @@ pub unsafe fn vst1q_s32_x4(a: *mut i32, b: int32x4x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1_s64_x4(a: *mut i64, b: int64x1x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i64.v1i64.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v1i64.p0")]
         fn _vst1_s64_x4(ptr: *mut i64, a: int64x1_t, b: int64x1_t, c: int64x1_t, d: int64x1_t);
     }
     _vst1_s64_x4(a, b.0, b.1, b.2, b.3)
@@ -66519,7 +66519,7 @@ pub unsafe fn vst1_s64_x4(a: *mut i64, b: int64x1x4_t) {
 #[cfg_attr(test, assert_instr(vst1))]
 pub unsafe fn vst1q_s64_x4(a: *mut i64, b: int64x2x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0i64.v2i64.p0")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst1x4.p0.v2i64.p0")]
         fn _vst1q_s64_x4(ptr: *mut i64, a: int64x2_t, b: int64x2_t, c: int64x2_t, d: int64x2_t);
     }
     _vst1q_s64_x4(a, b.0, b.1, b.2, b.3)
@@ -67594,7 +67594,7 @@ pub unsafe fn vst2_f16(a: *mut f16, b: float16x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v4f16.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v4f16.p0"
         )]
         fn _vst2_f16(a: float16x4_t, b: float16x4_t, ptr: *mut i8);
     }
@@ -67613,7 +67613,7 @@ pub unsafe fn vst2q_f16(a: *mut f16, b: float16x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v8f16.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v8f16.p0"
         )]
         fn _vst2q_f16(a: float16x8_t, b: float16x8_t, ptr: *mut i8);
     }
@@ -67631,7 +67631,7 @@ pub unsafe fn vst2q_f16(a: *mut f16, b: float16x8x2_t) {
 #[cfg_attr(test, assert_instr(vst2))]
 pub unsafe fn vst2_f16(a: *mut f16, b: float16x4x2_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2.p0i8.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2.p0.v4f16")]
         fn _vst2_f16(ptr: *mut i8, a: float16x4_t, b: float16x4_t, size: i32);
     }
     _vst2_f16(a as _, b.0, b.1, 2)
@@ -67648,7 +67648,7 @@ pub unsafe fn vst2_f16(a: *mut f16, b: float16x4x2_t) {
 #[cfg_attr(test, assert_instr(vst2))]
 pub unsafe fn vst2q_f16(a: *mut f16, b: float16x8x2_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2.p0i8.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2.p0.v8f16")]
         fn _vst2q_f16(ptr: *mut i8, a: float16x8_t, b: float16x8_t, size: i32);
     }
     _vst2q_f16(a as _, b.0, b.1, 2)
@@ -67666,7 +67666,7 @@ pub unsafe fn vst2_f32(a: *mut f32, b: float32x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v2f32.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v2f32.p0"
         )]
         fn _vst2_f32(a: float32x2_t, b: float32x2_t, ptr: *mut i8);
     }
@@ -67685,7 +67685,7 @@ pub unsafe fn vst2q_f32(a: *mut f32, b: float32x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v4f32.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v4f32.p0"
         )]
         fn _vst2q_f32(a: float32x4_t, b: float32x4_t, ptr: *mut i8);
     }
@@ -67704,7 +67704,7 @@ pub unsafe fn vst2_s8(a: *mut i8, b: int8x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v8i8.p0"
         )]
         fn _vst2_s8(a: int8x8_t, b: int8x8_t, ptr: *mut i8);
     }
@@ -67723,7 +67723,7 @@ pub unsafe fn vst2q_s8(a: *mut i8, b: int8x16x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v16i8.p0"
         )]
         fn _vst2q_s8(a: int8x16_t, b: int8x16_t, ptr: *mut i8);
     }
@@ -67742,7 +67742,7 @@ pub unsafe fn vst2_s16(a: *mut i16, b: int16x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v4i16.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v4i16.p0"
         )]
         fn _vst2_s16(a: int16x4_t, b: int16x4_t, ptr: *mut i8);
     }
@@ -67761,7 +67761,7 @@ pub unsafe fn vst2q_s16(a: *mut i16, b: int16x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v8i16.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v8i16.p0"
         )]
         fn _vst2q_s16(a: int16x8_t, b: int16x8_t, ptr: *mut i8);
     }
@@ -67780,7 +67780,7 @@ pub unsafe fn vst2_s32(a: *mut i32, b: int32x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v2i32.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v2i32.p0"
         )]
         fn _vst2_s32(a: int32x2_t, b: int32x2_t, ptr: *mut i8);
     }
@@ -67799,7 +67799,7 @@ pub unsafe fn vst2q_s32(a: *mut i32, b: int32x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v4i32.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v4i32.p0"
         )]
         fn _vst2q_s32(a: int32x4_t, b: int32x4_t, ptr: *mut i8);
     }
@@ -67948,7 +67948,7 @@ pub unsafe fn vst2_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v4f16.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v4f16.p0"
         )]
         fn _vst2_lane_f16(a: float16x4_t, b: float16x4_t, n: i64, ptr: *mut i8);
     }
@@ -67969,7 +67969,7 @@ pub unsafe fn vst2q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v8f16.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v8f16.p0"
         )]
         fn _vst2q_lane_f16(a: float16x8_t, b: float16x8_t, n: i64, ptr: *mut i8);
     }
@@ -67989,7 +67989,7 @@ pub unsafe fn vst2q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x2_t) {
 pub unsafe fn vst2_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x2_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2lane.p0i8.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2lane.p0.v4f16")]
         fn _vst2_lane_f16(ptr: *mut i8, a: float16x4_t, b: float16x4_t, n: i32, size: i32);
     }
     _vst2_lane_f16(a as _, b.0, b.1, LANE, 2)
@@ -68008,7 +68008,7 @@ pub unsafe fn vst2_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x2_t) {
 pub unsafe fn vst2q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x2_t) {
     static_assert_uimm_bits!(LANE, 1);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2lane.p0i8.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst2lane.p0.v8f16")]
         fn _vst2q_lane_f16(ptr: *mut i8, a: float16x8_t, b: float16x8_t, n: i32, size: i32);
     }
     _vst2q_lane_f16(a as _, b.0, b.1, LANE, 2)
@@ -68028,7 +68028,7 @@ pub unsafe fn vst2_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v2f32.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v2f32.p0"
         )]
         fn _vst2_lane_f32(a: float32x2_t, b: float32x2_t, n: i64, ptr: *mut i8);
     }
@@ -68049,7 +68049,7 @@ pub unsafe fn vst2q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v4f32.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v4f32.p0"
         )]
         fn _vst2q_lane_f32(a: float32x4_t, b: float32x4_t, n: i64, ptr: *mut i8);
     }
@@ -68070,7 +68070,7 @@ pub unsafe fn vst2_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v8i8.p0"
         )]
         fn _vst2_lane_s8(a: int8x8_t, b: int8x8_t, n: i64, ptr: *mut i8);
     }
@@ -68091,7 +68091,7 @@ pub unsafe fn vst2_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v4i16.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v4i16.p0"
         )]
         fn _vst2_lane_s16(a: int16x4_t, b: int16x4_t, n: i64, ptr: *mut i8);
     }
@@ -68112,7 +68112,7 @@ pub unsafe fn vst2q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v8i16.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v8i16.p0"
         )]
         fn _vst2q_lane_s16(a: int16x8_t, b: int16x8_t, n: i64, ptr: *mut i8);
     }
@@ -68133,7 +68133,7 @@ pub unsafe fn vst2_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v2i32.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v2i32.p0"
         )]
         fn _vst2_lane_s32(a: int32x2_t, b: int32x2_t, n: i64, ptr: *mut i8);
     }
@@ -68154,7 +68154,7 @@ pub unsafe fn vst2q_lane_s32<const LANE: i32>(a: *mut i32, b: int32x4x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2lane.v4i32.p0i8"
+            link_name = "llvm.aarch64.neon.st2lane.v4i32.p0"
         )]
         fn _vst2q_lane_s32(a: int32x4_t, b: int32x4_t, n: i64, ptr: *mut i8);
     }
@@ -68538,7 +68538,7 @@ pub unsafe fn vst2_s64(a: *mut i64, b: int64x1x2_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st2.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.st2.v1i64.p0"
         )]
         fn _vst2_s64(a: int64x1_t, b: int64x1_t, ptr: *mut i8);
     }
@@ -68809,7 +68809,7 @@ pub unsafe fn vst2q_p16(a: *mut p16, b: poly16x8x2_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3_f16(a: *mut f16, b: float16x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v4f16")]
         fn _vst3_f16(ptr: *mut i8, a: float16x4_t, b: float16x4_t, c: float16x4_t, size: i32);
     }
     _vst3_f16(a as _, b.0, b.1, b.2, 2)
@@ -68826,7 +68826,7 @@ pub unsafe fn vst3_f16(a: *mut f16, b: float16x4x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3q_f16(a: *mut f16, b: float16x8x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v8f16")]
         fn _vst3q_f16(ptr: *mut i8, a: float16x8_t, b: float16x8_t, c: float16x8_t, size: i32);
     }
     _vst3q_f16(a as _, b.0, b.1, b.2, 2)
@@ -68844,7 +68844,7 @@ pub unsafe fn vst3_f16(a: *mut f16, b: float16x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v4f16.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v4f16.p0"
         )]
         fn _vst3_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t, ptr: *mut i8);
     }
@@ -68863,7 +68863,7 @@ pub unsafe fn vst3q_f16(a: *mut f16, b: float16x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v8f16.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v8f16.p0"
         )]
         fn _vst3q_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t, ptr: *mut i8);
     }
@@ -68880,7 +68880,7 @@ pub unsafe fn vst3q_f16(a: *mut f16, b: float16x8x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3_f32(a: *mut f32, b: float32x2x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v2f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v2f32")]
         fn _vst3_f32(ptr: *mut i8, a: float32x2_t, b: float32x2_t, c: float32x2_t, size: i32);
     }
     _vst3_f32(a as _, b.0, b.1, b.2, 4)
@@ -68896,7 +68896,7 @@ pub unsafe fn vst3_f32(a: *mut f32, b: float32x2x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3q_f32(a: *mut f32, b: float32x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v4f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v4f32")]
         fn _vst3q_f32(ptr: *mut i8, a: float32x4_t, b: float32x4_t, c: float32x4_t, size: i32);
     }
     _vst3q_f32(a as _, b.0, b.1, b.2, 4)
@@ -68912,7 +68912,7 @@ pub unsafe fn vst3q_f32(a: *mut f32, b: float32x4x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3_s8(a: *mut i8, b: int8x8x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v8i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v8i8")]
         fn _vst3_s8(ptr: *mut i8, a: int8x8_t, b: int8x8_t, c: int8x8_t, size: i32);
     }
     _vst3_s8(a as _, b.0, b.1, b.2, 1)
@@ -68928,7 +68928,7 @@ pub unsafe fn vst3_s8(a: *mut i8, b: int8x8x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3q_s8(a: *mut i8, b: int8x16x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v16i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v16i8")]
         fn _vst3q_s8(ptr: *mut i8, a: int8x16_t, b: int8x16_t, c: int8x16_t, size: i32);
     }
     _vst3q_s8(a as _, b.0, b.1, b.2, 1)
@@ -68944,7 +68944,7 @@ pub unsafe fn vst3q_s8(a: *mut i8, b: int8x16x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3_s16(a: *mut i16, b: int16x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v4i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v4i16")]
         fn _vst3_s16(ptr: *mut i8, a: int16x4_t, b: int16x4_t, c: int16x4_t, size: i32);
     }
     _vst3_s16(a as _, b.0, b.1, b.2, 2)
@@ -68960,7 +68960,7 @@ pub unsafe fn vst3_s16(a: *mut i16, b: int16x4x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3q_s16(a: *mut i16, b: int16x8x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v8i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v8i16")]
         fn _vst3q_s16(ptr: *mut i8, a: int16x8_t, b: int16x8_t, c: int16x8_t, size: i32);
     }
     _vst3q_s16(a as _, b.0, b.1, b.2, 2)
@@ -68976,7 +68976,7 @@ pub unsafe fn vst3q_s16(a: *mut i16, b: int16x8x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3_s32(a: *mut i32, b: int32x2x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v2i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v2i32")]
         fn _vst3_s32(ptr: *mut i8, a: int32x2_t, b: int32x2_t, c: int32x2_t, size: i32);
     }
     _vst3_s32(a as _, b.0, b.1, b.2, 4)
@@ -68992,7 +68992,7 @@ pub unsafe fn vst3_s32(a: *mut i32, b: int32x2x3_t) {
 #[cfg_attr(test, assert_instr(vst3))]
 pub unsafe fn vst3q_s32(a: *mut i32, b: int32x4x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v4i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v4i32")]
         fn _vst3q_s32(ptr: *mut i8, a: int32x4_t, b: int32x4_t, c: int32x4_t, size: i32);
     }
     _vst3q_s32(a as _, b.0, b.1, b.2, 4)
@@ -69010,7 +69010,7 @@ pub unsafe fn vst3_f32(a: *mut f32, b: float32x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v2f32.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v2f32.p0"
         )]
         fn _vst3_f32(a: float32x2_t, b: float32x2_t, c: float32x2_t, ptr: *mut i8);
     }
@@ -69029,7 +69029,7 @@ pub unsafe fn vst3q_f32(a: *mut f32, b: float32x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v4f32.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v4f32.p0"
         )]
         fn _vst3q_f32(a: float32x4_t, b: float32x4_t, c: float32x4_t, ptr: *mut i8);
     }
@@ -69048,7 +69048,7 @@ pub unsafe fn vst3_s8(a: *mut i8, b: int8x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v8i8.p0"
         )]
         fn _vst3_s8(a: int8x8_t, b: int8x8_t, c: int8x8_t, ptr: *mut i8);
     }
@@ -69067,7 +69067,7 @@ pub unsafe fn vst3q_s8(a: *mut i8, b: int8x16x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v16i8.p0"
         )]
         fn _vst3q_s8(a: int8x16_t, b: int8x16_t, c: int8x16_t, ptr: *mut i8);
     }
@@ -69086,7 +69086,7 @@ pub unsafe fn vst3_s16(a: *mut i16, b: int16x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v4i16.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v4i16.p0"
         )]
         fn _vst3_s16(a: int16x4_t, b: int16x4_t, c: int16x4_t, ptr: *mut i8);
     }
@@ -69105,7 +69105,7 @@ pub unsafe fn vst3q_s16(a: *mut i16, b: int16x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v8i16.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v8i16.p0"
         )]
         fn _vst3q_s16(a: int16x8_t, b: int16x8_t, c: int16x8_t, ptr: *mut i8);
     }
@@ -69124,7 +69124,7 @@ pub unsafe fn vst3_s32(a: *mut i32, b: int32x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v2i32.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v2i32.p0"
         )]
         fn _vst3_s32(a: int32x2_t, b: int32x2_t, c: int32x2_t, ptr: *mut i8);
     }
@@ -69143,7 +69143,7 @@ pub unsafe fn vst3q_s32(a: *mut i32, b: int32x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v4i32.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v4i32.p0"
         )]
         fn _vst3q_s32(a: int32x4_t, b: int32x4_t, c: int32x4_t, ptr: *mut i8);
     }
@@ -69163,7 +69163,7 @@ pub unsafe fn vst3q_s32(a: *mut i32, b: int32x4x3_t) {
 pub unsafe fn vst3_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x3_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v4f16")]
         fn _vst3_lane_f16(
             ptr: *mut i8,
             a: float16x4_t,
@@ -69189,7 +69189,7 @@ pub unsafe fn vst3_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x3_t) {
 pub unsafe fn vst3q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x3_t) {
     static_assert_uimm_bits!(LANE, 3);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v8f16")]
         fn _vst3q_lane_f16(
             ptr: *mut i8,
             a: float16x8_t,
@@ -69216,7 +69216,7 @@ pub unsafe fn vst3_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v4f16.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v4f16.p0"
         )]
         fn _vst3_lane_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t, n: i64, ptr: *mut i8);
     }
@@ -69237,7 +69237,7 @@ pub unsafe fn vst3q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v8f16.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v8f16.p0"
         )]
         fn _vst3q_lane_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t, n: i64, ptr: *mut i8);
     }
@@ -69256,7 +69256,7 @@ pub unsafe fn vst3q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x3_t) {
 pub unsafe fn vst3_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x3_t) {
     static_assert_uimm_bits!(LANE, 1);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v2f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v2f32")]
         fn _vst3_lane_f32(
             ptr: *mut i8,
             a: float32x2_t,
@@ -69281,7 +69281,7 @@ pub unsafe fn vst3_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x3_t) {
 pub unsafe fn vst3q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x3_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v4f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v4f32")]
         fn _vst3q_lane_f32(
             ptr: *mut i8,
             a: float32x4_t,
@@ -69306,7 +69306,7 @@ pub unsafe fn vst3q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x3_t) {
 pub unsafe fn vst3_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x3_t) {
     static_assert_uimm_bits!(LANE, 3);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v8i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v8i8")]
         fn _vst3_lane_s8(ptr: *mut i8, a: int8x8_t, b: int8x8_t, c: int8x8_t, n: i32, size: i32);
     }
     _vst3_lane_s8(a as _, b.0, b.1, b.2, LANE, 1)
@@ -69324,7 +69324,7 @@ pub unsafe fn vst3_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x3_t) {
 pub unsafe fn vst3_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x3_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v4i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v4i16")]
         fn _vst3_lane_s16(
             ptr: *mut i8,
             a: int16x4_t,
@@ -69349,7 +69349,7 @@ pub unsafe fn vst3_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x3_t) {
 pub unsafe fn vst3q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x3_t) {
     static_assert_uimm_bits!(LANE, 3);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v8i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v8i16")]
         fn _vst3q_lane_s16(
             ptr: *mut i8,
             a: int16x8_t,
@@ -69374,7 +69374,7 @@ pub unsafe fn vst3q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x3_t) {
 pub unsafe fn vst3_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x3_t) {
     static_assert_uimm_bits!(LANE, 1);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v2i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v2i32")]
         fn _vst3_lane_s32(
             ptr: *mut i8,
             a: int32x2_t,
@@ -69399,7 +69399,7 @@ pub unsafe fn vst3_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x3_t) {
 pub unsafe fn vst3q_lane_s32<const LANE: i32>(a: *mut i32, b: int32x4x3_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0i8.v4i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3lane.p0.v4i32")]
         fn _vst3q_lane_s32(
             ptr: *mut i8,
             a: int32x4_t,
@@ -69426,7 +69426,7 @@ pub unsafe fn vst3_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v2f32.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v2f32.p0"
         )]
         fn _vst3_lane_f32(a: float32x2_t, b: float32x2_t, c: float32x2_t, n: i64, ptr: *mut i8);
     }
@@ -69447,7 +69447,7 @@ pub unsafe fn vst3q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v4f32.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v4f32.p0"
         )]
         fn _vst3q_lane_f32(a: float32x4_t, b: float32x4_t, c: float32x4_t, n: i64, ptr: *mut i8);
     }
@@ -69468,7 +69468,7 @@ pub unsafe fn vst3_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v8i8.p0"
         )]
         fn _vst3_lane_s8(a: int8x8_t, b: int8x8_t, c: int8x8_t, n: i64, ptr: *mut i8);
     }
@@ -69489,7 +69489,7 @@ pub unsafe fn vst3_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v4i16.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v4i16.p0"
         )]
         fn _vst3_lane_s16(a: int16x4_t, b: int16x4_t, c: int16x4_t, n: i64, ptr: *mut i8);
     }
@@ -69510,7 +69510,7 @@ pub unsafe fn vst3q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v8i16.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v8i16.p0"
         )]
         fn _vst3q_lane_s16(a: int16x8_t, b: int16x8_t, c: int16x8_t, n: i64, ptr: *mut i8);
     }
@@ -69531,7 +69531,7 @@ pub unsafe fn vst3_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v2i32.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v2i32.p0"
         )]
         fn _vst3_lane_s32(a: int32x2_t, b: int32x2_t, c: int32x2_t, n: i64, ptr: *mut i8);
     }
@@ -69552,7 +69552,7 @@ pub unsafe fn vst3q_lane_s32<const LANE: i32>(a: *mut i32, b: int32x4x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3lane.v4i32.p0i8"
+            link_name = "llvm.aarch64.neon.st3lane.v4i32.p0"
         )]
         fn _vst3q_lane_s32(a: int32x4_t, b: int32x4_t, c: int32x4_t, n: i64, ptr: *mut i8);
     }
@@ -69794,7 +69794,7 @@ pub unsafe fn vst3_s64(a: *mut i64, b: int64x1x3_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st3.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.st3.v1i64.p0"
         )]
         fn _vst3_s64(a: int64x1_t, b: int64x1_t, c: int64x1_t, ptr: *mut i8);
     }
@@ -69811,7 +69811,7 @@ pub unsafe fn vst3_s64(a: *mut i64, b: int64x1x3_t) {
 #[cfg_attr(test, assert_instr(nop))]
 pub unsafe fn vst3_s64(a: *mut i64, b: int64x1x3_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0i8.v1i64")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst3.p0.v1i64")]
         fn _vst3_s64(ptr: *mut i8, a: int64x1_t, b: int64x1_t, c: int64x1_t, size: i32);
     }
     _vst3_s64(a as _, b.0, b.1, b.2, 8)
@@ -70081,7 +70081,7 @@ pub unsafe fn vst3q_p16(a: *mut p16, b: poly16x8x3_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4_f16(a: *mut f16, b: float16x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v4f16")]
         fn _vst4_f16(
             ptr: *mut i8,
             a: float16x4_t,
@@ -70105,7 +70105,7 @@ pub unsafe fn vst4_f16(a: *mut f16, b: float16x4x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4q_f16(a: *mut f16, b: float16x8x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v8f16")]
         fn _vst4q_f16(
             ptr: *mut i8,
             a: float16x8_t,
@@ -70130,7 +70130,7 @@ pub unsafe fn vst4_f16(a: *mut f16, b: float16x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v4f16.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v4f16.p0"
         )]
         fn _vst4_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t, d: float16x4_t, ptr: *mut i8);
     }
@@ -70149,7 +70149,7 @@ pub unsafe fn vst4q_f16(a: *mut f16, b: float16x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v8f16.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v8f16.p0"
         )]
         fn _vst4q_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t, d: float16x8_t, ptr: *mut i8);
     }
@@ -70166,7 +70166,7 @@ pub unsafe fn vst4q_f16(a: *mut f16, b: float16x8x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4_f32(a: *mut f32, b: float32x2x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v2f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v2f32")]
         fn _vst4_f32(
             ptr: *mut i8,
             a: float32x2_t,
@@ -70189,7 +70189,7 @@ pub unsafe fn vst4_f32(a: *mut f32, b: float32x2x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4q_f32(a: *mut f32, b: float32x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v4f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v4f32")]
         fn _vst4q_f32(
             ptr: *mut i8,
             a: float32x4_t,
@@ -70212,7 +70212,7 @@ pub unsafe fn vst4q_f32(a: *mut f32, b: float32x4x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4_s8(a: *mut i8, b: int8x8x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v8i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v8i8")]
         fn _vst4_s8(ptr: *mut i8, a: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t, size: i32);
     }
     _vst4_s8(a as _, b.0, b.1, b.2, b.3, 1)
@@ -70228,7 +70228,7 @@ pub unsafe fn vst4_s8(a: *mut i8, b: int8x8x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4q_s8(a: *mut i8, b: int8x16x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v16i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v16i8")]
         fn _vst4q_s8(
             ptr: *mut i8,
             a: int8x16_t,
@@ -70251,7 +70251,7 @@ pub unsafe fn vst4q_s8(a: *mut i8, b: int8x16x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4_s16(a: *mut i16, b: int16x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v4i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v4i16")]
         fn _vst4_s16(
             ptr: *mut i8,
             a: int16x4_t,
@@ -70274,7 +70274,7 @@ pub unsafe fn vst4_s16(a: *mut i16, b: int16x4x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4q_s16(a: *mut i16, b: int16x8x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v8i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v8i16")]
         fn _vst4q_s16(
             ptr: *mut i8,
             a: int16x8_t,
@@ -70297,7 +70297,7 @@ pub unsafe fn vst4q_s16(a: *mut i16, b: int16x8x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4_s32(a: *mut i32, b: int32x2x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v2i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v2i32")]
         fn _vst4_s32(
             ptr: *mut i8,
             a: int32x2_t,
@@ -70320,7 +70320,7 @@ pub unsafe fn vst4_s32(a: *mut i32, b: int32x2x4_t) {
 #[cfg_attr(test, assert_instr(vst4))]
 pub unsafe fn vst4q_s32(a: *mut i32, b: int32x4x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v4i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v4i32")]
         fn _vst4q_s32(
             ptr: *mut i8,
             a: int32x4_t,
@@ -70345,7 +70345,7 @@ pub unsafe fn vst4_f32(a: *mut f32, b: float32x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v2f32.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v2f32.p0"
         )]
         fn _vst4_f32(a: float32x2_t, b: float32x2_t, c: float32x2_t, d: float32x2_t, ptr: *mut i8);
     }
@@ -70364,7 +70364,7 @@ pub unsafe fn vst4q_f32(a: *mut f32, b: float32x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v4f32.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v4f32.p0"
         )]
         fn _vst4q_f32(a: float32x4_t, b: float32x4_t, c: float32x4_t, d: float32x4_t, ptr: *mut i8);
     }
@@ -70383,7 +70383,7 @@ pub unsafe fn vst4_s8(a: *mut i8, b: int8x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v8i8.p0"
         )]
         fn _vst4_s8(a: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t, ptr: *mut i8);
     }
@@ -70402,7 +70402,7 @@ pub unsafe fn vst4q_s8(a: *mut i8, b: int8x16x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v16i8.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v16i8.p0"
         )]
         fn _vst4q_s8(a: int8x16_t, b: int8x16_t, c: int8x16_t, d: int8x16_t, ptr: *mut i8);
     }
@@ -70421,7 +70421,7 @@ pub unsafe fn vst4_s16(a: *mut i16, b: int16x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v4i16.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v4i16.p0"
         )]
         fn _vst4_s16(a: int16x4_t, b: int16x4_t, c: int16x4_t, d: int16x4_t, ptr: *mut i8);
     }
@@ -70440,7 +70440,7 @@ pub unsafe fn vst4q_s16(a: *mut i16, b: int16x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v8i16.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v8i16.p0"
         )]
         fn _vst4q_s16(a: int16x8_t, b: int16x8_t, c: int16x8_t, d: int16x8_t, ptr: *mut i8);
     }
@@ -70459,7 +70459,7 @@ pub unsafe fn vst4_s32(a: *mut i32, b: int32x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v2i32.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v2i32.p0"
         )]
         fn _vst4_s32(a: int32x2_t, b: int32x2_t, c: int32x2_t, d: int32x2_t, ptr: *mut i8);
     }
@@ -70478,7 +70478,7 @@ pub unsafe fn vst4q_s32(a: *mut i32, b: int32x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v4i32.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v4i32.p0"
         )]
         fn _vst4q_s32(a: int32x4_t, b: int32x4_t, c: int32x4_t, d: int32x4_t, ptr: *mut i8);
     }
@@ -70498,7 +70498,7 @@ pub unsafe fn vst4q_s32(a: *mut i32, b: int32x4x4_t) {
 pub unsafe fn vst4_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x4_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v4f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v4f16")]
         fn _vst4_lane_f16(
             ptr: *mut i8,
             a: float16x4_t,
@@ -70525,7 +70525,7 @@ pub unsafe fn vst4_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x4_t) {
 pub unsafe fn vst4q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x4_t) {
     static_assert_uimm_bits!(LANE, 3);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v8f16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v8f16")]
         fn _vst4q_lane_f16(
             ptr: *mut i8,
             a: float16x8_t,
@@ -70553,7 +70553,7 @@ pub unsafe fn vst4_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v4f16.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v4f16.p0"
         )]
         fn _vst4_lane_f16(
             a: float16x4_t,
@@ -70581,7 +70581,7 @@ pub unsafe fn vst4q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v8f16.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v8f16.p0"
         )]
         fn _vst4q_lane_f16(
             a: float16x8_t,
@@ -70607,7 +70607,7 @@ pub unsafe fn vst4q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x4_t) {
 pub unsafe fn vst4_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x4_t) {
     static_assert_uimm_bits!(LANE, 1);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v2f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v2f32")]
         fn _vst4_lane_f32(
             ptr: *mut i8,
             a: float32x2_t,
@@ -70633,7 +70633,7 @@ pub unsafe fn vst4_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x4_t) {
 pub unsafe fn vst4q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x4_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v4f32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v4f32")]
         fn _vst4q_lane_f32(
             ptr: *mut i8,
             a: float32x4_t,
@@ -70659,7 +70659,7 @@ pub unsafe fn vst4q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x4_t) {
 pub unsafe fn vst4_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x4_t) {
     static_assert_uimm_bits!(LANE, 3);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v8i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v8i8")]
         fn _vst4_lane_s8(
             ptr: *mut i8,
             a: int8x8_t,
@@ -70685,7 +70685,7 @@ pub unsafe fn vst4_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x4_t) {
 pub unsafe fn vst4_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x4_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v4i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v4i16")]
         fn _vst4_lane_s16(
             ptr: *mut i8,
             a: int16x4_t,
@@ -70711,7 +70711,7 @@ pub unsafe fn vst4_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x4_t) {
 pub unsafe fn vst4q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x4_t) {
     static_assert_uimm_bits!(LANE, 3);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v8i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v8i16")]
         fn _vst4q_lane_s16(
             ptr: *mut i8,
             a: int16x8_t,
@@ -70737,7 +70737,7 @@ pub unsafe fn vst4q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x4_t) {
 pub unsafe fn vst4_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x4_t) {
     static_assert_uimm_bits!(LANE, 1);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v2i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v2i32")]
         fn _vst4_lane_s32(
             ptr: *mut i8,
             a: int32x2_t,
@@ -70763,7 +70763,7 @@ pub unsafe fn vst4_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x4_t) {
 pub unsafe fn vst4q_lane_s32<const LANE: i32>(a: *mut i32, b: int32x4x4_t) {
     static_assert_uimm_bits!(LANE, 2);
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0i8.v4i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4lane.p0.v4i32")]
         fn _vst4q_lane_s32(
             ptr: *mut i8,
             a: int32x4_t,
@@ -70791,7 +70791,7 @@ pub unsafe fn vst4_lane_f32<const LANE: i32>(a: *mut f32, b: float32x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v2f32.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v2f32.p0"
         )]
         fn _vst4_lane_f32(
             a: float32x2_t,
@@ -70819,7 +70819,7 @@ pub unsafe fn vst4q_lane_f32<const LANE: i32>(a: *mut f32, b: float32x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v4f32.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v4f32.p0"
         )]
         fn _vst4q_lane_f32(
             a: float32x4_t,
@@ -70847,7 +70847,7 @@ pub unsafe fn vst4_lane_s8<const LANE: i32>(a: *mut i8, b: int8x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v8i8.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v8i8.p0"
         )]
         fn _vst4_lane_s8(a: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t, n: i64, ptr: *mut i8);
     }
@@ -70868,7 +70868,7 @@ pub unsafe fn vst4_lane_s16<const LANE: i32>(a: *mut i16, b: int16x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v4i16.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v4i16.p0"
         )]
         fn _vst4_lane_s16(
             a: int16x4_t,
@@ -70896,7 +70896,7 @@ pub unsafe fn vst4q_lane_s16<const LANE: i32>(a: *mut i16, b: int16x8x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v8i16.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v8i16.p0"
         )]
         fn _vst4q_lane_s16(
             a: int16x8_t,
@@ -70924,7 +70924,7 @@ pub unsafe fn vst4_lane_s32<const LANE: i32>(a: *mut i32, b: int32x2x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v2i32.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v2i32.p0"
         )]
         fn _vst4_lane_s32(
             a: int32x2_t,
@@ -70952,7 +70952,7 @@ pub unsafe fn vst4q_lane_s32<const LANE: i32>(a: *mut i32, b: int32x4x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4lane.v4i32.p0i8"
+            link_name = "llvm.aarch64.neon.st4lane.v4i32.p0"
         )]
         fn _vst4q_lane_s32(
             a: int32x4_t,
@@ -71199,7 +71199,7 @@ pub unsafe fn vst4_p64(a: *mut p64, b: poly64x1x4_t) {
 #[cfg_attr(test, assert_instr(nop))]
 pub unsafe fn vst4_s64(a: *mut i64, b: int64x1x4_t) {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0i8.v1i64")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vst4.p0.v1i64")]
         fn _vst4_s64(
             ptr: *mut i8,
             a: int64x1_t,
@@ -71224,7 +71224,7 @@ pub unsafe fn vst4_s64(a: *mut i64, b: int64x1x4_t) {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.st4.v1i64.p0i8"
+            link_name = "llvm.aarch64.neon.st4.v1i64.p0"
         )]
         fn _vst4_s64(a: int64x1_t, b: int64x1_t, c: int64x1_t, d: int64x1_t, ptr: *mut i8);
     }

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -34140,9 +34140,9 @@ pub fn vmull_s16(a: int16x4_t, b: int16x4_t) -> int32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smull.v4i16"
+            link_name = "llvm.aarch64.neon.smull.v4i32"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmulls.v4i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmulls.v4i32")]
         fn _vmull_s16(a: int16x4_t, b: int16x4_t) -> int32x4_t;
     }
     unsafe { _vmull_s16(a, b) }
@@ -34169,9 +34169,9 @@ pub fn vmull_s32(a: int32x2_t, b: int32x2_t) -> int64x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smull.v2i32"
+            link_name = "llvm.aarch64.neon.smull.v2i64"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmulls.v2i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmulls.v2i64")]
         fn _vmull_s32(a: int32x2_t, b: int32x2_t) -> int64x2_t;
     }
     unsafe { _vmull_s32(a, b) }
@@ -34198,9 +34198,9 @@ pub fn vmull_s8(a: int8x8_t, b: int8x8_t) -> int16x8_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smull.v8i8"
+            link_name = "llvm.aarch64.neon.smull.v8i16"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmulls.v8i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmulls.v8i16")]
         fn _vmull_s8(a: int8x8_t, b: int8x8_t) -> int16x8_t;
     }
     unsafe { _vmull_s8(a, b) }
@@ -34227,9 +34227,9 @@ pub fn vmull_u8(a: uint8x8_t, b: uint8x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umull.v8i8"
+            link_name = "llvm.aarch64.neon.umull.v8i16"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmullu.v8i8")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmullu.v8i16")]
         fn _vmull_u8(a: uint8x8_t, b: uint8x8_t) -> uint16x8_t;
     }
     unsafe { _vmull_u8(a, b) }
@@ -34256,9 +34256,9 @@ pub fn vmull_u16(a: uint16x4_t, b: uint16x4_t) -> uint32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umull.v4i16"
+            link_name = "llvm.aarch64.neon.umull.v4i32"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmullu.v4i16")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmullu.v4i32")]
         fn _vmull_u16(a: uint16x4_t, b: uint16x4_t) -> uint32x4_t;
     }
     unsafe { _vmull_u16(a, b) }
@@ -34285,9 +34285,9 @@ pub fn vmull_u32(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umull.v2i32"
+            link_name = "llvm.aarch64.neon.umull.v2i64"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmullu.v2i32")]
+        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmullu.v2i64")]
         fn _vmull_u32(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t;
     }
     unsafe { _vmull_u32(a, b) }

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -6924,15 +6924,7 @@ pub fn vcltzq_f16(a: float16x8_t) -> uint16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vclz_s8(a: int8x8_t) -> int8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctlz.v8i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctlz.v8i8"
-        )]
-        fn _vclz_s8(a: int8x8_t) -> int8x8_t;
-    }
-    unsafe { _vclz_s8(a) }
+    unsafe { simd_ctlz(a) }
 }
 #[doc = "Count leading zero bits"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vclzq_s8)"]
@@ -6953,15 +6945,7 @@ pub fn vclz_s8(a: int8x8_t) -> int8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vclzq_s8(a: int8x16_t) -> int8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctlz.v16i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctlz.v16i8"
-        )]
-        fn _vclzq_s8(a: int8x16_t) -> int8x16_t;
-    }
-    unsafe { _vclzq_s8(a) }
+    unsafe { simd_ctlz(a) }
 }
 #[doc = "Count leading zero bits"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vclz_s16)"]
@@ -6982,15 +6966,7 @@ pub fn vclzq_s8(a: int8x16_t) -> int8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vclz_s16(a: int16x4_t) -> int16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctlz.v4i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctlz.v4i16"
-        )]
-        fn _vclz_s16(a: int16x4_t) -> int16x4_t;
-    }
-    unsafe { _vclz_s16(a) }
+    unsafe { simd_ctlz(a) }
 }
 #[doc = "Count leading zero bits"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vclzq_s16)"]
@@ -7011,15 +6987,7 @@ pub fn vclz_s16(a: int16x4_t) -> int16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vclzq_s16(a: int16x8_t) -> int16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctlz.v8i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctlz.v8i16"
-        )]
-        fn _vclzq_s16(a: int16x8_t) -> int16x8_t;
-    }
-    unsafe { _vclzq_s16(a) }
+    unsafe { simd_ctlz(a) }
 }
 #[doc = "Count leading zero bits"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vclz_s32)"]
@@ -7040,15 +7008,7 @@ pub fn vclzq_s16(a: int16x8_t) -> int16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vclz_s32(a: int32x2_t) -> int32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctlz.v2i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctlz.v2i32"
-        )]
-        fn _vclz_s32(a: int32x2_t) -> int32x2_t;
-    }
-    unsafe { _vclz_s32(a) }
+    unsafe { simd_ctlz(a) }
 }
 #[doc = "Count leading zero bits"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vclzq_s32)"]
@@ -7069,15 +7029,7 @@ pub fn vclz_s32(a: int32x2_t) -> int32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vclzq_s32(a: int32x4_t) -> int32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctlz.v4i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctlz.v4i32"
-        )]
-        fn _vclzq_s32(a: int32x4_t) -> int32x4_t;
-    }
-    unsafe { _vclzq_s32(a) }
+    unsafe { simd_ctlz(a) }
 }
 #[doc = "Count leading zero bits"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vclz_u16)"]
@@ -7391,15 +7343,7 @@ pub fn vclzq_u8(a: uint8x16_t) -> uint8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vcnt_s8(a: int8x8_t) -> int8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctpop.v8i8"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctpop.v8i8")]
-        fn _vcnt_s8(a: int8x8_t) -> int8x8_t;
-    }
-    unsafe { _vcnt_s8(a) }
+    unsafe { simd_ctpop(a) }
 }
 #[doc = "Population count per byte."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vcntq_s8)"]
@@ -7420,15 +7364,7 @@ pub fn vcnt_s8(a: int8x8_t) -> int8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vcntq_s8(a: int8x16_t) -> int8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.ctpop.v16i8"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.ctpop.v16i8")]
-        fn _vcntq_s8(a: int8x16_t) -> int8x16_t;
-    }
-    unsafe { _vcntq_s8(a) }
+    unsafe { simd_ctpop(a) }
 }
 #[doc = "Population count per byte."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vcnt_u8)"]
@@ -12497,12 +12433,7 @@ pub fn vextq_p8<const N: i32>(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vfma_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.fma.v4f16")]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.fma.v4f16")]
-        fn _vfma_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vfma_f16(b, c, a) }
+    unsafe { simd_fma(b, c, a) }
 }
 #[doc = "Floating-point fused Multiply-Add to accumulator (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfmaq_f16)"]
@@ -12516,12 +12447,7 @@ pub fn vfma_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vfmaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.fma.v8f16")]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.fma.v8f16")]
-        fn _vfmaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vfmaq_f16(b, c, a) }
+    unsafe { simd_fma(b, c, a) }
 }
 #[doc = "Floating-point fused Multiply-Add to accumulator(vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfma_f32)"]
@@ -12542,12 +12468,7 @@ pub fn vfmaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t 
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vfma_f32(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.fma.v2f32")]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.fma.v2f32")]
-        fn _vfma_f32(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vfma_f32(b, c, a) }
+    unsafe { simd_fma(b, c, a) }
 }
 #[doc = "Floating-point fused Multiply-Add to accumulator(vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfmaq_f32)"]
@@ -12568,12 +12489,7 @@ pub fn vfma_f32(a: float32x2_t, b: float32x2_t, c: float32x2_t) -> float32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vfmaq_f32(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.fma.v4f32")]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.fma.v4f32")]
-        fn _vfmaq_f32(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vfmaq_f32(b, c, a) }
+    unsafe { simd_fma(b, c, a) }
 }
 #[doc = "Floating-point fused Multiply-Add to accumulator(vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vfma_n_f32)"]

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -110,9 +110,9 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.wasm.avgr.unsigned.v8i16"]
     fn llvm_avgr_u_i16x8(a: simd::i16x8, b: simd::i16x8) -> simd::i16x8;
 
-    #[link_name = "llvm.wasm.extadd.pairwise.signed.v16i8"]
+    #[link_name = "llvm.wasm.extadd.pairwise.signed.v4i32"]
     fn llvm_i32x4_extadd_pairwise_i16x8_s(x: simd::i16x8) -> simd::i32x4;
-    #[link_name = "llvm.wasm.extadd.pairwise.unsigned.v16i8"]
+    #[link_name = "llvm.wasm.extadd.pairwise.unsigned.v4i32"]
     fn llvm_i32x4_extadd_pairwise_i16x8_u(x: simd::i16x8) -> simd::i32x4;
     #[link_name = "llvm.wasm.alltrue.v4i32"]
     fn llvm_i32x4_all_true(x: simd::i32x4) -> i32;

--- a/crates/core_arch/src/x86/avx512dq.rs
+++ b/crates/core_arch/src/x86/avx512dq.rs
@@ -7071,18 +7071,18 @@ unsafe extern "C" {
     #[link_name = "llvm.x86.avx512.sitofp.round.v8f32.v8i64"]
     fn vcvtqq2ps_512(a: i64x8, rounding: i32) -> f32x8;
 
-    #[link_name = "llvm.x86.avx512.uitofp.round.v2f64.v2u64"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v2f64.v2i64"]
     fn vcvtuqq2pd_128(a: u64x2, rounding: i32) -> f64x2;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v4f64.v4u64"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v4f64.v4i64"]
     fn vcvtuqq2pd_256(a: u64x4, rounding: i32) -> f64x4;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v8f64.v8u64"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v8f64.v8i64"]
     fn vcvtuqq2pd_512(a: u64x8, rounding: i32) -> f64x8;
 
     #[link_name = "llvm.x86.avx512.mask.cvtuqq2ps.128"]
     fn vcvtuqq2ps_128(a: u64x2, src: f32x4, k: __mmask8) -> f32x4;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v4f32.v4u64"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v4f32.v4i64"]
     fn vcvtuqq2ps_256(a: u64x4, rounding: i32) -> f32x4;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v8f32.v8u64"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v8f32.v8i64"]
     fn vcvtuqq2ps_512(a: u64x8, rounding: i32) -> f32x8;
 
     #[link_name = "llvm.x86.avx512.mask.cvtpd2qq.128"]

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -16458,11 +16458,11 @@ unsafe extern "C" {
     fn vcvtw2ph_256(a: i16x16, rounding: i32) -> __m256h;
     #[link_name = "llvm.x86.avx512.sitofp.round.v32f16.v32i16"]
     fn vcvtw2ph_512(a: i16x32, rounding: i32) -> __m512h;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v8f16.v8u16"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v8f16.v8i16"]
     fn vcvtuw2ph_128(a: u16x8, rounding: i32) -> __m128h;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v16f16.v16u16"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v16f16.v16i16"]
     fn vcvtuw2ph_256(a: u16x16, rounding: i32) -> __m256h;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v32f16.v32u16"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v32f16.v32i16"]
     fn vcvtuw2ph_512(a: u16x32, rounding: i32) -> __m512h;
 
     #[link_name = "llvm.x86.avx512fp16.mask.vcvtdq2ph.128"]
@@ -16475,9 +16475,9 @@ unsafe extern "C" {
     fn vcvtsi2sh(a: __m128h, b: i32, rounding: i32) -> __m128h;
     #[link_name = "llvm.x86.avx512fp16.mask.vcvtudq2ph.128"]
     fn vcvtudq2ph_128(a: u32x4, src: __m128h, k: __mmask8) -> __m128h;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v8f16.v8u32"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v8f16.v8i32"]
     fn vcvtudq2ph_256(a: u32x8, rounding: i32) -> __m128h;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v16f16.v16u32"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v16f16.v16i32"]
     fn vcvtudq2ph_512(a: u32x16, rounding: i32) -> __m256h;
     #[link_name = "llvm.x86.avx512fp16.vcvtusi2sh"]
     fn vcvtusi2sh(a: __m128h, b: u32, rounding: i32) -> __m128h;
@@ -16492,7 +16492,7 @@ unsafe extern "C" {
     fn vcvtuqq2ph_128(a: u64x2, src: __m128h, k: __mmask8) -> __m128h;
     #[link_name = "llvm.x86.avx512fp16.mask.vcvtuqq2ph.256"]
     fn vcvtuqq2ph_256(a: u64x4, src: __m128h, k: __mmask8) -> __m128h;
-    #[link_name = "llvm.x86.avx512.uitofp.round.v8f16.v8u64"]
+    #[link_name = "llvm.x86.avx512.uitofp.round.v8f16.v8i64"]
     fn vcvtuqq2ph_512(a: u64x8, rounding: i32) -> __m128h;
 
     #[link_name = "llvm.x86.avx512fp16.mask.vcvtps2phx.128"]

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13183,16 +13183,16 @@ intrinsics:
     assert_instr: [addv]
     safety: safe
     types:
-      - [int8x8_t, i8, i32]
-      - [int16x4_t, i16, i32]
-      - [int8x16_t, i8, i32]
-      - [int16x8_t, i16, i32]
-      - [int32x4_t, i32, i32]
+      - [int8x8_t, i8]
+      - [int16x4_t, i16]
+      - [int8x16_t, i8]
+      - [int16x8_t, i16]
+      - [int32x4_t, i32]
     compose:
       - LLVMLink:
           name: "vaddv{neon_type[0].no}"
           links:
-            - link: "llvm.aarch64.neon.saddv.{type[2]}.{neon_type[0]}"
+            - link: "llvm.aarch64.neon.saddv.{type[1]}.{neon_type[0]}"
               arch: aarch64,arm64ec
 
   - name: "vaddv{neon_type[0].no}"
@@ -13238,16 +13238,16 @@ intrinsics:
     assert_instr: [addv]
     safety: safe
     types:
-      - [uint8x8_t,  u8, i32]
-      - [uint16x4_t, u16, i32]
-      - [uint8x16_t, u8, i32]
-      - [uint16x8_t, u16, i32]
-      - [uint32x4_t, u32, i32]
+      - [uint8x8_t,  u8]
+      - [uint16x4_t, u16]
+      - [uint8x16_t, u8]
+      - [uint16x8_t, u16]
+      - [uint32x4_t, u32]
     compose:
       - LLVMLink:
           name: "vaddv{neon_type[0].no}"
           links:
-            - link: "llvm.aarch64.neon.uaddv.{type[2]}.{neon_type[0]}"
+            - link: "llvm.aarch64.neon.uaddv.{type[1]}.{neon_type[0]}"
               arch: aarch64,arm64ec
 
   - name: "vaddv{neon_type[0].no}"

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -3015,11 +3015,7 @@ intrinsics:
     types:
       - [f16, 'h_']
     compose:
-      - LLVMLink:
-          name: "llvm.rint.{type[0]}"
-          links:
-            - link: "llvm.rint.{type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [round_ties_even_f16, [a]]
 
 
   - name: "vrnda{neon_type.no}"
@@ -3035,11 +3031,7 @@ intrinsics:
       - float64x1_t
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "llvm.round.{neon_type}"
-          links:
-            - link: "llvm.round.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_round, [a]]
 
 
   - name: "vrnda{neon_type.no}"
@@ -3055,11 +3047,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "llvm.round.{neon_type}"
-          links:
-            - link: "llvm.round.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_round, [a]]
 
 
   - name: "vrnda{type[1]}{type[0]}"
@@ -3074,11 +3062,7 @@ intrinsics:
     types:
       - [f16, 'h_']
     compose:
-      - LLVMLink:
-          name: "llvm.round.{type[0]}"
-          links:
-            - link: "llvm.round.{type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [roundf16, [a], [], true]
 
   - name: "vrndn{neon_type.no}"
     doc: "Floating-point round to integral, to nearest with ties to even"
@@ -3144,11 +3128,7 @@ intrinsics:
       - float64x1_t
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "llvm.floor.{neon_type}"
-          links:
-            - link: "llvm.floor.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_floor, [a]]
 
 
   - name: "vrndm{neon_type.no}"
@@ -3164,11 +3144,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "llvm.floor.{neon_type}"
-          links:
-            - link: "llvm.floor.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_floor, [a]]
 
 
   - name: "vrndm{type[1]}{type[0]}"
@@ -3183,11 +3159,7 @@ intrinsics:
     types:
       - [f16, 'h_']
     compose:
-      - LLVMLink:
-          name: "llvm.floor.{type[0]}"
-          links:
-            - link: "llvm.floor.{type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [floorf16, [a], [], true]
 
 
 
@@ -3204,11 +3176,7 @@ intrinsics:
       - float64x1_t
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "llvm.ceil.{neon_type}"
-          links:
-            - link: "llvm.ceil.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_ceil, [a]]
 
 
   - name: "vrndp{neon_type.no}"
@@ -3224,11 +3192,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "llvm.ceil.{neon_type}"
-          links:
-            - link: "llvm.ceil.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_ceil, [a]]
 
   - name: "vrndp{type[1]}{type[0]}"
     doc: "Floating-point round to integral, toward plus infinity"
@@ -3242,11 +3206,7 @@ intrinsics:
     types:
       - [f16, 'h_']
     compose:
-      - LLVMLink:
-          name: "llvm.ceil.{type[0]}"
-          links:
-            - link: "llvm.ceil.{type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [ceilf16, [a], [], true]
 
   - name: "vrnd{neon_type.no}"
     doc: "Floating-point round to integral, toward zero"
@@ -3261,11 +3221,7 @@ intrinsics:
       - float64x1_t
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "llvm.trunc.{neon_type}"
-          links:
-            - link: "llvm.trunc.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_trunc, [a]]
 
   - name: "vrnd{neon_type.no}"
     doc: "Floating-point round to integral, toward zero"
@@ -3280,11 +3236,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "llvm.trunc.{neon_type}"
-          links:
-            - link: "llvm.trunc.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_trunc, [a]]
 
 
   - name: "vrnd{type[1]}{type[0]}"
@@ -3299,11 +3251,7 @@ intrinsics:
     types:
       - [f16, 'h_']
     compose:
-      - LLVMLink:
-          name: "llvm.trunc.{type[0]}"
-          links:
-            - link: "llvm.trunc.{type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [truncf16, [a], [], true]
 
 
   - name: "vrndi{neon_type.no}"
@@ -5543,13 +5491,7 @@ intrinsics:
     types:
       - float64x1_t
     compose:
-      - LLVMLink:
-          name: "_vfma{neon_type.no}"
-          arguments: ["a: {type}", "b: {type}", "c: {type}"]
-          links:
-            - link: "llvm.fma.{neon_type}"
-              arch: aarch64,arm64ec
-      - FnCall: ["_vfma{neon_type.no}", [b, c, a], [], true]
+      - FnCall: [simd_fma, [b, c, a]]
 
   - name: "vfma{neon_type.no}"
     doc: Floating-point fused Multiply-Add to accumulator(vector)
@@ -5562,13 +5504,7 @@ intrinsics:
     types:
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "_vfma{neon_type.no}"
-          arguments: ["a: {type}", "b: {type}", "c: {type}"]
-          links:
-            - link: "llvm.fma.{neon_type}"
-              arch: aarch64,arm64ec
-      - FnCall: ["_vfma{neon_type.no}", [b, c, a], [], true]
+      - FnCall: [simd_fma, [b, c, a]]
 
   - name: "vfma_n_f64"
     doc: Floating-point fused Multiply-Add to accumulator(vector)
@@ -8511,11 +8447,7 @@ intrinsics:
     types:
       - [f16, 'h_']
     compose:
-      - LLVMLink:
-          name: "llvm.sqrt.{type[0]}"
-          links:
-            - link: "llvm.sqrt.{type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [sqrtf16, [a], [], true]
 
   - name: "vrsqrts{type[0]}"
     doc: "Floating-point reciprocal square root step"
@@ -10429,15 +10361,9 @@ intrinsics:
       - ["f32", float32x4_t, "s_laneq_f32", '2']
       - ["f64", float64x2_t, "d_laneq_f64", '1']
     compose:
-      - LLVMLink:
-          name: "_vfma{type[2]}"
-          arguments: ["a: {type[0]}", "b: {type[0]}", "c: {type[0]}"]
-          links:
-            - link: "llvm.fma.{type[0]}"
-              arch: aarch64,arm64ec
       - FnCall: [static_assert_uimm_bits!, ['LANE', "{type[3]}"]]
       - Let: [c, "{type[0]}", {FnCall: [simd_extract!, [c, 'LANE as u32']]}]
-      - FnCall: ["_vfma{type[2]}", [b, c, a], [], true]
+      - FnCall: ["fma{type[0]}", [b, c, a]]
 
   - name: "vfmad_lane_f64"
     doc: "Floating-point fused multiply-add to accumulator"
@@ -10452,15 +10378,9 @@ intrinsics:
     types:
       - ["f64", float64x1_t]
     compose:
-      - LLVMLink:
-          name: "_vfmad_lane_f64"
-          arguments: ["a: f64", "b: f64", "c: f64"]
-          links:
-            - link: "llvm.fma.{type[0]}"
-              arch: aarch64,arm64ec
       - FnCall: [static_assert!, ['LANE == 0']]
       - Let: [c, "{type[0]}", {FnCall: [simd_extract!, [c, 'LANE as u32']]}]
-      - FnCall: ["_vfmad_lane_f64", [b, c, a]]
+      - FnCall: [fmaf64, [b, c, a]]
 
 
   - name: "vfma{type[1]}"
@@ -10475,12 +10395,7 @@ intrinsics:
     types:
       - ["f16", "h_f16"]
     compose:
-      - LLVMLink:
-          name: "_vfma_{type[1]}"
-          links:
-            - link: "llvm.fma.{type[0]}"
-              arch: aarch64,arm64ec
-      - FnCall: ["_vfma{type[1]}", [b, c, a], [], true]
+      - FnCall: [fmaf16, [b, c, a], [], true]
 
 
   - name: "vfmah_lane{type[2]}"

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -3428,7 +3428,7 @@ intrinsics:
       - LLVMLink:
           name: "vld1{neon_type[1].no}"
           links:
-            - link: "llvm.aarch64.neon.ld1x{neon_type[1].tuple}.v{neon_type[1].lane}f{neon_type[1].base}.p0f64"
+            - link: "llvm.aarch64.neon.ld1x{neon_type[1].tuple}.v{neon_type[1].lane}f{neon_type[1].base}.p0"
               arch: aarch64,arm64ec
 
   - name: "vld2{neon_type[1].lane_nox}"
@@ -3460,7 +3460,7 @@ intrinsics:
             - "n: i64"
             - "ptr: *const i8"
           links:
-            - link: "llvm.aarch64.neon.ld2lane.v{neon_type[1].lane}{type[2]}.p0i8"
+            - link: "llvm.aarch64.neon.ld2lane.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vld2{neon_type[1].lane_nox}", ["b.0", "b.1", "LANE as i64", "a as _"]]
 
@@ -3489,7 +3489,7 @@ intrinsics:
             - "n: i64"
             - "ptr: *const i8"
           links:
-            - link: "llvm.aarch64.neon.ld2lane.v{neon_type[1].lane}{type[2]}.p0i8"
+            - link: "llvm.aarch64.neon.ld2lane.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vld2{neon_type[1].lane_nox}", ["b.0", "b.1", "LANE as i64", "a as _"]]
 
@@ -3613,7 +3613,7 @@ intrinsics:
           arguments:
             - "ptr: *const {neon_type[3]}"
           links:
-            - link: "llvm.aarch64.neon.ld2.v{neon_type[1].lane}{type[2]}.p0v{neon_type[1].lane}{type[2]}"
+            - link: "llvm.aarch64.neon.ld2.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld2{neon_type[1].nox}"
@@ -3635,7 +3635,7 @@ intrinsics:
           arguments:
             - "ptr: *const {neon_type[3]}"
           links:
-            - link: "llvm.aarch64.neon.ld2.v{neon_type[1].lane}{type[2]}.p0v{neon_type[1].lane}{type[2]}"
+            - link: "llvm.aarch64.neon.ld2.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld2{neon_type[1].nox}"
@@ -3696,7 +3696,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld2r.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld2r.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld2{neon_type[1].dup_nox}"
@@ -3769,7 +3769,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *const i8'
           links:
-            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0i8'
+            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -3798,7 +3798,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *const i8'
           links:
-            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0i8'
+            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -3827,7 +3827,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *const i8'
           links:
-            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0i8'
+            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -3856,7 +3856,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *const i8'
           links:
-            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0i8'
+            - link: 'llvm.aarch64.neon.ld3lane.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -3973,7 +3973,7 @@ intrinsics:
           arguments:
             - 'ptr: {type[2]}'
           links:
-            - link: 'llvm.aarch64.neon.ld3.v{neon_type[1].lane}{type[3]}.p0v{neon_type[1].lane}{type[3]}'
+            - link: 'llvm.aarch64.neon.ld3.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].nox}', ['a as _']]
 
@@ -3993,7 +3993,7 @@ intrinsics:
           arguments:
             - 'ptr: {type[2]}'
           links:
-            - link: 'llvm.aarch64.neon.ld3.v{neon_type[1].lane}{type[3]}.p0v{neon_type[1].lane}{type[3]}'
+            - link: 'llvm.aarch64.neon.ld3.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].nox}', ['a as _']]
 
@@ -4055,7 +4055,7 @@ intrinsics:
           arguments:
             - 'ptr: {type[0]}'
           links:
-            - link: 'llvm.aarch64.neon.ld3r.v{neon_type[1].lane}{type[2]}.p0{type[2]}'
+            - link: 'llvm.aarch64.neon.ld3r.v{neon_type[1].lane}{type[2]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld3{neon_type[1].dup_nox}', ['a as _']]
 
@@ -4117,7 +4117,7 @@ intrinsics:
           arguments:
             - 'ptr: {type[3]}'
           links:
-            - link: 'llvm.aarch64.neon.ld4.v{neon_type[1].lane}{type[2]}.p0v{neon_type[1].lane}{type[2]}'
+            - link: 'llvm.aarch64.neon.ld4.v{neon_type[1].lane}{type[2]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld4{neon_type[1].nox}', ['a as _']]
 
@@ -4138,7 +4138,7 @@ intrinsics:
           arguments:
             - 'ptr: {type[3]}'
           links:
-            - link: 'llvm.aarch64.neon.ld4.v{neon_type[1].lane}{type[2]}.p0v{neon_type[1].lane}{type[2]}'
+            - link: 'llvm.aarch64.neon.ld4.v{neon_type[1].lane}{type[2]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld4{neon_type[1].nox}', ['a as _']]
 
@@ -4210,7 +4210,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *const i8'
           links:
-            - link: 'llvm.aarch64.neon.ld4lane.v{neon_type[1].lane}{type[3]}.p0i8'
+            - link: 'llvm.aarch64.neon.ld4lane.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld4{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'LANE as i64', 'a as _']]
 
@@ -4241,7 +4241,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *const i8'
           links:
-            - link: 'llvm.aarch64.neon.ld4lane.v{neon_type[1].lane}{type[3]}.p0i8'
+            - link: 'llvm.aarch64.neon.ld4lane.v{neon_type[1].lane}{type[3]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vld4{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'LANE as i64', 'a as _']]
 
@@ -4398,7 +4398,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].nox}', ['b.0', 'b.1', 'a as _']]
 
@@ -4421,7 +4421,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].nox}', ['b.0', 'b.1', 'a as _']]
 
@@ -4448,7 +4448,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].lane_nox}', ['b.0', 'b.1', 'LANE as i64', 'a as _']]
 
@@ -4476,7 +4476,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].lane_nox}', ['b.0', 'b.1', 'LANE as i64', 'a as _']]
 
@@ -4611,7 +4611,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'a as _']]
 
@@ -4691,7 +4691,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'a as _']]
 
@@ -4775,7 +4775,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -4803,7 +4803,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -4826,7 +4826,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'a as _']]
 
@@ -4907,7 +4907,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'a as _']]
 
@@ -4992,7 +4992,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'LANE as i64', 'a as _']]
 
@@ -5021,7 +5021,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'LANE as i64', 'a as _']]
 
@@ -10142,7 +10142,7 @@ intrinsics:
             - "b: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x{neon_type[1].tuple}.{neon_type[2]}.p0f64"
+            - link: "llvm.aarch64.neon.st1x{neon_type[1].tuple}.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'a']]
 
@@ -10166,7 +10166,7 @@ intrinsics:
             - "c: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x{neon_type[1].tuple}.{neon_type[2]}.p0f64"
+            - link: "llvm.aarch64.neon.st1x{neon_type[1].tuple}.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'b.2', 'a']]
 
@@ -10191,7 +10191,7 @@ intrinsics:
             - "d: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x{neon_type[1].tuple}.{neon_type[2]}.p0f64"
+            - link: "llvm.aarch64.neon.st1x{neon_type[1].tuple}.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'b.2', 'b.3', 'a']]
 
@@ -11998,16 +11998,16 @@ intrinsics:
     safety:
       unsafe: [neon]
     types:
-      - ["*const i64", int64x2x4_t, "v2i64", "p0i64"]
-      - ["*const f64", float64x1x4_t, "v1f64", "p0f64"]
-      - ["*const f64", float64x2x4_t, "v2f64", "p0f64"]
+      - ["*const i64", int64x2x4_t, "v2i64"]
+      - ["*const f64", float64x1x4_t, "v1f64"]
+      - ["*const f64", float64x2x4_t, "v2f64"]
     compose:
       - LLVMLink:
           name: "vld4{neon_type[1].dup_nox}"
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld4r.{type[2]}.{type[3]}"
+            - link: "llvm.aarch64.neon.ld4r.{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vld4{neon_type[1].dup_nox}", ['a as _']]
 

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -6427,9 +6427,9 @@ intrinsics:
       - LLVMLink:
           name: "smull.{neon_type[1]}"
           links:
-            - link: "llvm.aarch64.neon.smull.{neon_type[1]}"
+            - link: "llvm.aarch64.neon.smull.{neon_type[2]}"
               arch: aarch64,arm64ec
-            - link: "llvm.arm.neon.vmulls.{neon_type[1]}"
+            - link: "llvm.arm.neon.vmulls.{neon_type[2]}"
               arch: arm
 
   - name: "vmull{neon_type[1].no}"
@@ -6451,9 +6451,9 @@ intrinsics:
       - LLVMLink:
           name: "smull.{neon_type[1]}"
           links:
-            - link: "llvm.aarch64.neon.umull.{neon_type[1]}"
+            - link: "llvm.aarch64.neon.umull.{neon_type[2]}"
               arch: aarch64,arm64ec
-            - link: "llvm.arm.neon.vmullu.{neon_type[1]}"
+            - link: "llvm.arm.neon.vmullu.{neon_type[2]}"
               arch: arm
 
   - name: "vmull{neon_type[1].no}"

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -790,13 +790,7 @@ intrinsics:
       - [int32x2_t, '.i32']
       - [int32x4_t, '.i32']
     compose:
-      - LLVMLink:
-          name: "vclz{neon_type[0].no}"
-          links:
-            - link: "llvm.ctlz.{neon_type[0]}"
-              arch: arm
-            - link: "llvm.ctlz.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_ctlz, [a]]
 
   - name: "vclz{neon_type[0].no}"
     doc: "Count leading zero bits"
@@ -6562,14 +6556,7 @@ intrinsics:
       - float32x2_t
       - float32x4_t
     compose:
-      - LLVMLink:
-          name: "fma.{neon_type}"
-          links:
-            - link: "llvm.fma.{neon_type}"
-              arch: aarch64
-            - link: "llvm.fma.{neon_type}"
-              arch: arm
-      - FnCall: ["_vfma{neon_type.no}", [b, c, a], [], true]
+      - FnCall: [simd_fma, [b, c, a]]
 
 
   - name: "vfma{neon_type.no}"
@@ -6587,14 +6574,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "fma.{neon_type}"
-          links:
-            - link: "llvm.fma.{neon_type}"
-              arch: aarch64
-            - link: "llvm.fma.{neon_type}"
-              arch: arm
-      - FnCall: ["_vfma{neon_type.no}", [b, c, a], [], true]
+      - FnCall: [simd_fma, [b, c, a]]
 
 
   - name: "vfma{neon_type[0].N}"
@@ -13359,13 +13339,7 @@ intrinsics:
       - int8x8_t
       - int8x16_t
     compose:
-      - LLVMLink:
-          name: "vcnt{neon_type.no}"
-          links:
-            - link: "llvm.ctpop.{neon_type}"
-              arch: aarch64,arm64ec
-            - link: "llvm.ctpop.{neon_type}"
-              arch: arm
+      - FnCall: [simd_ctpop, [a]]
 
   - name: "vcnt{neon_type[0].no}"
     doc: "Population count per byte."

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -2756,9 +2756,9 @@ intrinsics:
       - LLVMLink:
           name: "vld1x{neon_type[1].tuple}.{neon_type[1]}"
           links:
-            - link: "llvm.aarch64.neon.ld1x{neon_type[1].tuple}.v{neon_type[1].lane}f{neon_type[1].base}.p0f{neon_type[1].base}"
+            - link: "llvm.aarch64.neon.ld1x{neon_type[1].tuple}.v{neon_type[1].lane}f{neon_type[1].base}.p0"
               arch: aarch64,arm64ec
-            - link: "llvm.arm.neon.vld1x{neon_type[1].tuple}.v{neon_type[1].lane}f{neon_type[1].base}.p0f{neon_type[1].base}"
+            - link: "llvm.arm.neon.vld1x{neon_type[1].tuple}.v{neon_type[1].lane}f{neon_type[1].base}.p0"
               arch: arm
 
   - name: "vld1{type[2]}_{neon_type[1]}"
@@ -3397,7 +3397,7 @@ intrinsics:
             - "ptr: {type[0]}"
             - "size: i32"
           links:
-            - link: "llvm.arm.neon.vld2.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.arm.neon.vld2.v{neon_type[1].lane}{type[2]}.p0"
               arch: arm
       - FnCall:
           - "_vld2{neon_type[1].nox}"
@@ -3424,7 +3424,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld2.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld2.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld2{neon_type[1].nox}"
@@ -3452,7 +3452,7 @@ intrinsics:
             - "ptr: {type[0]}"
             - "size: i32"
           links:
-            - link: "llvm.arm.neon.vld2dup.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.arm.neon.vld2dup.v{neon_type[1].lane}{type[2]}.p0"
               arch: arm
       - FnCall:
           - "_vld2{neon_type[1].dup_nox}"
@@ -3480,7 +3480,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld2r.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld2r.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld2{neon_type[1].dup_nox}"
@@ -3592,7 +3592,7 @@ intrinsics:
             - "ptr: {type[0]}"
             - "size: i32"
           links:
-            - link: "llvm.arm.neon.vld3.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.arm.neon.vld3.v{neon_type[1].lane}{type[2]}.p0"
               arch: arm
       - FnCall:
           - "_vld3{neon_type[1].nox}"
@@ -3619,7 +3619,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld3.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld3.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld3{neon_type[1].nox}"
@@ -3647,7 +3647,7 @@ intrinsics:
             - "ptr: {type[0]}"
             - "size: i32"
           links:
-            - link: "llvm.arm.neon.vld3dup.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.arm.neon.vld3dup.v{neon_type[1].lane}{type[2]}.p0"
               arch: arm
       - FnCall:
           - "_vld3{neon_type[1].dup_nox}"
@@ -3675,7 +3675,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld3r.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld3r.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld3{neon_type[1].dup_nox}"
@@ -4755,7 +4755,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'ptr: *mut {type[0]}'
           links:
-            - link: 'llvm.aarch64.neon.st1x2.v{neon_type[1].lane}{type[0]}.p0{type[0]}'
+            - link: 'llvm.aarch64.neon.st1x2.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst1{neon_type[1].no}', ['b.0', 'b.1', 'a']]
 
@@ -4786,7 +4786,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'ptr: *mut {type[0]}'
           links:
-            - link: 'llvm.aarch64.neon.st1x3.v{neon_type[1].lane}{type[0]}.p0{type[0]}'
+            - link: 'llvm.aarch64.neon.st1x3.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst1{neon_type[1].no}', ['b.0', 'b.1', 'b.2', 'a']]
 
@@ -4818,7 +4818,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'ptr: *mut {type[0]}'
           links:
-            - link: 'llvm.aarch64.neon.st1x4.v{neon_type[1].lane}{type[0]}.p0{type[0]}'
+            - link: 'llvm.aarch64.neon.st1x4.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst1{neon_type[1].no}', ['b.0', 'b.1', 'b.2', 'b.3', 'a']]
 
@@ -4881,7 +4881,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'c: {type[2]}'
           links:
-            - link: 'llvm.arm.neon.vst1x3.p0{type[0]}.v{neon_type[1].lane}{type[0]}.p0'
+            - link: 'llvm.arm.neon.vst1x3.p0.v{neon_type[1].lane}{type[0]}.p0'
               arch: arm
       - FnCall: ['_vst1{neon_type[1].no}', ['a', 'b.0', 'b.1', 'b.2']]
 
@@ -4914,7 +4914,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'd: {type[2]}'
           links:
-            - link: 'llvm.arm.neon.vst1x4.p0{type[0]}.v{neon_type[1].lane}{type[0]}.p0'
+            - link: 'llvm.arm.neon.vst1x4.p0.v{neon_type[1].lane}{type[0]}.p0'
               arch: arm
       - FnCall: ['_vst1{neon_type[1].no}', ['a', 'b.0', 'b.1', 'b.2', 'b.3']]
 
@@ -4941,7 +4941,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'd: {type[2]}'
           links:
-            - link: 'llvm.arm.neon.vst1x4.p0{type[0]}.v{neon_type[1].lane}{type[0]}.p0'
+            - link: 'llvm.arm.neon.vst1x4.p0.v{neon_type[1].lane}{type[0]}.p0'
               arch: arm
       - FnCall: ['_vst1{neon_type[1].no}', ['a', 'b.0', 'b.1', 'b.2', 'b.3']]
 
@@ -4969,7 +4969,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'd: {type[2]}'
           links:
-            - link: 'llvm.arm.neon.vst1x4.p0{type[0]}.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst1x4.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst1{neon_type[1].no}', ['a', 'b.0', 'b.1', 'b.2', 'b.3']]
 
@@ -5056,7 +5056,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].nox}', ['b.0', 'b.1', 'a as _']]
 
@@ -5086,7 +5086,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].nox}', ['b.0', 'b.1', 'a as _']]
 
@@ -5112,7 +5112,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].nox}', ['b.0', 'b.1', 'a as _']]
 
@@ -5174,7 +5174,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].lane_nox}', ['b.0', 'b.1', 'LANE as i64', 'a as _']]
 
@@ -5204,7 +5204,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st2lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst2{neon_type[1].lane_nox}', ['b.0', 'b.1', 'LANE as i64', 'a as _']]
 
@@ -5294,7 +5294,7 @@ intrinsics:
             - 'b: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst2.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst2.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst2{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', "{type[3]}"]]
 
@@ -5362,7 +5362,7 @@ intrinsics:
             - 'n: i32'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst2lane.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst2lane.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst2{neon_type[1].lane_nox}', ['a as _', 'b.0', 'b.1', 'LANE', "{type[4]}"]]
 
@@ -5387,7 +5387,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'a as _']]
 
@@ -5433,7 +5433,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst3.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst3.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst3{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', 'b.2', '8']]
 
@@ -5542,7 +5542,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst3.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst3.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst3{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', 'b.2', "{type[3]}"]]
 
@@ -5571,7 +5571,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst3.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst3.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst3{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', 'b.2', "{type[3]}"]]
 
@@ -5608,7 +5608,7 @@ intrinsics:
             - 'n: i32'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst3lane.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst3lane.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst3{neon_type[1].lane_nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'LANE', "{type[4]}"]]
 
@@ -5641,7 +5641,7 @@ intrinsics:
             - 'n: i32'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst3lane.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst3lane.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst3{neon_type[1].lane_nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'LANE', "{type[4]}"]]
 
@@ -5671,7 +5671,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'a as _']]
 
@@ -5698,7 +5698,7 @@ intrinsics:
             - 'c: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'a as _']]
 
@@ -5733,7 +5733,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -5764,7 +5764,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st3lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst3{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'LANE as i64', 'a as _']]
 
@@ -5812,7 +5812,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst4.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst4.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst4{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'b.3', '8']]
 
@@ -5837,7 +5837,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4.{neon_type[2]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4.{neon_type[2]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'a as _']]
 
@@ -5947,7 +5947,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst4.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst4.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst4{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'b.3', "{type[3]}"]]
 
@@ -5977,7 +5977,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst4.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst4.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst4{neon_type[1].nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'b.3', "{type[3]}"]]
 
@@ -6015,7 +6015,7 @@ intrinsics:
             - 'n: i32'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst4lane.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst4lane.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst4{neon_type[1].lane_nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'b.3', 'LANE', "{type[4]}"]]
 
@@ -6048,7 +6048,7 @@ intrinsics:
             - 'n: i32'
             - 'size: i32'
           links:
-            - link: 'llvm.arm.neon.vst4lane.p0i8.v{neon_type[1].lane}{type[0]}'
+            - link: 'llvm.arm.neon.vst4lane.p0.v{neon_type[1].lane}{type[0]}'
               arch: arm
       - FnCall: ['_vst4{neon_type[1].lane_nox}', ['a as _', 'b.0', 'b.1', 'b.2', 'b.3', 'LANE', "{type[4]}"]]
 
@@ -6079,7 +6079,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'a as _']]
 
@@ -6107,7 +6107,7 @@ intrinsics:
             - 'd: {type[2]}'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'a as _']]
 
@@ -6143,7 +6143,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'LANE as i64', 'a as _']]
 
@@ -6175,7 +6175,7 @@ intrinsics:
             - 'n: i64'
             - 'ptr: *mut i8'
           links:
-            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0i8'
+            - link: 'llvm.aarch64.neon.st4lane.v{neon_type[1].lane}{type[0]}.p0'
               arch: aarch64,arm64ec
       - FnCall: ['_vst4{neon_type[1].lane_nox}', ['b.0', 'b.1', 'b.2', 'b.3', 'LANE as i64', 'a as _']]
 
@@ -10097,7 +10097,7 @@ intrinsics:
             - "a: {neon_type[2]}"
             - "b: {neon_type[2]}"
           links:
-            - link: "llvm.arm.neon.vst1x{neon_type[1].tuple}.p0f16.{neon_type[2]}"
+            - link: "llvm.arm.neon.vst1x{neon_type[1].tuple}.p0.{neon_type[2]}"
               arch: arm
       - FnCall: ["_vst1{neon_type[1].no}", ['a', 'b.0', 'b.1']]
 
@@ -10124,7 +10124,7 @@ intrinsics:
             - "b: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x2.{neon_type[2]}.p0f16"
+            - link: "llvm.aarch64.neon.st1x2.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', a]]
 
@@ -10151,7 +10151,7 @@ intrinsics:
             - "b: {neon_type[2]}"
             - "c: {neon_type[2]}"
           links:
-            - link: "llvm.arm.neon.vst1x{neon_type[1].tuple}.p0f16.{neon_type[2]}"
+            - link: "llvm.arm.neon.vst1x{neon_type[1].tuple}.p0.{neon_type[2]}"
               arch: arm
       - FnCall: ["_vst1{neon_type[1].no}", ['a', 'b.0', 'b.1', 'b.2']]
 
@@ -10175,7 +10175,7 @@ intrinsics:
             - "b: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x2.{neon_type[2]}.p0f32"
+            - link: "llvm.aarch64.neon.st1x2.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', a]]
 
@@ -10200,7 +10200,7 @@ intrinsics:
             - "c: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x3.{neon_type[2]}.p0f32"
+            - link: "llvm.aarch64.neon.st1x3.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'b.2', a]]
 
@@ -10227,7 +10227,7 @@ intrinsics:
             - "c: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x3.{neon_type[2]}.p0f16"
+            - link: "llvm.aarch64.neon.st1x3.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'b.2', a]]
 
@@ -10254,7 +10254,7 @@ intrinsics:
             - "d: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x4.{neon_type[2]}.p0f32"
+            - link: "llvm.aarch64.neon.st1x4.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'b.2', 'b.3', a]]
 
@@ -10282,7 +10282,7 @@ intrinsics:
             - "d: {neon_type[2]}"
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.st1x4.{neon_type[2]}.p0f16"
+            - link: "llvm.aarch64.neon.st1x4.{neon_type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vst1{neon_type[1].no}", ['b.0', 'b.1', 'b.2', 'b.3', a]]
 
@@ -11629,22 +11629,22 @@ intrinsics:
     safety:
       unsafe: [neon]
     types:
-      - ["*const i8", int8x8x4_t, int8x8_t, 'p0i8']
-      - ["*const i16", int16x4x4_t, int16x4_t, 'p0i16']
-      - ["*const i32", int32x2x4_t, int32x2_t, 'p0i32']
-      - ["*const i8", int8x16x4_t, int8x16_t, 'p0i8']
-      - ["*const i16", int16x8x4_t, int16x8_t, 'p0i16']
-      - ["*const i32", int32x4x4_t, int32x4_t, 'p0i32']
-      - ["*const i64", int64x1x4_t, int64x1_t, 'p0i64']
-      - ["*const f32", float32x2x4_t, float32x2_t, 'p0f32']
-      - ["*const f32", float32x4x4_t, float32x4_t, 'p0f32']
+      - ["*const i8", int8x8x4_t, int8x8_t]
+      - ["*const i16", int16x4x4_t, int16x4_t]
+      - ["*const i32", int32x2x4_t, int32x2_t]
+      - ["*const i8", int8x16x4_t, int8x16_t]
+      - ["*const i16", int16x8x4_t, int16x8_t]
+      - ["*const i32", int32x4x4_t, int32x4_t]
+      - ["*const i64", int64x1x4_t, int64x1_t]
+      - ["*const f32", float32x2x4_t, float32x2_t]
+      - ["*const f32", float32x4x4_t, float32x4_t]
     compose:
       - LLVMLink:
           name: "vld4{neon_type[1].dup_nox}"
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld4r.{neon_type[2]}.{type[3]}.p0"
+            - link: "llvm.aarch64.neon.ld4r.{neon_type[2]}.p0.p0"
               arch: aarch64,arm64ec
       - FnCall: ["_vld4{neon_type[1].dup_nox}", ['a as _']]
 
@@ -12163,7 +12163,7 @@ intrinsics:
             - "ptr: {type[0]}"
             - "size: i32"
           links:
-            - link: "llvm.arm.neon.vld4.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.arm.neon.vld4.v{neon_type[1].lane}{type[2]}.p0"
               arch: arm
       - FnCall:
           - "_vld4{neon_type[1].nox}"
@@ -12190,7 +12190,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld4.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld4.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld4{neon_type[1].nox}"
@@ -12218,7 +12218,7 @@ intrinsics:
             - "ptr: {type[0]}"
             - "size: i32"
           links:
-            - link: "llvm.arm.neon.vld4dup.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.arm.neon.vld4dup.v{neon_type[1].lane}{type[2]}.p0"
               arch: arm
       - FnCall:
           - "_vld4{neon_type[1].dup_nox}"
@@ -12246,7 +12246,7 @@ intrinsics:
           arguments:
             - "ptr: {type[0]}"
           links:
-            - link: "llvm.aarch64.neon.ld4r.v{neon_type[1].lane}{type[2]}.p0{type[2]}"
+            - link: "llvm.aarch64.neon.ld4r.v{neon_type[1].lane}{type[2]}.p0"
               arch: aarch64,arm64ec
       - FnCall:
           - "_vld4{neon_type[1].dup_nox}"


### PR DESCRIPTION
 - Use rust intrinsics for more ARM intrinsics
 - Fix incorrect intrinsic names (these were autoupgraded by LLVM, so didn't result in invalid IR)
 - Remove uses of deprecated type-specific pointers, LLVM only supports opaque pointers now.

@folkertdev is it okay to replace the `llvm.{u,s}{max,min}` calls with something like `simd_select(simd_gt(a, b), a, b))`? I am just worried if it will optimize well

edit: seems like it is not a problem actually https://godbolt.org/z/6r1javWc6