### PR TITLE
Feat: updated Argument<T> type for functional compatibility with other architectures

### DIFF
--- a/crates/intrinsic-test/src/arm/argument.rs
+++ b/crates/intrinsic-test/src/arm/argument.rs
@@ -1,0 +1,15 @@
+use crate::arm::intrinsic::ArmIntrinsicType;
+use crate::common::argument::Argument;
+
+// This functionality is present due to the nature
+// of how intrinsics are defined in the JSON source
+// of ARM intrinsics.
+impl Argument<ArmIntrinsicType> {
+    pub fn type_and_name_from_c(arg: &str) -> (&str, &str) {
+        let split_index = arg
+            .rfind([' ', '*'])
+            .expect("Couldn't split type and argname");
+
+        (arg[..split_index + 1].trim_end(), &arg[split_index + 1..])
+    }
+}

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -86,13 +86,16 @@ fn json_to_intrinsic(
         .into_iter()
         .enumerate()
         .map(|(i, arg)| {
-            let arg_name = Argument::<ArmIntrinsicType>::type_and_name_from_c(&arg).1;
+            let (type_name, arg_name) = Argument::<ArmIntrinsicType>::type_and_name_from_c(&arg);
             let metadata = intr.args_prep.as_mut();
             let metadata = metadata.and_then(|a| a.remove(arg_name));
             let arg_prep: Option<ArgPrep> = metadata.and_then(|a| a.try_into().ok());
             let constraint: Option<Constraint> = arg_prep.and_then(|a| a.try_into().ok());
+            let ty = ArmIntrinsicType::from_c(type_name, target)
+                .unwrap_or_else(|_| panic!("Failed to parse argument '{arg}'"));
 
-            let mut arg = Argument::<ArmIntrinsicType>::from_c(i, &arg, target, constraint);
+            let mut arg =
+                Argument::<ArmIntrinsicType>::new(i, String::from(arg_name), ty, constraint);
 
             // The JSON doesn't list immediates as const
             let IntrinsicType {

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -1,10 +1,11 @@
+mod argument;
 mod compile;
 mod config;
 mod intrinsic;
 mod json_parser;
 mod types;
 
-use std::fs::File;
+use std::fs::{self, File};
 
 use rayon::prelude::*;
 
@@ -72,6 +73,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         let cpp_compiler = compile::build_cpp_compilation(&self.cli_options).unwrap();
 
         let notice = &build_notices("// ");
+        fs::create_dir_all("c_programs").unwrap();
         self.intrinsics
             .par_chunks(chunk_size)
             .enumerate()

--- a/crates/intrinsic-test/src/common/argument.rs
+++ b/crates/intrinsic-test/src/common/argument.rs
@@ -20,6 +20,15 @@ impl<T> Argument<T>
 where
     T: IntrinsicTypeDefinition,
 {
+    pub fn new(pos: usize, name: String, ty: T, constraint: Option<Constraint>) -> Self {
+        Argument {
+            pos,
+            name,
+            ty,
+            constraint,
+        }
+    }
+
     pub fn to_c_type(&self) -> String {
         self.ty.c_type()
     }
@@ -34,14 +43,6 @@ where
 
     pub fn has_constraint(&self) -> bool {
         self.constraint.is_some()
-    }
-
-    pub fn type_and_name_from_c(arg: &str) -> (&str, &str) {
-        let split_index = arg
-            .rfind([' ', '*'])
-            .expect("Couldn't split type and argname");
-
-        (arg[..split_index + 1].trim_end(), &arg[split_index + 1..])
     }
 
     /// The binding keyword (e.g. "const" or "let") for the array of possible test inputs.
@@ -59,25 +60,6 @@ where
             format!("{}_VALS", self.name.to_uppercase())
         } else {
             format!("{}_vals", self.name.to_lowercase())
-        }
-    }
-
-    pub fn from_c(
-        pos: usize,
-        arg: &str,
-        target: &str,
-        constraint: Option<Constraint>,
-    ) -> Argument<T> {
-        let (ty, var_name) = Self::type_and_name_from_c(arg);
-
-        let ty =
-            T::from_c(ty, target).unwrap_or_else(|_| panic!("Failed to parse argument '{arg}'"));
-
-        Argument {
-            pos,
-            name: String::from(var_name),
-            ty: ty,
-            constraint,
         }
     }
 


### PR DESCRIPTION
## Summary
1. Moved the `type_and_name_from_c` function of `Argument<T>` to the architecture-specific `Argument<ArmArchitecture>` struct, since this specific functionality exists only to serve how ARM intrinsics are defined.

Example:
```JS
  {
    "SIMD_ISA": "Neon",
    "name": "__crc32b",

    // The below values (of "arguments") would be passed into the `type_and_name_from_c` function
    "arguments": [
      "uint32_t a",
      "uint8_t b"
    ],
    "return_type": {
      "value": "uint32_t"
    },
  },
```

## Context
This PR is part of the changes that were originally made in the x86 extension PR rust-lang/stdarch#1814 for intrinsic-test, and is intended to accomodate the changes made in PRs  rust-lang/stdarch#1862 and rust-lang/stdarch#1863.

cc: @folkertdev @Amanieu 