### PR TITLE
Use `simd_extract!` macro instead of calling `simd_extract` directly

### DIFF
--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -33248,7 +33248,7 @@ pub fn _mm512_reduce_add_ps(a: __m512) -> f32 {
         );
         let a = _mm_add_ps(_mm256_extractf128_ps::<0>(a), _mm256_extractf128_ps::<1>(a));
         let a = _mm_add_ps(a, simd_shuffle!(a, a, [2, 3, 0, 1]));
-        simd_extract::<_, f32>(a, 0) + simd_extract::<_, f32>(a, 1)
+        simd_extract!(a, 0, f32) + simd_extract!(a, 1, f32)
     }
 }
 
@@ -33275,7 +33275,7 @@ pub fn _mm512_reduce_add_pd(a: __m512d) -> f64 {
             _mm512_extractf64x4_pd::<1>(a),
         );
         let a = _mm_add_pd(_mm256_extractf128_pd::<0>(a), _mm256_extractf128_pd::<1>(a));
-        simd_extract::<_, f64>(a, 0) + simd_extract::<_, f64>(a, 1)
+        simd_extract!(a, 0, f64) + simd_extract!(a, 1, f64)
     }
 }
 
@@ -33356,7 +33356,7 @@ pub fn _mm512_reduce_mul_ps(a: __m512) -> f32 {
         );
         let a = _mm_mul_ps(_mm256_extractf128_ps::<0>(a), _mm256_extractf128_ps::<1>(a));
         let a = _mm_mul_ps(a, simd_shuffle!(a, a, [2, 3, 0, 1]));
-        simd_extract::<_, f32>(a, 0) * simd_extract::<_, f32>(a, 1)
+        simd_extract!(a, 0, f32) * simd_extract!(a, 1, f32)
     }
 }
 
@@ -33383,7 +33383,7 @@ pub fn _mm512_reduce_mul_pd(a: __m512d) -> f64 {
             _mm512_extractf64x4_pd::<1>(a),
         );
         let a = _mm_mul_pd(_mm256_extractf128_pd::<0>(a), _mm256_extractf128_pd::<1>(a));
-        simd_extract::<_, f64>(a, 0) * simd_extract::<_, f64>(a, 1)
+        simd_extract!(a, 0, f64) * simd_extract!(a, 1, f64)
     }
 }
 

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -11032,7 +11032,7 @@ pub fn _mm_reduce_add_ph(a: __m128h) -> f16 {
         let a = _mm_add_ph(a, b);
         let b = simd_shuffle!(a, a, [2, 3, 0, 1, 4, 5, 6, 7]);
         let a = _mm_add_ph(a, b);
-        simd_extract::<_, f16>(a, 0) + simd_extract::<_, f16>(a, 1)
+        simd_extract!(a, 0, f16) + simd_extract!(a, 1, f16)
     }
 }
 
@@ -11085,7 +11085,7 @@ pub fn _mm_reduce_mul_ph(a: __m128h) -> f16 {
         let a = _mm_mul_ph(a, b);
         let b = simd_shuffle!(a, a, [2, 3, 0, 1, 4, 5, 6, 7]);
         let a = _mm_mul_ph(a, b);
-        simd_extract::<_, f16>(a, 0) * simd_extract::<_, f16>(a, 1)
+        simd_extract!(a, 0, f16) * simd_extract!(a, 1, f16)
     }
 }
 


### PR DESCRIPTION
Was poking at this due to the desire to potentially change this intrinsic to use a const generic. The macro has been presumably updated to allow an explicit type parameter after this change was made, so, this uses that instead to allow potentially updating the calling convention later.

Side note: while looking into this, it feels unlikely we'll be able to do that *anyway* due to the fact that casting types is not allowed in generic constants, and some intrinsics have already stabilised `i32` const generics over `u32` ones. But this change felt okay anyway, so, I wanted to offer it as a PR.