### PR TITLE
`intrinsic-test`: Cleaning the `IntrinsicType` struct and related functionalities

### DIFF
--- a/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -5,19 +5,22 @@ use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, S
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ArmIntrinsicType(pub IntrinsicType);
+pub struct ArmIntrinsicType {
+    pub data: IntrinsicType,
+    pub target: String,
+}
 
 impl Deref for ArmIntrinsicType {
     type Target = IntrinsicType;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.data
     }
 }
 
 impl DerefMut for ArmIntrinsicType {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.data
     }
 }
 

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -100,7 +100,7 @@ fn json_to_intrinsic(
             // The JSON doesn't list immediates as const
             let IntrinsicType {
                 ref mut constant, ..
-            } = arg.ty.0;
+            } = arg.ty.data;
             if arg.name.starts_with("imm") {
                 *constant = true
             }

--- a/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/crates/intrinsic-test/src/arm/json_parser.rs
@@ -2,7 +2,7 @@ use super::intrinsic::ArmIntrinsicType;
 use crate::common::argument::{Argument, ArgumentList};
 use crate::common::constraint::Constraint;
 use crate::common::intrinsic::Intrinsic;
-use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition};
+use crate::common::intrinsic_helpers::IntrinsicType;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -9,8 +9,6 @@ use std::fs::{self, File};
 
 use rayon::prelude::*;
 
-use crate::arm::config::POLY128_OSTREAM_DEF;
-use crate::common::SupportedArchitectureTest;
 use crate::common::cli::ProcessedCli;
 use crate::common::compare::compare_outputs;
 use crate::common::gen_c::{write_main_cpp, write_mod_cpp};
@@ -19,20 +17,14 @@ use crate::common::gen_rust::{
 };
 use crate::common::intrinsic::Intrinsic;
 use crate::common::intrinsic_helpers::TypeKind;
-use config::{AARCH_CONFIGURATIONS, F16_FORMATTING_DEF, build_notices};
+use crate::common::{SupportedArchitectureTest, chunk_info};
+use config::{AARCH_CONFIGURATIONS, F16_FORMATTING_DEF, POLY128_OSTREAM_DEF, build_notices};
 use intrinsic::ArmIntrinsicType;
 use json_parser::get_neon_intrinsics;
 
 pub struct ArmArchitectureTest {
     intrinsics: Vec<Intrinsic<ArmIntrinsicType>>,
     cli_options: ProcessedCli,
-}
-
-fn chunk_info(intrinsic_count: usize) -> (usize, usize) {
-    let available_parallelism = std::thread::available_parallelism().unwrap().get();
-    let chunk_size = intrinsic_count.div_ceil(Ord::min(available_parallelism, intrinsic_count));
-
-    (chunk_size, intrinsic_count.div_ceil(chunk_size))
 }
 
 impl SupportedArchitectureTest for ArmArchitectureTest {

--- a/crates/intrinsic-test/src/arm/types.rs
+++ b/crates/intrinsic-test/src/arm/types.rs
@@ -8,9 +8,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
         let prefix = self.kind.c_prefix();
         let const_prefix = if self.constant { "const " } else { "" };
 
-        if let (Some(bit_len), simd_len, vec_len) =
-            (self.bit_len, self.simd_len, self.vec_len)
-        {
+        if let (Some(bit_len), simd_len, vec_len) = (self.bit_len, self.simd_len, self.vec_len) {
             match (simd_len, vec_len) {
                 (None, None) => format!("{const_prefix}{prefix}{bit_len}_t"),
                 (Some(simd), None) => format!("{prefix}{bit_len}x{simd}_t"),
@@ -102,7 +100,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
     }
 }
 
-impl ArmIntrinsicType { 
+impl ArmIntrinsicType {
     pub fn from_c(s: &str, target: &str) -> Result<Self, String> {
         const CONST_STR: &str = "const";
         if let Some(s) = s.strip_suffix('*') {
@@ -144,34 +142,36 @@ impl ArmIntrinsicType {
                     ),
                     None => None,
                 };
-                Ok(ArmIntrinsicType{
+                Ok(ArmIntrinsicType {
                     data: IntrinsicType {
-                    ptr: false,
-                    ptr_constant: false,
-                    constant,
-                    kind: arg_kind,
-                    bit_len: Some(bit_len),
-                    simd_len,
-                    vec_len,
-                },
-                target: target.to_string()})
+                        ptr: false,
+                        ptr_constant: false,
+                        constant,
+                        kind: arg_kind,
+                        bit_len: Some(bit_len),
+                        simd_len,
+                        vec_len,
+                    },
+                    target: target.to_string(),
+                })
             } else {
                 let kind = start.parse::<TypeKind>()?;
                 let bit_len = match kind {
                     TypeKind::Int(_) => Some(32),
                     _ => None,
                 };
-                Ok(ArmIntrinsicType{
+                Ok(ArmIntrinsicType {
                     data: IntrinsicType {
-                    ptr: false,
-                    ptr_constant: false,
-                    constant,
-                    kind: start.parse::<TypeKind>()?,
-                    bit_len,
-                    simd_len: None,
-                    vec_len: None,
-                },
-                target: target.to_string()})
+                        ptr: false,
+                        ptr_constant: false,
+                        constant,
+                        kind: start.parse::<TypeKind>()?,
+                        bit_len,
+                        simd_len: None,
+                        vec_len: None,
+                    },
+                    target: target.to_string(),
+                })
             }
         }
     }

--- a/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -120,8 +120,6 @@ pub struct IntrinsicType {
     /// rows encoded in the type (e.g. uint8x8_t).
     /// A value of `None` can be assumed to be 1 though.
     pub vec_len: Option<u32>,
-
-    pub target: String,
 }
 
 impl IntrinsicType {
@@ -320,11 +318,6 @@ pub trait IntrinsicTypeDefinition: Deref<Target = IntrinsicType> {
 
     /// can be implemented in an `impl` block
     fn get_lane_function(&self) -> String;
-
-    /// can be implemented in an `impl` block
-    fn from_c(_s: &str, _target: &str) -> Result<Self, String>
-    where
-        Self: Sized;
 
     /// Gets a string containing the typename for this type in C format.
     /// can be directly defined in `impl` blocks

--- a/crates/intrinsic-test/src/common/mod.rs
+++ b/crates/intrinsic-test/src/common/mod.rs
@@ -22,3 +22,10 @@ pub trait SupportedArchitectureTest {
     fn build_rust_file(&self) -> bool;
     fn compare_outputs(&self) -> bool;
 }
+
+pub fn chunk_info(intrinsic_count: usize) -> (usize, usize) {
+    let available_parallelism = std::thread::available_parallelism().unwrap().get();
+    let chunk_size = intrinsic_count.div_ceil(Ord::min(available_parallelism, intrinsic_count));
+
+    (chunk_size, intrinsic_count.div_ceil(chunk_size))
+}


### PR DESCRIPTION
## Summary
1. Changed from `IntrinsicType::target` to `ArmIntrinsicType::target` since its usage is highly architecture-dependent.
2. Changed the structure of `ArmIntrinsicType` from 
```Rust
pub struct ArmIntrinsicType(pub IntrinsicType);
```
to 
```Rust
pub struct ArmIntrinsicType {
    pub data: IntrinsicType,
    pub target: String,
}
```
3. Moved `arm::chunk_info` to `common::chunk_info`.
4. Removed `from_c` in `IntrinsicTypeDefinition` trait. 

r? @folkertdev 
cc: @Amanieu 