### PR TITLE
use `llvm.roundeven` on arm

### DIFF
--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -58256,10 +58256,9 @@ pub fn vrhaddq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 pub fn vrndn_f16(a: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "arm"),
             link_name = "llvm.roundeven.v4f16"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrintn.v4f16")]
         fn _vrndn_f16(a: float16x4_t) -> float16x4_t;
     }
     unsafe { _vrndn_f16(a) }
@@ -58279,10 +58278,9 @@ pub fn vrndn_f16(a: float16x4_t) -> float16x4_t {
 pub fn vrndnq_f16(a: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "arm"),
             link_name = "llvm.roundeven.v8f16"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrintn.v8f16")]
         fn _vrndnq_f16(a: float16x8_t) -> float16x8_t;
     }
     unsafe { _vrndnq_f16(a) }
@@ -58308,10 +58306,9 @@ pub fn vrndnq_f16(a: float16x8_t) -> float16x8_t {
 pub fn vrndn_f32(a: float32x2_t) -> float32x2_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "arm"),
             link_name = "llvm.roundeven.v2f32"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrintn.v2f32")]
         fn _vrndn_f32(a: float32x2_t) -> float32x2_t;
     }
     unsafe { _vrndn_f32(a) }
@@ -58337,10 +58334,9 @@ pub fn vrndn_f32(a: float32x2_t) -> float32x2_t {
 pub fn vrndnq_f32(a: float32x4_t) -> float32x4_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "arm"),
             link_name = "llvm.roundeven.v4f32"
         )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrintn.v4f32")]
         fn _vrndnq_f32(a: float32x4_t) -> float32x4_t;
     }
     unsafe { _vrndnq_f32(a) }

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -2486,9 +2486,7 @@ intrinsics:
           name: "llvm.frinn.{neon_type}"
           links:
             - link: "llvm.roundeven.{neon_type}"
-              arch: aarch64,arm64ec
-            - link: "llvm.arm.neon.vrintn.{neon_type}"
-              arch: arm
+              arch: aarch64,arm64ec,arm
 
   - name: "vrndn{neon_type.no}"
     doc: "Floating-point round to integral, to nearest with ties to even"
@@ -2510,9 +2508,7 @@ intrinsics:
           name: "llvm.frinn.{neon_type}"
           links:
             - link: "llvm.roundeven.{neon_type}"
-              arch: aarch64,arm64ec
-            - link: "llvm.arm.neon.vrintn.{neon_type}"
-              arch: arm
+              arch: aarch64,arm64ec,arm
 
   - name: "vqadd{neon_type.no}"
     doc: Saturating add


### PR DESCRIPTION
This did not work before (e.g. in https://github.com/rust-lang/stdarch/pull/1807), but I fixed the LLVM issue in https://github.com/llvm/llvm-project/pull/141786, which is now part of our LLVM.

Do we need to wait with this change for rust's minimum LLVM version to reach this version? 