### PR TITLE
`intrinsic-test`: use runner also for rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,20 +73,20 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -128,7 +128,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -403,9 +403,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linked-hash-map"
@@ -624,7 +624,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -838,7 +838,7 @@ version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -945,20 +945,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]

--- a/crates/intrinsic-test/src/arm/config.rs
+++ b/crates/intrinsic-test/src/arm/config.rs
@@ -114,7 +114,6 @@ pub const AARCH_CONFIGURATIONS: &str = r#"
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_fcma))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_dotprod))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_i8mm))]
-#![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sha3))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sm4))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_ftts))]
 #![feature(fmt_helpers_for_derive)]

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -104,7 +104,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
     }
 
     fn compare_outputs(&self) -> bool {
-        if let Some(ref toolchain) = self.cli_options.toolchain {
+        if self.cli_options.toolchain.is_some() {
             let intrinsics_name_list = self
                 .intrinsics
                 .iter()
@@ -113,8 +113,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
             compare_outputs(
                 &intrinsics_name_list,
-                toolchain,
-                &self.cli_options.c_runner,
+                &self.cli_options.runner,
                 &self.cli_options.target,
             )
         } else {

--- a/crates/intrinsic-test/src/common/cli.rs
+++ b/crates/intrinsic-test/src/common/cli.rs
@@ -60,7 +60,7 @@ pub struct ProcessedCli {
     pub filename: PathBuf,
     pub toolchain: Option<String>,
     pub cpp_compiler: Option<String>,
-    pub c_runner: String,
+    pub runner: String,
     pub target: String,
     pub linker: Option<String>,
     pub cxx_toolchain_dir: Option<String>,
@@ -70,7 +70,7 @@ pub struct ProcessedCli {
 impl ProcessedCli {
     pub fn new(cli_options: Cli) -> Self {
         let filename = cli_options.input;
-        let c_runner = cli_options.runner.unwrap_or_default();
+        let runner = cli_options.runner.unwrap_or_default();
         let target = cli_options.target;
         let linker = cli_options.linker;
         let cxx_toolchain_dir = cli_options.cxx_toolchain_dir;
@@ -102,7 +102,7 @@ impl ProcessedCli {
         Self {
             toolchain,
             cpp_compiler,
-            c_runner,
+            runner,
             target,
             linker,
             cxx_toolchain_dir,

--- a/crates/intrinsic-test/src/common/compare.rs
+++ b/crates/intrinsic-test/src/common/compare.rs
@@ -2,26 +2,24 @@ use super::cli::FailureReason;
 use rayon::prelude::*;
 use std::process::Command;
 
-pub fn compare_outputs(
-    intrinsic_name_list: &Vec<String>,
-    toolchain: &str,
-    runner: &str,
-    target: &str,
-) -> bool {
+pub fn compare_outputs(intrinsic_name_list: &Vec<String>, runner: &str, target: &str) -> bool {
+    fn runner_command(runner: &str) -> Command {
+        let mut it = runner.split_whitespace();
+        let mut cmd = Command::new(it.next().unwrap());
+        cmd.args(it);
+
+        cmd
+    }
+
     let intrinsics = intrinsic_name_list
         .par_iter()
         .filter_map(|intrinsic_name| {
-            let c = Command::new("sh")
-                .arg("-c")
-                .arg(format!("{runner} ./c_programs/{intrinsic_name}"))
+            let c = runner_command(runner)
+                .arg(format!("./c_programs/{intrinsic_name}"))
                 .output();
 
-            let rust = Command::new("sh")
-                .current_dir("rust_programs")
-                .arg("-c")
-                .arg(format!(
-                    "cargo {toolchain} run --target {target} --bin {intrinsic_name} --release",
-                ))
+            let rust = runner_command(runner)
+                .arg(format!("target/{target}/release/{intrinsic_name}"))
                 .env("RUSTFLAGS", "-Cdebuginfo=0")
                 .output();
 
@@ -42,8 +40,8 @@ pub fn compare_outputs(
             if !rust.status.success() {
                 error!(
                     "Failed to run Rust program for intrinsic {intrinsic_name}\nstdout: {stdout}\nstderr: {stderr}",
-                    stdout = std::str::from_utf8(&rust.stdout).unwrap_or(""),
-                    stderr = std::str::from_utf8(&rust.stderr).unwrap_or(""),
+                    stdout = String::from_utf8_lossy(&rust.stdout),
+                    stderr = String::from_utf8_lossy(&rust.stderr),
                 );
                 return Some(FailureReason::RunRust(intrinsic_name.clone()));
             }

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -30,12 +30,15 @@ fn main() {
 
     let test_environment = test_environment_result.unwrap();
 
+    info!("building C binaries");
     if !test_environment.build_c_file() {
         std::process::exit(2);
     }
+    info!("building Rust binaries");
     if !test_environment.build_rust_file() {
         std::process::exit(3);
     }
+    info!("comaparing outputs");
     if !test_environment.compare_outputs() {
         std::process::exit(1);
     }


### PR DESCRIPTION
Let's see what this does on CI. It uses `runner` also for running the rust programs, so that they can be run outside of the docker container (assuming qemu and clang etc.)