### PR TITLE
`intrinsic-test`: remove `lazy_static` dependency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,6 @@ dependencies = [
  "csv",
  "diff",
  "itertools",
- "lazy_static",
  "log",
  "pretty_env_logger",
  "rayon",
@@ -400,12 +399,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -635,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",

--- a/crates/intrinsic-test/Cargo.toml
+++ b/crates/intrinsic-test/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-lazy_static = "1.4.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 csv = "1.1"


### PR DESCRIPTION
we use `std::sync::LazyLock` now.