### PR TITLE
`intrinsic-test`: allow names that don't match rust's naming conventions

### DIFF
--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -25,6 +25,11 @@ pub fn format_rust_main_template(
         r#"{notices}#![feature(simd_ffi)]
 #![feature(link_llvm_intrinsics)]
 #![feature(f16)]
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
 {configurations}
 {definitions}
 


### PR DESCRIPTION
Locally, it looked like lots of time is spent by cargo printing warnings for incorrect names (lowercase constants, etc). Let's see if this matters in practice.