### PR TITLE
Remove `std_detect` dev dependency in `core_arch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,6 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "core_arch"
 version = "0.1.5"
 dependencies = [
- "std_detect",
  "stdarch-test",
  "syscalls",
 ]

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -22,7 +22,6 @@ maintenance = { status = "experimental" }
 
 [dev-dependencies]
 stdarch-test = { version = "0.*", path = "../stdarch-test" }
-std_detect = { version = "0.*", path = "../std_detect" }
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dev-dependencies]
 syscalls = { version = "0.6.18", default-features = false }

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -75,9 +75,7 @@
 #[cfg(test)]
 #[macro_use]
 extern crate std;
-#[cfg(test)]
-#[macro_use]
-extern crate std_detect;
+
 #[path = "mod.rs"]
 mod core_arch;
 

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -89,7 +89,7 @@ pub fn simd_test(
     for feature in target_features {
         let q = quote_spanned! {
             proc_macro2::Span::call_site() =>
-            if !#macro_test!(#feature) {
+            if !::std::arch::#macro_test!(#feature) {
                 missing_features.push(#feature);
             }
         };


### PR DESCRIPTION
Instead of `core_arch` loading the `is_XYZ_feature_enabled` macros from the local `std_detect` crate, they are loaded from `::std::arch` instead. This means that nothing in this repository will depend on `std_detect` anymore (except for tests, these will be ported later). The downside is that `core_arch` will need to wait for nightly std bumps to see changes in the detection macros, but I assume that should be rare.

This is one of the steps required to move `std_detect` fully into `rust-lang/rust`.