### PR TITLE
std_detect: Tidying of slice length

### DIFF
--- a/crates/std_detect/src/detect/os/linux/riscv.rs
+++ b/crates/std_detect/src/detect/os/linux/riscv.rs
@@ -124,8 +124,7 @@ fn _riscv_hwprobe(out: &mut [riscv_hwprobe]) -> bool {
         }
     }
 
-    let len = out.len();
-    unsafe { __riscv_hwprobe(out.as_mut_ptr(), len, 0, ptr::null_mut(), 0) == 0 }
+    unsafe { __riscv_hwprobe(out.as_mut_ptr(), out.len(), 0, ptr::null_mut(), 0) == 0 }
 }
 
 /// Read list of supported features from (1) the auxiliary vector


### PR DESCRIPTION
It's nothing more than a small tidying.
But since `stdarch` moved on to a Josh subtree, we (`stdarch` contributors) can test whether purely `stdarch` changes are still accepted through this repo.

We don't need to put the length of the `riscv_hwprobe` array into a variable.
This commit removes that variable and gives the length of the output slice to the `__riscv_hwprobe` directly.