### PR TITLE
`intrinsic-test`: Implemented DerefMut for ArmIntrinsicTest

### DIFF
--- a/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -2,7 +2,7 @@ use crate::common::argument::ArgumentList;
 use crate::common::indentation::Indentation;
 use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
 use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, Sign, TypeKind};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArmIntrinsicType(pub IntrinsicType);
@@ -12,6 +12,12 @@ impl Deref for ArmIntrinsicType {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for ArmIntrinsicType {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -110,7 +110,7 @@ fn json_to_intrinsic(
     Ok(Intrinsic {
         name,
         arguments,
-        results: *results,
+        results: results,
         arch_tags: intr.architectures,
     })
 }

--- a/crates/intrinsic-test/src/arm/types.rs
+++ b/crates/intrinsic-test/src/arm/types.rs
@@ -121,7 +121,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
         }
     }
 
-    fn from_c(s: &str, target: &str) -> Result<Box<Self>, String> {
+    fn from_c(s: &str, target: &str) -> Result<Self, String> {
         const CONST_STR: &str = "const";
         if let Some(s) = s.strip_suffix('*') {
             let (s, constant) = match s.trim().strip_suffix(CONST_STR) {
@@ -131,9 +131,8 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
             let s = s.trim_end();
             let temp_return = ArmIntrinsicType::from_c(s, target);
             temp_return.map(|mut op| {
-                let edited = op.as_mut();
-                edited.0.ptr = true;
-                edited.0.ptr_constant = constant;
+                op.ptr = true;
+                op.ptr_constant = constant;
                 op
             })
         } else {
@@ -163,7 +162,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
                     ),
                     None => None,
                 };
-                Ok(Box::new(ArmIntrinsicType(IntrinsicType {
+                Ok(ArmIntrinsicType(IntrinsicType {
                     ptr: false,
                     ptr_constant: false,
                     constant,
@@ -172,14 +171,14 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
                     simd_len,
                     vec_len,
                     target: target.to_string(),
-                })))
+                }))
             } else {
                 let kind = start.parse::<TypeKind>()?;
                 let bit_len = match kind {
                     TypeKind::Int(_) => Some(32),
                     _ => None,
                 };
-                Ok(Box::new(ArmIntrinsicType(IntrinsicType {
+                Ok(ArmIntrinsicType(IntrinsicType {
                     ptr: false,
                     ptr_constant: false,
                     constant,
@@ -188,7 +187,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
                     simd_len: None,
                     vec_len: None,
                     target: target.to_string(),
-                })))
+                }))
             }
         }
     }

--- a/crates/intrinsic-test/src/common/argument.rs
+++ b/crates/intrinsic-test/src/common/argument.rs
@@ -76,7 +76,7 @@ where
         Argument {
             pos,
             name: String::from(var_name),
-            ty: *ty,
+            ty: ty,
             constraint,
         }
     }

--- a/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -322,7 +322,9 @@ pub trait IntrinsicTypeDefinition: Deref<Target = IntrinsicType> {
     fn get_lane_function(&self) -> String;
 
     /// can be implemented in an `impl` block
-    fn from_c(_s: &str, _target: &str) -> Result<Box<Self>, String>;
+    fn from_c(_s: &str, _target: &str) -> Result<Self, String>
+    where
+        Self: Sized;
 
     /// Gets a string containing the typename for this type in C format.
     /// can be directly defined in `impl` blocks


### PR DESCRIPTION
## Summary
1. Moved the return type of IntrinsicType::from_c to Rust<Self, String> from Result<Box<Self>, String>
2. Implemented DerefMut for ArmIntrinsicTest struct

## Context
This PR is part 2 of the changes that were originally made in the x86 extension PR rust-lang/stdarch#1814 for intrinsic-test, and is intended to unblock the speedup efforts that are being made in PRs rust-lang/stdarch#1856 , rust-lang/stdarch#1862 and rust-lang/stdarch#1863.