### PR TITLE
Add `#[rustc_legacy_const_generics]` to all intrinsics with const-generic parameters

### DIFF
--- a/crates/core_arch/src/loongarch32/mod.rs
+++ b/crates/core_arch/src/loongarch32/mod.rs
@@ -16,6 +16,7 @@ unsafe extern "unadjusted" {
 
 /// Generates the cache operation instruction
 #[inline]
+#[rustc_legacy_const_generics(0, 2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn cacop<const IMM5: i32, const IMM_S12: i32>(b: i32) {
     static_assert_uimm_bits!(IMM5, 5);
@@ -25,6 +26,7 @@ pub unsafe fn cacop<const IMM5: i32, const IMM_S12: i32>(b: i32) {
 
 /// Reads the CSR
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn csrrd<const IMM14: i32>() -> i32 {
     static_assert_uimm_bits!(IMM14, 14);
@@ -33,6 +35,7 @@ pub unsafe fn csrrd<const IMM14: i32>() -> i32 {
 
 /// Writes the CSR
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn csrwr<const IMM14: i32>(a: i32) -> i32 {
     static_assert_uimm_bits!(IMM14, 14);
@@ -41,6 +44,7 @@ pub unsafe fn csrwr<const IMM14: i32>(a: i32) -> i32 {
 
 /// Exchanges the CSR
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn csrxchg<const IMM14: i32>(a: i32, b: i32) -> i32 {
     static_assert_uimm_bits!(IMM14, 14);

--- a/crates/core_arch/src/loongarch64/mod.rs
+++ b/crates/core_arch/src/loongarch64/mod.rs
@@ -63,6 +63,7 @@ pub fn crcc_w_d_w(a: i64, b: i32) -> i32 {
 
 /// Generates the cache operation instruction
 #[inline]
+#[rustc_legacy_const_generics(0, 2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn cacop<const IMM5: i64, const IMM_S12: i64>(b: i64) {
     static_assert_uimm_bits!(IMM5, 5);
@@ -72,6 +73,7 @@ pub unsafe fn cacop<const IMM5: i64, const IMM_S12: i64>(b: i64) {
 
 /// Reads the CSR
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn csrrd<const IMM14: i32>() -> i64 {
     static_assert_uimm_bits!(IMM14, 14);
@@ -80,6 +82,7 @@ pub unsafe fn csrrd<const IMM14: i32>() -> i64 {
 
 /// Writes the CSR
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn csrwr<const IMM14: i32>(a: i64) -> i64 {
     static_assert_uimm_bits!(IMM14, 14);
@@ -88,6 +91,7 @@ pub unsafe fn csrwr<const IMM14: i32>(a: i64) -> i64 {
 
 /// Exchanges the CSR
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn csrxchg<const IMM14: i32>(a: i64, b: i64) -> i64 {
     static_assert_uimm_bits!(IMM14, 14);

--- a/crates/core_arch/src/loongarch_shared/mod.rs
+++ b/crates/core_arch/src/loongarch_shared/mod.rs
@@ -114,6 +114,7 @@ pub fn crcc_w_w_w(a: i32, b: i32) -> i32 {
 
 /// Generates the memory barrier instruction
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn dbar<const IMM15: i32>() {
     static_assert_uimm_bits!(IMM15, 15);
@@ -122,6 +123,7 @@ pub fn dbar<const IMM15: i32>() {
 
 /// Generates the instruction-fetch barrier instruction
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn ibar<const IMM15: i32>() {
     static_assert_uimm_bits!(IMM15, 15);
@@ -130,6 +132,7 @@ pub fn ibar<const IMM15: i32>() {
 
 /// Moves data from a GPR to the FCSR
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn movgr2fcsr<const IMM2: i32>(a: i32) {
     static_assert_uimm_bits!(IMM2, 2);
@@ -138,6 +141,7 @@ pub unsafe fn movgr2fcsr<const IMM2: i32>(a: i32) {
 
 /// Moves data from a FCSR to the GPR
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn movfcsr2gr<const IMM2: i32>() -> i32 {
     static_assert_uimm_bits!(IMM2, 2);
@@ -188,6 +192,7 @@ pub unsafe fn iocsrwr_w(a: i32, b: i32) {
 
 /// Generates the breakpoint instruction
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn brk<const IMM15: i32>() {
     static_assert_uimm_bits!(IMM15, 15);
@@ -203,6 +208,7 @@ pub fn cpucfg(a: i32) -> i32 {
 
 /// Generates the syscall instruction
 #[inline]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn syscall<const IMM15: i32>() {
     static_assert_uimm_bits!(IMM15, 15);

--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -4073,6 +4073,7 @@ where
 /// Vector Convert to Signed Integer
 #[inline]
 #[target_feature(enable = "altivec")]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(vctsxs, IMM5 = 1))]
 #[unstable(feature = "stdarch_powerpc", issue = "111145")]
 pub unsafe fn vec_cts<const IMM5: i32>(a: vector_float) -> vector_signed_int {
@@ -4084,6 +4085,7 @@ pub unsafe fn vec_cts<const IMM5: i32>(a: vector_float) -> vector_signed_int {
 /// Vector Convert to Unsigned Integer
 #[inline]
 #[target_feature(enable = "altivec")]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(vctuxs, IMM5 = 1))]
 #[unstable(feature = "stdarch_powerpc", issue = "111145")]
 pub unsafe fn vec_ctu<const IMM5: i32>(a: vector_float) -> vector_unsigned_int {

--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -4558,6 +4558,7 @@ pub unsafe fn vec_unpackl<T: sealed::VectorUnpackl>(a: T) -> <T as sealed::Vecto
 /// in the corresponding byte element of d are set to ones. Otherwise, if the bit is zero, the corresponding byte element is set to zero.
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vgbm, MASK = 0x00FF))]
 pub unsafe fn vec_genmask<const MASK: u16>() -> vector_unsigned_char {
@@ -4567,6 +4568,7 @@ pub unsafe fn vec_genmask<const MASK: u16>() -> vector_unsigned_char {
 /// Vector Generate Mask (Byte)
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0, 1)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepib, L = 3, H = 5))]
 pub unsafe fn vec_genmasks_8<const L: u8, const H: u8>() -> vector_unsigned_char {
@@ -4576,6 +4578,7 @@ pub unsafe fn vec_genmasks_8<const L: u8, const H: u8>() -> vector_unsigned_char
 /// Vector Generate Mask (Halfword)
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0, 1)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepih, L = 3, H = 5))]
 pub unsafe fn vec_genmasks_16<const L: u8, const H: u8>() -> vector_unsigned_short {
@@ -4585,6 +4588,7 @@ pub unsafe fn vec_genmasks_16<const L: u8, const H: u8>() -> vector_unsigned_sho
 /// Vector Generate Mask (Word)
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0, 1)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vgmf, L = 3, H = 5))]
 pub unsafe fn vec_genmasks_32<const L: u8, const H: u8>() -> vector_unsigned_int {
@@ -4594,6 +4598,7 @@ pub unsafe fn vec_genmasks_32<const L: u8, const H: u8>() -> vector_unsigned_int
 /// Vector Generate Mask (Doubleword)
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0, 1)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vgmg, L = 3, H = 5))]
 pub unsafe fn vec_genmasks_64<const L: u8, const H: u8>() -> vector_unsigned_long_long {
@@ -4810,6 +4815,7 @@ pub unsafe fn vec_subec_u128(
 /// Vector Splat Signed Byte
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepib, IMM = 42))]
 pub unsafe fn vec_splat_s8<const IMM: i8>() -> vector_signed_char {
@@ -4819,6 +4825,7 @@ pub unsafe fn vec_splat_s8<const IMM: i8>() -> vector_signed_char {
 /// Vector Splat Signed Halfword
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepih, IMM = 42))]
 pub unsafe fn vec_splat_s16<const IMM: i16>() -> vector_signed_short {
@@ -4828,6 +4835,7 @@ pub unsafe fn vec_splat_s16<const IMM: i16>() -> vector_signed_short {
 /// Vector Splat Signed Word
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepif, IMM = 42))]
 pub unsafe fn vec_splat_s32<const IMM: i16>() -> vector_signed_int {
@@ -4837,6 +4845,7 @@ pub unsafe fn vec_splat_s32<const IMM: i16>() -> vector_signed_int {
 /// Vector Splat Signed Doubleword
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepig, IMM = 42))]
 pub unsafe fn vec_splat_s64<const IMM: i16>() -> vector_signed_long_long {
@@ -4846,6 +4855,7 @@ pub unsafe fn vec_splat_s64<const IMM: i16>() -> vector_signed_long_long {
 /// Vector Splat Unsigned Byte
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepib, IMM = 42))]
 pub unsafe fn vec_splat_u8<const IMM: u8>() -> vector_unsigned_char {
@@ -4855,6 +4865,7 @@ pub unsafe fn vec_splat_u8<const IMM: u8>() -> vector_unsigned_char {
 /// Vector Splat Unsigned Halfword
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepih, IMM = 42))]
 pub unsafe fn vec_splat_u16<const IMM: i16>() -> vector_unsigned_short {
@@ -4864,6 +4875,7 @@ pub unsafe fn vec_splat_u16<const IMM: i16>() -> vector_unsigned_short {
 /// Vector Splat Unsigned Word
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepif, IMM = 42))]
 pub unsafe fn vec_splat_u32<const IMM: i16>() -> vector_unsigned_int {
@@ -4873,6 +4885,7 @@ pub unsafe fn vec_splat_u32<const IMM: i16>() -> vector_unsigned_int {
 /// Vector Splat Unsigned Doubleword
 #[inline]
 #[target_feature(enable = "vector")]
+#[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(test, assert_instr(vrepig, IMM = 42))]
 pub unsafe fn vec_splat_u64<const IMM: i16>() -> vector_unsigned_long_long {
@@ -5366,6 +5379,7 @@ pub unsafe fn vec_cp_until_zero_cc<T: sealed::VectorCopyUntilZeroCC>(a: T) -> (T
 /// Vector Multiply Sum Logical
 #[inline]
 #[target_feature(enable = "vector-enhancements-1")]
+#[rustc_legacy_const_generics(3)]
 #[unstable(feature = "stdarch_s390x", issue = "135681")]
 #[cfg_attr(
     all(test, target_feature = "vector-enhancements-1"),

--- a/crates/core_arch/src/wasm32/mod.rs
+++ b/crates/core_arch/src/wasm32/mod.rs
@@ -190,6 +190,7 @@ unsafe extern "C-unwind" {
 //        reenable this attribute.
 // #[cfg_attr(test, assert_instr(throw, TAG = 0, ptr = core::ptr::null_mut()))]
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[unstable(feature = "wasm_exception_handling_intrinsics", issue = "122465")]
 // FIXME: Since this instruction unwinds, `core` built with `-C panic=unwind`
 //        cannot be linked with `-C panic=abort` programs. But that's not

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -458,6 +458,7 @@ pub unsafe fn v128_store(m: *mut v128, a: v128) {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned load.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.load8_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.load8_lane"))]
@@ -478,6 +479,7 @@ pub unsafe fn v128_load8_lane<const L: usize>(v: v128, m: *const u8) -> v128 {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned load.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.load16_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.load16_lane"))]
@@ -498,6 +500,7 @@ pub unsafe fn v128_load16_lane<const L: usize>(v: v128, m: *const u16) -> v128 {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned load.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.load32_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.load32_lane"))]
@@ -518,6 +521,7 @@ pub unsafe fn v128_load32_lane<const L: usize>(v: v128, m: *const u32) -> v128 {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned load.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.load64_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.load64_lane"))]
@@ -538,6 +542,7 @@ pub unsafe fn v128_load64_lane<const L: usize>(v: v128, m: *const u64) -> v128 {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned store.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.store8_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.store8_lane"))]
@@ -558,6 +563,7 @@ pub unsafe fn v128_store8_lane<const L: usize>(v: v128, m: *mut u8) {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned store.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.store16_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.store16_lane"))]
@@ -578,6 +584,7 @@ pub unsafe fn v128_store16_lane<const L: usize>(v: v128, m: *mut u16) {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned store.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.store32_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.store32_lane"))]
@@ -598,6 +605,7 @@ pub unsafe fn v128_store32_lane<const L: usize>(v: v128, m: *mut u32) {
 /// alignment requirement on this pointer since this intrinsic performs a
 /// 1-aligned store.
 #[inline]
+#[rustc_legacy_const_generics(2)]
 #[cfg_attr(test, assert_instr(v128.store64_lane, L = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("v128.store64_lane"))]
@@ -831,6 +839,7 @@ pub const fn f64x2(a0: f64, a1: f64) -> v128 {
 ///
 /// All indexes `$i*` must have the type `u32`.
 #[inline]
+#[rustc_legacy_const_generics(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)]
 #[cfg_attr(test,
     assert_instr(
         i8x16.shuffle,
@@ -917,6 +926,7 @@ pub use i8x16_shuffle as u8x16_shuffle;
 /// is no native `i16x8.shuffle` instruction (there is no need for one since
 /// `i8x16.shuffle` suffices).
 #[inline]
+#[rustc_legacy_const_generics(2, 3, 4, 5, 6, 7, 8, 9)]
 #[cfg_attr(test,
     assert_instr(
         i8x16.shuffle,
@@ -978,6 +988,7 @@ pub use i16x8_shuffle as u16x8_shuffle;
 /// is no native `i32x4.shuffle` instruction (there is no need for one since
 /// `i8x16.shuffle` suffices).
 #[inline]
+#[rustc_legacy_const_generics(2, 3, 4, 5)]
 #[cfg_attr(test, assert_instr(i8x16.shuffle, I0 = 0, I1 = 2, I2 = 4, I3 = 6))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i8x16.shuffle"))]
@@ -1011,6 +1022,7 @@ pub use i32x4_shuffle as u32x4_shuffle;
 /// is no native `i64x2.shuffle` instruction (there is no need for one since
 /// `i8x16.shuffle` suffices).
 #[inline]
+#[rustc_legacy_const_generics(2, 3)]
 #[cfg_attr(test, assert_instr(i8x16.shuffle, I0 = 0, I1 = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i8x16.shuffle"))]
@@ -1031,6 +1043,7 @@ pub use i64x2_shuffle as u64x2_shuffle;
 /// Extracts the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i8x16.extract_lane_s, N = 3))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i8x16.extract_lane_s"))]
@@ -1045,6 +1058,7 @@ pub fn i8x16_extract_lane<const N: usize>(a: v128) -> i8 {
 /// Extracts the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i8x16.extract_lane_u, N = 3))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i8x16.extract_lane_u"))]
@@ -1059,6 +1073,7 @@ pub fn u8x16_extract_lane<const N: usize>(a: v128) -> u8 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i8x16.replace_lane, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i8x16.replace_lane"))]
@@ -1073,6 +1088,7 @@ pub fn i8x16_replace_lane<const N: usize>(a: v128, val: i8) -> v128 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i8x16.replace_lane, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i8x16.replace_lane"))]
@@ -1087,6 +1103,7 @@ pub fn u8x16_replace_lane<const N: usize>(a: v128, val: u8) -> v128 {
 /// Extracts a the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i16x8.extract_lane_s, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.extract_lane_s"))]
@@ -1101,6 +1118,7 @@ pub fn i16x8_extract_lane<const N: usize>(a: v128) -> i16 {
 /// Extracts a the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i16x8.extract_lane_u, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.extract_lane_u"))]
@@ -1115,6 +1133,7 @@ pub fn u16x8_extract_lane<const N: usize>(a: v128) -> u16 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i16x8.replace_lane, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.replace_lane"))]
@@ -1129,6 +1148,7 @@ pub fn i16x8_replace_lane<const N: usize>(a: v128, val: i16) -> v128 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i16x8.replace_lane, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i16x8.replace_lane"))]
@@ -1143,6 +1163,7 @@ pub fn u16x8_replace_lane<const N: usize>(a: v128, val: u16) -> v128 {
 /// Extracts the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i32x4.extract_lane, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.extract_lane"))]
@@ -1157,6 +1178,7 @@ pub fn i32x4_extract_lane<const N: usize>(a: v128) -> i32 {
 /// Extracts the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.extract_lane"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -1169,6 +1191,7 @@ pub fn u32x4_extract_lane<const N: usize>(a: v128) -> u32 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i32x4.replace_lane, N = 2))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.replace_lane"))]
@@ -1183,6 +1206,7 @@ pub fn i32x4_replace_lane<const N: usize>(a: v128, val: i32) -> v128 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i32x4.replace_lane"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -1195,6 +1219,7 @@ pub fn u32x4_replace_lane<const N: usize>(a: v128, val: u32) -> v128 {
 /// Extracts the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i64x2.extract_lane, N = 1))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.extract_lane"))]
@@ -1209,6 +1234,7 @@ pub fn i64x2_extract_lane<const N: usize>(a: v128) -> i64 {
 /// Extracts the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.extract_lane"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -1221,6 +1247,7 @@ pub fn u64x2_extract_lane<const N: usize>(a: v128) -> u64 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(i64x2.replace_lane, N = 0))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.replace_lane"))]
@@ -1235,6 +1262,7 @@ pub fn i64x2_replace_lane<const N: usize>(a: v128, val: i64) -> v128 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "simd128")]
 #[doc(alias("i64x2.replace_lane"))]
 #[stable(feature = "wasm_simd", since = "1.54.0")]
@@ -1247,6 +1275,7 @@ pub fn u64x2_replace_lane<const N: usize>(a: v128, val: u64) -> v128 {
 /// Extracts the scalar value of lane specified fn the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(f32x4.extract_lane, N = 1))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("f32x4.extract_lane"))]
@@ -1261,6 +1290,7 @@ pub fn f32x4_extract_lane<const N: usize>(a: v128) -> f32 {
 /// Replaces the scalar value of lane specified fn the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(f32x4.replace_lane, N = 1))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("f32x4.replace_lane"))]
@@ -1275,6 +1305,7 @@ pub fn f32x4_replace_lane<const N: usize>(a: v128, val: f32) -> v128 {
 /// Extracts the scalar value of lane specified fn the immediate mode operand
 /// `N` from `a`. If `N` fs out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(f64x2.extract_lane, N = 1))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("f64x2.extract_lane"))]
@@ -1289,6 +1320,7 @@ pub fn f64x2_extract_lane<const N: usize>(a: v128) -> f64 {
 /// Replaces the scalar value of lane specified in the immediate mode operand
 /// `N` from `a`. If `N` is out of bounds then it is a compile time error.
 #[inline]
+#[rustc_legacy_const_generics(1)]
 #[cfg_attr(test, assert_instr(f64x2.replace_lane, N = 1))]
 #[target_feature(enable = "simd128")]
 #[doc(alias("f64x2.replace_lane"))]


### PR DESCRIPTION
This is very useful when writing intrinsic-heavy code. Adding it is not a semver hazard because the old style will still be allowed, but now the C-style code will also be allowed.

CCing arch-specific ppl to check that placement of the parameters are correct
LA64, LA32: @heiher
PPC: @lu-zero
S390X: @folkertdev 
WASM: @alexcrichton 

(I am tagging based on the commit history of the files I modified, pls cc if someone else is also involved)
