### PR TITLE
RISC-V: Lower requirements of `clmul` and `clmulh`

### DIFF
--- a/crates/core_arch/src/riscv_shared/zb.rs
+++ b/crates/core_arch/src/riscv_shared/zb.rs
@@ -68,7 +68,7 @@ pub fn orc_b(rs: usize) -> usize {
 ///
 /// Section: 2.11
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
-#[target_feature(enable = "zbc")]
+#[target_feature(enable = "zbkc")]
 #[cfg_attr(test, assert_instr(clmul))]
 #[inline]
 pub fn clmul(rs1: usize, rs2: usize) -> usize {
@@ -93,7 +93,7 @@ pub fn clmul(rs1: usize, rs2: usize) -> usize {
 ///
 /// Section: 2.12
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
-#[target_feature(enable = "zbc")]
+#[target_feature(enable = "zbkc")]
 #[cfg_attr(test, assert_instr(clmulh))]
 #[inline]
 pub fn clmulh(rs1: usize, rs2: usize) -> usize {


### PR DESCRIPTION
They don't need full "Zbc" extension but only its subset: the "Zbkc" extension.

Since the compiler implies `zbkc` from `zbc`, it's safe to use `#[target_feature(enable = "zbkc")]`.