### PR TITLE
RISC-V: "Lower" requirements of `aes64im`

### DIFF
--- a/crates/core_arch/src/riscv64/zk.rs
+++ b/crates/core_arch/src/riscv64/zk.rs
@@ -176,7 +176,7 @@ pub fn aes64ks2(rs1: u64, rs2: u64) -> u64 {
 /// Version: v1.0.1
 ///
 /// Section: 3.9
-#[target_feature(enable = "zkne", enable = "zknd")]
+#[target_feature(enable = "zknd")]
 #[cfg_attr(test, assert_instr(aes64im))]
 #[inline]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]


### PR DESCRIPTION
This instruction is incorrectly categorized as the same one as `aes64ks1i` and `aes64ks2` (that should require `zkne || zknd` but currently require `zkne && zknd`) but `aes64im` only requires the Zknd extension.

This commit fixes the category of this intrinsic (lowering the requirements from the Rust perspective but it does not actually lower it from the RISC-V perspective).