### PR TITLE
use `qemu-user` instead of `qemu-user-static` for loongarch CI

### DIFF
--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:25.10
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    gcc libc6-dev qemu-user-static ca-certificates \
+    gcc libc6-dev qemu-user ca-certificates \
     gcc-loongarch64-linux-gnu libc6-dev-loong64-cross
 
 
 ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc \
-    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-loongarch64-static -cpu max -L /usr/loongarch64-linux-gnu" \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-loongarch64 -cpu max -L /usr/loongarch64-linux-gnu" \
     OBJDUMP=loongarch64-linux-gnu-objdump \
     STDARCH_TEST_SKIP_FEATURE=frecipe


### PR DESCRIPTION
This fixes CI, I'm not sure what broke really, but this is more consistent with our other Dockerfiles as well.

cc @heiher 