### PR TITLE
`intrinsic-test`: Final code cleanup for the `arm` and `common` module

### DIFF
--- a/crates/intrinsic-test/src/arm/argument.rs
+++ b/crates/intrinsic-test/src/arm/argument.rs
@@ -1,0 +1,12 @@
+use crate::arm::intrinsic::ArmIntrinsicType;
+use crate::common::argument::Argument;
+
+impl Argument<ArmIntrinsicType> {
+    pub fn type_and_name_from_c(arg: &str) -> (&str, &str) {
+        let split_index = arg
+            .rfind([' ', '*'])
+            .expect("Couldn't split type and argname");
+
+        (arg[..split_index + 1].trim_end(), &arg[split_index + 1..])
+    }
+}

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -86,13 +86,16 @@ fn json_to_intrinsic(
         .into_iter()
         .enumerate()
         .map(|(i, arg)| {
-            let arg_name = Argument::<ArmIntrinsicType>::type_and_name_from_c(&arg).1;
+            let (type_name, arg_name) = Argument::<ArmIntrinsicType>::type_and_name_from_c(&arg);
             let metadata = intr.args_prep.as_mut();
             let metadata = metadata.and_then(|a| a.remove(arg_name));
             let arg_prep: Option<ArgPrep> = metadata.and_then(|a| a.try_into().ok());
             let constraint: Option<Constraint> = arg_prep.and_then(|a| a.try_into().ok());
+            let ty = ArmIntrinsicType::from_c(type_name, target)
+                .unwrap_or_else(|_| panic!("Failed to parse argument '{arg}'"));
 
-            let mut arg = Argument::<ArmIntrinsicType>::from_c(i, &arg, target, constraint);
+            let mut arg =
+                Argument::<ArmIntrinsicType>::new(i, String::from(arg_name), ty, constraint);
 
             // The JSON doesn't list immediates as const
             let IntrinsicType {

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -79,7 +79,8 @@ fn json_to_intrinsic(
 ) -> Result<Intrinsic<ArmIntrinsicType>, Box<dyn std::error::Error>> {
     let name = intr.name.replace(['[', ']'], "");
 
-    let results = ArmIntrinsicType::from_c(&intr.return_type.value, target)?;
+    let mut results = ArmIntrinsicType::from_c(&intr.return_type.value)?;
+    results.set_metadata("target", target);
 
     let args = intr
         .arguments
@@ -91,8 +92,9 @@ fn json_to_intrinsic(
             let metadata = metadata.and_then(|a| a.remove(arg_name));
             let arg_prep: Option<ArgPrep> = metadata.and_then(|a| a.try_into().ok());
             let constraint: Option<Constraint> = arg_prep.and_then(|a| a.try_into().ok());
-            let ty = ArmIntrinsicType::from_c(type_name, target)
+            let mut ty = ArmIntrinsicType::from_c(type_name)
                 .unwrap_or_else(|_| panic!("Failed to parse argument '{arg}'"));
+            ty.set_metadata("target", target);
 
             let mut arg =
                 Argument::<ArmIntrinsicType>::new(i, String::from(arg_name), ty, constraint);

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -69,7 +69,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
         let (chunk_size, chunk_count) = chunk_info(self.intrinsics.len());
 
-        let cpp_compiler = compile::build_cpp_compilation(&self.cli_options).unwrap();
+        let cpp_compiler_wrapped = compile::build_cpp_compilation(&self.cli_options);
 
         let notice = &build_notices("// ");
         self.intrinsics
@@ -81,9 +81,11 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
                 write_mod_cpp(&mut file, notice, c_target, platform_headers, chunk).unwrap();
 
                 // compile this cpp file into a .o file
-                let output = cpp_compiler
-                    .compile_object_file(&format!("mod_{i}.cpp"), &format!("mod_{i}.o"))?;
-                assert!(output.status.success(), "{output:?}");
+                if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {  
+                    let output = cpp_compiler
+                        .compile_object_file(&format!("mod_{i}.cpp"), &format!("mod_{i}.o"))?;
+                    assert!(output.status.success(), "{output:?}");
+                }
 
                 Ok(())
             })
@@ -99,21 +101,25 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         )
         .unwrap();
 
+        // This is done because `cpp_compiler_wrapped` is None when
+        // the --generate-only flag is passed
+        if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
         // compile this cpp file into a .o file
-        info!("compiling main.cpp");
-        let output = cpp_compiler
-            .compile_object_file("main.cpp", "intrinsic-test-programs.o")
-            .unwrap();
-        assert!(output.status.success(), "{output:?}");
-
-        let object_files = (0..chunk_count)
-            .map(|i| format!("mod_{i}.o"))
-            .chain(["intrinsic-test-programs.o".to_owned()]);
-
-        let output = cpp_compiler
-            .link_executable(object_files, "intrinsic-test-programs")
-            .unwrap();
-        assert!(output.status.success(), "{output:?}");
+            info!("compiling main.cpp");
+            let output = cpp_compiler
+                .compile_object_file("main.cpp", "intrinsic-test-programs.o")
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+    
+            let object_files = (0..chunk_count)
+                .map(|i| format!("mod_{i}.o"))
+                .chain(["intrinsic-test-programs.o".to_owned()]);
+    
+            let output = cpp_compiler
+                .link_executable(object_files, "intrinsic-test-programs")
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+        }
 
         true
     }

--- a/crates/intrinsic-test/src/common/argument.rs
+++ b/crates/intrinsic-test/src/common/argument.rs
@@ -20,6 +20,15 @@ impl<T> Argument<T>
 where
     T: IntrinsicTypeDefinition,
 {
+    pub fn new(pos: usize, name: String, ty: T, constraint: Option<Constraint>) -> Self {
+        Argument {
+            pos,
+            name,
+            ty,
+            constraint,
+        }
+    }
+
     pub fn to_c_type(&self) -> String {
         self.ty.c_type()
     }
@@ -34,14 +43,6 @@ where
 
     pub fn has_constraint(&self) -> bool {
         self.constraint.is_some()
-    }
-
-    pub fn type_and_name_from_c(arg: &str) -> (&str, &str) {
-        let split_index = arg
-            .rfind([' ', '*'])
-            .expect("Couldn't split type and argname");
-
-        (arg[..split_index + 1].trim_end(), &arg[split_index + 1..])
     }
 
     /// The binding keyword (e.g. "const" or "let") for the array of possible test inputs.
@@ -59,25 +60,6 @@ where
             format!("{}_VALS", self.name.to_uppercase())
         } else {
             format!("{}_vals", self.name.to_lowercase())
-        }
-    }
-
-    pub fn from_c(
-        pos: usize,
-        arg: &str,
-        target: &str,
-        constraint: Option<Constraint>,
-    ) -> Argument<T> {
-        let (ty, var_name) = Self::type_and_name_from_c(arg);
-
-        let ty =
-            T::from_c(ty, target).unwrap_or_else(|_| panic!("Failed to parse argument '{arg}'"));
-
-        Argument {
-            pos,
-            name: String::from(var_name),
-            ty: ty,
-            constraint,
         }
     }
 

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -130,6 +130,12 @@ pub fn compile_rust_programs(toolchain: Option<&str>, target: &str, linker: Opti
     /* If there has been a linker explicitly set from the command line then
      * we want to set it via setting it in the RUSTFLAGS*/
 
+     // This is done because `toolchain` is None when
+     // the --generate-only flag is passed
+    if toolchain.is_none() {
+        return true;
+    }
+
     trace!("Building cargo command");
 
     let mut cargo_command = Command::new("cargo");
@@ -138,10 +144,8 @@ pub fn compile_rust_programs(toolchain: Option<&str>, target: &str, linker: Opti
     // Do not use the target directory of the workspace please.
     cargo_command.env("CARGO_TARGET_DIR", "target");
 
-    if let Some(toolchain) = toolchain
-        && !toolchain.is_empty()
-    {
-        cargo_command.arg(toolchain);
+    if toolchain.is_some_and(|val| !val.is_empty()) {
+        cargo_command.arg(toolchain.unwrap());
     }
     cargo_command.args(["build", "--target", target, "--release"]);
 

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -130,8 +130,8 @@ pub fn compile_rust_programs(toolchain: Option<&str>, target: &str, linker: Opti
     /* If there has been a linker explicitly set from the command line then
      * we want to set it via setting it in the RUSTFLAGS*/
 
-     // This is done because `toolchain` is None when
-     // the --generate-only flag is passed
+    // This is done because `toolchain` is None when
+    // the --generate-only flag is passed
     if toolchain.is_none() {
         return true;
     }

--- a/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -121,7 +122,7 @@ pub struct IntrinsicType {
     /// A value of `None` can be assumed to be 1 though.
     pub vec_len: Option<u32>,
 
-    pub target: String,
+    pub metadata: HashMap<String, String>,
 }
 
 impl IntrinsicType {
@@ -151,6 +152,10 @@ impl IntrinsicType {
 
     pub fn is_ptr(&self) -> bool {
         self.ptr
+    }
+
+    pub fn set_metadata(&mut self, key: &str, value: &str) {
+        self.metadata.insert(key.to_string(), value.to_string());
     }
 
     pub fn c_scalar_type(&self) -> String {
@@ -322,7 +327,7 @@ pub trait IntrinsicTypeDefinition: Deref<Target = IntrinsicType> {
     fn get_lane_function(&self) -> String;
 
     /// can be implemented in an `impl` block
-    fn from_c(_s: &str, _target: &str) -> Result<Self, String>
+    fn from_c(_s: &str) -> Result<Self, String>
     where
         Self: Sized;
 


### PR DESCRIPTION
## Summary
1. Changed from `IntrinsicType::target` (String) to `IntrinsicType::metadata` (HashMap<String, String>) for better support for differing architectures
2. Added `Constraint::Set(Vec<i64>)` for support for distinct constant argument values (which may be of types similar to the IMM type)

## Context
This PR is part 3 of the changes that were originally made in the x86 extension PR rust-lang/stdarch#1814 for intrinsic-test, and is intended to accomodate the changes made in PRs  rust-lang/stdarch#1862 and rust-lang/stdarch#1863.

cc: @Amanieu @folkertdev 