### PR TITLE
`s390x`: use `simd_round_ties_even` in more places

### DIFF
--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -80,12 +80,6 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.umin.v4i32"] fn vmnlf(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_unsigned_int;
     #[link_name = "llvm.umin.v2i64"] fn vmnlg(a: vector_unsigned_long_long, b: vector_unsigned_long_long) -> vector_unsigned_long_long;
 
-    #[link_name = "llvm.nearbyint.v4f32"] fn nearbyint_v4f32(a: vector_float) -> vector_float;
-    #[link_name = "llvm.nearbyint.v2f64"] fn nearbyint_v2f64(a: vector_double) -> vector_double;
-
-    #[link_name = "llvm.roundeven.v4f32"] fn roundeven_v4f32(a: vector_float) -> vector_float;
-    #[link_name = "llvm.roundeven.v2f64"] fn roundeven_v2f64(a: vector_double) -> vector_double;
-
     #[link_name = "llvm.s390.vsra"] fn vsra(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
     #[link_name = "llvm.s390.vsrl"] fn vsrl(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
     #[link_name = "llvm.s390.vsl"] fn vsl(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
@@ -1181,14 +1175,14 @@ mod sealed {
 
     impl_vec_trait! { [VectorOrc vec_orc]+ 2c (orc) }
 
-    test_impl! { vec_roundc_f32 (a: vector_float) -> vector_float [nearbyint_v4f32,  "vector-enhancements-1" vfisb] }
-    test_impl! { vec_roundc_f64 (a: vector_double) -> vector_double [nearbyint_v2f64, vfidb] }
+    // Technically `llvm.nearbyint`, but it behaves like `llvm.roundeven` on this target.
+    test_impl! { vec_roundc_f32 (a: vector_float) -> vector_float [simd_round_ties_even,  "vector-enhancements-1" vfisb] }
+    test_impl! { vec_roundc_f64 (a: vector_double) -> vector_double [simd_round_ties_even, vfidb] }
 
-    // FIXME(llvm) llvm trunk already lowers roundeven to vfidb, but rust does not use it yet
-    // use https://godbolt.org/z/cWq95fexe to check, and enable the instruction test when it works
-    test_impl! { vec_round_f32 (a: vector_float) -> vector_float [roundeven_v4f32, _] }
-    test_impl! { vec_round_f64 (a: vector_double) -> vector_double [roundeven_v2f64, _] }
+    test_impl! { vec_round_f32 (a: vector_float) -> vector_float [simd_round_ties_even, "vector-enhancements-1" vfisb] }
+    test_impl! { vec_round_f64 (a: vector_double) -> vector_double [simd_round_ties_even, vfidb] }
 
+    // Technically `llvm.rint`, but it behaves like `llvm.roundeven` on this target.
     test_impl! { vec_rint_f32 (a: vector_float) -> vector_float [simd_round_ties_even, "vector-enhancements-1" vfisb] }
     test_impl! { vec_rint_f64 (a: vector_double) -> vector_double [simd_round_ties_even, vfidb] }
 


### PR DESCRIPTION
If I remember right, these all function equivalent on the target (because the rounding mode can't be changed). At least on CE they generate the same intstructions.

cc @uweigand