### PR TITLE
`stdarch-gen-wasm32`: Tool that creates spec sheet from wasm32's C and Rust source files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stdarch-gen-wasm"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "clap",
+ "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-rust",
+]
+
+[[package]]
 name = "stdarch-test"
 version = "0.1.0"
 dependencies = [
@@ -715,6 +726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +761,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/crates/stdarch-gen-wasm/Cargo.toml
+++ b/crates/stdarch-gen-wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stdarch-gen-wasm"
+version = "0.1.0"
+authors = ["Madhav Madhusoodanan <madhavmadhusoodanan@gmail.com>"]
+edition = "2024"
+
+[dependencies]
+tree-sitter = "0.24"
+tree-sitter-rust = "0.23"
+tree-sitter-c = "0.23"
+clap = { version = "4.5.45", features = ["derive"] }
+
+[build-dependencies]
+cc="*"

--- a/crates/stdarch-gen-wasm/src/cli.rs
+++ b/crates/stdarch-gen-wasm/src/cli.rs
@@ -9,5 +9,5 @@ pub struct Args {
 
     /// The Rust source file path argument
     #[arg(short, long)]
-    pub rust: String,
+    pub rust: Vec<String>,
 }

--- a/crates/stdarch-gen-wasm/src/cli.rs
+++ b/crates/stdarch-gen-wasm/src/cli.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// The Rust source file path argument
+    #[arg(short, long)]
+    pub c: String,
+
+    /// The Rust source file path argument
+    #[arg(short, long)]
+    pub rust: String,
+}

--- a/crates/stdarch-gen-wasm/src/main.rs
+++ b/crates/stdarch-gen-wasm/src/main.rs
@@ -1,0 +1,126 @@
+mod cli;
+mod matcher;
+mod structs;
+mod utils;
+
+use std::fs;
+
+use clap::Parser as ClapParser;
+use cli::Args;
+use tree_sitter::{Parser, Tree};
+
+use crate::matcher::match_intrinsic_definitions;
+use crate::structs::{CIntrinsic, RustIntrinsic};
+use crate::utils::leaf_nodes_from_grammar_name;
+
+/// Read the Rust source code and returns its AST
+fn process_rust_code(source: &String) -> (String, Tree) {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .expect("Error loading Rust grammar");
+    let source_code = fs::read_to_string(source);
+
+    if let Err(ref err) = source_code {
+        eprintln!("Rust parsing error: {}", err);
+        panic!()
+    }
+    let source_code_string = source_code.unwrap();
+    let tree = parser.parse(source_code_string.clone(), None).unwrap();
+    (source_code_string, tree)
+}
+
+/// Reads the C source code and returns its AST
+fn process_c_code(source: &String) -> (String, Tree) {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_c::LANGUAGE.into())
+        .expect("Error loading Rust grammar");
+    let source_code = fs::read_to_string(source);
+
+    if let Err(ref err) = source_code {
+        eprintln!("C parsing error: {}", err);
+        panic!()
+    }
+    let source_code_string = source_code.unwrap();
+    let tree = parser.parse(source_code_string.clone(), None).unwrap();
+    (source_code_string, tree)
+}
+
+/// Creates an entry in the spec sheet that corresponds to a specific intrinsic
+fn generate_spec(c_intrinsic: &CIntrinsic, rust_intrinsic: &RustIntrinsic) -> String {
+    format!(
+        "/// {}
+c-intrinsic-name = {}
+c-arguments = {}
+c-arguments-data-types = {}
+c-return-type = {}
+rust-intrinsic-name = {}
+rust-arguments = {}
+rust-arguments-data-types = {}
+rust-const-generic-arguments = {}
+rust-const-generic-arguments-data-types = {}
+rust-return-type = {}",
+        rust_intrinsic.intrinsic,
+        c_intrinsic.intrinsic,
+        c_intrinsic.arg_names.join(", "),
+        c_intrinsic.arg_types.join(", "),
+        c_intrinsic.return_type.unwrap_or(""),
+        rust_intrinsic.intrinsic,
+        rust_intrinsic.arg_names.join(", "),
+        rust_intrinsic.arg_types.join(", "),
+        rust_intrinsic.generic_arg_names.join(", "),
+        rust_intrinsic.generic_arg_types.join(", "),
+        rust_intrinsic.return_type.unwrap_or(""),
+    )
+}
+
+/// Create the spec sheet.
+/// 
+/// Fields that would be present in the spec sheet:
+/// 1. c-intrinsic-name
+/// 2. c-arguments
+/// 3. c-arguments-data-types
+/// 4. c-return-type
+/// 5. rust-intrinsic-name
+/// 6. rust-arguments
+/// 7. rust-arguments-data-types
+/// 8. rust-const-generic-arguments
+/// 9. rust-const-generic-arguments-data-types
+/// 10. rust-return-type
+fn main() {
+    // Read the file-paths from CLI arguments
+    // obtain the tree of tokens from the code
+    let args = Args::parse();
+    let (c_source, c_tree) = process_c_code(&args.c);
+    let (rust_source, rust_tree) = process_rust_code(&args.rust);
+
+    let preproc_node = c_tree.root_node();
+
+    let c_intrinsics = leaf_nodes_from_grammar_name(preproc_node, "function_definition")
+        .iter()
+        .map(|&node| CIntrinsic::new(node, &c_source))
+        .collect::<Vec<_>>();
+
+    let mut rust_cursor = rust_tree.root_node().walk();
+    let rust_intrinsics = rust_tree
+        .root_node()
+        .children(&mut rust_cursor)
+        .filter(|node| node.grammar_name() == "function_item")
+        .map(|node| RustIntrinsic::new(node, &rust_source))
+        .collect::<Vec<_>>();
+
+    let matching_intrinsics = match_intrinsic_definitions(&c_intrinsics, &rust_intrinsics);
+    println!(
+        "// This code is automatically generated. DO NOT MODIFY.
+// Number of matched intrinsics: {}\n",
+        matching_intrinsics.len()
+    );
+
+    let spec_details = matching_intrinsics
+        .iter()
+        .map(|&(c_intrinsic, rust_intrinsic)| generate_spec(c_intrinsic, rust_intrinsic))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    println!("{}", spec_details);
+}

--- a/crates/stdarch-gen-wasm/src/matcher.rs
+++ b/crates/stdarch-gen-wasm/src/matcher.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use crate::structs::{CIntrinsic, RustIntrinsic};
 
 /// Matches the set of intrinsics in Rust to their C counterpart.
-/// 
+///
 /// This function assumes that the list of Rust definitions
 /// will be a subset of the list of definitions in C.
 pub fn match_intrinsic_definitions<'a>(
@@ -33,10 +33,10 @@ pub fn match_intrinsic_definitions<'a>(
 fn match_intrinsic_definition(c_definition: &str, rust_definition: &str) -> bool {
     // Most intrinsics in C are of the format: `wasm_v128_load`.
     // Its Rust counterpart is named `v128_load`.
-    // 
+    //
     // Another one is `wasm_i8x16_const_splat`, and its Rust counterpart is `i8x16_splat`.
-    // 
-    // The pattern that is observed is that, each keyword "chunk" that constructs 
+    //
+    // The pattern that is observed is that, each keyword "chunk" that constructs
     // the intrinsic name in Rust will also be used to construct the intrinsic name in C.
     // These names are constructed by joining the chunks with an underscore (_).
 

--- a/crates/stdarch-gen-wasm/src/matcher.rs
+++ b/crates/stdarch-gen-wasm/src/matcher.rs
@@ -1,0 +1,47 @@
+use std::collections::HashSet;
+
+use crate::structs::{CIntrinsic, RustIntrinsic};
+
+/// Matches the set of intrinsics in Rust to their C counterpart.
+/// 
+/// This function assumes that the list of Rust definitions
+/// will be a subset of the list of definitions in C.
+pub fn match_intrinsic_definitions<'a>(
+    c_definitions: &'a Vec<CIntrinsic>,
+    rust_definitions: &'a Vec<RustIntrinsic>,
+) -> Vec<(&'a CIntrinsic<'a>, &'a RustIntrinsic<'a>)> {
+    // This function assumes that the list of Rust definitions
+    // will be a subset of the list of definitions in C
+
+    let mut matched_definitions: Vec<(&'a CIntrinsic, &'a RustIntrinsic)> = Vec::new();
+    matched_definitions.reserve(rust_definitions.len());
+
+    for rust_definition in rust_definitions.iter() {
+        let c_definition = c_definitions
+            .iter()
+            .find(|&c_def| match_intrinsic_definition(c_def.intrinsic, rust_definition.intrinsic));
+        if let Some(c_def) = c_definition {
+            matched_definitions.push((c_def, rust_definition));
+        }
+    }
+
+    matched_definitions
+}
+
+/// checks if the function name of the intrinsic in Rust
+/// matches that of the intrinsic in C.
+fn match_intrinsic_definition(c_definition: &str, rust_definition: &str) -> bool {
+    // Most intrinsics in C are of the format: `wasm_v128_load`.
+    // Its Rust counterpart is named `v128_load`.
+    // 
+    // Another one is `wasm_i8x16_const_splat`, and its Rust counterpart is `i8x16_splat`.
+    // 
+    // The pattern that is observed is that, each keyword "chunk" that constructs 
+    // the intrinsic name in Rust will also be used to construct the intrinsic name in C.
+    // These names are constructed by joining the chunks with an underscore (_).
+
+    let c_definition_split: HashSet<_> = c_definition.split('_').collect();
+    rust_definition
+        .split('_')
+        .all(|keyword| c_definition_split.contains(keyword))
+}

--- a/crates/stdarch-gen-wasm/src/structs.rs
+++ b/crates/stdarch-gen-wasm/src/structs.rs
@@ -22,14 +22,14 @@ pub struct CIntrinsic<'a> {
 }
 
 impl<'a> CIntrinsic<'a> {
-    pub fn new(node: Node, source: &'a String) -> Self {
+    pub fn new(node: Node, source: &'a str) -> Self {
         // Take an intrinsic definition for example:
-        // 
+        //
         // static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_make(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3) {...}
-        // 
+        //
         // For a C intrinsic, the immediate children
         // would have their grammar names as:
-        // 
+        //
         // "storage_class_specifier" (which is `static`)
         // "storage_class_specifier" (which is `__inline__`)
         // "identifier" (which is `v128_t`. The parser doesn't recognize that it is a type, instead thinks that it is an identifier)
@@ -54,7 +54,7 @@ impl<'a> CIntrinsic<'a> {
 
         // The immediate children of the `function_declarator` node would have
         // their grammar as follows:
-        // 
+        //
         // "identifier" (which is the intrinsic name)
         // "parameter_list" (which is the arguments to the intrinsic)
         let declarator_node = node
@@ -64,27 +64,27 @@ impl<'a> CIntrinsic<'a> {
 
         // The immediate children of a `parameter_list` node would have
         // their grammar as follows (assuming 2 arguments):
-        // 
+        //
         // "(" -> The opening bracket that denotes the start of the arguments definition
         // "parameter_declaration" -> The definition for the first argument
         // "," -> The comma that separates the first and the second arguments
         // "parameter_declaration" -> The definition for the first argument
         // ")"  -> The closing bracket that denotes the start of the arguments definition
-        // 
+        //
         // Each node with grammar name as `parameter_declaration` could have their children as
         // (incase of `int x`):
         // 1. "primitive_type" -> Points to `int`
         // 2. "indentifier" -> Points to `x`
-        // 
+        //
         // or have (incase of `v128_t x`):
         // 1. "identifier" -> Points to `v128_t` which is actually a type (but the parser is unaware of it)
         // 2. "identifier" -> Points to `x`
-        // 
+        //
         // or have (incase of `const void *__mem`):
         // 1. "type_qualifier" -> Points to `const`
         // 2. "primitive_type" -> Points to `void`
         // 3. "pointer_declarator" -> breaks down into "*" and "identifier" (which is `__mem`)
-        //  
+        //
         let intrinsic_name = source
             .get(
                 declarator_node
@@ -108,9 +108,9 @@ impl<'a> CIntrinsic<'a> {
                     // Since the type could be identified as either `primitive_type, `indentifier`,
                     // or a combination of `type_qualifier`, `primitive_type` and `*` (in the case of "const void *")
                     // this approach first calculates the end index (which is right before the start of an argument variable)
-                    // 
+                    //
                     // And then searches backwards until it finds a break (either a comma
-                    // or the opening bracket). The entire portion contained within this range 
+                    // or the opening bracket). The entire portion contained within this range
                     // is then considered as the type of the argument.
                     let end_index = arg_name_node.byte_range().start;
                     let start_index = source
@@ -149,10 +149,10 @@ impl<'a> CIntrinsic<'a> {
 }
 
 impl<'a> RustIntrinsic<'a> {
-    pub fn new(node: Node, source: &'a String) -> Self {
+    pub fn new(node: Node, source: &'a str) -> Self {
         // For a Rust intrinsic, the immediate children
         // would have their grammar names as:
-        // 
+        //
         // 1. "visibility_modifier"  (for `pub`)
         // 2. "function_modifiers" (for `unsafe`. May not always be present)
         // 3. "fn" (the actual keyword `fn`)
@@ -162,7 +162,7 @@ impl<'a> RustIntrinsic<'a> {
         // 7. "->" (the arrow used to specify return type)
         // 8. "identifier" (the return type of the function)
         // 9. "block" (the body of the function)
-        // 
+        //
         let mut cursor = node.walk();
         let intrinsic_name = source
             .get(
@@ -196,14 +196,13 @@ impl<'a> RustIntrinsic<'a> {
         if let Some(generic_args) = generic_args {
             // The children of this node have their grammar_names as the following
             // (assuming 2 generic arguments):
-            // 
+            //
             // "<" (The opening angle bracket that starts the generic arguments definition)
             // "const_parameter" (The first const generic argument)
             // "," (The comma that denotes the end of definition of the first const generic argument)
             // "const_parameter" (The second const generic argument)
             // ">" (The closing angle bracket that concludes the generic arguments definition)
-            // 
-
+            //
             (generic_arg_names, generic_arg_types) = generic_args
                 .children(&mut cursor)
                 .filter(|arg| arg.grammar_name() == "const_parameter")
@@ -225,13 +224,12 @@ impl<'a> RustIntrinsic<'a> {
         if let Some(args) = args {
             // The children of this node have their grammar_names as the following
             // (assuming 2 generic arguments):
-            // 
+            //
             // "(" (The opening circular bracket that starts the arguments definition)
             // "parameter" (The first argument)
             // "," (The comma that denotes the end of definition of the first argument)
             // "parameter" (The second argument)
             // ")" (The closing circular bracket that concludes the arguments definition)
-            // 
             (arg_names, arg_types) = args
                 .children(&mut cursor)
                 .filter(|arg| arg.grammar_name() == "parameter")

--- a/crates/stdarch-gen-wasm/src/structs.rs
+++ b/crates/stdarch-gen-wasm/src/structs.rs
@@ -1,0 +1,260 @@
+use crate::utils::leaf_nodes_from_grammar_name;
+use std::ops::Add;
+use tree_sitter::Node;
+
+#[derive(Debug)]
+pub struct RustIntrinsic<'a> {
+    pub intrinsic: &'a str,
+    pub arg_names: Vec<&'a str>,
+    pub arg_types: Vec<&'a str>,
+    pub generic_arg_names: Vec<&'a str>,
+    pub generic_arg_types: Vec<&'a str>,
+    pub return_type: Option<&'a str>,
+}
+
+#[derive(Debug)]
+pub struct CIntrinsic<'a> {
+    pub intrinsic: &'a str,
+    pub arg_names: Vec<&'a str>,
+    pub arg_types: Vec<&'a str>,
+    pub specifier: &'a str,
+    pub return_type: Option<&'a str>,
+}
+
+impl<'a> CIntrinsic<'a> {
+    pub fn new(node: Node, source: &'a String) -> Self {
+        // Take an intrinsic definition for example:
+        // 
+        // static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_make(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3) {...}
+        // 
+        // For a C intrinsic, the immediate children
+        // would have their grammar names as:
+        // 
+        // "storage_class_specifier" (which is `static`)
+        // "storage_class_specifier" (which is `__inline__`)
+        // "identifier" (which is `v128_t`. The parser doesn't recognize that it is a type, instead thinks that it is an identifier)
+        // "ERROR" (which points to the keyword `__DEFAULT_FN_ATTRS`. The parser doesn't recognize it as a valid part of the tree, and annotates it as ERROR.)
+        // "function_declarator" (points to `wasm_u32x4_make(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3)`)
+        // "compound_statement" (the body of the function)
+        let mut cursor = node.walk();
+
+        let return_type = node
+            .children(&mut cursor)
+            .find(|node| node.grammar_name() == "identifier")
+            .map(|node| source.get(node.byte_range()).unwrap());
+
+        let specifier = source
+            .get(
+                node.children(&mut cursor)
+                    .find(|node| node.grammar_name() == "ERROR")
+                    .unwrap()
+                    .byte_range(),
+            )
+            .unwrap();
+
+        // The immediate children of the `function_declarator` node would have
+        // their grammar as follows:
+        // 
+        // "identifier" (which is the intrinsic name)
+        // "parameter_list" (which is the arguments to the intrinsic)
+        let declarator_node = node
+            .children(&mut cursor)
+            .find(|node| node.grammar_name() == "function_declarator")
+            .unwrap();
+
+        // The immediate children of a `parameter_list` node would have
+        // their grammar as follows (assuming 2 arguments):
+        // 
+        // "(" -> The opening bracket that denotes the start of the arguments definition
+        // "parameter_declaration" -> The definition for the first argument
+        // "," -> The comma that separates the first and the second arguments
+        // "parameter_declaration" -> The definition for the first argument
+        // ")"  -> The closing bracket that denotes the start of the arguments definition
+        // 
+        // Each node with grammar name as `parameter_declaration` could have their children as
+        // (incase of `int x`):
+        // 1. "primitive_type" -> Points to `int`
+        // 2. "indentifier" -> Points to `x`
+        // 
+        // or have (incase of `v128_t x`):
+        // 1. "identifier" -> Points to `v128_t` which is actually a type (but the parser is unaware of it)
+        // 2. "identifier" -> Points to `x`
+        // 
+        // or have (incase of `const void *__mem`):
+        // 1. "type_qualifier" -> Points to `const`
+        // 2. "primitive_type" -> Points to `void`
+        // 3. "pointer_declarator" -> breaks down into "*" and "identifier" (which is `__mem`)
+        //  
+        let intrinsic_name = source
+            .get(
+                declarator_node
+                    .children(&mut cursor)
+                    .find(|node| node.grammar_name() == "identifier")
+                    .unwrap()
+                    .byte_range(),
+            )
+            .unwrap();
+
+        let args = declarator_node
+            .children(&mut cursor)
+            .find(|node| node.grammar_name() == "parameter_list");
+
+        let (arg_names, arg_types): (Vec<&str>, Vec<&str>) = if let Some(args) = args {
+            let arg_name_nodes = leaf_nodes_from_grammar_name(args, "identifier");
+            let arg_name_nodes = arg_name_nodes.iter();
+
+            arg_name_nodes
+                .map(|arg_name_node| {
+                    // Since the type could be identified as either `primitive_type, `indentifier`,
+                    // or a combination of `type_qualifier`, `primitive_type` and `*` (in the case of "const void *")
+                    // this approach first calculates the end index (which is right before the start of an argument variable)
+                    // 
+                    // And then searches backwards until it finds a break (either a comma
+                    // or the opening bracket). The entire portion contained within this range 
+                    // is then considered as the type of the argument.
+                    let end_index = arg_name_node.byte_range().start;
+                    let start_index = source
+                        .get(0..end_index)
+                        .unwrap()
+                        .bytes()
+                        .rposition(|character| character == b',' || character == b'(')
+                        .unwrap()
+                        .add(1);
+                    (
+                        source
+                            .get(arg_name_node.byte_range())
+                            .expect("C arg name construction")
+                            .trim(),
+                        source
+                            .get(start_index..end_index)
+                            .expect("C arg type construction")
+                            .trim(),
+                    )
+                })
+                .filter(|(_, arg_type)| arg_type.len() > 0)
+                .filter(|(_, arg_type)| !arg_type.starts_with("\""))
+                .unzip()
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        Self {
+            intrinsic: intrinsic_name,
+            arg_names,
+            arg_types,
+            return_type,
+            specifier: specifier,
+        }
+    }
+}
+
+impl<'a> RustIntrinsic<'a> {
+    pub fn new(node: Node, source: &'a String) -> Self {
+        // For a Rust intrinsic, the immediate children
+        // would have their grammar names as:
+        // 
+        // 1. "visibility_modifier"  (for `pub`)
+        // 2. "function_modifiers" (for `unsafe`. May not always be present)
+        // 3. "fn" (the actual keyword `fn`)
+        // 4. "identifier" (the name of the function)
+        // 5. "type_parameters" (the const generic arguments. This is not always present)
+        // 6. "parameters" (the arguments passed to the function)
+        // 7. "->" (the arrow used to specify return type)
+        // 8. "identifier" (the return type of the function)
+        // 9. "block" (the body of the function)
+        // 
+        let mut cursor = node.walk();
+        let intrinsic_name = source
+            .get(
+                node.children(&mut cursor)
+                    .find(|node| node.grammar_name() == "identifier")
+                    .unwrap()
+                    .byte_range(),
+            )
+            .unwrap();
+
+        let arrow_pos = node
+            .children(&mut cursor)
+            .position(|node| node.grammar_name() == "->");
+
+        let return_type = arrow_pos.map(|index| {
+            source
+                .get(node.child(index + 1).unwrap().byte_range())
+                .unwrap()
+        });
+
+        let generic_args = node
+            .children(&mut cursor)
+            .find(|node| node.grammar_name() == "type_parameters");
+
+        let args = node
+            .children(&mut cursor)
+            .find(|node| node.grammar_name() == "parameters");
+
+        let mut generic_arg_names: Vec<&str> = Vec::new();
+        let mut generic_arg_types: Vec<&str> = Vec::new();
+        if let Some(generic_args) = generic_args {
+            // The children of this node have their grammar_names as the following
+            // (assuming 2 generic arguments):
+            // 
+            // "<" (The opening angle bracket that starts the generic arguments definition)
+            // "const_parameter" (The first const generic argument)
+            // "," (The comma that denotes the end of definition of the first const generic argument)
+            // "const_parameter" (The second const generic argument)
+            // ">" (The closing angle bracket that concludes the generic arguments definition)
+            // 
+
+            (generic_arg_names, generic_arg_types) = generic_args
+                .children(&mut cursor)
+                .filter(|arg| arg.grammar_name() == "const_parameter")
+                .map(|arg| {
+                    (
+                        source
+                            .get(arg.named_child(0).unwrap().byte_range())
+                            .unwrap(),
+                        source
+                            .get(arg.named_child(1).unwrap().byte_range())
+                            .unwrap(),
+                    )
+                })
+                .unzip();
+        }
+
+        let mut arg_names: Vec<&str> = Vec::new();
+        let mut arg_types: Vec<&str> = Vec::new();
+        if let Some(args) = args {
+            // The children of this node have their grammar_names as the following
+            // (assuming 2 generic arguments):
+            // 
+            // "(" (The opening circular bracket that starts the arguments definition)
+            // "parameter" (The first argument)
+            // "," (The comma that denotes the end of definition of the first argument)
+            // "parameter" (The second argument)
+            // ")" (The closing circular bracket that concludes the arguments definition)
+            // 
+            (arg_names, arg_types) = args
+                .children(&mut cursor)
+                .filter(|arg| arg.grammar_name() == "parameter")
+                .map(|arg| {
+                    (
+                        source
+                            .get(arg.named_child(0).unwrap().byte_range())
+                            .unwrap(),
+                        source
+                            .get(arg.named_child(1).unwrap().byte_range())
+                            .unwrap(),
+                    )
+                })
+                .unzip();
+        }
+
+        Self {
+            intrinsic: intrinsic_name,
+            arg_names,
+            arg_types,
+            generic_arg_names,
+            generic_arg_types,
+            return_type,
+        }
+    }
+}

--- a/crates/stdarch-gen-wasm/src/structs.rs
+++ b/crates/stdarch-gen-wasm/src/structs.rs
@@ -40,7 +40,9 @@ impl<'a> CIntrinsic<'a> {
 
         let return_type = node
             .children(&mut cursor)
-            .find(|node| node.grammar_name() == "identifier")
+            .find(|node| {
+                node.grammar_name() == "identifier" || node.grammar_name() == "primitive_type"
+            })
             .map(|node| source.get(node.byte_range()).unwrap());
 
         let specifier = source

--- a/crates/stdarch-gen-wasm/src/utils.rs
+++ b/crates/stdarch-gen-wasm/src/utils.rs
@@ -1,0 +1,24 @@
+use tree_sitter::Node;
+
+/// Recursively searches the node and its children for a node 
+/// that matches its grammar name, using Depth-first search.
+pub fn leaf_nodes_from_grammar_name<'a>(node: Node<'a>, name: &str) -> Vec<Node<'a>> {
+    if node.grammar_name() == name {
+        // handle the base case
+        vec![node]
+    } else if node.child_count() > 0 {
+        // search through the children
+        (0..node.child_count())
+            .into_iter()
+            .filter_map(|index| {
+                let tags = leaf_nodes_from_grammar_name(node.child(index).unwrap(), name);
+                if tags.len() == 0 { None } else { Some(tags) }
+            })
+            .flatten()
+            .collect()
+    } else {
+        // Node has no children and doesnt have its grammar name as `name`.
+        // Return empty vector.
+        Vec::new()
+    }
+}

--- a/crates/stdarch-gen-wasm/src/utils.rs
+++ b/crates/stdarch-gen-wasm/src/utils.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Node;
 
-/// Recursively searches the node and its children for a node 
+/// Recursively searches the node and its children for a node
 /// that matches its grammar name, using Depth-first search.
 pub fn leaf_nodes_from_grammar_name<'a>(node: Node<'a>, name: &str) -> Vec<Node<'a>> {
     if node.grammar_name() == name {

--- a/intrinsics_data/wasm_simd128.h
+++ b/intrinsics_data/wasm_simd128.h
@@ -1,0 +1,2143 @@
+/*===---- wasm_simd128.h - WebAssembly portable SIMD intrinsics ------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+ 
+#ifndef __WASM_SIMD128_H
+#define __WASM_SIMD128_H
+ 
+#include <stdbool.h>
+#include <stdint.h>
+ 
+// User-facing type
+typedef int32_t v128_t __attribute__((__vector_size__(16), __aligned__(16)));
+ 
+// Internal types determined by clang builtin definitions
+typedef int32_t __v128_u __attribute__((__vector_size__(16), __aligned__(1)));
+typedef signed char __i8x16
+    __attribute__((__vector_size__(16), __aligned__(16)));
+typedef unsigned char __u8x16
+    __attribute__((__vector_size__(16), __aligned__(16)));
+typedef short __i16x8 __attribute__((__vector_size__(16), __aligned__(16)));
+typedef unsigned short __u16x8
+    __attribute__((__vector_size__(16), __aligned__(16)));
+typedef int __i32x4 __attribute__((__vector_size__(16), __aligned__(16)));
+typedef unsigned int __u32x4
+    __attribute__((__vector_size__(16), __aligned__(16)));
+typedef long long __i64x2 __attribute__((__vector_size__(16), __aligned__(16)));
+typedef unsigned long long __u64x2
+    __attribute__((__vector_size__(16), __aligned__(16)));
+typedef float __f32x4 __attribute__((__vector_size__(16), __aligned__(16)));
+typedef double __f64x2 __attribute__((__vector_size__(16), __aligned__(16)));
+typedef __fp16 __f16x8 __attribute__((__vector_size__(16), __aligned__(16)));
+ 
+typedef signed char __i8x8 __attribute__((__vector_size__(8), __aligned__(8)));
+typedef unsigned char __u8x8
+    __attribute__((__vector_size__(8), __aligned__(8)));
+typedef short __i16x4 __attribute__((__vector_size__(8), __aligned__(8)));
+typedef unsigned short __u16x4
+    __attribute__((__vector_size__(8), __aligned__(8)));
+typedef int __i32x2 __attribute__((__vector_size__(8), __aligned__(8)));
+typedef unsigned int __u32x2
+    __attribute__((__vector_size__(8), __aligned__(8)));
+typedef float __f32x2 __attribute__((__vector_size__(8), __aligned__(8)));
+ 
+#define __DEFAULT_FN_ATTRS                                                     \
+  __attribute__((__always_inline__, __nodebug__, __target__("simd128"),        \
+                 __min_vector_width__(128)))
+ 
+#define __REQUIRE_CONSTANT(c)                                                  \
+  __attribute__((__diagnose_if__(!__builtin_constant_p(c),                     \
+                                 #c " must be constant", "error")))
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load(const void *__mem) {
+  // UB-free unaligned access copied from xmmintrin.h
+  struct __wasm_v128_load_struct {
+    __v128_u __v;
+  } __attribute__((__packed__, __may_alias__));
+  return ((const struct __wasm_v128_load_struct *)__mem)->__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_v128_load8_splat(const void *__mem) {
+  struct __wasm_v128_load8_splat_struct {
+    uint8_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  uint8_t __v = ((const struct __wasm_v128_load8_splat_struct *)__mem)->__v;
+  return (v128_t)(__u8x16){__v, __v, __v, __v, __v, __v, __v, __v,
+                           __v, __v, __v, __v, __v, __v, __v, __v};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_v128_load16_splat(const void *__mem) {
+  struct __wasm_v128_load16_splat_struct {
+    uint16_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  uint16_t __v = ((const struct __wasm_v128_load16_splat_struct *)__mem)->__v;
+  return (v128_t)(__u16x8){__v, __v, __v, __v, __v, __v, __v, __v};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_v128_load32_splat(const void *__mem) {
+  struct __wasm_v128_load32_splat_struct {
+    uint32_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  uint32_t __v = ((const struct __wasm_v128_load32_splat_struct *)__mem)->__v;
+  return (v128_t)(__u32x4){__v, __v, __v, __v};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_v128_load64_splat(const void *__mem) {
+  struct __wasm_v128_load64_splat_struct {
+    uint64_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  uint64_t __v = ((const struct __wasm_v128_load64_splat_struct *)__mem)->__v;
+  return (v128_t)(__u64x2){__v, __v};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_load8x8(const void *__mem) {
+  struct __wasm_i16x8_load8x8_struct {
+    __i8x8 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __i8x8 __v = ((const struct __wasm_i16x8_load8x8_struct *)__mem)->__v;
+  return (v128_t) __builtin_convertvector(__v, __i16x8);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_load8x8(const void *__mem) {
+  struct __wasm_u16x8_load8x8_struct {
+    __u8x8 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __u8x8 __v = ((const struct __wasm_u16x8_load8x8_struct *)__mem)->__v;
+  return (v128_t) __builtin_convertvector(__v, __u16x8);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_load16x4(const void *__mem) {
+  struct __wasm_i32x4_load16x4_struct {
+    __i16x4 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __i16x4 __v = ((const struct __wasm_i32x4_load16x4_struct *)__mem)->__v;
+  return (v128_t) __builtin_convertvector(__v, __i32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_load16x4(const void *__mem) {
+  struct __wasm_u32x4_load16x4_struct {
+    __u16x4 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __u16x4 __v = ((const struct __wasm_u32x4_load16x4_struct *)__mem)->__v;
+  return (v128_t) __builtin_convertvector(__v, __u32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i64x2_load32x2(const void *__mem) {
+  struct __wasm_i64x2_load32x2_struct {
+    __i32x2 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __i32x2 __v = ((const struct __wasm_i64x2_load32x2_struct *)__mem)->__v;
+  return (v128_t) __builtin_convertvector(__v, __i64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u64x2_load32x2(const void *__mem) {
+  struct __wasm_u64x2_load32x2_struct {
+    __u32x2 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __u32x2 __v = ((const struct __wasm_u64x2_load32x2_struct *)__mem)->__v;
+  return (v128_t) __builtin_convertvector(__v, __u64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_v128_load32_zero(const void *__mem) {
+  struct __wasm_v128_load32_zero_struct {
+    int32_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  int32_t __v = ((const struct __wasm_v128_load32_zero_struct *)__mem)->__v;
+  return (v128_t)(__i32x4){__v, 0, 0, 0};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_v128_load64_zero(const void *__mem) {
+  struct __wasm_v128_load64_zero_struct {
+    int64_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  int64_t __v = ((const struct __wasm_v128_load64_zero_struct *)__mem)->__v;
+  return (v128_t)(__i64x2){__v, 0};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load8_lane(
+    const void *__mem, v128_t __vec, int __i) __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_load8_lane_struct {
+    int8_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  int8_t __v = ((const struct __wasm_v128_load8_lane_struct *)__mem)->__v;
+  __i8x16 __ret = (__i8x16)__vec;
+  __ret[__i] = __v;
+  return (v128_t)__ret;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load16_lane(
+    const void *__mem, v128_t __vec, int __i) __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_load16_lane_struct {
+    int16_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  int16_t __v = ((const struct __wasm_v128_load16_lane_struct *)__mem)->__v;
+  __i16x8 __ret = (__i16x8)__vec;
+  __ret[__i] = __v;
+  return (v128_t)__ret;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load32_lane(
+    const void *__mem, v128_t __vec, int __i) __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_load32_lane_struct {
+    int32_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  int32_t __v = ((const struct __wasm_v128_load32_lane_struct *)__mem)->__v;
+  __i32x4 __ret = (__i32x4)__vec;
+  __ret[__i] = __v;
+  return (v128_t)__ret;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load64_lane(
+    const void *__mem, v128_t __vec, int __i) __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_load64_lane_struct {
+    int64_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  int64_t __v = ((const struct __wasm_v128_load64_lane_struct *)__mem)->__v;
+  __i64x2 __ret = (__i64x2)__vec;
+  __ret[__i] = __v;
+  return (v128_t)__ret;
+}
+ 
+static __inline__ void __DEFAULT_FN_ATTRS wasm_v128_store(void *__mem,
+                                                          v128_t __a) {
+  // UB-free unaligned access copied from xmmintrin.h
+  struct __wasm_v128_store_struct {
+    __v128_u __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __wasm_v128_store_struct *)__mem)->__v = __a;
+}
+ 
+static __inline__ void __DEFAULT_FN_ATTRS wasm_v128_store8_lane(void *__mem,
+                                                                v128_t __vec,
+                                                                int __i)
+    __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_store8_lane_struct {
+    int8_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __wasm_v128_store8_lane_struct *)__mem)->__v = ((__i8x16)__vec)[__i];
+}
+ 
+static __inline__ void __DEFAULT_FN_ATTRS wasm_v128_store16_lane(void *__mem,
+                                                                 v128_t __vec,
+                                                                 int __i)
+    __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_store16_lane_struct {
+    int16_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __wasm_v128_store16_lane_struct *)__mem)->__v =
+      ((__i16x8)__vec)[__i];
+}
+ 
+static __inline__ void __DEFAULT_FN_ATTRS wasm_v128_store32_lane(void *__mem,
+                                                                 v128_t __vec,
+                                                                 int __i)
+    __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_store32_lane_struct {
+    int32_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __wasm_v128_store32_lane_struct *)__mem)->__v =
+      ((__i32x4)__vec)[__i];
+}
+ 
+static __inline__ void __DEFAULT_FN_ATTRS wasm_v128_store64_lane(void *__mem,
+                                                                 v128_t __vec,
+                                                                 int __i)
+    __REQUIRE_CONSTANT(__i) {
+  struct __wasm_v128_store64_lane_struct {
+    int64_t __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __wasm_v128_store64_lane_struct *)__mem)->__v =
+      ((__i64x2)__vec)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i8x16_make(int8_t __c0, int8_t __c1, int8_t __c2, int8_t __c3, int8_t __c4,
+                int8_t __c5, int8_t __c6, int8_t __c7, int8_t __c8, int8_t __c9,
+                int8_t __c10, int8_t __c11, int8_t __c12, int8_t __c13,
+                int8_t __c14, int8_t __c15) {
+  return (v128_t)(__i8x16){__c0,  __c1,  __c2,  __c3, __c4,  __c5,
+                           __c6,  __c7,  __c8,  __c9, __c10, __c11,
+                           __c12, __c13, __c14, __c15};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u8x16_make(uint8_t __c0, uint8_t __c1, uint8_t __c2, uint8_t __c3,
+                uint8_t __c4, uint8_t __c5, uint8_t __c6, uint8_t __c7,
+                uint8_t __c8, uint8_t __c9, uint8_t __c10, uint8_t __c11,
+                uint8_t __c12, uint8_t __c13, uint8_t __c14, uint8_t __c15) {
+  return (v128_t)(__u8x16){__c0,  __c1,  __c2,  __c3, __c4,  __c5,
+                           __c6,  __c7,  __c8,  __c9, __c10, __c11,
+                           __c12, __c13, __c14, __c15};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_make(int16_t __c0, int16_t __c1, int16_t __c2, int16_t __c3,
+                int16_t __c4, int16_t __c5, int16_t __c6, int16_t __c7) {
+  return (v128_t)(__i16x8){__c0, __c1, __c2, __c3, __c4, __c5, __c6, __c7};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_make(uint16_t __c0, uint16_t __c1, uint16_t __c2, uint16_t __c3,
+                uint16_t __c4, uint16_t __c5, uint16_t __c6, uint16_t __c7) {
+  return (v128_t)(__u16x8){__c0, __c1, __c2, __c3, __c4, __c5, __c6, __c7};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_make(int32_t __c0,
+                                                            int32_t __c1,
+                                                            int32_t __c2,
+                                                            int32_t __c3) {
+  return (v128_t)(__i32x4){__c0, __c1, __c2, __c3};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_make(uint32_t __c0,
+                                                            uint32_t __c1,
+                                                            uint32_t __c2,
+                                                            uint32_t __c3) {
+  return (v128_t)(__u32x4){__c0, __c1, __c2, __c3};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_make(int64_t __c0,
+                                                            int64_t __c1) {
+  return (v128_t)(__i64x2){__c0, __c1};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_make(uint64_t __c0,
+                                                            uint64_t __c1) {
+  return (v128_t)(__u64x2){__c0, __c1};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_make(float __c0,
+                                                            float __c1,
+                                                            float __c2,
+                                                            float __c3) {
+  return (v128_t)(__f32x4){__c0, __c1, __c2, __c3};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_make(double __c0,
+                                                            double __c1) {
+  return (v128_t)(__f64x2){__c0, __c1};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i8x16_const(int8_t __c0, int8_t __c1, int8_t __c2, int8_t __c3,
+                 int8_t __c4, int8_t __c5, int8_t __c6, int8_t __c7,
+                 int8_t __c8, int8_t __c9, int8_t __c10, int8_t __c11,
+                 int8_t __c12, int8_t __c13, int8_t __c14, int8_t __c15)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) __REQUIRE_CONSTANT(__c4)
+            __REQUIRE_CONSTANT(__c5) __REQUIRE_CONSTANT(__c6)
+                __REQUIRE_CONSTANT(__c7) __REQUIRE_CONSTANT(__c8)
+                    __REQUIRE_CONSTANT(__c9) __REQUIRE_CONSTANT(__c10)
+                        __REQUIRE_CONSTANT(__c11) __REQUIRE_CONSTANT(__c12)
+                            __REQUIRE_CONSTANT(__c13) __REQUIRE_CONSTANT(__c14)
+                                __REQUIRE_CONSTANT(__c15) {
+  return (v128_t)(__i8x16){__c0,  __c1,  __c2,  __c3, __c4,  __c5,
+                           __c6,  __c7,  __c8,  __c9, __c10, __c11,
+                           __c12, __c13, __c14, __c15};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u8x16_const(uint8_t __c0, uint8_t __c1, uint8_t __c2, uint8_t __c3,
+                 uint8_t __c4, uint8_t __c5, uint8_t __c6, uint8_t __c7,
+                 uint8_t __c8, uint8_t __c9, uint8_t __c10, uint8_t __c11,
+                 uint8_t __c12, uint8_t __c13, uint8_t __c14, uint8_t __c15)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) __REQUIRE_CONSTANT(__c4)
+            __REQUIRE_CONSTANT(__c5) __REQUIRE_CONSTANT(__c6)
+                __REQUIRE_CONSTANT(__c7) __REQUIRE_CONSTANT(__c8)
+                    __REQUIRE_CONSTANT(__c9) __REQUIRE_CONSTANT(__c10)
+                        __REQUIRE_CONSTANT(__c11) __REQUIRE_CONSTANT(__c12)
+                            __REQUIRE_CONSTANT(__c13) __REQUIRE_CONSTANT(__c14)
+                                __REQUIRE_CONSTANT(__c15) {
+  return (v128_t)(__u8x16){__c0,  __c1,  __c2,  __c3, __c4,  __c5,
+                           __c6,  __c7,  __c8,  __c9, __c10, __c11,
+                           __c12, __c13, __c14, __c15};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_const(int16_t __c0, int16_t __c1, int16_t __c2, int16_t __c3,
+                 int16_t __c4, int16_t __c5, int16_t __c6, int16_t __c7)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) __REQUIRE_CONSTANT(__c4)
+            __REQUIRE_CONSTANT(__c5) __REQUIRE_CONSTANT(__c6)
+                __REQUIRE_CONSTANT(__c7) {
+  return (v128_t)(__i16x8){__c0, __c1, __c2, __c3, __c4, __c5, __c6, __c7};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_const(uint16_t __c0, uint16_t __c1, uint16_t __c2, uint16_t __c3,
+                 uint16_t __c4, uint16_t __c5, uint16_t __c6, uint16_t __c7)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) __REQUIRE_CONSTANT(__c4)
+            __REQUIRE_CONSTANT(__c5) __REQUIRE_CONSTANT(__c6)
+                __REQUIRE_CONSTANT(__c7) {
+  return (v128_t)(__u16x8){__c0, __c1, __c2, __c3, __c4, __c5, __c6, __c7};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_const(int32_t __c0, int32_t __c1, int32_t __c2, int32_t __c3)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) {
+  return (v128_t)(__i32x4){__c0, __c1, __c2, __c3};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_const(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) {
+  return (v128_t)(__u32x4){__c0, __c1, __c2, __c3};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_const(int64_t __c0,
+                                                             int64_t __c1)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) {
+  return (v128_t)(__i64x2){__c0, __c1};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_const(uint64_t __c0,
+                                                             uint64_t __c1)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) {
+  return (v128_t)(__u64x2){__c0, __c1};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f32x4_const(float __c0, float __c1, float __c2, float __c3)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) __REQUIRE_CONSTANT(__c2)
+        __REQUIRE_CONSTANT(__c3) {
+  return (v128_t)(__f32x4){__c0, __c1, __c2, __c3};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_const(double __c0,
+                                                             double __c1)
+    __REQUIRE_CONSTANT(__c0) __REQUIRE_CONSTANT(__c1) {
+  return (v128_t)(__f64x2){__c0, __c1};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_const_splat(int8_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__i8x16){__c, __c, __c, __c, __c, __c, __c, __c,
+                           __c, __c, __c, __c, __c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_const_splat(uint8_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__u8x16){__c, __c, __c, __c, __c, __c, __c, __c,
+                           __c, __c, __c, __c, __c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_const_splat(int16_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__i16x8){__c, __c, __c, __c, __c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_const_splat(uint16_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__u16x8){__c, __c, __c, __c, __c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_const_splat(int32_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__i32x4){__c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_const_splat(uint32_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__u32x4){__c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_const_splat(int64_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__i64x2){__c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_const_splat(uint64_t __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__u64x2){__c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_const_splat(float __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__f32x4){__c, __c, __c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_const_splat(double __c)
+    __REQUIRE_CONSTANT(__c) {
+  return (v128_t)(__f64x2){__c, __c};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_splat(int8_t __a) {
+  return (v128_t)(__i8x16){__a, __a, __a, __a, __a, __a, __a, __a,
+                           __a, __a, __a, __a, __a, __a, __a, __a};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_splat(uint8_t __a) {
+  return (v128_t)(__u8x16){__a, __a, __a, __a, __a, __a, __a, __a,
+                           __a, __a, __a, __a, __a, __a, __a, __a};
+}
+ 
+static __inline__ int8_t __DEFAULT_FN_ATTRS wasm_i8x16_extract_lane(v128_t __a,
+                                                                    int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__i8x16)__a)[__i];
+}
+ 
+static __inline__ uint8_t __DEFAULT_FN_ATTRS wasm_u8x16_extract_lane(v128_t __a,
+                                                                     int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__u8x16)__a)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    int8_t __b)
+    __REQUIRE_CONSTANT(__i) {
+  __i8x16 __v = (__i8x16)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    uint8_t __b)
+    __REQUIRE_CONSTANT(__i) {
+  __u8x16 __v = (__u8x16)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_splat(int16_t __a) {
+  return (v128_t)(__i16x8){__a, __a, __a, __a, __a, __a, __a, __a};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_splat(uint16_t __a) {
+  return (v128_t)(__u16x8){__a, __a, __a, __a, __a, __a, __a, __a};
+}
+ 
+static __inline__ int16_t __DEFAULT_FN_ATTRS wasm_i16x8_extract_lane(v128_t __a,
+                                                                     int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__i16x8)__a)[__i];
+}
+ 
+static __inline__ uint16_t __DEFAULT_FN_ATTRS
+wasm_u16x8_extract_lane(v128_t __a, int __i) __REQUIRE_CONSTANT(__i) {
+  return ((__u16x8)__a)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    int16_t __b)
+    __REQUIRE_CONSTANT(__i) {
+  __i16x8 __v = (__i16x8)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_replace_lane(
+    v128_t __a, int __i, uint16_t __b) __REQUIRE_CONSTANT(__i) {
+  __u16x8 __v = (__u16x8)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_splat(int32_t __a) {
+  return (v128_t)(__i32x4){__a, __a, __a, __a};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_splat(uint32_t __a) {
+  return (v128_t)(__u32x4){__a, __a, __a, __a};
+}
+ 
+static __inline__ int32_t __DEFAULT_FN_ATTRS wasm_i32x4_extract_lane(v128_t __a,
+                                                                     int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__i32x4)__a)[__i];
+}
+ 
+static __inline__ uint32_t __DEFAULT_FN_ATTRS
+wasm_u32x4_extract_lane(v128_t __a, int __i) __REQUIRE_CONSTANT(__i) {
+  return ((__u32x4)__a)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    int32_t __b)
+    __REQUIRE_CONSTANT(__i) {
+  __i32x4 __v = (__i32x4)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_replace_lane(
+    v128_t __a, int __i, uint32_t __b) __REQUIRE_CONSTANT(__i) {
+  __u32x4 __v = (__u32x4)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_splat(int64_t __a) {
+  return (v128_t)(__i64x2){__a, __a};
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_splat(uint64_t __a) {
+  return (v128_t)(__u64x2){__a, __a};
+}
+ 
+static __inline__ int64_t __DEFAULT_FN_ATTRS wasm_i64x2_extract_lane(v128_t __a,
+                                                                     int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__i64x2)__a)[__i];
+}
+ 
+static __inline__ uint64_t __DEFAULT_FN_ATTRS
+wasm_u64x2_extract_lane(v128_t __a, int __i) __REQUIRE_CONSTANT(__i) {
+  return ((__u64x2)__a)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    int64_t __b)
+    __REQUIRE_CONSTANT(__i) {
+  __i64x2 __v = (__i64x2)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_replace_lane(
+    v128_t __a, int __i, uint64_t __b) __REQUIRE_CONSTANT(__i) {
+  __u64x2 __v = (__u64x2)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_splat(float __a) {
+  return (v128_t)(__f32x4){__a, __a, __a, __a};
+}
+ 
+static __inline__ float __DEFAULT_FN_ATTRS wasm_f32x4_extract_lane(v128_t __a,
+                                                                   int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__f32x4)__a)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    float __b)
+    __REQUIRE_CONSTANT(__i) {
+  __f32x4 __v = (__f32x4)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_splat(double __a) {
+  return (v128_t)(__f64x2){__a, __a};
+}
+ 
+static __inline__ double __DEFAULT_FN_ATTRS wasm_f64x2_extract_lane(v128_t __a,
+                                                                    int __i)
+    __REQUIRE_CONSTANT(__i) {
+  return ((__f64x2)__a)[__i];
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_replace_lane(v128_t __a,
+                                                                    int __i,
+                                                                    double __b)
+    __REQUIRE_CONSTANT(__i) {
+  __f64x2 __v = (__f64x2)__a;
+  __v[__i] = __b;
+  return (v128_t)__v;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_eq(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i8x16)__a == (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_ne(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i8x16)__a != (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i8x16)__a < (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u8x16)__a < (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i8x16)__a > (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u8x16)__a > (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i8x16)__a <= (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u8x16)__a <= (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i8x16)__a >= (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u8x16)__a >= (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_eq(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i16x8)__a == (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_ne(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u16x8)__a != (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i16x8)__a < (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u16x8)__a < (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i16x8)__a > (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u16x8)__a > (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i16x8)__a <= (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u16x8)__a <= (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i16x8)__a >= (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u16x8)__a >= (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_eq(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i32x4)__a == (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_ne(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i32x4)__a != (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i32x4)__a < (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u32x4)__a < (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i32x4)__a > (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u32x4)__a > (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i32x4)__a <= (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u32x4)__a <= (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i32x4)__a >= (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__u32x4)__a >= (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_eq(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i64x2)__a == (__i64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_ne(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i64x2)__a != (__i64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i64x2)__a < (__i64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i64x2)__a > (__i64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i64x2)__a <= (__i64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__i64x2)__a >= (__i64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_eq(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f32x4)__a == (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_ne(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f32x4)__a != (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f32x4)__a < (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f32x4)__a > (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f32x4)__a <= (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f32x4)__a >= (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_eq(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f64x2)__a == (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_ne(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f64x2)__a != (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_lt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f64x2)__a < (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_gt(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f64x2)__a > (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_le(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f64x2)__a <= (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_ge(v128_t __a,
+                                                          v128_t __b) {
+  return (v128_t)((__f64x2)__a >= (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_not(v128_t __a) {
+  return ~__a;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_and(v128_t __a,
+                                                          v128_t __b) {
+  return __a & __b;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_or(v128_t __a,
+                                                         v128_t __b) {
+  return __a | __b;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_xor(v128_t __a,
+                                                          v128_t __b) {
+  return __a ^ __b;
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_andnot(v128_t __a,
+                                                             v128_t __b) {
+  return __a & ~__b;
+}
+ 
+static __inline__ bool __DEFAULT_FN_ATTRS wasm_v128_any_true(v128_t __a) {
+  return __builtin_wasm_any_true_v128((__i8x16)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_bitselect(v128_t __a,
+                                                                v128_t __b,
+                                                                v128_t __mask) {
+  return (v128_t)__builtin_wasm_bitselect((__i32x4)__a, (__i32x4)__b,
+                                          (__i32x4)__mask);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_i8x16((__i8x16)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_neg(v128_t __a) {
+  return (v128_t)(-(__u8x16)__a);
+}
+ 
+static __inline__ bool __DEFAULT_FN_ATTRS wasm_i8x16_all_true(v128_t __a) {
+  return __builtin_wasm_all_true_i8x16((__i8x16)__a);
+}
+ 
+static __inline__ uint32_t __DEFAULT_FN_ATTRS wasm_i8x16_bitmask(v128_t __a) {
+  return __builtin_wasm_bitmask_i8x16((__i8x16)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_popcnt(v128_t __a) {
+  return (v128_t)__builtin_elementwise_popcount((__i8x16)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_shl(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i8x16)__a << (__b & 0x7));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i8x16)__a >> (__b & 0x7));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__u8x16)__a >> (__b & 0x7));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_add(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u8x16)__a + (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_add_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_add_sat((__i8x16)__a, (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_add_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_add_sat((__u8x16)__a, (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_sub(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u8x16)__a - (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_sub_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_sub_sat((__i8x16)__a, (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_sub_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_sub_sat((__u8x16)__a, (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_min((__i8x16)__a, (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_min((__u8x16)__a, (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_max((__i8x16)__a, (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_max((__u8x16)__a, (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u8x16_avgr(v128_t __a,
+                                                            v128_t __b) {
+  return (v128_t)__builtin_wasm_avgr_u_i8x16((__u8x16)__a, (__u8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_i16x8((__i16x8)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_neg(v128_t __a) {
+  return (v128_t)(-(__u16x8)__a);
+}
+ 
+static __inline__ bool __DEFAULT_FN_ATTRS wasm_i16x8_all_true(v128_t __a) {
+  return __builtin_wasm_all_true_i16x8((__i16x8)__a);
+}
+ 
+static __inline__ uint32_t __DEFAULT_FN_ATTRS wasm_i16x8_bitmask(v128_t __a) {
+  return __builtin_wasm_bitmask_i16x8((__i16x8)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_shl(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i16x8)__a << (__b & 0xF));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i16x8)__a >> (__b & 0xF));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__u16x8)__a >> (__b & 0xF));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_add(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u16x8)__a + (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_add_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_add_sat((__i16x8)__a, (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_add_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_add_sat((__u16x8)__a, (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_sub(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__i16x8)__a - (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_sub_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_sub_sat((__i16x8)__a, (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_sub_sat(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_elementwise_sub_sat((__u16x8)__a, (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_mul(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u16x8)__a * (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_min((__i16x8)__a, (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_min((__u16x8)__a, (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_max((__i16x8)__a, (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_max((__u16x8)__a, (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_avgr(v128_t __a,
+                                                            v128_t __b) {
+  return (v128_t)__builtin_wasm_avgr_u_i16x8((__u16x8)__a, (__u16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_i32x4((__i32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_neg(v128_t __a) {
+  return (v128_t)(-(__u32x4)__a);
+}
+ 
+static __inline__ bool __DEFAULT_FN_ATTRS wasm_i32x4_all_true(v128_t __a) {
+  return __builtin_wasm_all_true_i32x4((__i32x4)__a);
+}
+ 
+static __inline__ uint32_t __DEFAULT_FN_ATTRS wasm_i32x4_bitmask(v128_t __a) {
+  return __builtin_wasm_bitmask_i32x4((__i32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_shl(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i32x4)__a << (__b & 0x1F));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i32x4)__a >> (__b & 0x1F));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__u32x4)__a >> (__b & 0x1F));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_add(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u32x4)__a + (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_sub(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u32x4)__a - (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_mul(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u32x4)__a * (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_min((__i32x4)__a, (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_min((__u32x4)__a, (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_max((__i32x4)__a, (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_elementwise_max((__u32x4)__a, (__u32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_dot_i16x8(v128_t __a,
+                                                                 v128_t __b) {
+  return (v128_t)__builtin_wasm_dot_s_i32x4_i16x8((__i16x8)__a, (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_i64x2((__i64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_neg(v128_t __a) {
+  return (v128_t)(-(__u64x2)__a);
+}
+ 
+static __inline__ bool __DEFAULT_FN_ATTRS wasm_i64x2_all_true(v128_t __a) {
+  return __builtin_wasm_all_true_i64x2((__i64x2)__a);
+}
+ 
+static __inline__ uint32_t __DEFAULT_FN_ATTRS wasm_i64x2_bitmask(v128_t __a) {
+  return __builtin_wasm_bitmask_i64x2((__i64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_shl(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i64x2)__a << ((int64_t)__b & 0x3F));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__i64x2)__a >> ((int64_t)__b & 0x3F));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_shr(v128_t __a,
+                                                           uint32_t __b) {
+  return (v128_t)((__u64x2)__a >> ((int64_t)__b & 0x3F));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_add(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u64x2)__a + (__u64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_sub(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u64x2)__a - (__u64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_mul(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__u64x2)__a * (__u64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_neg(v128_t __a) {
+  return (v128_t)(-(__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_sqrt(v128_t __a) {
+  return (v128_t)__builtin_wasm_sqrt_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_ceil(v128_t __a) {
+  return (v128_t)__builtin_wasm_ceil_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_floor(v128_t __a) {
+  return (v128_t)__builtin_wasm_floor_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_trunc(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_nearest(v128_t __a) {
+  return (v128_t)__builtin_wasm_nearest_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_add(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f32x4)__a + (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_sub(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f32x4)__a - (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_mul(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f32x4)__a * (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_div(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f32x4)__a / (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_wasm_min_f32x4((__f32x4)__a, (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_wasm_max_f32x4((__f32x4)__a, (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_pmin(v128_t __a,
+                                                            v128_t __b) {
+  return (v128_t)__builtin_wasm_pmin_f32x4((__f32x4)__a, (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f32x4_pmax(v128_t __a,
+                                                            v128_t __b) {
+  return (v128_t)__builtin_wasm_pmax_f32x4((__f32x4)__a, (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_neg(v128_t __a) {
+  return (v128_t)(-(__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_sqrt(v128_t __a) {
+  return (v128_t)__builtin_wasm_sqrt_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_ceil(v128_t __a) {
+  return (v128_t)__builtin_wasm_ceil_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_floor(v128_t __a) {
+  return (v128_t)__builtin_wasm_floor_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_trunc(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_nearest(v128_t __a) {
+  return (v128_t)__builtin_wasm_nearest_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_add(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f64x2)__a + (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_sub(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f64x2)__a - (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_mul(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f64x2)__a * (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_div(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)((__f64x2)__a / (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_min(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_wasm_min_f64x2((__f64x2)__a, (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_max(v128_t __a,
+                                                           v128_t __b) {
+  return (v128_t)__builtin_wasm_max_f64x2((__f64x2)__a, (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_pmin(v128_t __a,
+                                                            v128_t __b) {
+  return (v128_t)__builtin_wasm_pmin_f64x2((__f64x2)__a, (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_pmax(v128_t __a,
+                                                            v128_t __b) {
+  return (v128_t)__builtin_wasm_pmax_f64x2((__f64x2)__a, (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_trunc_sat_f32x4(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_saturate_s_i32x4_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_trunc_sat_f32x4(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_saturate_u_i32x4_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f32x4_convert_i32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector((__i32x4)__a, __f32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f32x4_convert_u32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector((__u32x4)__a, __f32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f64x2_convert_low_i32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector((__i32x2){__a[0], __a[1]}, __f64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f64x2_convert_low_u32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector((__u32x2){__a[0], __a[1]}, __f64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_trunc_sat_f64x2_zero(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_sat_s_zero_f64x2_i32x4((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_trunc_sat_f64x2_zero(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_sat_u_zero_f64x2_i32x4((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f32x4_demote_f64x2_zero(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      __builtin_shufflevector((__f64x2)__a, (__f64x2){0, 0}, 0, 1, 2, 3),
+      __f32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_f64x2_promote_low_f32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__f32x2){((__f32x4)__a)[0], ((__f32x4)__a)[1]}, __f64x2);
+}
+ 
+#define wasm_i8x16_shuffle(__a, __b, __c0, __c1, __c2, __c3, __c4, __c5, __c6, \
+                           __c7, __c8, __c9, __c10, __c11, __c12, __c13,       \
+                           __c14, __c15)                                       \
+  ((v128_t)__builtin_wasm_shuffle_i8x16(                                       \
+      (__i8x16)(__a), (__i8x16)(__b), __c0, __c1, __c2, __c3, __c4, __c5,      \
+      __c6, __c7, __c8, __c9, __c10, __c11, __c12, __c13, __c14, __c15))
+ 
+#define wasm_i16x8_shuffle(__a, __b, __c0, __c1, __c2, __c3, __c4, __c5, __c6, \
+                           __c7)                                               \
+  ((v128_t)__builtin_wasm_shuffle_i8x16(                                       \
+      (__i8x16)(__a), (__i8x16)(__b), (__c0)*2, (__c0)*2 + 1, (__c1)*2,        \
+      (__c1)*2 + 1, (__c2)*2, (__c2)*2 + 1, (__c3)*2, (__c3)*2 + 1, (__c4)*2,  \
+      (__c4)*2 + 1, (__c5)*2, (__c5)*2 + 1, (__c6)*2, (__c6)*2 + 1, (__c7)*2,  \
+      (__c7)*2 + 1))
+ 
+#define wasm_i32x4_shuffle(__a, __b, __c0, __c1, __c2, __c3)                   \
+  ((v128_t)__builtin_wasm_shuffle_i8x16(                                       \
+      (__i8x16)(__a), (__i8x16)(__b), (__c0)*4, (__c0)*4 + 1, (__c0)*4 + 2,    \
+      (__c0)*4 + 3, (__c1)*4, (__c1)*4 + 1, (__c1)*4 + 2, (__c1)*4 + 3,        \
+      (__c2)*4, (__c2)*4 + 1, (__c2)*4 + 2, (__c2)*4 + 3, (__c3)*4,            \
+      (__c3)*4 + 1, (__c3)*4 + 2, (__c3)*4 + 3))
+ 
+#define wasm_i64x2_shuffle(__a, __b, __c0, __c1)                               \
+  ((v128_t)__builtin_wasm_shuffle_i8x16(                                       \
+      (__i8x16)(__a), (__i8x16)(__b), (__c0)*8, (__c0)*8 + 1, (__c0)*8 + 2,    \
+      (__c0)*8 + 3, (__c0)*8 + 4, (__c0)*8 + 5, (__c0)*8 + 6, (__c0)*8 + 7,    \
+      (__c1)*8, (__c1)*8 + 1, (__c1)*8 + 2, (__c1)*8 + 3, (__c1)*8 + 4,        \
+      (__c1)*8 + 5, (__c1)*8 + 6, (__c1)*8 + 7))
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_swizzle(v128_t __a,
+                                                               v128_t __b) {
+  return (v128_t)__builtin_wasm_swizzle_i8x16((__i8x16)__a, (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i8x16_narrow_i16x8(v128_t __a, v128_t __b) {
+  return (v128_t)__builtin_wasm_narrow_s_i8x16_i16x8((__i16x8)__a,
+                                                     (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u8x16_narrow_i16x8(v128_t __a, v128_t __b) {
+  return (v128_t)__builtin_wasm_narrow_u_i8x16_i16x8((__i16x8)__a,
+                                                     (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_narrow_i32x4(v128_t __a, v128_t __b) {
+  return (v128_t)__builtin_wasm_narrow_s_i16x8_i32x4((__i32x4)__a,
+                                                     (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_narrow_i32x4(v128_t __a, v128_t __b) {
+  return (v128_t)__builtin_wasm_narrow_u_i16x8_i32x4((__i32x4)__a,
+                                                     (__i32x4)__b);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_extend_low_i8x16(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__i8x8){((__i8x16)__a)[0], ((__i8x16)__a)[1], ((__i8x16)__a)[2],
+               ((__i8x16)__a)[3], ((__i8x16)__a)[4], ((__i8x16)__a)[5],
+               ((__i8x16)__a)[6], ((__i8x16)__a)[7]},
+      __i16x8);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_extend_high_i8x16(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__i8x8){((__i8x16)__a)[8], ((__i8x16)__a)[9], ((__i8x16)__a)[10],
+               ((__i8x16)__a)[11], ((__i8x16)__a)[12], ((__i8x16)__a)[13],
+               ((__i8x16)__a)[14], ((__i8x16)__a)[15]},
+      __i16x8);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_extend_low_u8x16(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__u8x8){((__u8x16)__a)[0], ((__u8x16)__a)[1], ((__u8x16)__a)[2],
+               ((__u8x16)__a)[3], ((__u8x16)__a)[4], ((__u8x16)__a)[5],
+               ((__u8x16)__a)[6], ((__u8x16)__a)[7]},
+      __u16x8);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_extend_high_u8x16(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__u8x8){((__u8x16)__a)[8], ((__u8x16)__a)[9], ((__u8x16)__a)[10],
+               ((__u8x16)__a)[11], ((__u8x16)__a)[12], ((__u8x16)__a)[13],
+               ((__u8x16)__a)[14], ((__u8x16)__a)[15]},
+      __u16x8);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_extend_low_i16x8(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__i16x4){((__i16x8)__a)[0], ((__i16x8)__a)[1], ((__i16x8)__a)[2],
+                ((__i16x8)__a)[3]},
+      __i32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_extend_high_i16x8(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__i16x4){((__i16x8)__a)[4], ((__i16x8)__a)[5], ((__i16x8)__a)[6],
+                ((__i16x8)__a)[7]},
+      __i32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_extend_low_u16x8(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__u16x4){((__u16x8)__a)[0], ((__u16x8)__a)[1], ((__u16x8)__a)[2],
+                ((__u16x8)__a)[3]},
+      __u32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_extend_high_u16x8(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__u16x4){((__u16x8)__a)[4], ((__u16x8)__a)[5], ((__u16x8)__a)[6],
+                ((__u16x8)__a)[7]},
+      __u32x4);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i64x2_extend_low_i32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__i32x2){((__i32x4)__a)[0], ((__i32x4)__a)[1]}, __i64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i64x2_extend_high_i32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__i32x2){((__i32x4)__a)[2], ((__i32x4)__a)[3]}, __i64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u64x2_extend_low_u32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__u32x2){((__u32x4)__a)[0], ((__u32x4)__a)[1]}, __u64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u64x2_extend_high_u32x4(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      (__u32x2){((__u32x4)__a)[2], ((__u32x4)__a)[3]}, __u64x2);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_extadd_pairwise_i8x16(v128_t __a) {
+  return (v128_t)__builtin_wasm_extadd_pairwise_i8x16_s_i16x8((__i8x16)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_extadd_pairwise_u8x16(v128_t __a) {
+  return (v128_t)__builtin_wasm_extadd_pairwise_i8x16_u_i16x8((__u8x16)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_extadd_pairwise_i16x8(v128_t __a) {
+  return (v128_t)__builtin_wasm_extadd_pairwise_i16x8_s_i32x4((__i16x8)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_extadd_pairwise_u16x8(v128_t __a) {
+  return (v128_t)__builtin_wasm_extadd_pairwise_i16x8_u_i32x4((__u16x8)__a);
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_extmul_low_i8x16(v128_t __a, v128_t __b) {
+  return (v128_t)((__i16x8)wasm_i16x8_extend_low_i8x16(__a) *
+                  (__i16x8)wasm_i16x8_extend_low_i8x16(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i16x8_extmul_high_i8x16(v128_t __a, v128_t __b) {
+  return (v128_t)((__i16x8)wasm_i16x8_extend_high_i8x16(__a) *
+                  (__i16x8)wasm_i16x8_extend_high_i8x16(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_extmul_low_u8x16(v128_t __a, v128_t __b) {
+  return (v128_t)((__u16x8)wasm_u16x8_extend_low_u8x16(__a) *
+                  (__u16x8)wasm_u16x8_extend_low_u8x16(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u16x8_extmul_high_u8x16(v128_t __a, v128_t __b) {
+  return (v128_t)((__u16x8)wasm_u16x8_extend_high_u8x16(__a) *
+                  (__u16x8)wasm_u16x8_extend_high_u8x16(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_extmul_low_i16x8(v128_t __a, v128_t __b) {
+  return (v128_t)((__i32x4)wasm_i32x4_extend_low_i16x8(__a) *
+                  (__i32x4)wasm_i32x4_extend_low_i16x8(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i32x4_extmul_high_i16x8(v128_t __a, v128_t __b) {
+  return (v128_t)((__i32x4)wasm_i32x4_extend_high_i16x8(__a) *
+                  (__i32x4)wasm_i32x4_extend_high_i16x8(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_extmul_low_u16x8(v128_t __a, v128_t __b) {
+  return (v128_t)((__u32x4)wasm_u32x4_extend_low_u16x8(__a) *
+                  (__u32x4)wasm_u32x4_extend_low_u16x8(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u32x4_extmul_high_u16x8(v128_t __a, v128_t __b) {
+  return (v128_t)((__u32x4)wasm_u32x4_extend_high_u16x8(__a) *
+                  (__u32x4)wasm_u32x4_extend_high_u16x8(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i64x2_extmul_low_i32x4(v128_t __a, v128_t __b) {
+  return (v128_t)((__i64x2)wasm_i64x2_extend_low_i32x4(__a) *
+                  (__i64x2)wasm_i64x2_extend_low_i32x4(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_i64x2_extmul_high_i32x4(v128_t __a, v128_t __b) {
+  return (v128_t)((__i64x2)wasm_i64x2_extend_high_i32x4(__a) *
+                  (__i64x2)wasm_i64x2_extend_high_i32x4(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u64x2_extmul_low_u32x4(v128_t __a, v128_t __b) {
+  return (v128_t)((__u64x2)wasm_u64x2_extend_low_u32x4(__a) *
+                  (__u64x2)wasm_u64x2_extend_low_u32x4(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS
+wasm_u64x2_extmul_high_u32x4(v128_t __a, v128_t __b) {
+  return (v128_t)((__u64x2)wasm_u64x2_extend_high_u32x4(__a) *
+                  (__u64x2)wasm_u64x2_extend_high_u32x4(__b));
+}
+ 
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_q15mulr_sat(v128_t __a,
+                                                                   v128_t __b) {
+  return (v128_t)__builtin_wasm_q15mulr_sat_s_i16x8((__i16x8)__a, (__i16x8)__b);
+}
+ 
+// Old intrinsic names supported to ease transitioning to the standard names. Do
+// not use these; they will be removed in the near future.
+ 
+#define __DEPRECATED_FN_ATTRS(__replacement)                                   \
+  __DEFAULT_FN_ATTRS __attribute__(                                            \
+      (deprecated("use " __replacement " instead", __replacement)))
+ 
+#define __WASM_STR(X) #X
+ 
+#ifdef __DEPRECATED
+#define __DEPRECATED_WASM_MACRO(__name, __replacement)                         \
+  _Pragma(__WASM_STR(GCC warning(                                              \
+      "'" __name "' is deprecated: use '" __replacement "' instead")))
+#else
+#define __DEPRECATED_WASM_MACRO(__name, __replacement)
+#endif
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_v128_load8_splat")
+wasm_v8x16_load_splat(const void *__mem) {
+  return wasm_v128_load8_splat(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_v128_load16_splat")
+wasm_v16x8_load_splat(const void *__mem) {
+  return wasm_v128_load16_splat(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_v128_load32_splat")
+wasm_v32x4_load_splat(const void *__mem) {
+  return wasm_v128_load32_splat(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_v128_load64_splat")
+wasm_v64x2_load_splat(const void *__mem) {
+  return wasm_v128_load64_splat(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i16x8_load8x8")
+wasm_i16x8_load_8x8(const void *__mem) {
+  return wasm_i16x8_load8x8(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u16x8_load8x8")
+wasm_u16x8_load_8x8(const void *__mem) {
+  return wasm_u16x8_load8x8(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i32x4_load16x4")
+wasm_i32x4_load_16x4(const void *__mem) {
+  return wasm_i32x4_load16x4(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u32x4_load16x4")
+wasm_u32x4_load_16x4(const void *__mem) {
+  return wasm_u32x4_load16x4(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i64x2_load32x2")
+wasm_i64x2_load_32x2(const void *__mem) {
+  return wasm_i64x2_load32x2(__mem);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u64x2_load32x2")
+wasm_u64x2_load_32x2(const void *__mem) {
+  return wasm_u64x2_load32x2(__mem);
+}
+ 
+#define wasm_v8x16_shuffle(__a, __b, __c0, __c1, __c2, __c3, __c4, __c5, __c6, \
+                           __c7, __c8, __c9, __c10, __c11, __c12, __c13,       \
+                           __c14, __c15)                                       \
+  __DEPRECATED_WASM_MACRO("wasm_v8x16_shuffle", "wasm_i8x16_shuffle")          \
+  wasm_i8x16_shuffle(__a, __b, __c0, __c1, __c2, __c3, __c4, __c5, __c6, __c7, \
+                     __c8, __c9, __c10, __c11, __c12, __c13, __c14, __c15)
+ 
+#define wasm_v16x8_shuffle(__a, __b, __c0, __c1, __c2, __c3, __c4, __c5, __c6, \
+                           __c7)                                               \
+  __DEPRECATED_WASM_MACRO("wasm_v16x8_shuffle", "wasm_i16x8_shuffle")          \
+  wasm_i16x8_shuffle(__a, __b, __c0, __c1, __c2, __c3, __c4, __c5, __c6, __c7)
+ 
+#define wasm_v32x4_shuffle(__a, __b, __c0, __c1, __c2, __c3)                   \
+  __DEPRECATED_WASM_MACRO("wasm_v32x4_shuffle", "wasm_i32x4_shuffle")          \
+  wasm_i32x4_shuffle(__a, __b, __c0, __c1, __c2, __c3)
+ 
+#define wasm_v64x2_shuffle(__a, __b, __c0, __c1)                               \
+  __DEPRECATED_WASM_MACRO("wasm_v64x2_shuffle", "wasm_i64x2_shuffle")          \
+  wasm_i64x2_shuffle(__a, __b, __c0, __c1)
+ 
+// Relaxed SIMD intrinsics
+ 
+#define __RELAXED_FN_ATTRS                                                     \
+  __attribute__((__always_inline__, __nodebug__, __target__("relaxed-simd"),   \
+                 __min_vector_width__(128)))
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_f32x4_relaxed_madd(v128_t __a, v128_t __b, v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_madd_f32x4((__f32x4)__a, (__f32x4)__b,
+                                                   (__f32x4)__c);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_f32x4_relaxed_nmadd(v128_t __a, v128_t __b, v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_nmadd_f32x4((__f32x4)__a, (__f32x4)__b,
+                                                    (__f32x4)__c);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_f64x2_relaxed_madd(v128_t __a, v128_t __b, v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_madd_f64x2((__f64x2)__a, (__f64x2)__b,
+                                                   (__f64x2)__c);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_f64x2_relaxed_nmadd(v128_t __a, v128_t __b, v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_nmadd_f64x2((__f64x2)__a, (__f64x2)__b,
+                                                    (__f64x2)__c);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i8x16_relaxed_laneselect(v128_t __a, v128_t __b, v128_t __m) {
+  return (v128_t)__builtin_wasm_relaxed_laneselect_i8x16(
+      (__i8x16)__a, (__i8x16)__b, (__i8x16)__m);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i16x8_relaxed_laneselect(v128_t __a, v128_t __b, v128_t __m) {
+  return (v128_t)__builtin_wasm_relaxed_laneselect_i16x8(
+      (__i16x8)__a, (__i16x8)__b, (__i16x8)__m);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i32x4_relaxed_laneselect(v128_t __a, v128_t __b, v128_t __m) {
+  return (v128_t)__builtin_wasm_relaxed_laneselect_i32x4(
+      (__i32x4)__a, (__i32x4)__b, (__i32x4)__m);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i64x2_relaxed_laneselect(v128_t __a, v128_t __b, v128_t __m) {
+  return (v128_t)__builtin_wasm_relaxed_laneselect_i64x2(
+      (__i64x2)__a, (__i64x2)__b, (__i64x2)__m);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i8x16_relaxed_swizzle(v128_t __a, v128_t __s) {
+  return (v128_t)__builtin_wasm_relaxed_swizzle_i8x16((__i8x16)__a,
+                                                      (__i8x16)__s);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS wasm_f32x4_relaxed_min(v128_t __a,
+                                                                   v128_t __b) {
+  return (v128_t)__builtin_wasm_relaxed_min_f32x4((__f32x4)__a, (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS wasm_f32x4_relaxed_max(v128_t __a,
+                                                                   v128_t __b) {
+  return (v128_t)__builtin_wasm_relaxed_max_f32x4((__f32x4)__a, (__f32x4)__b);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS wasm_f64x2_relaxed_min(v128_t __a,
+                                                                   v128_t __b) {
+  return (v128_t)__builtin_wasm_relaxed_min_f64x2((__f64x2)__a, (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS wasm_f64x2_relaxed_max(v128_t __a,
+                                                                   v128_t __b) {
+  return (v128_t)__builtin_wasm_relaxed_max_f64x2((__f64x2)__a, (__f64x2)__b);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i32x4_relaxed_trunc_f32x4(v128_t __a) {
+  return (v128_t)__builtin_wasm_relaxed_trunc_s_i32x4_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_u32x4_relaxed_trunc_f32x4(v128_t __a) {
+  return (v128_t)__builtin_wasm_relaxed_trunc_u_i32x4_f32x4((__f32x4)__a);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i32x4_relaxed_trunc_f64x2_zero(v128_t __a) {
+  return (v128_t)__builtin_wasm_relaxed_trunc_s_zero_i32x4_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_u32x4_relaxed_trunc_f64x2_zero(v128_t __a) {
+  return (v128_t)__builtin_wasm_relaxed_trunc_u_zero_i32x4_f64x2((__f64x2)__a);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i16x8_relaxed_q15mulr(v128_t __a, v128_t __b) {
+  return (v128_t)__builtin_wasm_relaxed_q15mulr_s_i16x8((__i16x8)__a,
+                                                        (__i16x8)__b);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i16x8_relaxed_dot_i8x16_i7x16(v128_t __a, v128_t __b) {
+  return (v128_t)__builtin_wasm_relaxed_dot_i8x16_i7x16_s_i16x8((__i8x16)__a,
+                                                                (__i8x16)__b);
+}
+ 
+static __inline__ v128_t __RELAXED_FN_ATTRS
+wasm_i32x4_relaxed_dot_i8x16_i7x16_add(v128_t __a, v128_t __b, v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_dot_i8x16_i7x16_add_s_i32x4(
+      (__i8x16)__a, (__i8x16)__b, (__i32x4)__c);
+}
+ 
+// FP16 intrinsics
+#define __FP16_FN_ATTRS                                                        \
+  __attribute__((__always_inline__, __nodebug__, __target__("fp16"),           \
+                 __min_vector_width__(128)))
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_splat(float __a) {
+  return (v128_t)__builtin_wasm_splat_f16x8(__a);
+}
+ 
+#ifdef __wasm_fp16__
+// TODO Replace the following macros with regular C functions and use normal
+// target-independent vector code like the other replace/extract instructions.
+ 
+#define wasm_f16x8_extract_lane(__a, __i)                                      \
+  (__builtin_wasm_extract_lane_f16x8((__f16x8)(__a), __i))
+ 
+#define wasm_f16x8_replace_lane(__a, __i, __b)                                 \
+  ((v128_t)__builtin_wasm_replace_lane_f16x8((__f16x8)(__a), __i, __b))
+ 
+#endif
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_abs(v128_t __a) {
+  return (v128_t)__builtin_wasm_abs_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_neg(v128_t __a) {
+  return (v128_t)(-(__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_sqrt(v128_t __a) {
+  return (v128_t)__builtin_wasm_sqrt_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_ceil(v128_t __a) {
+  return (v128_t)__builtin_wasm_ceil_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_floor(v128_t __a) {
+  return (v128_t)__builtin_wasm_floor_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_trunc(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_nearest(v128_t __a) {
+  return (v128_t)__builtin_wasm_nearest_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_eq(v128_t __a, v128_t __b) {
+  return (v128_t)((__f16x8)__a == (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_ne(v128_t __a, v128_t __b) {
+  return (v128_t)((__f16x8)__a != (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_lt(v128_t __a, v128_t __b) {
+  return (v128_t)((__f16x8)__a < (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_gt(v128_t __a, v128_t __b) {
+  return (v128_t)((__f16x8)__a > (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_le(v128_t __a, v128_t __b) {
+  return (v128_t)((__f16x8)__a <= (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_ge(v128_t __a, v128_t __b) {
+  return (v128_t)((__f16x8)__a >= (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_add(v128_t __a,
+                                                        v128_t __b) {
+  return (v128_t)((__f16x8)__a + (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_sub(v128_t __a,
+                                                        v128_t __b) {
+  return (v128_t)((__f16x8)__a - (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_mul(v128_t __a,
+                                                        v128_t __b) {
+  return (v128_t)((__f16x8)__a * (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_div(v128_t __a,
+                                                        v128_t __b) {
+  return (v128_t)((__f16x8)__a / (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_min(v128_t __a,
+                                                        v128_t __b) {
+  return (v128_t)__builtin_wasm_min_f16x8((__f16x8)__a, (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_max(v128_t __a,
+                                                        v128_t __b) {
+  return (v128_t)__builtin_wasm_max_f16x8((__f16x8)__a, (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_pmin(v128_t __a,
+                                                         v128_t __b) {
+  return (v128_t)__builtin_wasm_pmin_f16x8((__f16x8)__a, (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_pmax(v128_t __a,
+                                                         v128_t __b) {
+  return (v128_t)__builtin_wasm_pmax_f16x8((__f16x8)__a, (__f16x8)__b);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS
+wasm_i16x8_trunc_sat_f16x8(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_saturate_s_i16x8_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS
+wasm_u16x8_trunc_sat_f16x8(v128_t __a) {
+  return (v128_t)__builtin_wasm_trunc_saturate_u_i16x8_f16x8((__f16x8)__a);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_convert_i16x8(v128_t __a) {
+  return (v128_t) __builtin_convertvector((__i16x8)__a, __f16x8);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_convert_u16x8(v128_t __a) {
+  return (v128_t) __builtin_convertvector((__u16x8)__a, __f16x8);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_relaxed_madd(v128_t __a,
+                                                                 v128_t __b,
+                                                                 v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_madd_f16x8((__f16x8)__a, (__f16x8)__b,
+                                                   (__f16x8)__c);
+}
+ 
+static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_relaxed_nmadd(v128_t __a,
+                                                                  v128_t __b,
+                                                                  v128_t __c) {
+  return (v128_t)__builtin_wasm_relaxed_nmadd_f16x8((__f16x8)__a, (__f16x8)__b,
+                                                    (__f16x8)__c);
+}
+ 
+// Deprecated intrinsics
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i8x16_swizzle")
+wasm_v8x16_swizzle(v128_t __a, v128_t __b) {
+  return wasm_i8x16_swizzle(__a, __b);
+}
+ 
+static __inline__ bool __DEPRECATED_FN_ATTRS("wasm_v128_any_true")
+wasm_i8x16_any_true(v128_t __a) {
+  return wasm_v128_any_true(__a);
+}
+ 
+static __inline__ bool __DEPRECATED_FN_ATTRS("wasm_v128_any_true")
+wasm_i16x8_any_true(v128_t __a) {
+  return wasm_v128_any_true(__a);
+}
+ 
+static __inline__ bool __DEPRECATED_FN_ATTRS("wasm_v128_any_true")
+wasm_i32x4_any_true(v128_t __a) {
+  return wasm_v128_any_true(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i8x16_add_sat")
+wasm_i8x16_add_saturate(v128_t __a, v128_t __b) {
+  return wasm_i8x16_add_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u8x16_add_sat")
+wasm_u8x16_add_saturate(v128_t __a, v128_t __b) {
+  return wasm_u8x16_add_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i8x16_sub_sat")
+wasm_i8x16_sub_saturate(v128_t __a, v128_t __b) {
+  return wasm_i8x16_sub_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u8x16_sub_sat")
+wasm_u8x16_sub_saturate(v128_t __a, v128_t __b) {
+  return wasm_u8x16_sub_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i16x8_add_sat")
+wasm_i16x8_add_saturate(v128_t __a, v128_t __b) {
+  return wasm_i16x8_add_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u16x8_add_sat")
+wasm_u16x8_add_saturate(v128_t __a, v128_t __b) {
+  return wasm_u16x8_add_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i16x8_sub_sat")
+wasm_i16x8_sub_saturate(v128_t __a, v128_t __b) {
+  return wasm_i16x8_sub_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u16x8_sub_sat")
+wasm_u16x8_sub_saturate(v128_t __a, v128_t __b) {
+  return wasm_u16x8_sub_sat(__a, __b);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i16x8_extend_low_i8x16")
+wasm_i16x8_widen_low_i8x16(v128_t __a) {
+  return wasm_i16x8_extend_low_i8x16(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i16x8_extend_high_i8x16")
+wasm_i16x8_widen_high_i8x16(v128_t __a) {
+  return wasm_i16x8_extend_high_i8x16(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u16x8_extend_low_u8x16")
+wasm_i16x8_widen_low_u8x16(v128_t __a) {
+  return wasm_u16x8_extend_low_u8x16(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u16x8_extend_high_u8x16")
+wasm_i16x8_widen_high_u8x16(v128_t __a) {
+  return wasm_u16x8_extend_high_u8x16(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i32x4_extend_low_i16x8")
+wasm_i32x4_widen_low_i16x8(v128_t __a) {
+  return wasm_i32x4_extend_low_i16x8(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i32x4_extend_high_i16x8")
+wasm_i32x4_widen_high_i16x8(v128_t __a) {
+  return wasm_i32x4_extend_high_i16x8(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u32x4_extend_low_u16x8")
+wasm_i32x4_widen_low_u16x8(v128_t __a) {
+  return wasm_u32x4_extend_low_u16x8(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u32x4_extend_high_u16x8")
+wasm_i32x4_widen_high_u16x8(v128_t __a) {
+  return wasm_u32x4_extend_high_u16x8(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_i32x4_trunc_sat_f32x4")
+wasm_i32x4_trunc_saturate_f32x4(v128_t __a) {
+  return wasm_i32x4_trunc_sat_f32x4(__a);
+}
+ 
+static __inline__ v128_t __DEPRECATED_FN_ATTRS("wasm_u32x4_trunc_sat_f32x4")
+wasm_u32x4_trunc_saturate_f32x4(v128_t __a) {
+  return wasm_u32x4_trunc_sat_f32x4(__a);
+}
+ 
+// Undefine helper macros
+#undef __DEFAULT_FN_ATTRS
+#undef __DEPRECATED_FN_ATTRS
+ 
+#endif // __WASM_SIMD128_H


### PR DESCRIPTION
## What does `stdarch-gen-wasm32` do?
1. First it collects the intrinsic definitions from the `wasm_simd128.h` file (for the definitions in C)
2. Then it collects the intrinsic definitions from the Rust source files
3. It extracts details (such as intrinsic name, function arguments, return types, etc) of the C and the Rust intrinsics by decomposing their definitions into their Abstract Syntax Tree (using the `tree-sitter` crate)
4. It matches the C and the Rust definitions and creates a spec sheet like the below (for an example intrinsic):
```
/// u16x8_extract_lane
c-intrinsic-name = wasm_u16x8_extract_lane
c-arguments = __a, __i
c-arguments-data-types = v128_t, int
c-return-type = 
rust-intrinsic-name = u16x8_extract_lane
rust-arguments = a
rust-arguments-data-types = v128
rust-const-generic-arguments = N
rust-const-generic-arguments-data-types = usize
rust-return-type = u16
```

## How to run
```bash
cd crates/stdarch-gen-wasm
cargo run -- --c ../../intrinsics_data/wasm_simd128.h --rust ../core_arch/src/wasm32/simd128.rs --rust ../core_arch/src/wasm32/relaxed_simd.rs > wasm32.spec
```

## Context
### C Abstract Syntax Tree
Take an intrinsic definition for example:
```C
static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_make(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3) {...}
```
For a C intrinsic, the immediate children would have their grammar names as:
- **storage_class_specifier**: which is `static`
- **storage_class_specifier**: which is `__inline__`
- **identifier**: which is v128_t. The parser doesn't recognize that it is a type, instead thinks that it is an identifier.
- **ERROR**: which points to the keyword `__DEFAULT_FN_ATTRS`. The parser doesn't recognize it as a valid part of the tree and annotates it as ERROR.
- **function_declarator**: points to `wasm_u32x4_make(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3)`
- **compound_statement**: the body of the function

The immediate children of the `function_declarator` node would have their grammar as follows:
 - **identifier** : which is the intrinsic name `wasm_u32x4_make `
  - **parameter_list** : which represents the arguments to the intrinsic `(uint32_t __c0, uint32_t __c1, uint32_t __c2, uint32_t __c3)`

The immediate children of a parameter_list node would have their grammar as follows:
- **(** : The opening bracket that denotes the start of the arguments definition.
- **parameter_declaration** : The definition for the first argument `uint32_t __c0`
- **,** : The comma that separates the first and the second arguments.
- **parameter_declaration** : The definition for the second argument `uint32_t __c1`
- **,** : The comma that separates the second and the third arguments.
- **parameter_declaration** : The definition for the third argument. `uint32_t __c2`
- *,** : The comma that separates the third and the fourth arguments.
- **parameter_declaration** : The definition for the fourth argument. `uint32_t __c3`
- **)** : The closing bracket that denotes the end of the arguments definition.

Each node with the grammar name parameter_declaration could have its children structured in a few ways:
1. In the case of `int x`:
- **primitive_type** : Points to int
- **identifier** : Points to x

3. In the case of v128_t x:
- **identifier** : Points to `v128_t`, which is actually a type (but the parser is unaware of the same).
- **identifier** : Points to `x`.

4. In the case of const void *__mem:
- **type_qualifier** : Points to const.
- **primitive_type**: Points to void.
- **pointer_declarator** : Breaks down into `*` and **identifier** (which is `__mem`).

### Rust Abstract Syntax Tree
Take a Rust intrinsic definition for example:
```Rust
pub unsafe fn v128_load64_splat(m: *const u64) -> v128 {
    u64x2_splat(ptr::read_unaligned(m))
}
```

For this Rust intrinsic, the immediate children would have their grammar names as:
-  **visibility_modifier**: For `pub`
-  **function_modifiers** : For `unsafe`. May not always be present
-   **fn** : The actual keyword `fn`
-   **identifier** : the name of the function `v128_load64_splat`
-   **type_parameters** : the `const` generic arguments. (This is not always present)
-   **parameters** : The arguments passed to the function `(m: *const u64)`
-   **->** : The arrow used to specify the return type
-   **identifier** : The return type of the function `v128`
-   **block**:  The body of the function

The children of the `const_parameters` node have their `grammar_names` as the following (assuming 2 generic arguments):
- **<**: The opening angle bracket that starts the generic arguments definition
- **const_parameter**: The first `const` generic argument
- **,**: The comma that separates the generic arguments
- **const_parameter**: The second `const` generic argument
- **>**: The closing angle bracket that concludes the generic arguments definition

The children of the `parameters` node have their `grammar_names` as the following (assuming 2 arguments):
- **(**: The opening parenthesis that starts the arguments definition
- **parameter** : The first argument
- **,**: The comma that separates the arguments
- **parameter** : The second argument
- **)** : The closing parenthesis that concludes the arguments definition


cc: @Amanieu @folkertdev 