### PR TITLE
`Intrinsic-test`: Updated the Constraint enum to support discrete values

### DIFF
--- a/crates/intrinsic-test/src/common/constraint.rs
+++ b/crates/intrinsic-test/src/common/constraint.rs
@@ -1,17 +1,24 @@
 use serde::Deserialize;
 use std::ops::Range;
 
+/// Describes the values to test for a const generic parameter.
 #[derive(Debug, PartialEq, Clone, Deserialize)]
 pub enum Constraint {
+    /// Test a single value.
     Equal(i64),
+    /// Test a range of values, e.g. `0..16`.
     Range(Range<i64>),
+    /// Test discrete values, e.g. `vec![1, 2, 4, 8]`.
+    Set(Vec<i64>),
 }
 
 impl Constraint {
-    pub fn to_range(&self) -> Range<i64> {
+    /// Iterate over the values of this constraint.
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = i64> + 'a {
         match self {
-            Constraint::Equal(eq) => *eq..*eq + 1,
-            Constraint::Range(range) => range.clone(),
+            Constraint::Equal(i) => std::slice::Iter::default().copied().chain(*i..*i + 1),
+            Constraint::Range(range) => std::slice::Iter::default().copied().chain(range.clone()),
+            Constraint::Set(items) => items.iter().copied().chain(std::ops::Range::default()),
         }
     }
 }

--- a/crates/intrinsic-test/src/common/gen_c.rs
+++ b/crates/intrinsic-test/src/common/gen_c.rs
@@ -40,7 +40,7 @@ pub fn generate_c_constraint_blocks<'a, T: IntrinsicTypeDefinition + 'a>(
     };
 
     let body_indentation = indentation.nested();
-    for i in current.constraint.iter().flat_map(|c| c.to_range()) {
+    for i in current.constraint.iter().flat_map(|c| c.iter()) {
         let ty = current.ty.c_type();
 
         writeln!(w, "{indentation}{{")?;

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -255,7 +255,7 @@ pub fn generate_rust_test_loop<T: IntrinsicTypeDefinition>(
 
 /// Generate the specializations (unique sequences of const-generic arguments) for this intrinsic.
 fn generate_rust_specializations<'a>(
-    constraints: &mut impl Iterator<Item = std::ops::Range<i64>>,
+    constraints: &mut impl Iterator<Item = impl Iterator<Item = i64>>,
 ) -> Vec<Vec<u8>> {
     let mut specializations = vec![vec![]];
 
@@ -292,7 +292,7 @@ pub fn create_rust_test_module<T: IntrinsicTypeDefinition>(
     let specializations = generate_rust_specializations(
         &mut arguments
             .iter()
-            .filter_map(|i| i.constraint.as_ref().map(|v| v.to_range())),
+            .filter_map(|i| i.constraint.as_ref().map(|v| v.iter())),
     );
 
     generate_rust_test_loop(w, intrinsic, indentation, &specializations, PASSES)?;


### PR DESCRIPTION
## Context
This PR is part of the changes that were originally made in the x86 extension PR rust-lang/stdarch#1814 for `intrinsic-test`, and is intended to unblock efforts to support other architectures too.

cc: @folkertdev @Amanieu 