### PR TITLE
use `is_multiple_of` to check if an addr is aligned

### DIFF
--- a/crates/core_arch/src/powerpc/macros.rs
+++ b/crates/core_arch/src/powerpc/macros.rs
@@ -278,6 +278,7 @@ macro_rules! impl_from {
     ($s: ident) => {
         #[unstable(feature = "stdarch_powerpc", issue = "111145")]
         impl From<$s> for s_t_l!($s) {
+            #[inline]
             fn from (v: $s) -> Self {
                 unsafe {
                     transmute(v)
@@ -297,6 +298,7 @@ macro_rules! impl_neg {
         #[unstable(feature = "stdarch_powerpc", issue = "111145")]
         impl crate::ops::Neg for s_t_l!($s) {
             type Output = s_t_l!($s);
+            #[inline]
             fn neg(self) -> Self::Output {
                 unsafe { simd_neg(self) }
             }

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -435,6 +435,7 @@ macro_rules! impl_from {
     ($s: ident) => {
         #[unstable(feature = "stdarch_s390x", issue = "135681")]
         impl From<$s> for s_t_l!($s) {
+            #[inline]
             fn from (v: $s) -> Self {
                 unsafe {
                     transmute(v)
@@ -454,6 +455,7 @@ macro_rules! impl_neg {
         #[unstable(feature = "stdarch_s390x", issue = "135681")]
         impl crate::ops::Neg for s_t_l!($s) {
             type Output = s_t_l!($s);
+            #[inline]
             fn neg(self) -> Self::Output {
                 unsafe { simd_neg(self) }
             }

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -51,7 +51,7 @@ types! {
     pub struct vector_double(2 x f64);
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct PackedTuple<T, U> {
     x: T,
     y: U,
@@ -4787,7 +4787,7 @@ pub unsafe fn vec_splat_s8<const IMM: i8>() -> vector_signed_char {
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepih, IMM = 42))]
 pub unsafe fn vec_splat_s16<const IMM: i16>() -> vector_signed_short {
-    vector_signed_short([IMM as i16; 8])
+    vector_signed_short([IMM; 8])
 }
 
 /// Vector Splat Signed Word

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -141,7 +141,7 @@ unsafe extern "unadjusted" {
     fn llvm_f64x2_max(x: simd::f64x2, y: simd::f64x2) -> simd::f64x2;
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Copy)]
 struct Unaligned<T>(T);
 

--- a/crates/core_arch/src/x86_64/cmpxchg16b.rs
+++ b/crates/core_arch/src/x86_64/cmpxchg16b.rs
@@ -48,7 +48,7 @@ pub unsafe fn cmpxchg16b(
     success: Ordering,
     failure: Ordering,
 ) -> u128 {
-    debug_assert!(dst as usize % 16 == 0);
+    debug_assert!(dst.addr().is_multiple_of(16));
 
     let res = crate::sync::atomic::atomic_compare_exchange(dst, old, new, success, failure);
     res.unwrap_or_else(|x| x)


### PR DESCRIPTION
And some various other things reported by clippy.

extracted from https://github.com/rust-lang/rust/pull/143477