### PR TITLE
loongarch: Align intrinsic signatures with LLVM

### DIFF
--- a/crates/core_arch/src/loongarch32/mod.rs
+++ b/crates/core_arch/src/loongarch32/mod.rs
@@ -17,9 +17,10 @@ unsafe extern "unadjusted" {
 /// Generates the cache operation instruction
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn cacop<const IMM12: i32>(a: i32, b: i32) {
-    static_assert_simm_bits!(IMM12, 12);
-    __cacop(a, b, IMM12);
+pub unsafe fn cacop<const IMM5: i32, const IMM_S12: i32>(b: i32) {
+    static_assert_uimm_bits!(IMM5, 5);
+    static_assert_simm_bits!(IMM_S12, 12);
+    __cacop(IMM5, b, IMM_S12);
 }
 
 /// Reads the CSR

--- a/crates/core_arch/src/loongarch64/mod.rs
+++ b/crates/core_arch/src/loongarch64/mod.rs
@@ -64,9 +64,10 @@ pub fn crcc_w_d_w(a: i64, b: i32) -> i32 {
 /// Generates the cache operation instruction
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn cacop<const IMM12: i64>(a: i64, b: i64) {
-    static_assert_simm_bits!(IMM12, 12);
-    __cacop(a, b, IMM12);
+pub unsafe fn cacop<const IMM5: i64, const IMM_S12: i64>(b: i64) {
+    static_assert_uimm_bits!(IMM5, 5);
+    static_assert_simm_bits!(IMM_S12, 12);
+    __cacop(IMM5, b, IMM_S12);
 }
 
 /// Reads the CSR
@@ -125,14 +126,16 @@ pub unsafe fn asrtgt(a: i64, b: i64) {
 #[inline]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lddir<const B: i64>(a: i64) -> i64 {
-    __lddir(a, B)
+pub unsafe fn lddir<const IMM8: i64>(a: i64) -> i64 {
+    static_assert_uimm_bits!(IMM8, 8);
+    __lddir(a, IMM8)
 }
 
 /// Loads the page table entry
 #[inline]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn ldpte<const B: i64>(a: i64) {
-    __ldpte(a, B)
+pub unsafe fn ldpte<const IMM8: i64>(a: i64) {
+    static_assert_uimm_bits!(IMM8, 8);
+    __ldpte(a, IMM8)
 }

--- a/crates/core_arch/src/loongarch_shared/mod.rs
+++ b/crates/core_arch/src/loongarch_shared/mod.rs
@@ -131,17 +131,17 @@ pub fn ibar<const IMM15: i32>() {
 /// Moves data from a GPR to the FCSR
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn movgr2fcsr<const IMM5: i32>(a: i32) {
-    static_assert_uimm_bits!(IMM5, 5);
-    __movgr2fcsr(IMM5, a);
+pub unsafe fn movgr2fcsr<const IMM2: i32>(a: i32) {
+    static_assert_uimm_bits!(IMM2, 2);
+    __movgr2fcsr(IMM2, a);
 }
 
 /// Moves data from a FCSR to the GPR
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn movfcsr2gr<const IMM5: i32>() -> i32 {
-    static_assert_uimm_bits!(IMM5, 5);
-    unsafe { __movfcsr2gr(IMM5) }
+pub fn movfcsr2gr<const IMM2: i32>() -> i32 {
+    static_assert_uimm_bits!(IMM2, 2);
+    unsafe { __movfcsr2gr(IMM2) }
 }
 
 /// Reads the 8-bit IO-CSR


### PR DESCRIPTION
Update LoongArch intrinsics to match LLVM’s signature and immediate constraints.