### PR TITLE
`intrinsic-test`: combine rust intrinsics in one program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,20 +73,20 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -128,7 +128,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -403,9 +403,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linked-hash-map"
@@ -624,7 +624,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -838,7 +838,7 @@ version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -945,20 +945,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]

--- a/crates/intrinsic-test/src/arm/config.rs
+++ b/crates/intrinsic-test/src/arm/config.rs
@@ -114,7 +114,6 @@ pub const AARCH_CONFIGURATIONS: &str = r#"
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_fcma))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_dotprod))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_i8mm))]
-#![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sha3))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sm4))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_ftts))]
 #![feature(fmt_helpers_for_derive)]

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -104,7 +104,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
     }
 
     fn compare_outputs(&self) -> bool {
-        if let Some(ref toolchain) = self.cli_options.toolchain {
+        if self.cli_options.toolchain.is_some() {
             let intrinsics_name_list = self
                 .intrinsics
                 .iter()
@@ -113,8 +113,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
             compare_outputs(
                 &intrinsics_name_list,
-                toolchain,
-                &self.cli_options.c_runner,
+                &self.cli_options.runner,
                 &self.cli_options.target,
             )
         } else {

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -72,7 +72,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         match compiler {
             None => true,
             Some(compiler) => compile_c_arm(
-                intrinsics_name_list.as_slice(),
+                intrinsics_name_list.unwrap().as_slice(),
                 compiler,
                 target,
                 cxx_toolchain_dir,

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -57,11 +57,9 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         let c_target = "aarch64";
 
         let intrinsics_name_list = write_c_testfiles(
-            &self
-                .intrinsics
+            self.intrinsics
                 .iter()
-                .map(|i| i as &dyn IntrinsicDefinition<_>)
-                .collect::<Vec<_>>(),
+                .map(|i| i as &dyn IntrinsicDefinition<_>),
             target,
             c_target,
             &["arm_neon.h", "arm_acle.h", "arm_fp16.h"],
@@ -92,15 +90,14 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         let intrinsics_name_list = write_rust_testfiles(
             self.intrinsics
                 .iter()
-                .map(|i| i as &dyn IntrinsicDefinition<_>)
-                .collect::<Vec<_>>(),
+                .map(|i| i as &dyn IntrinsicDefinition<_>),
             rust_target,
             &build_notices("// "),
             F16_FORMATTING_DEF,
             AARCH_CONFIGURATIONS,
         );
 
-        compile_rust_programs(intrinsics_name_list, toolchain, target, linker)
+        compile_rust_programs(intrinsics_name_list.unwrap(), toolchain, target, linker)
     }
 
     fn compare_outputs(&self) -> bool {

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -1,3 +1,5 @@
+use rayon::prelude::*;
+
 mod compile;
 mod config;
 mod intrinsic;
@@ -8,7 +10,7 @@ use crate::common::SupportedArchitectureTest;
 use crate::common::cli::ProcessedCli;
 use crate::common::compare::compare_outputs;
 use crate::common::gen_rust::compile_rust_programs;
-use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
+use crate::common::intrinsic::Intrinsic;
 use crate::common::intrinsic_helpers::TypeKind;
 use crate::common::write_file::{write_c_testfiles, write_rust_testfiles};
 use compile::compile_c_arm;
@@ -57,9 +59,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         let c_target = "aarch64";
 
         let intrinsics_name_list = write_c_testfiles(
-            self.intrinsics
-                .iter()
-                .map(|i| i as &dyn IntrinsicDefinition<_>),
+            self.intrinsics.par_iter(),
             target,
             c_target,
             &["arm_neon.h", "arm_acle.h", "arm_fp16.h"],
@@ -88,9 +88,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         let toolchain = self.cli_options.toolchain.as_deref();
         let linker = self.cli_options.linker.as_deref();
         let intrinsics_name_list = write_rust_testfiles(
-            self.intrinsics
-                .iter()
-                .map(|i| i as &dyn IntrinsicDefinition<_>),
+            self.intrinsics.par_iter(),
             rust_target,
             &build_notices("// "),
             F16_FORMATTING_DEF,

--- a/crates/intrinsic-test/src/common/argument.rs
+++ b/crates/intrinsic-test/src/common/argument.rs
@@ -125,19 +125,23 @@ where
     /// Creates a line for each argument that initializes an array for C from which `loads` argument
     /// values can be loaded  as a sliding window.
     /// e.g `const int32x2_t a_vals = {0x3effffff, 0x3effffff, 0x3f7fffff}`, if loads=2.
-    pub fn gen_arglists_c(&self, indentation: Indentation, loads: u32) -> String {
-        self.iter()
-            .filter(|&arg| !arg.has_constraint())
-            .map(|arg| {
-                format!(
-                    "{indentation}const {ty} {name}_vals[] = {values};",
-                    ty = arg.ty.c_scalar_type(),
-                    name = arg.name,
-                    values = arg.ty.populate_random(indentation, loads, &Language::C)
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
+    pub fn gen_arglists_c(
+        &self,
+        w: &mut impl std::io::Write,
+        indentation: Indentation,
+        loads: u32,
+    ) -> std::io::Result<()> {
+        for arg in self.iter().filter(|&arg| !arg.has_constraint()) {
+            writeln!(
+                w,
+                "{indentation}const {ty} {name}_vals[] = {values};",
+                ty = arg.ty.c_scalar_type(),
+                name = arg.name,
+                values = arg.ty.populate_random(indentation, loads, &Language::C)
+            )?
+        }
+
+        Ok(())
     }
 
     /// Creates a line for each argument that initializes an array for Rust from which `loads` argument

--- a/crates/intrinsic-test/src/common/argument.rs
+++ b/crates/intrinsic-test/src/common/argument.rs
@@ -142,21 +142,25 @@ where
 
     /// Creates a line for each argument that initializes an array for Rust from which `loads` argument
     /// values can be loaded as a sliding window, e.g `const A_VALS: [u32; 20]  = [...];`
-    pub fn gen_arglists_rust(&self, indentation: Indentation, loads: u32) -> String {
-        self.iter()
-            .filter(|&arg| !arg.has_constraint())
-            .map(|arg| {
-                format!(
-                    "{indentation}{bind} {name}: [{ty}; {load_size}] = {values};",
-                    bind = arg.rust_vals_array_binding(),
-                    name = arg.rust_vals_array_name(),
-                    ty = arg.ty.rust_scalar_type(),
-                    load_size = arg.ty.num_lanes() * arg.ty.num_vectors() + loads - 1,
-                    values = arg.ty.populate_random(indentation, loads, &Language::Rust)
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
+    pub fn gen_arglists_rust(
+        &self,
+        w: &mut impl std::io::Write,
+        indentation: Indentation,
+        loads: u32,
+    ) -> std::io::Result<()> {
+        for arg in self.iter().filter(|&arg| !arg.has_constraint()) {
+            writeln!(
+                w,
+                "{indentation}{bind} {name}: [{ty}; {load_size}] = {values};",
+                bind = arg.rust_vals_array_binding(),
+                name = arg.rust_vals_array_name(),
+                ty = arg.ty.rust_scalar_type(),
+                load_size = arg.ty.num_lanes() * arg.ty.num_vectors() + loads - 1,
+                values = arg.ty.populate_random(indentation, loads, &Language::Rust)
+            )?
+        }
+
+        Ok(())
     }
 
     /// Creates a line for each argument that initializes the argument from an array `[arg]_vals` at

--- a/crates/intrinsic-test/src/common/cli.rs
+++ b/crates/intrinsic-test/src/common/cli.rs
@@ -60,7 +60,7 @@ pub struct ProcessedCli {
     pub filename: PathBuf,
     pub toolchain: Option<String>,
     pub cpp_compiler: Option<String>,
-    pub c_runner: String,
+    pub runner: String,
     pub target: String,
     pub linker: Option<String>,
     pub cxx_toolchain_dir: Option<String>,
@@ -102,7 +102,7 @@ impl ProcessedCli {
         Self {
             toolchain,
             cpp_compiler,
-            c_runner,
+            runner: c_runner,
             target,
             linker,
             cxx_toolchain_dir,

--- a/crates/intrinsic-test/src/common/compare.rs
+++ b/crates/intrinsic-test/src/common/compare.rs
@@ -2,26 +2,24 @@ use super::cli::FailureReason;
 use rayon::prelude::*;
 use std::process::Command;
 
-pub fn compare_outputs(
-    intrinsic_name_list: &Vec<String>,
-    toolchain: &str,
-    runner: &str,
-    target: &str,
-) -> bool {
+pub fn compare_outputs(intrinsic_name_list: &Vec<String>, runner: &str, target: &str) -> bool {
+    fn runner_command(runner: &str) -> Command {
+        let mut it = runner.split_whitespace();
+        let mut cmd = Command::new(it.next().unwrap());
+        cmd.args(it);
+
+        cmd
+    }
+
     let intrinsics = intrinsic_name_list
         .par_iter()
         .filter_map(|intrinsic_name| {
-            let c = Command::new("sh")
-                .arg("-c")
-                .arg(format!("{runner} ./c_programs/{intrinsic_name}"))
+            let c = runner_command(runner)
+                .arg(format!("./c_programs/{intrinsic_name}"))
                 .output();
 
-            let rust = Command::new("sh")
-                .current_dir("rust_programs")
-                .arg("-c")
-                .arg(format!(
-                    "cargo {toolchain} run --target {target} --bin {intrinsic_name} --release",
-                ))
+            let rust = runner_command(runner)
+                .arg(format!("target/{target}/release/{intrinsic_name}"))
                 .env("RUSTFLAGS", "-Cdebuginfo=0")
                 .output();
 
@@ -42,8 +40,8 @@ pub fn compare_outputs(
             if !rust.status.success() {
                 error!(
                     "Failed to run Rust program for intrinsic {intrinsic_name}\nstdout: {stdout}\nstderr: {stderr}",
-                    stdout = std::str::from_utf8(&rust.stdout).unwrap_or(""),
-                    stderr = std::str::from_utf8(&rust.stderr).unwrap_or(""),
+                    stdout = String::from_utf8_lossy(&rust.stdout),
+                    stderr = String::from_utf8_lossy(&rust.stderr),
                 );
                 return Some(FailureReason::RunRust(intrinsic_name.clone()));
             }

--- a/crates/intrinsic-test/src/common/gen_c.rs
+++ b/crates/intrinsic-test/src/common/gen_c.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
 use rayon::prelude::*;
-use std::collections::BTreeMap;
 use std::process::Command;
 
 use super::argument::Argument;
@@ -85,19 +84,6 @@ pub fn compile_c_programs(compiler_commands: &[String]) -> bool {
         })
         .find_any(|x| !x)
         .is_none()
-}
-
-// Creates directory structure and file path mappings
-pub fn setup_c_file_paths(identifiers: &Vec<String>) -> BTreeMap<&String, String> {
-    let _ = std::fs::create_dir("c_programs");
-    identifiers
-        .par_iter()
-        .map(|identifier| {
-            let c_filename = format!(r#"c_programs/{identifier}.cpp"#);
-
-            (identifier, c_filename)
-        })
-        .collect::<BTreeMap<&String, String>>()
 }
 
 pub fn generate_c_test_loop<T: IntrinsicTypeDefinition + Sized>(

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -1,6 +1,4 @@
 use itertools::Itertools;
-use rayon::prelude::*;
-use std::collections::BTreeMap;
 use std::fs::File;
 use std::process::Command;
 
@@ -122,20 +120,6 @@ pub fn compile_rust_programs(
         error!("Command failed: {output:#?}");
         false
     }
-}
-
-// Creates directory structure and file path mappings
-pub fn setup_rust_file_paths(identifiers: &Vec<String>) -> BTreeMap<&String, String> {
-    identifiers
-        .par_iter()
-        .map(|identifier| {
-            let rust_dir = format!("rust_programs/{identifier}");
-            let _ = std::fs::create_dir_all(&rust_dir);
-            let rust_filename = format!("{rust_dir}/main.rs");
-
-            (identifier, rust_filename)
-        })
-        .collect::<BTreeMap<&String, String>>()
 }
 
 pub fn generate_rust_test_loop<T: IntrinsicTypeDefinition>(

--- a/crates/intrinsic-test/src/common/write_file.rs
+++ b/crates/intrinsic-test/src/common/write_file.rs
@@ -1,34 +1,32 @@
 use std::fs::File;
 use std::io::Write;
 
-use super::gen_rust::{create_rust_test_program, setup_rust_file_paths};
+use super::gen_rust::create_rust_test_program;
 use super::intrinsic::IntrinsicDefinition;
 use super::intrinsic_helpers::IntrinsicTypeDefinition;
 
-pub fn write_file(filename: &String, code: String) {
-    let mut file = File::create(filename).unwrap();
-    file.write_all(code.into_bytes().as_slice()).unwrap();
-}
-
-pub fn write_c_testfiles<T: IntrinsicTypeDefinition + Sized>(
-    intrinsics: &[&dyn IntrinsicDefinition<T>],
+pub fn write_c_testfiles<'a, T, I>(
+    intrinsics: I,
     target: &str,
     c_target: &str,
     headers: &[&str],
     notice: &str,
     arch_specific_definitions: &[&str],
-) -> std::io::Result<Vec<String>> {
+) -> std::io::Result<Vec<String>>
+where
+    T: IntrinsicTypeDefinition + Sized + 'a,
+    I: Iterator<Item = &'a dyn IntrinsicDefinition<T>>,
+{
     std::fs::create_dir_all("c_programs")?;
 
     intrinsics
-        .iter()
         .map(|intrinsic| {
             let identifier = intrinsic.name().to_owned();
             let mut file = File::create(format!("c_programs/{identifier}.cpp")).unwrap();
 
             // write_c_test_program(&mut file, intrinsic)?;
             let c_code = crate::common::gen_c::create_c_test_program(
-                *intrinsic,
+                intrinsic,
                 headers,
                 target,
                 c_target,
@@ -43,25 +41,34 @@ pub fn write_c_testfiles<T: IntrinsicTypeDefinition + Sized>(
         .collect()
 }
 
-pub fn write_rust_testfiles<T: IntrinsicTypeDefinition>(
-    intrinsics: Vec<&dyn IntrinsicDefinition<T>>,
+pub fn write_rust_testfiles<'a, T, I>(
+    intrinsics: I,
     rust_target: &str,
     notice: &str,
     definitions: &str,
     cfg: &str,
-) -> Vec<String> {
-    let intrinsics_name_list = intrinsics
-        .iter()
-        .map(|i| i.name().clone())
-        .collect::<Vec<_>>();
-    let filename_mapping = setup_rust_file_paths(&intrinsics_name_list);
+) -> std::io::Result<Vec<String>>
+where
+    T: IntrinsicTypeDefinition + Sized + 'a,
+    I: Iterator<Item = &'a dyn IntrinsicDefinition<T>>,
+{
+    std::fs::create_dir_all("rust_programs")?;
 
-    intrinsics.iter().for_each(|&i| {
-        let rust_code = create_rust_test_program(i, rust_target, notice, definitions, cfg);
-        if let Some(filename) = filename_mapping.get(&i.name()) {
-            write_file(filename, rust_code)
-        }
-    });
+    intrinsics
+        .map(|intrinsic| {
+            let identifier = intrinsic.name().to_owned();
 
-    intrinsics_name_list
+            let rust_dir = format!("rust_programs/{identifier}");
+            std::fs::create_dir_all(&rust_dir)?;
+            let rust_filename = format!("{rust_dir}/main.rs");
+            let mut file = File::create(rust_filename).unwrap();
+
+            let rust_code =
+                create_rust_test_program(intrinsic, rust_target, notice, definitions, cfg);
+
+            file.write_all(rust_code.as_bytes())?;
+
+            Ok(identifier)
+        })
+        .collect()
 }

--- a/crates/intrinsic-test/src/common/write_file.rs
+++ b/crates/intrinsic-test/src/common/write_file.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::io::Write;
 
 use super::gen_rust::create_rust_test_program;
 use super::intrinsic::IntrinsicDefinition;
@@ -24,17 +23,15 @@ where
             let identifier = intrinsic.name().to_owned();
             let mut file = File::create(format!("c_programs/{identifier}.cpp")).unwrap();
 
-            // write_c_test_program(&mut file, intrinsic)?;
-            let c_code = crate::common::gen_c::create_c_test_program(
+            crate::common::gen_c::create_c_test_program(
+                &mut file,
                 intrinsic,
                 headers,
                 target,
                 c_target,
                 notice,
                 arch_specific_definitions,
-            );
-
-            file.write_all(c_code.as_bytes())?;
+            )?;
 
             Ok(identifier)
         })

--- a/crates/intrinsic-test/src/common/write_file.rs
+++ b/crates/intrinsic-test/src/common/write_file.rs
@@ -4,7 +4,9 @@ use super::gen_rust::create_rust_test_program;
 use super::intrinsic::IntrinsicDefinition;
 use super::intrinsic_helpers::IntrinsicTypeDefinition;
 
-pub fn write_c_testfiles<'a, T, I>(
+use rayon::prelude::*;
+
+pub fn write_c_testfiles<'a, T, I, E>(
     intrinsics: I,
     target: &str,
     c_target: &str,
@@ -14,7 +16,8 @@ pub fn write_c_testfiles<'a, T, I>(
 ) -> std::io::Result<Vec<String>>
 where
     T: IntrinsicTypeDefinition + Sized + 'a,
-    I: Iterator<Item = &'a dyn IntrinsicDefinition<T>>,
+    I: ParallelIterator<Item = &'a E>,
+    E: IntrinsicDefinition<T> + 'a,
 {
     std::fs::create_dir_all("c_programs")?;
 
@@ -38,7 +41,7 @@ where
         .collect()
 }
 
-pub fn write_rust_testfiles<'a, T, I>(
+pub fn write_rust_testfiles<'a, T, I, E>(
     intrinsics: I,
     rust_target: &str,
     notice: &str,
@@ -47,7 +50,8 @@ pub fn write_rust_testfiles<'a, T, I>(
 ) -> std::io::Result<Vec<String>>
 where
     T: IntrinsicTypeDefinition + Sized + 'a,
-    I: Iterator<Item = &'a dyn IntrinsicDefinition<T>>,
+    I: ParallelIterator<Item = &'a E>,
+    E: IntrinsicDefinition<T> + 'a,
 {
     std::fs::create_dir_all("rust_programs")?;
 

--- a/crates/intrinsic-test/src/common/write_file.rs
+++ b/crates/intrinsic-test/src/common/write_file.rs
@@ -63,10 +63,7 @@ where
             let rust_filename = format!("{rust_dir}/main.rs");
             let mut file = File::create(rust_filename).unwrap();
 
-            let rust_code =
-                create_rust_test_program(intrinsic, rust_target, notice, definitions, cfg);
-
-            file.write_all(rust_code.as_bytes())?;
+            create_rust_test_program(&mut file, intrinsic, rust_target, notice, definitions, cfg)?;
 
             Ok(identifier)
         })

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -30,12 +30,15 @@ fn main() {
 
     let test_environment = test_environment_result.unwrap();
 
+    info!("building C binaries");
     if !test_environment.build_c_file() {
         std::process::exit(2);
     }
+    info!("building Rust binaries");
     if !test_environment.build_rust_file() {
         std::process::exit(3);
     }
+    info!("comaparing outputs");
     if !test_environment.compare_outputs() {
         std::process::exit(1);
     }

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
     if !test_environment.build_rust_file() {
         std::process::exit(3);
     }
-    info!("comaparing outputs");
+    info!("comparing outputs");
     if !test_environment.compare_outputs() {
         std::process::exit(1);
     }


### PR DESCRIPTION
Basically just a big switch on the name, executing the (otherwise unchanged) logic for the intrinsic. Locally, this gives a 5 second speedup when processing the first 500 aarch64 intrinsics.

Let's see what CI says here. 