### PR TITLE
`intrinsic-test`: bringing back support for  --generate-only flag

### DIFF
--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -70,7 +70,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
         let (chunk_size, chunk_count) = chunk_info(self.intrinsics.len());
 
-        let cpp_compiler = compile::build_cpp_compilation(&self.cli_options).unwrap();
+        let cpp_compiler_wrapped = compile::build_cpp_compilation(&self.cli_options);
 
         let notice = &build_notices("// ");
         fs::create_dir_all("c_programs").unwrap();
@@ -82,10 +82,15 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
                 let mut file = File::create(&c_filename).unwrap();
                 write_mod_cpp(&mut file, notice, c_target, platform_headers, chunk).unwrap();
 
-                // compile this cpp file into a .o file
-                let output = cpp_compiler
-                    .compile_object_file(&format!("mod_{i}.cpp"), &format!("mod_{i}.o"))?;
-                assert!(output.status.success(), "{output:?}");
+                // compile this cpp file into a .o file.
+                //
+                // This is done because `cpp_compiler_wrapped` is None when
+                // the --generate-only flag is passed
+                if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
+                    let output = cpp_compiler
+                        .compile_object_file(&format!("mod_{i}.cpp"), &format!("mod_{i}.o"))?;
+                    assert!(output.status.success(), "{output:?}");
+                }
 
                 Ok(())
             })
@@ -101,21 +106,25 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         )
         .unwrap();
 
-        // compile this cpp file into a .o file
-        info!("compiling main.cpp");
-        let output = cpp_compiler
-            .compile_object_file("main.cpp", "intrinsic-test-programs.o")
-            .unwrap();
-        assert!(output.status.success(), "{output:?}");
+        // This is done because `cpp_compiler_wrapped` is None when
+        // the --generate-only flag is passed
+        if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
+            // compile this cpp file into a .o file
+            info!("compiling main.cpp");
+            let output = cpp_compiler
+                .compile_object_file("main.cpp", "intrinsic-test-programs.o")
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
 
-        let object_files = (0..chunk_count)
-            .map(|i| format!("mod_{i}.o"))
-            .chain(["intrinsic-test-programs.o".to_owned()]);
+            let object_files = (0..chunk_count)
+                .map(|i| format!("mod_{i}.o"))
+                .chain(["intrinsic-test-programs.o".to_owned()]);
 
-        let output = cpp_compiler
-            .link_executable(object_files, "intrinsic-test-programs")
-            .unwrap();
-        assert!(output.status.success(), "{output:?}");
+            let output = cpp_compiler
+                .link_executable(object_files, "intrinsic-test-programs")
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+        }
 
         true
     }

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -130,6 +130,12 @@ pub fn compile_rust_programs(toolchain: Option<&str>, target: &str, linker: Opti
     /* If there has been a linker explicitly set from the command line then
      * we want to set it via setting it in the RUSTFLAGS*/
 
+    // This is done because `toolchain` is None when
+    // the --generate-only flag is passed
+    if toolchain.is_none() {
+        return true;
+    }
+
     trace!("Building cargo command");
 
     let mut cargo_command = Command::new("cargo");
@@ -138,10 +144,8 @@ pub fn compile_rust_programs(toolchain: Option<&str>, target: &str, linker: Opti
     // Do not use the target directory of the workspace please.
     cargo_command.env("CARGO_TARGET_DIR", "target");
 
-    if let Some(toolchain) = toolchain
-        && !toolchain.is_empty()
-    {
-        cargo_command.arg(toolchain);
+    if toolchain.is_some_and(|val| !val.is_empty()) {
+        cargo_command.arg(toolchain.unwrap());
     }
     cargo_command.args(["build", "--target", target, "--release"]);
 


### PR DESCRIPTION
## Summary
1. Added support for the case when the `--generate-only` flag is passed. This helps with generating the Rust and C artifacts even if the compilation environment is not supported

## Context
This PR is part of the changes that were originally made in the x86 extension PR rust-lang/stdarch#1814 for intrinsic-test, and is intended to accomodate the changes made in PRs  rust-lang/stdarch#1862 and rust-lang/stdarch#1863.

cc: @folkertdev @Amanieu 