### PR TITLE
Make some remaining X86 intrinsics safe

### DIFF
--- a/crates/core_arch/src/x86/adx.rs
+++ b/crates/core_arch/src/x86/adx.rs
@@ -19,8 +19,8 @@ unsafe extern "unadjusted" {
 #[inline]
 #[cfg_attr(test, assert_instr(adc))]
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
-pub unsafe fn _addcarry_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
-    let (a, b) = llvm_addcarry_u32(c_in, a, b);
+pub fn _addcarry_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
+    let (a, b) = unsafe { llvm_addcarry_u32(c_in, a, b) };
     *out = b;
     a
 }
@@ -34,8 +34,8 @@ pub unsafe fn _addcarry_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
 #[target_feature(enable = "adx")]
 #[cfg_attr(test, assert_instr(adc))]
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
-pub unsafe fn _addcarryx_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
-    llvm_addcarryx_u32(c_in, a, b, out as *mut _)
+pub fn _addcarryx_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
+    unsafe { llvm_addcarryx_u32(c_in, a, b, out as *mut _) }
 }
 
 /// Adds unsigned 32-bit integers `a` and `b` with unsigned 8-bit carry-in `c_in`
@@ -46,8 +46,8 @@ pub unsafe fn _addcarryx_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
 #[inline]
 #[cfg_attr(test, assert_instr(sbb))]
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
-pub unsafe fn _subborrow_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
-    let (a, b) = llvm_subborrow_u32(c_in, a, b);
+pub fn _subborrow_u32(c_in: u8, a: u32, b: u32, out: &mut u32) -> u8 {
+    let (a, b) = unsafe { llvm_subborrow_u32(c_in, a, b) };
     *out = b;
     a
 }
@@ -60,38 +60,36 @@ mod tests {
 
     #[test]
     fn test_addcarry_u32() {
-        unsafe {
-            let a = u32::MAX;
-            let mut out = 0;
+        let a = u32::MAX;
+        let mut out = 0;
 
-            let r = _addcarry_u32(0, a, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, 0);
+        let r = _addcarry_u32(0, a, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, 0);
 
-            let r = _addcarry_u32(0, a, 0, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, a);
+        let r = _addcarry_u32(0, a, 0, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, a);
 
-            let r = _addcarry_u32(1, a, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, 1);
+        let r = _addcarry_u32(1, a, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, 1);
 
-            let r = _addcarry_u32(1, a, 0, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, 0);
+        let r = _addcarry_u32(1, a, 0, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, 0);
 
-            let r = _addcarry_u32(0, 3, 4, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 7);
+        let r = _addcarry_u32(0, 3, 4, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 7);
 
-            let r = _addcarry_u32(1, 3, 4, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 8);
-        }
+        let r = _addcarry_u32(1, 3, 4, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 8);
     }
 
     #[simd_test(enable = "adx")]
-    unsafe fn test_addcarryx_u32() {
+    fn test_addcarryx_u32() {
         let a = u32::MAX;
         let mut out = 0;
 
@@ -121,44 +119,39 @@ mod tests {
     }
 
     #[simd_test(enable = "adx")]
-    unsafe fn test_addcarryx_u32_2() {
-        unsafe fn add_1_2_3() -> u32 {
-            let mut out = 0;
-            _addcarryx_u32(1, 2, 3, &mut out);
-            out
-        }
-        assert_eq!(6, add_1_2_3());
+    fn test_addcarryx_u32_2() {
+        let mut out = 0;
+        _addcarryx_u32(1, 2, 3, &mut out);
+        assert_eq!(6, out);
     }
 
     #[test]
     fn test_subborrow_u32() {
-        unsafe {
-            let a = u32::MAX;
-            let mut out = 0;
+        let a = u32::MAX;
+        let mut out = 0;
 
-            let r = _subborrow_u32(0, 0, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, a);
+        let r = _subborrow_u32(0, 0, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, a);
 
-            let r = _subborrow_u32(0, 0, 0, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 0);
+        let r = _subborrow_u32(0, 0, 0, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 0);
 
-            let r = _subborrow_u32(1, 0, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, a - 1);
+        let r = _subborrow_u32(1, 0, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, a - 1);
 
-            let r = _subborrow_u32(1, 0, 0, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, a);
+        let r = _subborrow_u32(1, 0, 0, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, a);
 
-            let r = _subborrow_u32(0, 7, 3, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 4);
+        let r = _subborrow_u32(0, 7, 3, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 4);
 
-            let r = _subborrow_u32(1, 7, 3, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 3);
-        }
+        let r = _subborrow_u32(1, 7, 3, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 3);
     }
 }

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -11111,7 +11111,7 @@ pub fn _mm256_reduce_mul_ph(a: __m256h) -> f16 {
 #[inline]
 #[target_feature(enable = "avx512fp16")]
 #[unstable(feature = "stdarch_x86_avx512_f16", issue = "127213")]
-pub unsafe fn _mm512_reduce_mul_ph(a: __m512h) -> f16 {
+pub fn _mm512_reduce_mul_ph(a: __m512h) -> f16 {
     unsafe {
         let p = simd_shuffle!(a, a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
         let q = simd_shuffle!(

--- a/crates/core_arch/src/x86/bswap.rs
+++ b/crates/core_arch/src/x86/bswap.rs
@@ -10,7 +10,7 @@ use stdarch_test::assert_instr;
 #[inline]
 #[cfg_attr(test, assert_instr(bswap))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _bswap(x: i32) -> i32 {
+pub fn _bswap(x: i32) -> i32 {
     x.swap_bytes()
 }
 
@@ -20,9 +20,7 @@ mod tests {
 
     #[test]
     fn test_bswap() {
-        unsafe {
-            assert_eq!(_bswap(0x0EADBE0F), 0x0FBEAD0E);
-            assert_eq!(_bswap(0x00000000), 0x00000000);
-        }
+        assert_eq!(_bswap(0x0EADBE0F), 0x0FBEAD0E);
+        assert_eq!(_bswap(0x00000000), 0x00000000);
     }
 }

--- a/crates/core_arch/src/x86/rdrand.rs
+++ b/crates/core_arch/src/x86/rdrand.rs
@@ -26,8 +26,8 @@ use stdarch_test::assert_instr;
 #[target_feature(enable = "rdrand")]
 #[cfg_attr(test, assert_instr(rdrand))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdrand16_step(val: &mut u16) -> i32 {
-    let (v, flag) = x86_rdrand16_step();
+pub fn _rdrand16_step(val: &mut u16) -> i32 {
+    let (v, flag) = unsafe { x86_rdrand16_step() };
     *val = v;
     flag
 }
@@ -40,8 +40,8 @@ pub unsafe fn _rdrand16_step(val: &mut u16) -> i32 {
 #[target_feature(enable = "rdrand")]
 #[cfg_attr(test, assert_instr(rdrand))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdrand32_step(val: &mut u32) -> i32 {
-    let (v, flag) = x86_rdrand32_step();
+pub fn _rdrand32_step(val: &mut u32) -> i32 {
+    let (v, flag) = unsafe { x86_rdrand32_step() };
     *val = v;
     flag
 }
@@ -54,8 +54,8 @@ pub unsafe fn _rdrand32_step(val: &mut u32) -> i32 {
 #[target_feature(enable = "rdseed")]
 #[cfg_attr(test, assert_instr(rdseed))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdseed16_step(val: &mut u16) -> i32 {
-    let (v, flag) = x86_rdseed16_step();
+pub fn _rdseed16_step(val: &mut u16) -> i32 {
+    let (v, flag) = unsafe { x86_rdseed16_step() };
     *val = v;
     flag
 }
@@ -68,8 +68,8 @@ pub unsafe fn _rdseed16_step(val: &mut u16) -> i32 {
 #[target_feature(enable = "rdseed")]
 #[cfg_attr(test, assert_instr(rdseed))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdseed32_step(val: &mut u32) -> i32 {
-    let (v, flag) = x86_rdseed32_step();
+pub fn _rdseed32_step(val: &mut u32) -> i32 {
+    let (v, flag) = unsafe { x86_rdseed32_step() };
     *val = v;
     flag
 }

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1445,8 +1445,8 @@ pub fn _mm_move_ss(a: __m128, b: __m128) -> __m128 {
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(sfence))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_sfence() {
-    sfence()
+pub fn _mm_sfence() {
+    unsafe { sfence() }
 }
 
 /// Gets the unsigned 32-bit value of the MXCSR control and status register.

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1897,11 +1897,13 @@ pub const _MM_HINT_ET1: i32 = 6;
 #[cfg_attr(test, assert_instr(prefetchnta, STRATEGY = _MM_HINT_NTA))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_prefetch<const STRATEGY: i32>(p: *const i8) {
+pub fn _mm_prefetch<const STRATEGY: i32>(p: *const i8) {
     static_assert_uimm_bits!(STRATEGY, 3);
     // We use the `llvm.prefetch` intrinsic with `cache type` = 1 (data cache).
     // `locality` and `rw` are based on our `STRATEGY`.
-    prefetch(p, (STRATEGY >> 2) & 1, STRATEGY & 3, 1);
+    unsafe {
+        prefetch(p, (STRATEGY >> 2) & 1, STRATEGY & 3, 1);
+    }
 }
 
 /// Returns vector of type __m128 with indeterminate elements.with indetermination elements.

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -19,10 +19,10 @@ use crate::{
 #[inline]
 #[cfg_attr(all(test, target_feature = "sse2"), assert_instr(pause))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_pause() {
+pub fn _mm_pause() {
     // note: `pause` is guaranteed to be interpreted as a `nop` by CPUs without
     // the SSE2 target-feature - therefore it does not require any target features
-    pause()
+    unsafe { pause() }
 }
 
 /// Invalidates and flushes the cache line that contains `p` from all levels of
@@ -49,8 +49,8 @@ pub unsafe fn _mm_clflush(p: *const u8) {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(lfence))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_lfence() {
-    lfence()
+pub fn _mm_lfence() {
+    unsafe { lfence() }
 }
 
 /// Performs a serializing operation on all load-from-memory and store-to-memory
@@ -65,8 +65,8 @@ pub unsafe fn _mm_lfence() {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(mfence))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_mfence() {
-    mfence()
+pub fn _mm_mfence() {
+    unsafe { mfence() }
 }
 
 /// Adds packed 8-bit integers in `a` and `b`.
@@ -3142,7 +3142,7 @@ mod tests {
 
     #[test]
     fn test_mm_pause() {
-        unsafe { _mm_pause() }
+        _mm_pause()
     }
 
     #[simd_test(enable = "sse2")]

--- a/crates/core_arch/src/x86/tbm.rs
+++ b/crates/core_arch/src/x86/tbm.rs
@@ -30,7 +30,7 @@ unsafe extern "C" {
 #[cfg_attr(test, assert_instr(bextr, CONTROL = 0x0404))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86_updates", since = "1.82.0")]
-pub unsafe fn _bextri_u32<const CONTROL: u32>(a: u32) -> u32 {
+pub fn _bextri_u32<const CONTROL: u32>(a: u32) -> u32 {
     static_assert_uimm_bits!(CONTROL, 16);
     unsafe { bextri_u32(a, CONTROL) }
 }
@@ -42,7 +42,7 @@ pub unsafe fn _bextri_u32<const CONTROL: u32>(a: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcfill))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcfill_u32(x: u32) -> u32 {
+pub fn _blcfill_u32(x: u32) -> u32 {
     x & (x.wrapping_add(1))
 }
 
@@ -53,7 +53,7 @@ pub unsafe fn _blcfill_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blci))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blci_u32(x: u32) -> u32 {
+pub fn _blci_u32(x: u32) -> u32 {
     x | !x.wrapping_add(1)
 }
 
@@ -64,7 +64,7 @@ pub unsafe fn _blci_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcic))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcic_u32(x: u32) -> u32 {
+pub fn _blcic_u32(x: u32) -> u32 {
     !x & x.wrapping_add(1)
 }
 
@@ -76,7 +76,7 @@ pub unsafe fn _blcic_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcmsk))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcmsk_u32(x: u32) -> u32 {
+pub fn _blcmsk_u32(x: u32) -> u32 {
     x ^ x.wrapping_add(1)
 }
 
@@ -87,7 +87,7 @@ pub unsafe fn _blcmsk_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcs))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcs_u32(x: u32) -> u32 {
+pub fn _blcs_u32(x: u32) -> u32 {
     x | x.wrapping_add(1)
 }
 
@@ -98,7 +98,7 @@ pub unsafe fn _blcs_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsfill))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blsfill_u32(x: u32) -> u32 {
+pub fn _blsfill_u32(x: u32) -> u32 {
     x | x.wrapping_sub(1)
 }
 
@@ -109,7 +109,7 @@ pub unsafe fn _blsfill_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsic))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blsic_u32(x: u32) -> u32 {
+pub fn _blsic_u32(x: u32) -> u32 {
     !x | x.wrapping_sub(1)
 }
 
@@ -121,7 +121,7 @@ pub unsafe fn _blsic_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(t1mskc))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _t1mskc_u32(x: u32) -> u32 {
+pub fn _t1mskc_u32(x: u32) -> u32 {
     !x | x.wrapping_add(1)
 }
 
@@ -133,7 +133,7 @@ pub unsafe fn _t1mskc_u32(x: u32) -> u32 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(tzmsk))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _tzmsk_u32(x: u32) -> u32 {
+pub fn _tzmsk_u32(x: u32) -> u32 {
     !x & x.wrapping_sub(1)
 }
 

--- a/crates/core_arch/src/x86_64/adx.rs
+++ b/crates/core_arch/src/x86_64/adx.rs
@@ -19,8 +19,8 @@ unsafe extern "unadjusted" {
 #[inline]
 #[cfg_attr(test, assert_instr(adc))]
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
-pub unsafe fn _addcarry_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
-    let (a, b) = llvm_addcarry_u64(c_in, a, b);
+pub fn _addcarry_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
+    let (a, b) = unsafe { llvm_addcarry_u64(c_in, a, b) };
     *out = b;
     a
 }
@@ -34,8 +34,8 @@ pub unsafe fn _addcarry_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
 #[target_feature(enable = "adx")]
 #[cfg_attr(test, assert_instr(adc))]
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
-pub unsafe fn _addcarryx_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
-    llvm_addcarryx_u64(c_in, a, b, out as *mut _)
+pub fn _addcarryx_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
+    unsafe { llvm_addcarryx_u64(c_in, a, b, out as *mut _) }
 }
 
 /// Adds unsigned 64-bit integers `a` and `b` with unsigned 8-bit carry-in `c_in`.
@@ -46,8 +46,8 @@ pub unsafe fn _addcarryx_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
 #[inline]
 #[cfg_attr(test, assert_instr(sbb))]
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
-pub unsafe fn _subborrow_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
-    let (a, b) = llvm_subborrow_u64(c_in, a, b);
+pub fn _subborrow_u64(c_in: u8, a: u64, b: u64, out: &mut u64) -> u8 {
+    let (a, b) = unsafe { llvm_subborrow_u64(c_in, a, b) };
     *out = b;
     a
 }
@@ -60,38 +60,36 @@ mod tests {
 
     #[test]
     fn test_addcarry_u64() {
-        unsafe {
-            let a = u64::MAX;
-            let mut out = 0;
+        let a = u64::MAX;
+        let mut out = 0;
 
-            let r = _addcarry_u64(0, a, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, 0);
+        let r = _addcarry_u64(0, a, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, 0);
 
-            let r = _addcarry_u64(0, a, 0, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, a);
+        let r = _addcarry_u64(0, a, 0, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, a);
 
-            let r = _addcarry_u64(1, a, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, 1);
+        let r = _addcarry_u64(1, a, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, 1);
 
-            let r = _addcarry_u64(1, a, 0, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, 0);
+        let r = _addcarry_u64(1, a, 0, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, 0);
 
-            let r = _addcarry_u64(0, 3, 4, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 7);
+        let r = _addcarry_u64(0, 3, 4, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 7);
 
-            let r = _addcarry_u64(1, 3, 4, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 8);
-        }
+        let r = _addcarry_u64(1, 3, 4, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 8);
     }
 
     #[simd_test(enable = "adx")]
-    unsafe fn test_addcarryx_u64() {
+    fn test_addcarryx_u64() {
         let a = u64::MAX;
         let mut out = 0;
 
@@ -122,33 +120,31 @@ mod tests {
 
     #[test]
     fn test_subborrow_u64() {
-        unsafe {
-            let a = u64::MAX;
-            let mut out = 0;
+        let a = u64::MAX;
+        let mut out = 0;
 
-            let r = _subborrow_u64(0, 0, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, a);
+        let r = _subborrow_u64(0, 0, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, a);
 
-            let r = _subborrow_u64(0, 0, 0, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 0);
+        let r = _subborrow_u64(0, 0, 0, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 0);
 
-            let r = _subborrow_u64(1, 0, 1, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, a - 1);
+        let r = _subborrow_u64(1, 0, 1, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, a - 1);
 
-            let r = _subborrow_u64(1, 0, 0, &mut out);
-            assert_eq!(r, 1);
-            assert_eq!(out, a);
+        let r = _subborrow_u64(1, 0, 0, &mut out);
+        assert_eq!(r, 1);
+        assert_eq!(out, a);
 
-            let r = _subborrow_u64(0, 7, 3, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 4);
+        let r = _subborrow_u64(0, 7, 3, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 4);
 
-            let r = _subborrow_u64(1, 7, 3, &mut out);
-            assert_eq!(r, 0);
-            assert_eq!(out, 3);
-        }
+        let r = _subborrow_u64(1, 7, 3, &mut out);
+        assert_eq!(r, 0);
+        assert_eq!(out, 3);
     }
 }

--- a/crates/core_arch/src/x86_64/bswap.rs
+++ b/crates/core_arch/src/x86_64/bswap.rs
@@ -11,7 +11,7 @@ use stdarch_test::assert_instr;
 #[inline]
 #[cfg_attr(test, assert_instr(bswap))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _bswap64(x: i64) -> i64 {
+pub fn _bswap64(x: i64) -> i64 {
     x.swap_bytes()
 }
 
@@ -21,9 +21,7 @@ mod tests {
 
     #[test]
     fn test_bswap64() {
-        unsafe {
-            assert_eq!(_bswap64(0x0EADBEEFFADECA0E), 0x0ECADEFAEFBEAD0E);
-            assert_eq!(_bswap64(0x0000000000000000), 0x0000000000000000);
-        }
+        assert_eq!(_bswap64(0x0EADBEEFFADECA0E), 0x0ECADEFAEFBEAD0E);
+        assert_eq!(_bswap64(0x0000000000000000), 0x0000000000000000);
     }
 }

--- a/crates/core_arch/src/x86_64/rdrand.rs
+++ b/crates/core_arch/src/x86_64/rdrand.rs
@@ -23,8 +23,8 @@ use stdarch_test::assert_instr;
 #[target_feature(enable = "rdrand")]
 #[cfg_attr(test, assert_instr(rdrand))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdrand64_step(val: &mut u64) -> i32 {
-    let (v, flag) = x86_rdrand64_step();
+pub fn _rdrand64_step(val: &mut u64) -> i32 {
+    let (v, flag) = unsafe { x86_rdrand64_step() };
     *val = v;
     flag
 }
@@ -37,8 +37,8 @@ pub unsafe fn _rdrand64_step(val: &mut u64) -> i32 {
 #[target_feature(enable = "rdseed")]
 #[cfg_attr(test, assert_instr(rdseed))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdseed64_step(val: &mut u64) -> i32 {
-    let (v, flag) = x86_rdseed64_step();
+pub fn _rdseed64_step(val: &mut u64) -> i32 {
+    let (v, flag) = unsafe { x86_rdseed64_step() };
     *val = v;
     flag
 }

--- a/crates/core_arch/src/x86_64/tbm.rs
+++ b/crates/core_arch/src/x86_64/tbm.rs
@@ -30,7 +30,7 @@ unsafe extern "C" {
 #[cfg_attr(test, assert_instr(bextr, CONTROL = 0x0404))]
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "simd_x86_updates", since = "1.82.0")]
-pub unsafe fn _bextri_u64<const CONTROL: u64>(a: u64) -> u64 {
+pub fn _bextri_u64<const CONTROL: u64>(a: u64) -> u64 {
     static_assert_uimm_bits!(CONTROL, 16);
     unsafe { bextri_u64(a, CONTROL) }
 }
@@ -42,7 +42,7 @@ pub unsafe fn _bextri_u64<const CONTROL: u64>(a: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcfill))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcfill_u64(x: u64) -> u64 {
+pub fn _blcfill_u64(x: u64) -> u64 {
     x & x.wrapping_add(1)
 }
 
@@ -53,7 +53,7 @@ pub unsafe fn _blcfill_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blci))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blci_u64(x: u64) -> u64 {
+pub fn _blci_u64(x: u64) -> u64 {
     x | !x.wrapping_add(1)
 }
 
@@ -64,7 +64,7 @@ pub unsafe fn _blci_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcic))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcic_u64(x: u64) -> u64 {
+pub fn _blcic_u64(x: u64) -> u64 {
     !x & x.wrapping_add(1)
 }
 
@@ -76,7 +76,7 @@ pub unsafe fn _blcic_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcmsk))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcmsk_u64(x: u64) -> u64 {
+pub fn _blcmsk_u64(x: u64) -> u64 {
     x ^ x.wrapping_add(1)
 }
 
@@ -87,7 +87,7 @@ pub unsafe fn _blcmsk_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcs))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blcs_u64(x: u64) -> u64 {
+pub fn _blcs_u64(x: u64) -> u64 {
     x | x.wrapping_add(1)
 }
 
@@ -98,7 +98,7 @@ pub unsafe fn _blcs_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsfill))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blsfill_u64(x: u64) -> u64 {
+pub fn _blsfill_u64(x: u64) -> u64 {
     x | x.wrapping_sub(1)
 }
 
@@ -109,7 +109,7 @@ pub unsafe fn _blsfill_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsic))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _blsic_u64(x: u64) -> u64 {
+pub fn _blsic_u64(x: u64) -> u64 {
     !x | x.wrapping_sub(1)
 }
 
@@ -121,7 +121,7 @@ pub unsafe fn _blsic_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(t1mskc))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _t1mskc_u64(x: u64) -> u64 {
+pub fn _t1mskc_u64(x: u64) -> u64 {
     !x | x.wrapping_add(1)
 }
 
@@ -133,7 +133,7 @@ pub unsafe fn _t1mskc_u64(x: u64) -> u64 {
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(tzmsk))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _tzmsk_u64(x: u64) -> u64 {
+pub fn _tzmsk_u64(x: u64) -> u64 {
     !x & x.wrapping_sub(1)
 }
 


### PR DESCRIPTION
 - ADC/ADX
 - `_mm512_reduce_mul_ph` (missed)
 - `_bswap{,64}`
 - RDRAND/RDSEED
 - TBM
 - `_mm_prefetch` - It doesn't actually dereference the pointer argument, so it's safe
 - `_mm_{l,s,m}fence` - These can't introduce inconsistencies, as they are fences.
 - `_mm_pause` - It's like `std::hint::spin_loop`, so nothing unsafe here. Worst it can do is make the program slower