### PR TITLE
`intrinsic-test`: make `build_{c, rust}_file` generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,29 +43,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "assert-instr-macro"
@@ -84,30 +84,31 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -115,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -127,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -259,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,9 +290,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -323,12 +330,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -353,7 +360,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -379,9 +386,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linked-hash-map"
@@ -391,9 +398,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
@@ -428,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -497,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -507,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -517,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -529,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -540,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustc-demangle"
@@ -593,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -715,9 +722,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -774,7 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "semver",
 ]
 
@@ -791,12 +798,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
@@ -804,7 +817,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -813,14 +835,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -830,10 +869,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -842,10 +893,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -854,10 +917,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -866,10 +941,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "yaml-rust"
@@ -882,18 +969,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/intrinsic-test/src/arm/config.rs
+++ b/crates/intrinsic-test/src/arm/config.rs
@@ -1,12 +1,7 @@
-pub fn build_notices(line_prefix: &str) -> String {
-    format!(
-        "\
-{line_prefix}This is a transient test file, not intended for distribution. Some aspects of the
-{line_prefix}test are derived from a JSON specification, published under the same license as the
-{line_prefix}`intrinsic-test` crate.\n
-"
-    )
-}
+pub const NOTICE: &str = "\
+// This is a transient test file, not intended for distribution. Some aspects of the
+// test are derived from a JSON specification, published under the same license as the
+// `intrinsic-test` crate.\n";
 
 pub const POLY128_OSTREAM_DEF: &str = r#"std::ostream& operator<<(std::ostream& os, poly128_t value) {
     std::stringstream temp;

--- a/crates/intrinsic-test/src/arm/config.rs
+++ b/crates/intrinsic-test/src/arm/config.rs
@@ -3,7 +3,15 @@ pub const NOTICE: &str = "\
 // test are derived from a JSON specification, published under the same license as the
 // `intrinsic-test` crate.\n";
 
-pub const POLY128_OSTREAM_DEF: &str = r#"std::ostream& operator<<(std::ostream& os, poly128_t value) {
+pub const POLY128_OSTREAM_DECL: &str = r#"
+#ifdef __aarch64__
+std::ostream& operator<<(std::ostream& os, poly128_t value);
+#endif
+"#;
+
+pub const POLY128_OSTREAM_DEF: &str = r#"
+#ifdef __aarch64__
+std::ostream& operator<<(std::ostream& os, poly128_t value) {
     std::stringstream temp;
     do {
       int n = value % 10;
@@ -14,7 +22,9 @@ pub const POLY128_OSTREAM_DEF: &str = r#"std::ostream& operator<<(std::ostream& 
     std::string res(tempstr.rbegin(), tempstr.rend());
     os << res;
     return os;
-}"#;
+}
+#endif
+"#;
 
 // Format f16 values (and vectors containing them) in a way that is consistent with C.
 pub const F16_FORMATTING_DEF: &str = r#"
@@ -113,4 +123,10 @@ pub const AARCH_CONFIGURATIONS: &str = r#"
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_ftts))]
 #![feature(fmt_helpers_for_derive)]
 #![feature(stdarch_neon_f16)]
+
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+use core::arch::aarch64::*;
+
+#[cfg(target_arch = "arm")]
+use core::arch::arm::*;
 "#;

--- a/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -1,5 +1,3 @@
-use crate::common::argument::ArgumentList;
-use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
 use crate::common::intrinsic_helpers::IntrinsicType;
 use std::ops::{Deref, DerefMut};
 
@@ -20,19 +18,5 @@ impl Deref for ArmIntrinsicType {
 impl DerefMut for ArmIntrinsicType {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.data
-    }
-}
-
-impl IntrinsicDefinition<ArmIntrinsicType> for Intrinsic<ArmIntrinsicType> {
-    fn arguments(&self) -> ArgumentList<ArmIntrinsicType> {
-        self.arguments.clone()
-    }
-
-    fn results(&self) -> ArmIntrinsicType {
-        self.results.clone()
-    }
-
-    fn name(&self) -> String {
-        self.name.clone()
     }
 }

--- a/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -1,7 +1,6 @@
 use crate::common::argument::ArgumentList;
-use crate::common::indentation::Indentation;
 use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
-use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, Sign, TypeKind};
+use crate::common::intrinsic_helpers::IntrinsicType;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,79 +34,5 @@ impl IntrinsicDefinition<ArmIntrinsicType> for Intrinsic<ArmIntrinsicType> {
 
     fn name(&self) -> String {
         self.name.clone()
-    }
-
-    /// Generates a std::cout for the intrinsics results that will match the
-    /// rust debug output format for the return type. The generated line assumes
-    /// there is an int i in scope which is the current pass number.
-    fn print_result_c(&self, indentation: Indentation, additional: &str) -> String {
-        self.results().print_result_c(indentation, additional)
-    }
-}
-
-impl ArmIntrinsicType {
-    /// Generates a std::cout for the intrinsics results that will match the
-    /// rust debug output format for the return type. The generated line assumes
-    /// there is an int i in scope which is the current pass number.
-    fn print_result_c(&self, indentation: Indentation, additional: &str) -> String {
-        let lanes = if self.num_vectors() > 1 {
-            (0..self.num_vectors())
-                .map(|vector| {
-                    format!(
-                        r#""{ty}(" << {lanes} << ")""#,
-                        ty = self.c_single_vector_type(),
-                        lanes = (0..self.num_lanes())
-                            .map(move |idx| -> std::string::String {
-                                format!(
-                                    "{cast}{lane_fn}(__return_value.val[{vector}], {lane})",
-                                    cast = self.c_promotion(),
-                                    lane_fn = self.get_lane_function(),
-                                    lane = idx,
-                                    vector = vector,
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                            .join(r#" << ", " << "#)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(r#" << ", " << "#)
-        } else if self.num_lanes() > 1 {
-            (0..self.num_lanes())
-                .map(|idx| -> std::string::String {
-                    format!(
-                        "{cast}{lane_fn}(__return_value, {lane})",
-                        cast = self.c_promotion(),
-                        lane_fn = self.get_lane_function(),
-                        lane = idx
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(r#" << ", " << "#)
-        } else {
-            format!(
-                "{promote}cast<{cast}>(__return_value)",
-                cast = match self.kind() {
-                    TypeKind::Float if self.inner_size() == 16 => "float16_t".to_string(),
-                    TypeKind::Float if self.inner_size() == 32 => "float".to_string(),
-                    TypeKind::Float if self.inner_size() == 64 => "double".to_string(),
-                    TypeKind::Int(Sign::Signed) => format!("int{}_t", self.inner_size()),
-                    TypeKind::Int(Sign::Unsigned) => format!("uint{}_t", self.inner_size()),
-                    TypeKind::Poly => format!("poly{}_t", self.inner_size()),
-                    ty => todo!("print_result_c - Unknown type: {:#?}", ty),
-                },
-                promote = self.c_promotion(),
-            )
-        };
-
-        format!(
-            r#"{indentation}std::cout << "Result {additional}-" << i+1 << ": {ty}" << std::fixed << std::setprecision(150) <<  {lanes} << "{close}" << std::endl;"#,
-            ty = if self.is_simd() {
-                format!("{}(", self.c_type())
-            } else {
-                String::from("")
-            },
-            close = if self.is_simd() { ")" } else { "" },
-        )
     }
 }

--- a/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -41,18 +41,27 @@ impl IntrinsicDefinition<ArmIntrinsicType> for Intrinsic<ArmIntrinsicType> {
     /// rust debug output format for the return type. The generated line assumes
     /// there is an int i in scope which is the current pass number.
     fn print_result_c(&self, indentation: Indentation, additional: &str) -> String {
-        let lanes = if self.results().num_vectors() > 1 {
-            (0..self.results().num_vectors())
+        self.results().print_result_c(indentation, additional)
+    }
+}
+
+impl ArmIntrinsicType {
+    /// Generates a std::cout for the intrinsics results that will match the
+    /// rust debug output format for the return type. The generated line assumes
+    /// there is an int i in scope which is the current pass number.
+    fn print_result_c(&self, indentation: Indentation, additional: &str) -> String {
+        let lanes = if self.num_vectors() > 1 {
+            (0..self.num_vectors())
                 .map(|vector| {
                     format!(
                         r#""{ty}(" << {lanes} << ")""#,
-                        ty = self.results().c_single_vector_type(),
-                        lanes = (0..self.results().num_lanes())
+                        ty = self.c_single_vector_type(),
+                        lanes = (0..self.num_lanes())
                             .map(move |idx| -> std::string::String {
                                 format!(
                                     "{cast}{lane_fn}(__return_value.val[{vector}], {lane})",
-                                    cast = self.results().c_promotion(),
-                                    lane_fn = self.results().get_lane_function(),
+                                    cast = self.c_promotion(),
+                                    lane_fn = self.get_lane_function(),
                                     lane = idx,
                                     vector = vector,
                                 )
@@ -63,13 +72,13 @@ impl IntrinsicDefinition<ArmIntrinsicType> for Intrinsic<ArmIntrinsicType> {
                 })
                 .collect::<Vec<_>>()
                 .join(r#" << ", " << "#)
-        } else if self.results().num_lanes() > 1 {
-            (0..self.results().num_lanes())
+        } else if self.num_lanes() > 1 {
+            (0..self.num_lanes())
                 .map(|idx| -> std::string::String {
                     format!(
                         "{cast}{lane_fn}(__return_value, {lane})",
-                        cast = self.results().c_promotion(),
-                        lane_fn = self.results().get_lane_function(),
+                        cast = self.c_promotion(),
+                        lane_fn = self.get_lane_function(),
                         lane = idx
                     )
                 })
@@ -78,28 +87,27 @@ impl IntrinsicDefinition<ArmIntrinsicType> for Intrinsic<ArmIntrinsicType> {
         } else {
             format!(
                 "{promote}cast<{cast}>(__return_value)",
-                cast = match self.results.kind() {
-                    TypeKind::Float if self.results().inner_size() == 16 => "float16_t".to_string(),
-                    TypeKind::Float if self.results().inner_size() == 32 => "float".to_string(),
-                    TypeKind::Float if self.results().inner_size() == 64 => "double".to_string(),
-                    TypeKind::Int(Sign::Signed) => format!("int{}_t", self.results().inner_size()),
-                    TypeKind::Int(Sign::Unsigned) =>
-                        format!("uint{}_t", self.results().inner_size()),
-                    TypeKind::Poly => format!("poly{}_t", self.results().inner_size()),
+                cast = match self.kind() {
+                    TypeKind::Float if self.inner_size() == 16 => "float16_t".to_string(),
+                    TypeKind::Float if self.inner_size() == 32 => "float".to_string(),
+                    TypeKind::Float if self.inner_size() == 64 => "double".to_string(),
+                    TypeKind::Int(Sign::Signed) => format!("int{}_t", self.inner_size()),
+                    TypeKind::Int(Sign::Unsigned) => format!("uint{}_t", self.inner_size()),
+                    TypeKind::Poly => format!("poly{}_t", self.inner_size()),
                     ty => todo!("print_result_c - Unknown type: {:#?}", ty),
                 },
-                promote = self.results().c_promotion(),
+                promote = self.c_promotion(),
             )
         };
 
         format!(
             r#"{indentation}std::cout << "Result {additional}-" << i+1 << ": {ty}" << std::fixed << std::setprecision(150) <<  {lanes} << "{close}" << std::endl;"#,
-            ty = if self.results().is_simd() {
-                format!("{}(", self.results().c_type())
+            ty = if self.is_simd() {
+                format!("{}(", self.c_type())
             } else {
                 String::from("")
             },
-            close = if self.results.is_simd() { ")" } else { "" },
+            close = if self.is_simd() { ")" } else { "" },
         )
     }
 }

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -29,6 +29,19 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         &self.intrinsics
     }
 
+    const NOTICE: &str = config::NOTICE;
+
+    const PLATFORM_C_HEADERS: &[&str] = &["arm_neon.h", "arm_acle.h", "arm_fp16.h"];
+    const PLATFORM_C_DEFINITIONS: &str = config::POLY128_OSTREAM_DEF;
+    const PLATFORM_C_FORWARD_DECLARATIONS: &str = config::POLY128_OSTREAM_DECL;
+
+    const PLATFORM_RUST_DEFINITIONS: &str = config::F16_FORMATTING_DEF;
+    const PLATFORM_RUST_CFGS: &str = config::AARCH_CONFIGURATIONS;
+
+    fn cpp_compilation(&self) -> Option<CppCompilation> {
+        compile::build_cpp_compilation(&self.cli_options)
+    }
+
     fn create(cli_options: ProcessedCli) -> Self {
         let a32 = cli_options.target.contains("v7");
         let mut intrinsics = get_neon_intrinsics(&cli_options.filename, &cli_options.target)
@@ -55,17 +68,5 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
             intrinsics,
             cli_options,
         }
-    }
-
-    const NOTICE: &str = config::NOTICE;
-
-    const PLATFORM_C_HEADERS: &[&str] = &["arm_neon.h", "arm_acle.h", "arm_fp16.h"];
-    const PLATFORM_C_DEFINITIONS: &str = config::POLY128_OSTREAM_DEF;
-
-    const PLATFORM_RUST_DEFINITIONS: &str = config::F16_FORMATTING_DEF;
-    const PLATFORM_RUST_CFGS: &str = config::AARCH_CONFIGURATIONS;
-
-    fn cpp_compilation(&self) -> Option<CppCompilation> {
-        compile::build_cpp_compilation(&self.cli_options)
     }
 }

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -65,9 +65,10 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         }
     }
 
+    const PLATFORM_HEADERS: &[&str] = &["arm_neon.h", "arm_acle.h", "arm_fp16.h"];
+
     fn build_c_file(&self) -> bool {
         let c_target = "aarch64";
-        let platform_headers = &["arm_neon.h", "arm_acle.h", "arm_fp16.h"];
 
         let (chunk_size, chunk_count) = chunk_info(self.intrinsics.len());
 
@@ -81,7 +82,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
             .map(|(i, chunk)| {
                 let c_filename = format!("c_programs/mod_{i}.cpp");
                 let mut file = File::create(&c_filename).unwrap();
-                write_mod_cpp(&mut file, notice, c_target, platform_headers, chunk).unwrap();
+                write_mod_cpp(&mut file, notice, c_target, Self::PLATFORM_HEADERS, chunk).unwrap();
 
                 // compile this cpp file into a .o file.
                 //

--- a/crates/intrinsic-test/src/arm/mod.rs
+++ b/crates/intrinsic-test/src/arm/mod.rs
@@ -5,19 +5,11 @@ mod intrinsic;
 mod json_parser;
 mod types;
 
-use std::fs::File;
-
-use rayon::prelude::*;
-
+use crate::common::SupportedArchitectureTest;
 use crate::common::cli::ProcessedCli;
 use crate::common::compile_c::CppCompilation;
-use crate::common::gen_c::{write_main_cpp, write_mod_cpp};
-use crate::common::gen_rust::{
-    compile_rust_programs, write_bin_cargo_toml, write_lib_cargo_toml, write_lib_rs, write_main_rs,
-};
 use crate::common::intrinsic::Intrinsic;
 use crate::common::intrinsic_helpers::TypeKind;
-use crate::common::{SupportedArchitectureTest, chunk_info};
 use intrinsic::ArmIntrinsicType;
 use json_parser::get_neon_intrinsics;
 
@@ -75,136 +67,5 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
     fn cpp_compilation(&self) -> Option<CppCompilation> {
         compile::build_cpp_compilation(&self.cli_options)
-    }
-
-    fn build_c_file(&self) -> bool {
-        let c_target = "aarch64";
-
-        let (chunk_size, chunk_count) = chunk_info(self.intrinsics().len());
-
-        let cpp_compiler_wrapped = self.cpp_compilation();
-
-        std::fs::create_dir_all("c_programs").unwrap();
-        self.intrinsics()
-            .par_chunks(chunk_size)
-            .enumerate()
-            .map(|(i, chunk)| {
-                let c_filename = format!("c_programs/mod_{i}.cpp");
-                let mut file = File::create(&c_filename).unwrap();
-                write_mod_cpp(
-                    &mut file,
-                    Self::NOTICE,
-                    c_target,
-                    Self::PLATFORM_C_HEADERS,
-                    chunk,
-                )
-                .unwrap();
-
-                // compile this cpp file into a .o file.
-                //
-                // This is done because `cpp_compiler_wrapped` is None when
-                // the --generate-only flag is passed
-                if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
-                    let output = cpp_compiler
-                        .compile_object_file(&format!("mod_{i}.cpp"), &format!("mod_{i}.o"))?;
-                    assert!(output.status.success(), "{output:?}");
-                }
-
-                Ok(())
-            })
-            .collect::<Result<(), std::io::Error>>()
-            .unwrap();
-
-        let mut file = File::create("c_programs/main.cpp").unwrap();
-        write_main_cpp(
-            &mut file,
-            c_target,
-            Self::PLATFORM_C_DEFINITIONS,
-            self.intrinsics().iter().map(|i| i.name.as_str()),
-        )
-        .unwrap();
-
-        // This is done because `cpp_compiler_wrapped` is None when
-        // the --generate-only flag is passed
-        if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
-            // compile this cpp file into a .o file
-            info!("compiling main.cpp");
-            let output = cpp_compiler
-                .compile_object_file("main.cpp", "intrinsic-test-programs.o")
-                .unwrap();
-            assert!(output.status.success(), "{output:?}");
-
-            let object_files = (0..chunk_count)
-                .map(|i| format!("mod_{i}.o"))
-                .chain(["intrinsic-test-programs.o".to_owned()]);
-
-            let output = cpp_compiler
-                .link_executable(object_files, "intrinsic-test-programs")
-                .unwrap();
-            assert!(output.status.success(), "{output:?}");
-        }
-
-        true
-    }
-
-    fn build_rust_file(&self) -> bool {
-        std::fs::create_dir_all("rust_programs/src").unwrap();
-
-        let architecture = if self.cli_options.target.contains("v7") {
-            "arm"
-        } else {
-            "aarch64"
-        };
-
-        let (chunk_size, chunk_count) = chunk_info(self.intrinsics.len());
-
-        let mut cargo = File::create("rust_programs/Cargo.toml").unwrap();
-        write_bin_cargo_toml(&mut cargo, chunk_count).unwrap();
-
-        let mut main_rs = File::create("rust_programs/src/main.rs").unwrap();
-        write_main_rs(
-            &mut main_rs,
-            chunk_count,
-            Self::PLATFORM_RUST_CFGS,
-            "",
-            self.intrinsics.iter().map(|i| i.name.as_str()),
-        )
-        .unwrap();
-
-        let target = &self.cli_options.target;
-        let toolchain = self.cli_options.toolchain.as_deref();
-        let linker = self.cli_options.linker.as_deref();
-
-        self.intrinsics
-            .par_chunks(chunk_size)
-            .enumerate()
-            .map(|(i, chunk)| {
-                std::fs::create_dir_all(format!("rust_programs/mod_{i}/src"))?;
-
-                let rust_filename = format!("rust_programs/mod_{i}/src/lib.rs");
-                trace!("generating `{rust_filename}`");
-                let mut file = File::create(rust_filename)?;
-
-                write_lib_rs(
-                    &mut file,
-                    architecture,
-                    Self::NOTICE,
-                    Self::PLATFORM_RUST_CFGS,
-                    Self::PLATFORM_RUST_DEFINITIONS,
-                    chunk,
-                )?;
-
-                let toml_filename = format!("rust_programs/mod_{i}/Cargo.toml");
-                trace!("generating `{toml_filename}`");
-                let mut file = File::create(toml_filename).unwrap();
-
-                write_lib_cargo_toml(&mut file, &format!("mod_{i}"))?;
-
-                Ok(())
-            })
-            .collect::<Result<(), std::io::Error>>()
-            .unwrap();
-
-        compile_rust_programs(toolchain, target, linker)
     }
 }

--- a/crates/intrinsic-test/src/common/gen_c.rs
+++ b/crates/intrinsic-test/src/common/gen_c.rs
@@ -24,7 +24,9 @@ pub fn generate_c_test_loop<T: IntrinsicTypeDefinition + Sized>(
         loaded_args = intrinsic.arguments().load_values_c(body_indentation),
         intrinsic_call = intrinsic.name(),
         args = intrinsic.arguments().as_call_param_c(),
-        print_result = intrinsic.print_result_c(body_indentation, additional)
+        print_result = intrinsic
+            .results()
+            .print_result_c(body_indentation, additional)
     )
 }
 

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -1,8 +1,10 @@
 use itertools::Itertools;
 use std::process::Command;
 
+use crate::common::intrinsic::Intrinsic;
+
 use super::indentation::Indentation;
-use super::intrinsic::{IntrinsicDefinition, format_f16_return_value};
+use super::intrinsic::format_f16_return_value;
 use super::intrinsic_helpers::IntrinsicTypeDefinition;
 
 // The number of times each intrinsic will be called.
@@ -100,7 +102,7 @@ pub fn write_lib_rs<T: IntrinsicTypeDefinition>(
     notice: &str,
     cfg: &str,
     definitions: &str,
-    intrinsics: &[impl IntrinsicDefinition<T>],
+    intrinsics: &[Intrinsic<T>],
 ) -> std::io::Result<()> {
     write!(w, "{notice}")?;
 
@@ -189,16 +191,16 @@ pub fn compile_rust_programs(toolchain: Option<&str>, target: &str, linker: Opti
 
 pub fn generate_rust_test_loop<T: IntrinsicTypeDefinition>(
     w: &mut impl std::io::Write,
-    intrinsic: &dyn IntrinsicDefinition<T>,
+    intrinsic: &Intrinsic<T>,
     indentation: Indentation,
     specializations: &[Vec<u8>],
     passes: u32,
 ) -> std::io::Result<()> {
-    let intrinsic_name = intrinsic.name();
+    let intrinsic_name = &intrinsic.name;
 
     // Each function (and each specialization) has its own type. Erase that type with a cast.
     let mut coerce = String::from("unsafe fn(");
-    for _ in intrinsic.arguments().iter().filter(|a| !a.has_constraint()) {
+    for _ in intrinsic.arguments.iter().filter(|a| !a.has_constraint()) {
         coerce += "_, ";
     }
     coerce += ") -> _";
@@ -248,8 +250,8 @@ pub fn generate_rust_test_loop<T: IntrinsicTypeDefinition>(
                     }}\n\
                 }}\n\
             }}",
-        loaded_args = intrinsic.arguments().load_values_rust(indentation3),
-        args = intrinsic.arguments().as_call_param_rust(),
+        loaded_args = intrinsic.arguments.load_values_rust(indentation3),
+        args = intrinsic.arguments.as_call_param_rust(),
     )
 }
 
@@ -277,15 +279,15 @@ fn generate_rust_specializations<'a>(
 // Top-level function to create complete test program
 pub fn create_rust_test_module<T: IntrinsicTypeDefinition>(
     w: &mut impl std::io::Write,
-    intrinsic: &dyn IntrinsicDefinition<T>,
+    intrinsic: &Intrinsic<T>,
 ) -> std::io::Result<()> {
-    trace!("generating `{}`", intrinsic.name());
+    trace!("generating `{}`", intrinsic.name);
     let indentation = Indentation::default();
 
-    writeln!(w, "pub fn run_{}() {{", intrinsic.name())?;
+    writeln!(w, "pub fn run_{}() {{", intrinsic.name)?;
 
     // Define the arrays of arguments.
-    let arguments = intrinsic.arguments();
+    let arguments = &intrinsic.arguments;
     arguments.gen_arglists_rust(w, indentation.nested(), PASSES)?;
 
     // Define any const generics as `const` items, then generate the actual test loop.

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -98,7 +98,6 @@ pub fn write_main_rs<'a>(
 
 pub fn write_lib_rs<T: IntrinsicTypeDefinition>(
     w: &mut impl std::io::Write,
-    architecture: &str,
     notice: &str,
     cfg: &str,
     definitions: &str,
@@ -116,8 +115,6 @@ pub fn write_lib_rs<T: IntrinsicTypeDefinition>(
     writeln!(w, "#![allow(non_snake_case)]")?;
 
     writeln!(w, "{cfg}")?;
-
-    writeln!(w, "use core_arch::arch::{architecture}::*;")?;
 
     writeln!(w, "{definitions}")?;
 

--- a/crates/intrinsic-test/src/common/intrinsic.rs
+++ b/crates/intrinsic-test/src/common/intrinsic.rs
@@ -17,27 +17,14 @@ pub struct Intrinsic<T: IntrinsicTypeDefinition> {
     pub arch_tags: Vec<String>,
 }
 
-pub trait IntrinsicDefinition<T>
-where
-    T: IntrinsicTypeDefinition,
-{
-    fn arguments(&self) -> ArgumentList<T>;
-
-    fn results(&self) -> T;
-
-    fn name(&self) -> String;
-}
-
-pub fn format_f16_return_value<T: IntrinsicTypeDefinition>(
-    intrinsic: &dyn IntrinsicDefinition<T>,
-) -> String {
+pub fn format_f16_return_value<T: IntrinsicTypeDefinition>(intrinsic: &Intrinsic<T>) -> String {
     // the `intrinsic-test` crate compares the output of C and Rust intrinsics. Currently, It uses
     // a string representation of the output value to compare. In C, f16 values are currently printed
     // as hexadecimal integers. Since https://github.com/rust-lang/rust/pull/127013, rust does print
     // them as decimal floating point values. To keep the intrinsics tests working, for now, format
     // vectors containing f16 values like C prints them.
-    let return_value = match intrinsic.results().kind() {
-        TypeKind::Float if intrinsic.results().inner_size() == 16 => "debug_f16(__return_value)",
+    let return_value = match intrinsic.results.kind() {
+        TypeKind::Float if intrinsic.results.inner_size() == 16 => "debug_f16(__return_value)",
         _ => "format_args!(\"{__return_value:.150?}\")",
     };
 

--- a/crates/intrinsic-test/src/common/intrinsic.rs
+++ b/crates/intrinsic-test/src/common/intrinsic.rs
@@ -1,5 +1,4 @@
 use super::argument::ArgumentList;
-use super::indentation::Indentation;
 use super::intrinsic_helpers::{IntrinsicTypeDefinition, TypeKind};
 
 /// An intrinsic
@@ -27,11 +26,6 @@ where
     fn results(&self) -> T;
 
     fn name(&self) -> String;
-
-    /// Generates a std::cout for the intrinsics results that will match the
-    /// rust debug output format for the return type. The generated line assumes
-    /// there is an int i in scope which is the current pass number.
-    fn print_result_c(&self, _indentation: Indentation, _additional: &str) -> String;
 }
 
 pub fn format_f16_return_value<T: IntrinsicTypeDefinition>(

--- a/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -325,4 +325,9 @@ pub trait IntrinsicTypeDefinition: Deref<Target = IntrinsicType> {
 
     /// can be directly defined in `impl` blocks
     fn c_single_vector_type(&self) -> String;
+
+    /// Generates a std::cout for the intrinsics results that will match the
+    /// rust debug output format for the return type. The generated line assumes
+    /// there is an int i in scope which is the current pass number.
+    fn print_result_c(&self, indentation: Indentation, additional: &str) -> String;
 }

--- a/crates/intrinsic-test/src/common/mod.rs
+++ b/crates/intrinsic-test/src/common/mod.rs
@@ -1,7 +1,18 @@
+use std::fs::File;
+
+use rayon::prelude::*;
+
 use cli::ProcessedCli;
 
 use crate::common::{
-    compile_c::CppCompilation, intrinsic::Intrinsic, intrinsic_helpers::IntrinsicTypeDefinition,
+    compile_c::CppCompilation,
+    gen_c::{write_main_cpp, write_mod_cpp},
+    gen_rust::{
+        compile_rust_programs, write_bin_cargo_toml, write_lib_cargo_toml, write_lib_rs,
+        write_main_rs,
+    },
+    intrinsic::Intrinsic,
+    intrinsic_helpers::IntrinsicTypeDefinition,
 };
 
 pub mod argument;
@@ -36,8 +47,136 @@ pub trait SupportedArchitectureTest {
 
     fn cpp_compilation(&self) -> Option<CppCompilation>;
 
-    fn build_c_file(&self) -> bool;
-    fn build_rust_file(&self) -> bool;
+    fn build_c_file(&self) -> bool {
+        let c_target = "aarch64";
+
+        let (chunk_size, chunk_count) = chunk_info(self.intrinsics().len());
+
+        let cpp_compiler_wrapped = self.cpp_compilation();
+
+        std::fs::create_dir_all("c_programs").unwrap();
+        self.intrinsics()
+            .par_chunks(chunk_size)
+            .enumerate()
+            .map(|(i, chunk)| {
+                let c_filename = format!("c_programs/mod_{i}.cpp");
+                let mut file = File::create(&c_filename).unwrap();
+                write_mod_cpp(
+                    &mut file,
+                    Self::NOTICE,
+                    c_target,
+                    Self::PLATFORM_C_HEADERS,
+                    chunk,
+                )
+                .unwrap();
+
+                // compile this cpp file into a .o file.
+                //
+                // This is done because `cpp_compiler_wrapped` is None when
+                // the --generate-only flag is passed
+                if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
+                    let output = cpp_compiler
+                        .compile_object_file(&format!("mod_{i}.cpp"), &format!("mod_{i}.o"))?;
+                    assert!(output.status.success(), "{output:?}");
+                }
+
+                Ok(())
+            })
+            .collect::<Result<(), std::io::Error>>()
+            .unwrap();
+
+        let mut file = File::create("c_programs/main.cpp").unwrap();
+        write_main_cpp(
+            &mut file,
+            c_target,
+            Self::PLATFORM_C_DEFINITIONS,
+            self.intrinsics().iter().map(|i| i.name.as_str()),
+        )
+        .unwrap();
+
+        // This is done because `cpp_compiler_wrapped` is None when
+        // the --generate-only flag is passed
+        if let Some(cpp_compiler) = cpp_compiler_wrapped.as_ref() {
+            // compile this cpp file into a .o file
+            info!("compiling main.cpp");
+            let output = cpp_compiler
+                .compile_object_file("main.cpp", "intrinsic-test-programs.o")
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+
+            let object_files = (0..chunk_count)
+                .map(|i| format!("mod_{i}.o"))
+                .chain(["intrinsic-test-programs.o".to_owned()]);
+
+            let output = cpp_compiler
+                .link_executable(object_files, "intrinsic-test-programs")
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+        }
+
+        true
+    }
+
+    fn build_rust_file(&self) -> bool {
+        std::fs::create_dir_all("rust_programs/src").unwrap();
+
+        let architecture = if self.cli_options().target.contains("v7") {
+            "arm"
+        } else {
+            "aarch64"
+        };
+
+        let (chunk_size, chunk_count) = chunk_info(self.intrinsics().len());
+
+        let mut cargo = File::create("rust_programs/Cargo.toml").unwrap();
+        write_bin_cargo_toml(&mut cargo, chunk_count).unwrap();
+
+        let mut main_rs = File::create("rust_programs/src/main.rs").unwrap();
+        write_main_rs(
+            &mut main_rs,
+            chunk_count,
+            Self::PLATFORM_RUST_CFGS,
+            "",
+            self.intrinsics().iter().map(|i| i.name.as_str()),
+        )
+        .unwrap();
+
+        let target = &self.cli_options().target;
+        let toolchain = self.cli_options().toolchain.as_deref();
+        let linker = self.cli_options().linker.as_deref();
+
+        self.intrinsics()
+            .par_chunks(chunk_size)
+            .enumerate()
+            .map(|(i, chunk)| {
+                std::fs::create_dir_all(format!("rust_programs/mod_{i}/src"))?;
+
+                let rust_filename = format!("rust_programs/mod_{i}/src/lib.rs");
+                trace!("generating `{rust_filename}`");
+                let mut file = File::create(rust_filename)?;
+
+                write_lib_rs(
+                    &mut file,
+                    architecture,
+                    Self::NOTICE,
+                    Self::PLATFORM_RUST_CFGS,
+                    Self::PLATFORM_RUST_DEFINITIONS,
+                    chunk,
+                )?;
+
+                let toml_filename = format!("rust_programs/mod_{i}/Cargo.toml");
+                trace!("generating `{toml_filename}`");
+                let mut file = File::create(toml_filename).unwrap();
+
+                write_lib_cargo_toml(&mut file, &format!("mod_{i}"))?;
+
+                Ok(())
+            })
+            .collect::<Result<(), std::io::Error>>()
+            .unwrap();
+
+        compile_rust_programs(toolchain, target, linker)
+    }
 
     fn compare_outputs(&self) -> bool {
         if self.cli_options().toolchain.is_some() {

--- a/crates/intrinsic-test/src/common/mod.rs
+++ b/crates/intrinsic-test/src/common/mod.rs
@@ -1,6 +1,8 @@
 use cli::ProcessedCli;
 
-use crate::common::{intrinsic::Intrinsic, intrinsic_helpers::IntrinsicTypeDefinition};
+use crate::common::{
+    compile_c::CppCompilation, intrinsic::Intrinsic, intrinsic_helpers::IntrinsicTypeDefinition,
+};
 
 pub mod argument;
 pub mod cli;
@@ -17,14 +19,22 @@ pub mod values;
 /// Architectures must support this trait
 /// to be successfully tested.
 pub trait SupportedArchitectureTest {
-    type IntrinsicImpl: IntrinsicTypeDefinition;
+    type IntrinsicImpl: IntrinsicTypeDefinition + Sync;
 
     fn cli_options(&self) -> &ProcessedCli;
     fn intrinsics(&self) -> &[Intrinsic<Self::IntrinsicImpl>];
 
     fn create(cli_options: ProcessedCli) -> Self;
 
-    const PLATFORM_HEADERS: &[&str];
+    const NOTICE: &str;
+
+    const PLATFORM_C_HEADERS: &[&str];
+    const PLATFORM_C_DEFINITIONS: &str;
+
+    const PLATFORM_RUST_CFGS: &str;
+    const PLATFORM_RUST_DEFINITIONS: &str;
+
+    fn cpp_compilation(&self) -> Option<CppCompilation>;
 
     fn build_c_file(&self) -> bool;
     fn build_rust_file(&self) -> bool;

--- a/crates/intrinsic-test/src/common/mod.rs
+++ b/crates/intrinsic-test/src/common/mod.rs
@@ -24,6 +24,8 @@ pub trait SupportedArchitectureTest {
 
     fn create(cli_options: ProcessedCli) -> Self;
 
+    const PLATFORM_HEADERS: &[&str];
+
     fn build_c_file(&self) -> bool;
     fn build_rust_file(&self) -> bool;
 

--- a/crates/intrinsic-test/src/common/mod.rs
+++ b/crates/intrinsic-test/src/common/mod.rs
@@ -41,6 +41,7 @@ pub trait SupportedArchitectureTest {
 
     const PLATFORM_C_HEADERS: &[&str];
     const PLATFORM_C_DEFINITIONS: &str;
+    const PLATFORM_C_FORWARD_DECLARATIONS: &str;
 
     const PLATFORM_RUST_CFGS: &str;
     const PLATFORM_RUST_DEFINITIONS: &str;
@@ -48,8 +49,6 @@ pub trait SupportedArchitectureTest {
     fn cpp_compilation(&self) -> Option<CppCompilation>;
 
     fn build_c_file(&self) -> bool {
-        let c_target = "aarch64";
-
         let (chunk_size, chunk_count) = chunk_info(self.intrinsics().len());
 
         let cpp_compiler_wrapped = self.cpp_compilation();
@@ -64,8 +63,8 @@ pub trait SupportedArchitectureTest {
                 write_mod_cpp(
                     &mut file,
                     Self::NOTICE,
-                    c_target,
                     Self::PLATFORM_C_HEADERS,
+                    Self::PLATFORM_C_FORWARD_DECLARATIONS,
                     chunk,
                 )
                 .unwrap();
@@ -88,7 +87,6 @@ pub trait SupportedArchitectureTest {
         let mut file = File::create("c_programs/main.cpp").unwrap();
         write_main_cpp(
             &mut file,
-            c_target,
             Self::PLATFORM_C_DEFINITIONS,
             self.intrinsics().iter().map(|i| i.name.as_str()),
         )
@@ -119,12 +117,6 @@ pub trait SupportedArchitectureTest {
 
     fn build_rust_file(&self) -> bool {
         std::fs::create_dir_all("rust_programs/src").unwrap();
-
-        let architecture = if self.cli_options().target.contains("v7") {
-            "arm"
-        } else {
-            "aarch64"
-        };
 
         let (chunk_size, chunk_count) = chunk_info(self.intrinsics().len());
 
@@ -157,7 +149,6 @@ pub trait SupportedArchitectureTest {
 
                 write_lib_rs(
                     &mut file,
-                    architecture,
                     Self::NOTICE,
                     Self::PLATFORM_RUST_CFGS,
                     Self::PLATFORM_RUST_DEFINITIONS,

--- a/crates/intrinsic-test/src/main.rs
+++ b/crates/intrinsic-test/src/main.rs
@@ -13,23 +13,16 @@ fn main() {
     let args: Cli = clap::Parser::parse();
     let processed_cli_options = ProcessedCli::new(args);
 
-    let test_environment_result: Option<Box<dyn SupportedArchitectureTest>> =
-        match processed_cli_options.target.as_str() {
-            "aarch64-unknown-linux-gnu"
-            | "armv7-unknown-linux-gnueabihf"
-            | "aarch64_be-unknown-linux-gnu" => {
-                Some(ArmArchitectureTest::create(processed_cli_options))
-            }
+    match processed_cli_options.target.as_str() {
+        "aarch64-unknown-linux-gnu"
+        | "armv7-unknown-linux-gnueabihf"
+        | "aarch64_be-unknown-linux-gnu" => run(ArmArchitectureTest::create(processed_cli_options)),
 
-            _ => None,
-        };
-
-    if test_environment_result.is_none() {
-        std::process::exit(0);
+        _ => std::process::exit(0),
     }
+}
 
-    let test_environment = test_environment_result.unwrap();
-
+fn run(test_environment: impl SupportedArchitectureTest) {
     info!("building C binaries");
     if !test_environment.build_c_file() {
         std::process::exit(2);


### PR DESCRIPTION
Most of the tricky logic of `SupportedArchitectureTest` is now in the trait, making it a lot easier, and shorter, to define new variants. That should make the x86 work a lot simpler.

best reviewed commit-by-commit I think.

cc @madhav-madhusoodanan 