### PR TITLE
S390x llvm 21 fixes

### DIFF
--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -1194,10 +1194,8 @@ mod sealed {
     test_impl! { vec_roundc_f32 (a: vector_float) -> vector_float [nearbyint_v4f32,  "vector-enhancements-1" vfisb] }
     test_impl! { vec_roundc_f64 (a: vector_double) -> vector_double [nearbyint_v2f64, vfidb] }
 
-    // FIXME(llvm) llvm trunk already lowers roundeven to vfidb, but rust does not use it yet
-    // use https://godbolt.org/z/cWq95fexe to check, and enable the instruction test when it works
-    test_impl! { vec_round_f32 (a: vector_float) -> vector_float [roundeven_v4f32, _] }
-    test_impl! { vec_round_f64 (a: vector_double) -> vector_double [roundeven_v2f64, _] }
+    test_impl! { vec_round_f32 (a: vector_float) -> vector_float [roundeven_v4f32, "vector-enhancements-1" vfisb] }
+    test_impl! { vec_round_f64 (a: vector_double) -> vector_double [roundeven_v2f64, vfidb] }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorRoundc {

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -4678,11 +4678,9 @@ pub unsafe fn vec_subc_u128(
     a: vector_unsigned_char,
     b: vector_unsigned_char,
 ) -> vector_unsigned_char {
-    // FIXME(llvm) sadly this does not work https://github.com/llvm/llvm-project/issues/129608
-    // let a: u128 = transmute(a);
-    // let b: u128 = transmute(b);
-    // transmute(!a.overflowing_sub(b).1 as u128)
-    transmute(vscbiq(transmute(a), transmute(b)))
+    let a: u128 = transmute(a);
+    let b: u128 = transmute(b);
+    transmute(!a.overflowing_sub(b).1 as u128)
 }
 
 /// Vector Add Compute Carryout unsigned 128-bits
@@ -4714,7 +4712,7 @@ pub unsafe fn vec_adde_u128(
     let a: u128 = transmute(a);
     let b: u128 = transmute(b);
     let c: u128 = transmute(c);
-    // FIXME(llvm) sadly this does not work
+    // FIXME(llvm) https://github.com/llvm/llvm-project/pull/153557
     //     let (d, _carry) = a.carrying_add(b, c & 1 != 0);
     //     transmute(d)
     transmute(vacq(a, b, c))

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -3319,8 +3319,7 @@ mod sealed {
 
     #[inline]
     #[target_feature(enable = "vector")]
-    // FIXME(llvm): https://github.com/llvm/llvm-project/issues/129899
-    // #[cfg_attr(test, assert_instr(vsegb))]
+    #[cfg_attr(test, assert_instr(vsegb))]
     pub unsafe fn vsegb(a: vector_signed_char) -> vector_signed_long_long {
         simd_as(simd_shuffle::<_, _, i8x2>(
             a,
@@ -3331,8 +3330,7 @@ mod sealed {
 
     #[inline]
     #[target_feature(enable = "vector")]
-    // FIXME(llvm): https://github.com/llvm/llvm-project/issues/129899
-    // #[cfg_attr(test, assert_instr(vsegh))]
+    #[cfg_attr(test, assert_instr(vsegh))]
     pub unsafe fn vsegh(a: vector_signed_short) -> vector_signed_long_long {
         simd_as(simd_shuffle::<_, _, i16x2>(
             a,
@@ -3343,8 +3341,7 @@ mod sealed {
 
     #[inline]
     #[target_feature(enable = "vector")]
-    // FIXME(llvm): https://github.com/llvm/llvm-project/issues/129899
-    // #[cfg_attr(test, assert_instr(vsegf))]
+    #[cfg_attr(test, assert_instr(vsegf))]
     pub unsafe fn vsegf(a: vector_signed_int) -> vector_signed_long_long {
         simd_as(simd_shuffle::<_, _, i32x2>(
             a,

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -169,13 +169,6 @@ unsafe extern "unadjusted" {
     #[link_name = "llvm.s390.vpklsfs"] fn vpklsfs(a: vector_unsigned_int, b: vector_unsigned_int) -> PackedTuple<vector_unsigned_short, i32>;
     #[link_name = "llvm.s390.vpklsgs"] fn vpklsgs(a: vector_unsigned_long_long, b: vector_unsigned_long_long) -> PackedTuple<vector_unsigned_int, i32>;
 
-    #[link_name = "llvm.s390.vuplb"] fn vuplb (a: vector_signed_char) -> vector_signed_short;
-    #[link_name = "llvm.s390.vuplhw"] fn vuplhw (a: vector_signed_short) -> vector_signed_int;
-    #[link_name = "llvm.s390.vuplf"] fn vuplf (a: vector_signed_int) -> vector_signed_long_long;
-    #[link_name = "llvm.s390.vupllb"] fn vupllb (a: vector_unsigned_char) -> vector_unsigned_short;
-    #[link_name = "llvm.s390.vupllh"] fn vupllh (a: vector_unsigned_short) -> vector_unsigned_int;
-    #[link_name = "llvm.s390.vupllf"] fn vupllf (a: vector_unsigned_int) -> vector_unsigned_long_long;
-
     #[link_name = "llvm.s390.vavgb"] fn vavgb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_char;
     #[link_name = "llvm.s390.vavgh"] fn vavgh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_short;
     #[link_name = "llvm.s390.vavgf"] fn vavgf(a: vector_signed_int, b: vector_signed_int) -> vector_signed_int;
@@ -2583,8 +2576,14 @@ mod sealed {
         unsafe fn vec_unpackl(self) -> Self::Result;
     }
 
-    // FIXME(llvm): a shuffle + simd_as does not currently optimize into a single instruction like
-    // unpachk above. Tracked in https://github.com/llvm/llvm-project/issues/129576.
+    // NOTE: `vuplh` is used for "unpack logical high", hence `vuplhw`.
+    impl_vec_unpack!(unpack_low vuplb vector_signed_char i8x8 vector_signed_short 8);
+    impl_vec_unpack!(unpack_low vuplhw vector_signed_short i16x4 vector_signed_int 4);
+    impl_vec_unpack!(unpack_low vuplf vector_signed_int i32x2 vector_signed_long_long 2);
+
+    impl_vec_unpack!(unpack_low vupllb vector_unsigned_char u8x8 vector_unsigned_short 8);
+    impl_vec_unpack!(unpack_low vupllh vector_unsigned_short u16x4 vector_unsigned_int 4);
+    impl_vec_unpack!(unpack_low vupllf vector_unsigned_int u32x2 vector_unsigned_long_long 2);
 
     impl_vec_trait! {[VectorUnpackl vec_unpackl] vuplb (vector_signed_char) -> vector_signed_short}
     impl_vec_trait! {[VectorUnpackl vec_unpackl] vuplhw (vector_signed_short) -> vector_signed_int}

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -2352,6 +2352,9 @@ mod sealed {
         unsafe fn vec_packs(self, b: Other) -> Self::Result;
     }
 
+    // FIXME(llvm): https://github.com/llvm/llvm-project/issues/153655
+    // Other targets can use a min/max for the saturation + a truncation.
+
     impl_vec_trait! { [VectorPacks vec_packs] vpksh (vector_signed_short, vector_signed_short) -> vector_signed_char }
     impl_vec_trait! { [VectorPacks vec_packs] vpklsh (vector_unsigned_short, vector_unsigned_short) -> vector_unsigned_char }
     impl_vec_trait! { [VectorPacks vec_packs] vpksf (vector_signed_int, vector_signed_int) -> vector_signed_short }


### PR DESCRIPTION
LLVM 21 brings some new optimizations that mean that we can use fewer llvm intrinsics. No new instructions are used, so this code works with older LLVM versions, but does not optimize (nearly) as well.