### PR TITLE
Add triagebot config for subtree syncs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -50,3 +50,13 @@ Hey Apple Group! This issue or PR could use some Darwin-specific guidance. Could
 one of you weigh in please?
 Thanks!
 """
+
+# Canonicalize issue numbers to avoid closing the wrong issue
+# when commits are included in subtrees, as well as warning links in commits.
+# Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
+[issue-links]
+check-commits = false
+
+# Prevents mentions in commits to avoid users being spammed
+# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
+[no-mentions]


### PR DESCRIPTION
Adds checking of PR descriptions to avoid relative issue links (without repository prefix) and mentions in commits.

I didn't enable checking of relative issue links in commits, see discussion in https://github.com/rust-lang/compiler-builtins/pull/956.

We should also add a `[no-merges]` policy, but I haven't yet added the josh sync tooling here, so we don't know the PR title prefix that we will use, so we can do that later.