### PR TITLE
(Partially) Stabilize `stdarch_neon_f16`

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -961,7 +961,7 @@ pub fn vbcaxq_u64(a: uint64x2_t, b: uint64x2_t, c: uint64x2_t) -> uint64x2_t {
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcadd))]
 pub fn vcadd_rot270_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -979,7 +979,7 @@ pub fn vcadd_rot270_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcadd))]
 pub fn vcaddq_rot270_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -1045,7 +1045,7 @@ pub fn vcaddq_rot270_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcadd))]
 pub fn vcadd_rot90_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -1063,7 +1063,7 @@ pub fn vcadd_rot90_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcadd))]
 pub fn vcaddq_rot90_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -1501,7 +1501,7 @@ pub fn vceqh_f16(a: f16, b: f16) -> u16 {
 #[inline]
 #[cfg_attr(test, assert_instr(fcmeq))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vceqz_f16(a: float16x4_t) -> uint16x4_t {
     let b: f16x4 = f16x4::new(0.0, 0.0, 0.0, 0.0);
@@ -1512,7 +1512,7 @@ pub fn vceqz_f16(a: float16x4_t) -> uint16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcmeq))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vceqzq_f16(a: float16x8_t) -> uint16x8_t {
     let b: f16x8 = f16x8::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -2837,7 +2837,7 @@ pub fn vcltzh_f16(a: f16) -> u16 {
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmla_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
@@ -2855,7 +2855,7 @@ pub fn vcmla_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t 
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmlaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
@@ -2923,7 +2923,7 @@ pub fn vcmlaq_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_lane_f16<const LANE: i32>(
     a: float16x4_t,
@@ -2952,7 +2952,7 @@ pub fn vcmla_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_lane_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3030,7 +3030,7 @@ pub fn vcmlaq_lane_f32<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_laneq_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3059,7 +3059,7 @@ pub fn vcmla_laneq_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_laneq_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3135,7 +3135,7 @@ pub fn vcmlaq_laneq_f32<const LANE: i32>(
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmla_rot180_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
@@ -3153,7 +3153,7 @@ pub fn vcmla_rot180_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmlaq_rot180_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
@@ -3221,7 +3221,7 @@ pub fn vcmlaq_rot180_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> floa
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_rot180_lane_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3250,7 +3250,7 @@ pub fn vcmla_rot180_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_rot180_lane_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3328,7 +3328,7 @@ pub fn vcmlaq_rot180_lane_f32<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_rot180_laneq_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3357,7 +3357,7 @@ pub fn vcmla_rot180_laneq_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_rot180_laneq_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3433,7 +3433,7 @@ pub fn vcmlaq_rot180_laneq_f32<const LANE: i32>(
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmla_rot270_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
@@ -3451,7 +3451,7 @@ pub fn vcmla_rot270_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmlaq_rot270_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
@@ -3519,7 +3519,7 @@ pub fn vcmlaq_rot270_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> floa
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_rot270_lane_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3548,7 +3548,7 @@ pub fn vcmla_rot270_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_rot270_lane_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3626,7 +3626,7 @@ pub fn vcmlaq_rot270_lane_f32<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_rot270_laneq_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3655,7 +3655,7 @@ pub fn vcmla_rot270_laneq_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_rot270_laneq_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3731,7 +3731,7 @@ pub fn vcmlaq_rot270_laneq_f32<const LANE: i32>(
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmla_rot90_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
@@ -3749,7 +3749,7 @@ pub fn vcmla_rot90_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float1
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fcmla))]
 pub fn vcmlaq_rot90_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
@@ -3817,7 +3817,7 @@ pub fn vcmlaq_rot90_f64(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_rot90_lane_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3846,7 +3846,7 @@ pub fn vcmla_rot90_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_rot90_lane_f16<const LANE: i32>(
     a: float16x8_t,
@@ -3924,7 +3924,7 @@ pub fn vcmlaq_rot90_lane_f32<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmla_rot90_laneq_f16<const LANE: i32>(
     a: float16x4_t,
@@ -3953,7 +3953,7 @@ pub fn vcmla_rot90_laneq_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fcmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcmlaq_rot90_laneq_f16<const LANE: i32>(
     a: float16x8_t,
@@ -7219,7 +7219,7 @@ pub fn vcvtq_f64_u64(a: uint64x2_t) -> float64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(fcvtn2))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_high_f16_f32(a: float16x4_t, b: float32x4_t) -> float16x8_t {
     vcombine_f16(a, vcvt_f16_f32(b))
@@ -7229,7 +7229,7 @@ pub fn vcvt_high_f16_f32(a: float16x4_t, b: float32x4_t) -> float16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(fcvtl2))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_high_f32_f16(a: float16x8_t) -> float32x4_t {
     vcvt_f32_f16(vget_high_f16(a))
@@ -7468,7 +7468,7 @@ pub fn vcvtq_u64_f64(a: float64x2_t) -> uint64x2_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtas))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvta_s16_f16(a: float16x4_t) -> int16x4_t {
     unsafe extern "unadjusted" {
@@ -7485,7 +7485,7 @@ pub fn vcvta_s16_f16(a: float16x4_t) -> int16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtas))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtaq_s16_f16(a: float16x8_t) -> int16x8_t {
     unsafe extern "unadjusted" {
@@ -7566,7 +7566,7 @@ pub fn vcvtaq_s64_f64(a: float64x2_t) -> int64x2_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtau))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvta_u16_f16(a: float16x4_t) -> uint16x4_t {
     unsafe extern "unadjusted" {
@@ -7583,7 +7583,7 @@ pub fn vcvta_u16_f16(a: float16x4_t) -> uint16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtau))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtaq_u16_f16(a: float16x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
@@ -8154,7 +8154,7 @@ pub fn vcvth_u64_f16(a: f16) -> u64 {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtms))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtm_s16_f16(a: float16x4_t) -> int16x4_t {
     unsafe extern "unadjusted" {
@@ -8171,7 +8171,7 @@ pub fn vcvtm_s16_f16(a: float16x4_t) -> int16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtms))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtmq_s16_f16(a: float16x8_t) -> int16x8_t {
     unsafe extern "unadjusted" {
@@ -8252,7 +8252,7 @@ pub fn vcvtmq_s64_f64(a: float64x2_t) -> int64x2_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtmu))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtm_u16_f16(a: float16x4_t) -> uint16x4_t {
     unsafe extern "unadjusted" {
@@ -8269,7 +8269,7 @@ pub fn vcvtm_u16_f16(a: float16x4_t) -> uint16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtmu))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtmq_u16_f16(a: float16x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
@@ -8502,7 +8502,7 @@ pub fn vcvtmd_u64_f64(a: f64) -> u64 {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtns))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtn_s16_f16(a: float16x4_t) -> int16x4_t {
     unsafe extern "unadjusted" {
@@ -8519,7 +8519,7 @@ pub fn vcvtn_s16_f16(a: float16x4_t) -> int16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtns))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtnq_s16_f16(a: float16x8_t) -> int16x8_t {
     unsafe extern "unadjusted" {
@@ -8600,7 +8600,7 @@ pub fn vcvtnq_s64_f64(a: float64x2_t) -> int64x2_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtnu))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtn_u16_f16(a: float16x4_t) -> uint16x4_t {
     unsafe extern "unadjusted" {
@@ -8617,7 +8617,7 @@ pub fn vcvtn_u16_f16(a: float16x4_t) -> uint16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtnu))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtnq_u16_f16(a: float16x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
@@ -8850,7 +8850,7 @@ pub fn vcvtnd_u64_f64(a: f64) -> u64 {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtps))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtp_s16_f16(a: float16x4_t) -> int16x4_t {
     unsafe extern "unadjusted" {
@@ -8867,7 +8867,7 @@ pub fn vcvtp_s16_f16(a: float16x4_t) -> int16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtps))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtpq_s16_f16(a: float16x8_t) -> int16x8_t {
     unsafe extern "unadjusted" {
@@ -8948,7 +8948,7 @@ pub fn vcvtpq_s64_f64(a: float64x2_t) -> int64x2_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtpu))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtp_u16_f16(a: float16x4_t) -> uint16x4_t {
     unsafe extern "unadjusted" {
@@ -8965,7 +8965,7 @@ pub fn vcvtp_u16_f16(a: float16x4_t) -> uint16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fcvtpu))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtpq_u16_f16(a: float16x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
@@ -9429,7 +9429,7 @@ pub fn vcvtxd_f32_f64(a: f64) -> f32 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vdiv_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fdiv))]
 pub fn vdiv_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -9439,7 +9439,7 @@ pub fn vdiv_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vdivq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fdiv))]
 pub fn vdivq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -10106,7 +10106,7 @@ pub fn vfma_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t) -> float64x1_t {
 #[cfg_attr(test, assert_instr(fmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfma_lane_f16<const LANE: i32>(
     a: float16x4_t,
@@ -10122,7 +10122,7 @@ pub fn vfma_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfma_laneq_f16<const LANE: i32>(
     a: float16x4_t,
@@ -10138,7 +10138,7 @@ pub fn vfma_laneq_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmaq_lane_f16<const LANE: i32>(
     a: float16x8_t,
@@ -10154,7 +10154,7 @@ pub fn vfmaq_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fmla, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmaq_laneq_f16<const LANE: i32>(
     a: float16x8_t,
@@ -10432,7 +10432,7 @@ pub fn vfmad_laneq_f64<const LANE: i32>(a: f64, b: f64, c: float64x2_t) -> f64 {
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlal2))]
 pub fn vfmlal_high_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32x2_t {
@@ -10450,7 +10450,7 @@ pub fn vfmlal_high_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float3
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlal2))]
 pub fn vfmlalq_high_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float32x4_t {
@@ -10470,7 +10470,7 @@ pub fn vfmlalq_high_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlal_lane_high_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10487,7 +10487,7 @@ pub fn vfmlal_lane_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlal_laneq_high_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10504,7 +10504,7 @@ pub fn vfmlal_laneq_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlalq_lane_high_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10521,7 +10521,7 @@ pub fn vfmlalq_lane_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlalq_laneq_high_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10538,7 +10538,7 @@ pub fn vfmlalq_laneq_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlal_lane_low_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10555,7 +10555,7 @@ pub fn vfmlal_lane_low_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlal_laneq_low_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10572,7 +10572,7 @@ pub fn vfmlal_laneq_low_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlalq_lane_low_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10589,7 +10589,7 @@ pub fn vfmlalq_lane_low_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlalq_laneq_low_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10604,7 +10604,7 @@ pub fn vfmlalq_laneq_low_f16<const LANE: i32>(
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlal))]
 pub fn vfmlal_low_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32x2_t {
@@ -10622,7 +10622,7 @@ pub fn vfmlal_low_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlal))]
 pub fn vfmlalq_low_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float32x4_t {
@@ -10640,7 +10640,7 @@ pub fn vfmlalq_low_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float3
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlsl2))]
 pub fn vfmlsl_high_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32x2_t {
@@ -10658,7 +10658,7 @@ pub fn vfmlsl_high_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float3
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlsl2))]
 pub fn vfmlslq_high_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float32x4_t {
@@ -10678,7 +10678,7 @@ pub fn vfmlslq_high_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlsl_lane_high_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10695,7 +10695,7 @@ pub fn vfmlsl_lane_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlsl_laneq_high_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10712,7 +10712,7 @@ pub fn vfmlsl_laneq_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlslq_lane_high_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10729,7 +10729,7 @@ pub fn vfmlslq_lane_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlslq_laneq_high_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10746,7 +10746,7 @@ pub fn vfmlslq_laneq_high_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlsl_lane_low_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10763,7 +10763,7 @@ pub fn vfmlsl_lane_low_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlsl_laneq_low_f16<const LANE: i32>(
     r: float32x2_t,
@@ -10780,7 +10780,7 @@ pub fn vfmlsl_laneq_low_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlslq_lane_low_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10797,7 +10797,7 @@ pub fn vfmlslq_lane_low_f16<const LANE: i32>(
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmlslq_laneq_low_f16<const LANE: i32>(
     r: float32x4_t,
@@ -10812,7 +10812,7 @@ pub fn vfmlslq_laneq_low_f16<const LANE: i32>(
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlsl))]
 pub fn vfmlsl_low_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32x2_t {
@@ -10830,7 +10830,7 @@ pub fn vfmlsl_low_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32
 #[inline]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmlsl))]
 pub fn vfmlslq_low_f16(r: float32x4_t, a: float16x8_t, b: float16x8_t) -> float32x4_t {
@@ -10861,7 +10861,7 @@ pub fn vfms_f64(a: float64x1_t, b: float64x1_t, c: float64x1_t) -> float64x1_t {
 #[cfg_attr(test, assert_instr(fmls, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfms_lane_f16<const LANE: i32>(
     a: float16x4_t,
@@ -10877,7 +10877,7 @@ pub fn vfms_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fmls, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfms_laneq_f16<const LANE: i32>(
     a: float16x4_t,
@@ -10893,7 +10893,7 @@ pub fn vfms_laneq_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fmls, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmsq_lane_f16<const LANE: i32>(
     a: float16x8_t,
@@ -10909,7 +10909,7 @@ pub fn vfmsq_lane_f16<const LANE: i32>(
 #[cfg_attr(test, assert_instr(fmls, LANE = 0))]
 #[rustc_legacy_const_generics(3)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmsq_laneq_f16<const LANE: i32>(
     a: float16x8_t,
@@ -14739,7 +14739,7 @@ pub fn vmul_lane_f64<const LANE: i32>(a: float64x1_t, b: float64x1_t) -> float64
 #[cfg_attr(test, assert_instr(fmul, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmul_laneq_f16<const LANE: i32>(a: float16x4_t, b: float16x8_t) -> float16x4_t {
     static_assert_uimm_bits!(LANE, 3);
@@ -14756,7 +14756,7 @@ pub fn vmul_laneq_f16<const LANE: i32>(a: float16x4_t, b: float16x8_t) -> float1
 #[cfg_attr(test, assert_instr(fmul, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulq_laneq_f16<const LANE: i32>(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     static_assert_uimm_bits!(LANE, 3);
@@ -15263,7 +15263,7 @@ pub fn vmuld_laneq_f64<const LANE: i32>(a: f64, b: float64x2_t) -> f64 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmulx_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmulx))]
 pub fn vmulx_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -15280,7 +15280,7 @@ pub fn vmulx_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmulxq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmulx))]
 pub fn vmulxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -15363,7 +15363,7 @@ pub fn vmulxq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[cfg_attr(test, assert_instr(fmulx, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulx_lane_f16<const LANE: i32>(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     static_assert_uimm_bits!(LANE, 2);
@@ -15380,7 +15380,7 @@ pub fn vmulx_lane_f16<const LANE: i32>(a: float16x4_t, b: float16x4_t) -> float1
 #[cfg_attr(test, assert_instr(fmulx, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulx_laneq_f16<const LANE: i32>(a: float16x4_t, b: float16x8_t) -> float16x4_t {
     static_assert_uimm_bits!(LANE, 3);
@@ -15397,7 +15397,7 @@ pub fn vmulx_laneq_f16<const LANE: i32>(a: float16x4_t, b: float16x8_t) -> float
 #[cfg_attr(test, assert_instr(fmulx, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulxq_lane_f16<const LANE: i32>(a: float16x8_t, b: float16x4_t) -> float16x8_t {
     static_assert_uimm_bits!(LANE, 2);
@@ -15427,7 +15427,7 @@ pub fn vmulxq_lane_f16<const LANE: i32>(a: float16x8_t, b: float16x4_t) -> float
 #[cfg_attr(test, assert_instr(fmulx, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulxq_laneq_f16<const LANE: i32>(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     static_assert_uimm_bits!(LANE, 3);
@@ -15789,7 +15789,7 @@ pub fn vpaddd_u64(a: uint64x2_t) -> u64 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpaddq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(faddp))]
 pub fn vpaddq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -16008,7 +16008,7 @@ pub fn vpaddq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpmax_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmaxp))]
 pub fn vpmax_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -16025,7 +16025,7 @@ pub fn vpmax_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpmaxq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmaxp))]
 pub fn vpmaxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -16042,7 +16042,7 @@ pub fn vpmaxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpmaxnm_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmaxnmp))]
 pub fn vpmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -16059,7 +16059,7 @@ pub fn vpmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpmaxnmq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fmaxnmp))]
 pub fn vpmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -16316,7 +16316,7 @@ pub fn vpmaxs_f32(a: float32x2_t) -> f32 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpmin_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fminp))]
 pub fn vpmin_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -16333,7 +16333,7 @@ pub fn vpmin_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpminq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fminp))]
 pub fn vpminq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -16350,7 +16350,7 @@ pub fn vpminq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpminnm_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fminnmp))]
 pub fn vpminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -16367,7 +16367,7 @@ pub fn vpminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpminnmq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(fminnmp))]
 pub fn vpminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -21493,7 +21493,7 @@ pub fn vrecpxh_f16(a: f16) -> f16 {
 #[inline]
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpret_f64_f16(a: float16x4_t) -> float64x1_t {
@@ -21504,7 +21504,7 @@ pub fn vreinterpret_f64_f16(a: float16x4_t) -> float64x1_t {
 #[inline]
 #[cfg(target_endian = "big")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpret_f64_f16(a: float16x4_t) -> float64x1_t {
@@ -21516,7 +21516,7 @@ pub fn vreinterpret_f64_f16(a: float16x4_t) -> float64x1_t {
 #[inline]
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpretq_f64_f16(a: float16x8_t) -> float64x2_t {
@@ -21527,7 +21527,7 @@ pub fn vreinterpretq_f64_f16(a: float16x8_t) -> float64x2_t {
 #[inline]
 #[cfg(target_endian = "big")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpretq_f64_f16(a: float16x8_t) -> float64x2_t {
@@ -21542,7 +21542,7 @@ pub fn vreinterpretq_f64_f16(a: float16x8_t) -> float64x2_t {
 #[inline]
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpret_f16_f64(a: float64x1_t) -> float16x4_t {
@@ -21553,7 +21553,7 @@ pub fn vreinterpret_f16_f64(a: float64x1_t) -> float16x4_t {
 #[inline]
 #[cfg(target_endian = "big")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpret_f16_f64(a: float64x1_t) -> float16x4_t {
@@ -21567,7 +21567,7 @@ pub fn vreinterpret_f16_f64(a: float64x1_t) -> float16x4_t {
 #[inline]
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpretq_f16_f64(a: float64x2_t) -> float16x8_t {
@@ -21578,7 +21578,7 @@ pub fn vreinterpretq_f16_f64(a: float64x2_t) -> float16x8_t {
 #[inline]
 #[cfg(target_endian = "big")]
 #[target_feature(enable = "neon")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vreinterpretq_f16_f64(a: float64x2_t) -> float16x8_t {
@@ -23157,7 +23157,7 @@ pub fn vrnd64z_f64(a: float64x1_t) -> float64x1_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnd_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrnd_f16(a: float16x4_t) -> float16x4_t {
@@ -23167,7 +23167,7 @@ pub fn vrnd_f16(a: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintz))]
 pub fn vrndq_f16(a: float16x8_t) -> float16x8_t {
@@ -23213,7 +23213,7 @@ pub fn vrndq_f64(a: float64x2_t) -> float64x2_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrnda_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrnda_f16(a: float16x4_t) -> float16x4_t {
@@ -23223,7 +23223,7 @@ pub fn vrnda_f16(a: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndaq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frinta))]
 pub fn vrndaq_f16(a: float16x8_t) -> float16x8_t {
@@ -23289,7 +23289,7 @@ pub fn vrndh_f16(a: f16) -> f16 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndi_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frinti))]
 pub fn vrndi_f16(a: float16x4_t) -> float16x4_t {
@@ -23306,7 +23306,7 @@ pub fn vrndi_f16(a: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndiq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frinti))]
 pub fn vrndiq_f16(a: float16x8_t) -> float16x8_t {
@@ -23404,7 +23404,7 @@ pub fn vrndih_f16(a: f16) -> f16 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndm_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndm_f16(a: float16x4_t) -> float16x4_t {
@@ -23414,7 +23414,7 @@ pub fn vrndm_f16(a: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndmq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintm))]
 pub fn vrndmq_f16(a: float16x8_t) -> float16x8_t {
@@ -23535,7 +23535,7 @@ pub fn vrndns_f32(a: f32) -> f32 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndp_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndp_f16(a: float16x4_t) -> float16x4_t {
@@ -23545,7 +23545,7 @@ pub fn vrndp_f16(a: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndpq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintp))]
 pub fn vrndpq_f16(a: float16x8_t) -> float16x8_t {
@@ -23601,7 +23601,7 @@ pub fn vrndph_f16(a: f16) -> f16 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndx_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintx))]
 pub fn vrndx_f16(a: float16x4_t) -> float16x4_t {
@@ -23611,7 +23611,7 @@ pub fn vrndx_f16(a: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrndxq_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(frintx))]
 pub fn vrndxq_f16(a: float16x8_t) -> float16x8_t {
@@ -25034,7 +25034,7 @@ pub fn vsqadds_u32(a: u32, b: i32) -> u32 {
 #[inline]
 #[cfg_attr(test, assert_instr(fsqrt))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vsqrt_f16(a: float16x4_t) -> float16x4_t {
     unsafe { simd_fsqrt(a) }
@@ -25044,7 +25044,7 @@ pub fn vsqrt_f16(a: float16x4_t) -> float16x4_t {
 #[inline]
 #[cfg_attr(test, assert_instr(fsqrt))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vsqrtq_f16(a: float16x8_t) -> float16x8_t {
     unsafe { simd_fsqrt(a) }
@@ -27532,7 +27532,7 @@ pub fn vtbx4_p8(a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t) -> poly8x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn1_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(trn1))]
 pub fn vtrn1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -27542,7 +27542,7 @@ pub fn vtrn1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn1q_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(trn1))]
 pub fn vtrn1q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -27768,7 +27768,7 @@ pub fn vtrn1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn2_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(trn2))]
 pub fn vtrn2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -27778,7 +27778,7 @@ pub fn vtrn2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn2q_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(trn2))]
 pub fn vtrn2q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -28309,7 +28309,7 @@ pub fn vusdotq_laneq_s32<const LANE: i32>(a: int32x4_t, b: uint8x16_t, c: int8x1
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vuzp1_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uzp1))]
 pub fn vuzp1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -28319,7 +28319,7 @@ pub fn vuzp1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vuzp1q_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uzp1))]
 pub fn vuzp1q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -28545,7 +28545,7 @@ pub fn vuzp1q_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vuzp2_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uzp2))]
 pub fn vuzp2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -28555,7 +28555,7 @@ pub fn vuzp2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vuzp2q_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uzp2))]
 pub fn vuzp2q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -28799,7 +28799,7 @@ pub fn vxarq_u64<const IMM6: i32>(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vzip1_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(zip1))]
 pub fn vzip1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -28809,7 +28809,7 @@ pub fn vzip1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vzip1q_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(zip1))]
 pub fn vzip1q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
@@ -29035,7 +29035,7 @@ pub fn vzip1q_p64(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vzip2_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(zip2))]
 pub fn vzip2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
@@ -29045,7 +29045,7 @@ pub fn vzip2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vzip2q_f16)"]
 #[inline]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(zip2))]
 pub fn vzip2q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -819,7 +819,14 @@ pub fn vabaq_u8(a: uint8x16_t, b: uint8x16_t, c: uint8x16_t) -> uint8x16_t {
     assert_instr(fabd)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vabd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -842,7 +849,14 @@ pub fn vabd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fabd)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vabdq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -1406,7 +1420,14 @@ pub fn vabdl_u32(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     assert_instr(fabs)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vabs_f16(a: float16x4_t) -> float16x4_t {
     unsafe { simd_fabs(a) }
@@ -1421,7 +1442,14 @@ pub fn vabs_f16(a: float16x4_t) -> float16x4_t {
     assert_instr(fabs)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vabsq_f16(a: float16x8_t) -> float16x8_t {
     unsafe { simd_fabs(a) }
@@ -1643,7 +1671,14 @@ pub fn vabsh_f16(a: f16) -> f16 {
     assert_instr(fadd)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vadd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe { simd_add(a, b) }
@@ -1658,7 +1693,14 @@ pub fn vadd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fadd)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vaddq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe { simd_add(a, b) }
@@ -3835,7 +3877,14 @@ pub fn vbicq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(bsl)
 )]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vbsl_f16(a: uint16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     let not = int16x4_t::splat(-1);
@@ -3856,7 +3905,14 @@ pub fn vbsl_f16(a: uint16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(bsl)
 )]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vbslq_f16(a: uint16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
     let not = int16x8_t::splat(-1);
@@ -4471,7 +4527,14 @@ pub fn vbslq_u8(a: uint8x16_t, b: uint8x16_t, c: uint8x16_t) -> uint8x16_t {
     assert_instr(facge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcage_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe extern "unadjusted" {
@@ -4494,7 +4557,14 @@ pub fn vcage_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(facge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcageq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
@@ -4575,7 +4645,14 @@ pub fn vcageq_f32(a: float32x4_t, b: float32x4_t) -> uint32x4_t {
     assert_instr(facgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcagt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe extern "unadjusted" {
@@ -4598,7 +4675,14 @@ pub fn vcagt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(facgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcagtq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe extern "unadjusted" {
@@ -4679,7 +4763,14 @@ pub fn vcagtq_f32(a: float32x4_t, b: float32x4_t) -> uint32x4_t {
     assert_instr(facge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcale_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     vcage_f16(b, a)
@@ -4694,7 +4785,14 @@ pub fn vcale_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(facge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcaleq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     vcageq_f16(b, a)
@@ -4751,7 +4849,14 @@ pub fn vcaleq_f32(a: float32x4_t, b: float32x4_t) -> uint32x4_t {
     assert_instr(facgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcalt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     vcagt_f16(b, a)
@@ -4766,7 +4871,14 @@ pub fn vcalt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(facgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcaltq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     vcagtq_f16(b, a)
@@ -4823,7 +4935,14 @@ pub fn vcaltq_f32(a: float32x4_t, b: float32x4_t) -> uint32x4_t {
     assert_instr(fcmeq)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vceq_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe { simd_eq(a, b) }
@@ -4838,7 +4957,14 @@ pub fn vceq_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(fcmeq)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vceqq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe { simd_eq(a, b) }
@@ -5189,7 +5315,14 @@ pub fn vceqq_p8(a: poly8x16_t, b: poly8x16_t) -> uint8x16_t {
     assert_instr(fcmge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcge_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe { simd_ge(a, b) }
@@ -5204,7 +5337,14 @@ pub fn vcge_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(fcmge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgeq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe { simd_ge(a, b) }
@@ -5513,7 +5653,14 @@ pub fn vcgeq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(fcmge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgez_f16(a: float16x4_t) -> uint16x4_t {
     let b: f16x4 = f16x4::new(0.0, 0.0, 0.0, 0.0);
@@ -5529,7 +5676,14 @@ pub fn vcgez_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(fcmge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgezq_f16(a: float16x8_t) -> uint16x8_t {
     let b: f16x8 = f16x8::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -5545,7 +5699,14 @@ pub fn vcgezq_f16(a: float16x8_t) -> uint16x8_t {
     assert_instr(fcmgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe { simd_gt(a, b) }
@@ -5560,7 +5721,14 @@ pub fn vcgt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(fcmgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgtq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe { simd_gt(a, b) }
@@ -5869,7 +6037,14 @@ pub fn vcgtq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(fcmgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgtz_f16(a: float16x4_t) -> uint16x4_t {
     let b: f16x4 = f16x4::new(0.0, 0.0, 0.0, 0.0);
@@ -5885,7 +6060,14 @@ pub fn vcgtz_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(fcmgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcgtzq_f16(a: float16x8_t) -> uint16x8_t {
     let b: f16x8 = f16x8::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -5901,7 +6083,14 @@ pub fn vcgtzq_f16(a: float16x8_t) -> uint16x8_t {
     assert_instr(fcmge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcle_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe { simd_le(a, b) }
@@ -5916,7 +6105,14 @@ pub fn vcle_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(fcmge)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcleq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe { simd_le(a, b) }
@@ -6225,7 +6421,14 @@ pub fn vcleq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(fcmle)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vclez_f16(a: float16x4_t) -> uint16x4_t {
     let b: f16x4 = f16x4::new(0.0, 0.0, 0.0, 0.0);
@@ -6241,7 +6444,14 @@ pub fn vclez_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(fcmle)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vclezq_f16(a: float16x8_t) -> uint16x8_t {
     let b: f16x8 = f16x8::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -6557,7 +6767,14 @@ pub fn vclsq_u32(a: uint32x4_t) -> int32x4_t {
     assert_instr(fcmgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vclt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     unsafe { simd_lt(a, b) }
@@ -6572,7 +6789,14 @@ pub fn vclt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t {
     assert_instr(fcmgt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcltq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t {
     unsafe { simd_lt(a, b) }
@@ -6881,7 +7105,14 @@ pub fn vcltq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(fcmlt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcltz_f16(a: float16x4_t) -> uint16x4_t {
     let b: f16x4 = f16x4::new(0.0, 0.0, 0.0, 0.0);
@@ -6897,7 +7128,14 @@ pub fn vcltz_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(fcmlt)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcltzq_f16(a: float16x8_t) -> uint16x8_t {
     let b: f16x8 = f16x8::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -7572,7 +7810,14 @@ pub fn vcntq_p8(a: poly8x16_t) -> poly8x16_t {
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vcombine_f16(a: float16x4_t, b: float16x4_t) -> float16x8_t {
@@ -7794,7 +8039,14 @@ pub fn vcombine_p64(a: poly64x1_t, b: poly64x1_t) -> poly64x2_t {
     assert_instr(nop)
 )]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcreate_f16(a: u64) -> float16x4_t {
     unsafe { transmute(a) }
@@ -7811,7 +8063,14 @@ pub fn vcreate_f16(a: u64) -> float16x4_t {
     assert_instr(nop)
 )]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcreate_f16(a: u64) -> float16x4_t {
     unsafe {
@@ -8316,7 +8575,14 @@ pub fn vcreate_p64(a: u64) -> poly64x1_t {
     assert_instr(fcvtn)
 )]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_f16_f32(a: float32x4_t) -> float16x4_t {
     unsafe { simd_cast(a) }
@@ -8331,7 +8597,14 @@ pub fn vcvt_f16_f32(a: float32x4_t) -> float16x4_t {
     assert_instr(scvtf)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_f16_s16(a: int16x4_t) -> float16x4_t {
     unsafe { simd_cast(a) }
@@ -8346,7 +8619,14 @@ pub fn vcvt_f16_s16(a: int16x4_t) -> float16x4_t {
     assert_instr(scvtf)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_f16_s16(a: int16x8_t) -> float16x8_t {
     unsafe { simd_cast(a) }
@@ -8361,7 +8641,14 @@ pub fn vcvtq_f16_s16(a: int16x8_t) -> float16x8_t {
     assert_instr(ucvtf)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_f16_u16(a: uint16x4_t) -> float16x4_t {
     unsafe { simd_cast(a) }
@@ -8376,7 +8663,14 @@ pub fn vcvt_f16_u16(a: uint16x4_t) -> float16x4_t {
     assert_instr(ucvtf)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_f16_u16(a: uint16x8_t) -> float16x8_t {
     unsafe { simd_cast(a) }
@@ -8392,7 +8686,14 @@ pub fn vcvtq_f16_u16(a: uint16x8_t) -> float16x8_t {
     assert_instr(fcvtl)
 )]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_f32_f16(a: float16x4_t) -> float32x4_t {
     unsafe { simd_cast(a) }
@@ -8492,7 +8793,14 @@ pub fn vcvtq_f32_u32(a: uint32x4_t) -> float32x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_n_f16_s16<const N: i32>(a: int16x4_t) -> float16x4_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8520,7 +8828,14 @@ pub fn vcvt_n_f16_s16<const N: i32>(a: int16x4_t) -> float16x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_n_f16_s16<const N: i32>(a: int16x8_t) -> float16x8_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8548,7 +8863,14 @@ pub fn vcvtq_n_f16_s16<const N: i32>(a: int16x8_t) -> float16x8_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_n_f16_u16<const N: i32>(a: uint16x4_t) -> float16x4_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8576,7 +8898,14 @@ pub fn vcvt_n_f16_u16<const N: i32>(a: uint16x4_t) -> float16x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_n_f16_u16<const N: i32>(a: uint16x8_t) -> float16x8_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8756,7 +9085,14 @@ pub fn vcvtq_n_f32_u32<const N: i32>(a: uint32x4_t) -> float32x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_n_s16_f16<const N: i32>(a: float16x4_t) -> int16x4_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8784,7 +9120,14 @@ pub fn vcvt_n_s16_f16<const N: i32>(a: float16x4_t) -> int16x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_n_s16_f16<const N: i32>(a: float16x8_t) -> int16x8_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8888,7 +9231,14 @@ pub fn vcvtq_n_s32_f32<const N: i32>(a: float32x4_t) -> int32x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_n_u16_f16<const N: i32>(a: float16x4_t) -> uint16x4_t {
     static_assert!(N >= 1 && N <= 16);
@@ -8916,7 +9266,14 @@ pub fn vcvt_n_u16_f16<const N: i32>(a: float16x4_t) -> uint16x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_n_u16_f16<const N: i32>(a: float16x8_t) -> uint16x8_t {
     static_assert!(N >= 1 && N <= 16);
@@ -9019,7 +9376,14 @@ pub fn vcvtq_n_u32_f32<const N: i32>(a: float32x4_t) -> uint32x4_t {
     assert_instr(fcvtzs)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_s16_f16(a: float16x4_t) -> int16x4_t {
     unsafe { simd_cast(a) }
@@ -9034,7 +9398,14 @@ pub fn vcvt_s16_f16(a: float16x4_t) -> int16x4_t {
     assert_instr(fcvtzs)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_s16_f16(a: float16x8_t) -> int16x8_t {
     unsafe { simd_cast(a) }
@@ -9107,7 +9478,14 @@ pub fn vcvtq_s32_f32(a: float32x4_t) -> int32x4_t {
     assert_instr(fcvtzu)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvt_u16_f16(a: float16x4_t) -> uint16x4_t {
     unsafe { simd_cast(a) }
@@ -9122,7 +9500,14 @@ pub fn vcvt_u16_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(fcvtzu)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vcvtq_u16_f16(a: float16x8_t) -> uint16x8_t {
     unsafe { simd_cast(a) }
@@ -9559,7 +9944,14 @@ pub fn vdotq_u32(a: uint32x4_t, b: uint8x16_t, c: uint8x16_t) -> uint32x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vdup_lane_f16<const N: i32>(a: float16x4_t) -> float16x4_t {
     static_assert_uimm_bits!(N, 2);
@@ -9577,7 +9969,14 @@ pub fn vdup_lane_f16<const N: i32>(a: float16x4_t) -> float16x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vdupq_lane_f16<const N: i32>(a: float16x4_t) -> float16x8_t {
     static_assert_uimm_bits!(N, 2);
@@ -10124,7 +10523,14 @@ pub fn vdup_lane_u64<const N: i32>(a: uint64x1_t) -> uint64x1_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vdup_laneq_f16<const N: i32>(a: float16x8_t) -> float16x4_t {
     static_assert_uimm_bits!(N, 3);
@@ -10142,7 +10548,14 @@ pub fn vdup_laneq_f16<const N: i32>(a: float16x8_t) -> float16x4_t {
 )]
 #[rustc_legacy_const_generics(1)]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vdupq_laneq_f16<const N: i32>(a: float16x8_t) -> float16x8_t {
     static_assert_uimm_bits!(N, 3);
@@ -11652,7 +12065,14 @@ pub fn veorq_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 )]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vext_f16<const N: i32>(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     static_assert_uimm_bits!(N, 2);
@@ -12024,7 +12444,14 @@ pub fn vextq_p16<const N: i32>(a: poly16x8_t, b: poly16x8_t) -> poly16x8_t {
 )]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vextq_f16<const N: i32>(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     static_assert_uimm_bits!(N, 3);
@@ -12605,7 +13032,14 @@ pub fn vextq_p8<const N: i32>(a: poly8x16_t, b: poly8x16_t) -> poly8x16_t {
     assert_instr(fmla)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfma_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     unsafe { simd_fma(b, c, a) }
@@ -12620,7 +13054,14 @@ pub fn vfma_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     assert_instr(fmla)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
     unsafe { simd_fma(b, c, a) }
@@ -12720,7 +13161,14 @@ pub fn vfmaq_n_f32(a: float32x4_t, b: float32x4_t, c: f32) -> float32x4_t {
     assert_instr(fmls)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfms_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     unsafe {
@@ -12739,7 +13187,14 @@ pub fn vfms_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t {
     assert_instr(fmls)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vfmsq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t {
     unsafe {
@@ -12843,7 +13298,14 @@ pub fn vfmsq_n_f32(a: float32x4_t, b: float32x4_t, c: f32) -> float32x4_t {
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vget_high_f16(a: float16x8_t) -> float16x4_t {
@@ -12855,7 +13317,14 @@ pub fn vget_high_f16(a: float16x8_t) -> float16x4_t {
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(test, assert_instr(nop))]
 pub fn vget_low_f16(a: float16x8_t) -> float16x4_t {
@@ -19431,7 +19900,7 @@ unsafe fn vld1q_v8i16<const ALIGN: i32>(a: *const i8) -> int16x8_t {
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
 #[cfg(not(target_arch = "arm64ec"))]
 unsafe fn vld1_v4f16(a: *const i8, b: i32) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -19445,7 +19914,7 @@ unsafe fn vld1_v4f16(a: *const i8, b: i32) -> float16x4_t {
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(nop))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
 #[cfg(not(target_arch = "arm64ec"))]
 unsafe fn vld1q_v8f16(a: *const i8, b: i32) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -27522,7 +27991,14 @@ pub unsafe fn vldrq_p128(a: *const p128) -> p128 {
     assert_instr(fmax)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmax_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -27545,7 +28021,14 @@ pub fn vmax_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fmax)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmaxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -27914,7 +28397,14 @@ pub fn vmaxq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(fmaxnm)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe { simd_fmax(a, b) }
@@ -27929,7 +28419,14 @@ pub fn vmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fmaxnm)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe { simd_fmax(a, b) }
@@ -27986,7 +28483,14 @@ pub fn vmaxnmq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     assert_instr(fmin)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmin_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -28009,7 +28513,14 @@ pub fn vmin_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fmin)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vminq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -28378,7 +28889,14 @@ pub fn vminq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(fminnm)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe { simd_fmin(a, b) }
@@ -28393,7 +28911,14 @@ pub fn vminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fminnm)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe { simd_fmin(a, b) }
@@ -32322,7 +32847,14 @@ pub fn vmovn_u64(a: uint64x2_t) -> uint32x2_t {
     assert_instr(fmul)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmul_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe { simd_mul(a, b) }
@@ -32337,7 +32869,14 @@ pub fn vmul_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fmul)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe { simd_mul(a, b) }
@@ -32395,7 +32934,14 @@ pub fn vmulq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
 )]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmul_lane_f16<const LANE: i32>(a: float16x4_t, v: float16x4_t) -> float16x4_t {
     static_assert_uimm_bits!(LANE, 2);
@@ -32417,7 +32963,14 @@ pub fn vmul_lane_f16<const LANE: i32>(a: float16x4_t, v: float16x4_t) -> float16
 )]
 #[rustc_legacy_const_generics(2)]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vmulq_lane_f16<const LANE: i32>(a: float16x8_t, v: float16x4_t) -> float16x8_t {
     static_assert_uimm_bits!(LANE, 2);
@@ -34382,7 +34935,14 @@ pub fn vmvnq_u8(a: uint8x16_t) -> uint8x16_t {
     assert_instr(fneg)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vneg_f16(a: float16x4_t) -> float16x4_t {
     unsafe { simd_neg(a) }
@@ -34397,7 +34957,14 @@ pub fn vneg_f16(a: float16x4_t) -> float16x4_t {
     assert_instr(fneg)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vnegq_f16(a: float16x8_t) -> float16x8_t {
     unsafe { simd_neg(a) }
@@ -35628,7 +36195,14 @@ pub fn vpadalq_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
     assert_instr(faddp)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vpadd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -41703,7 +42277,14 @@ pub fn vraddhn_u64(a: uint64x2_t, b: uint64x2_t) -> uint32x2_t {
     assert_instr(frecpe)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrecpe_f16(a: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -41726,7 +42307,14 @@ pub fn vrecpe_f16(a: float16x4_t) -> float16x4_t {
     assert_instr(frecpe)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrecpeq_f16(a: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -41865,7 +42453,14 @@ pub fn vrecpeq_u32(a: uint32x4_t) -> uint32x4_t {
     assert_instr(frecps)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrecps_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -41888,7 +42483,14 @@ pub fn vrecps_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(frecps)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrecpsq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -41970,7 +42572,14 @@ pub fn vrecpsq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f32_f16(a: float16x4_t) -> float32x2_t {
     unsafe { transmute(a) }
@@ -41986,7 +42595,14 @@ pub fn vreinterpret_f32_f16(a: float16x4_t) -> float32x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f32_f16(a: float16x4_t) -> float32x2_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42006,7 +42622,14 @@ pub fn vreinterpret_f32_f16(a: float16x4_t) -> float32x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s8_f16(a: float16x4_t) -> int8x8_t {
     unsafe { transmute(a) }
@@ -42022,7 +42645,14 @@ pub fn vreinterpret_s8_f16(a: float16x4_t) -> int8x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s8_f16(a: float16x4_t) -> int8x8_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42042,7 +42672,14 @@ pub fn vreinterpret_s8_f16(a: float16x4_t) -> int8x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s16_f16(a: float16x4_t) -> int16x4_t {
     unsafe { transmute(a) }
@@ -42058,7 +42695,14 @@ pub fn vreinterpret_s16_f16(a: float16x4_t) -> int16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s16_f16(a: float16x4_t) -> int16x4_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42078,7 +42722,14 @@ pub fn vreinterpret_s16_f16(a: float16x4_t) -> int16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s32_f16(a: float16x4_t) -> int32x2_t {
     unsafe { transmute(a) }
@@ -42094,7 +42745,14 @@ pub fn vreinterpret_s32_f16(a: float16x4_t) -> int32x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s32_f16(a: float16x4_t) -> int32x2_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42114,7 +42772,14 @@ pub fn vreinterpret_s32_f16(a: float16x4_t) -> int32x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s64_f16(a: float16x4_t) -> int64x1_t {
     unsafe { transmute(a) }
@@ -42130,7 +42795,14 @@ pub fn vreinterpret_s64_f16(a: float16x4_t) -> int64x1_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_s64_f16(a: float16x4_t) -> int64x1_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42147,7 +42819,14 @@ pub fn vreinterpret_s64_f16(a: float16x4_t) -> int64x1_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u8_f16(a: float16x4_t) -> uint8x8_t {
     unsafe { transmute(a) }
@@ -42163,7 +42842,14 @@ pub fn vreinterpret_u8_f16(a: float16x4_t) -> uint8x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u8_f16(a: float16x4_t) -> uint8x8_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42183,7 +42869,14 @@ pub fn vreinterpret_u8_f16(a: float16x4_t) -> uint8x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u16_f16(a: float16x4_t) -> uint16x4_t {
     unsafe { transmute(a) }
@@ -42199,7 +42892,14 @@ pub fn vreinterpret_u16_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u16_f16(a: float16x4_t) -> uint16x4_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42219,7 +42919,14 @@ pub fn vreinterpret_u16_f16(a: float16x4_t) -> uint16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u32_f16(a: float16x4_t) -> uint32x2_t {
     unsafe { transmute(a) }
@@ -42235,7 +42942,14 @@ pub fn vreinterpret_u32_f16(a: float16x4_t) -> uint32x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u32_f16(a: float16x4_t) -> uint32x2_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42255,7 +42969,14 @@ pub fn vreinterpret_u32_f16(a: float16x4_t) -> uint32x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u64_f16(a: float16x4_t) -> uint64x1_t {
     unsafe { transmute(a) }
@@ -42271,7 +42992,14 @@ pub fn vreinterpret_u64_f16(a: float16x4_t) -> uint64x1_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_u64_f16(a: float16x4_t) -> uint64x1_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42288,7 +43016,14 @@ pub fn vreinterpret_u64_f16(a: float16x4_t) -> uint64x1_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_p8_f16(a: float16x4_t) -> poly8x8_t {
     unsafe { transmute(a) }
@@ -42304,7 +43039,14 @@ pub fn vreinterpret_p8_f16(a: float16x4_t) -> poly8x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_p8_f16(a: float16x4_t) -> poly8x8_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42324,7 +43066,14 @@ pub fn vreinterpret_p8_f16(a: float16x4_t) -> poly8x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_p16_f16(a: float16x4_t) -> poly16x4_t {
     unsafe { transmute(a) }
@@ -42340,7 +43089,14 @@ pub fn vreinterpret_p16_f16(a: float16x4_t) -> poly16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_p16_f16(a: float16x4_t) -> poly16x4_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42360,7 +43116,14 @@ pub fn vreinterpret_p16_f16(a: float16x4_t) -> poly16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f32_f16(a: float16x8_t) -> float32x4_t {
     unsafe { transmute(a) }
@@ -42376,7 +43139,14 @@ pub fn vreinterpretq_f32_f16(a: float16x8_t) -> float32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f32_f16(a: float16x8_t) -> float32x4_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42396,7 +43166,14 @@ pub fn vreinterpretq_f32_f16(a: float16x8_t) -> float32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s8_f16(a: float16x8_t) -> int8x16_t {
     unsafe { transmute(a) }
@@ -42412,7 +43189,14 @@ pub fn vreinterpretq_s8_f16(a: float16x8_t) -> int8x16_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s8_f16(a: float16x8_t) -> int8x16_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42436,7 +43220,14 @@ pub fn vreinterpretq_s8_f16(a: float16x8_t) -> int8x16_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s16_f16(a: float16x8_t) -> int16x8_t {
     unsafe { transmute(a) }
@@ -42452,7 +43243,14 @@ pub fn vreinterpretq_s16_f16(a: float16x8_t) -> int16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s16_f16(a: float16x8_t) -> int16x8_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42472,7 +43270,14 @@ pub fn vreinterpretq_s16_f16(a: float16x8_t) -> int16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s32_f16(a: float16x8_t) -> int32x4_t {
     unsafe { transmute(a) }
@@ -42488,7 +43293,14 @@ pub fn vreinterpretq_s32_f16(a: float16x8_t) -> int32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s32_f16(a: float16x8_t) -> int32x4_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42508,7 +43320,14 @@ pub fn vreinterpretq_s32_f16(a: float16x8_t) -> int32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s64_f16(a: float16x8_t) -> int64x2_t {
     unsafe { transmute(a) }
@@ -42524,7 +43343,14 @@ pub fn vreinterpretq_s64_f16(a: float16x8_t) -> int64x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_s64_f16(a: float16x8_t) -> int64x2_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42544,7 +43370,14 @@ pub fn vreinterpretq_s64_f16(a: float16x8_t) -> int64x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u8_f16(a: float16x8_t) -> uint8x16_t {
     unsafe { transmute(a) }
@@ -42560,7 +43393,14 @@ pub fn vreinterpretq_u8_f16(a: float16x8_t) -> uint8x16_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u8_f16(a: float16x8_t) -> uint8x16_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42584,7 +43424,14 @@ pub fn vreinterpretq_u8_f16(a: float16x8_t) -> uint8x16_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u16_f16(a: float16x8_t) -> uint16x8_t {
     unsafe { transmute(a) }
@@ -42600,7 +43447,14 @@ pub fn vreinterpretq_u16_f16(a: float16x8_t) -> uint16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u16_f16(a: float16x8_t) -> uint16x8_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42620,7 +43474,14 @@ pub fn vreinterpretq_u16_f16(a: float16x8_t) -> uint16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u32_f16(a: float16x8_t) -> uint32x4_t {
     unsafe { transmute(a) }
@@ -42636,7 +43497,14 @@ pub fn vreinterpretq_u32_f16(a: float16x8_t) -> uint32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u32_f16(a: float16x8_t) -> uint32x4_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42656,7 +43524,14 @@ pub fn vreinterpretq_u32_f16(a: float16x8_t) -> uint32x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u64_f16(a: float16x8_t) -> uint64x2_t {
     unsafe { transmute(a) }
@@ -42672,7 +43547,14 @@ pub fn vreinterpretq_u64_f16(a: float16x8_t) -> uint64x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_u64_f16(a: float16x8_t) -> uint64x2_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42692,7 +43574,14 @@ pub fn vreinterpretq_u64_f16(a: float16x8_t) -> uint64x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p8_f16(a: float16x8_t) -> poly8x16_t {
     unsafe { transmute(a) }
@@ -42708,7 +43597,14 @@ pub fn vreinterpretq_p8_f16(a: float16x8_t) -> poly8x16_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p8_f16(a: float16x8_t) -> poly8x16_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42732,7 +43628,14 @@ pub fn vreinterpretq_p8_f16(a: float16x8_t) -> poly8x16_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p16_f16(a: float16x8_t) -> poly16x8_t {
     unsafe { transmute(a) }
@@ -42748,7 +43651,14 @@ pub fn vreinterpretq_p16_f16(a: float16x8_t) -> poly16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p16_f16(a: float16x8_t) -> poly16x8_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42768,7 +43678,14 @@ pub fn vreinterpretq_p16_f16(a: float16x8_t) -> poly16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_f32(a: float32x2_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -42784,7 +43701,14 @@ pub fn vreinterpret_f16_f32(a: float32x2_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_f32(a: float32x2_t) -> float16x4_t {
     let a: float32x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
@@ -42804,7 +43728,14 @@ pub fn vreinterpret_f16_f32(a: float32x2_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_f32(a: float32x4_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -42820,7 +43751,14 @@ pub fn vreinterpretq_f16_f32(a: float32x4_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_f32(a: float32x4_t) -> float16x8_t {
     let a: float32x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42840,7 +43778,14 @@ pub fn vreinterpretq_f16_f32(a: float32x4_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s8(a: int8x8_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -42856,7 +43801,14 @@ pub fn vreinterpret_f16_s8(a: int8x8_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s8(a: int8x8_t) -> float16x4_t {
     let a: int8x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42876,7 +43828,14 @@ pub fn vreinterpret_f16_s8(a: int8x8_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s8(a: int8x16_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -42892,7 +43851,14 @@ pub fn vreinterpretq_f16_s8(a: int8x16_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s8(a: int8x16_t) -> float16x8_t {
     let a: int8x16_t =
@@ -42913,7 +43879,14 @@ pub fn vreinterpretq_f16_s8(a: int8x16_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s16(a: int16x4_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -42929,7 +43902,14 @@ pub fn vreinterpret_f16_s16(a: int16x4_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s16(a: int16x4_t) -> float16x4_t {
     let a: int16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -42949,7 +43929,14 @@ pub fn vreinterpret_f16_s16(a: int16x4_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s16(a: int16x8_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -42965,7 +43952,14 @@ pub fn vreinterpretq_f16_s16(a: int16x8_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s16(a: int16x8_t) -> float16x8_t {
     let a: int16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -42985,7 +43979,14 @@ pub fn vreinterpretq_f16_s16(a: int16x8_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s32(a: int32x2_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43001,7 +44002,14 @@ pub fn vreinterpret_f16_s32(a: int32x2_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s32(a: int32x2_t) -> float16x4_t {
     let a: int32x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
@@ -43021,7 +44029,14 @@ pub fn vreinterpret_f16_s32(a: int32x2_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s32(a: int32x4_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43037,7 +44052,14 @@ pub fn vreinterpretq_f16_s32(a: int32x4_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s32(a: int32x4_t) -> float16x8_t {
     let a: int32x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -43057,7 +44079,14 @@ pub fn vreinterpretq_f16_s32(a: int32x4_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s64(a: int64x1_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43073,7 +44102,14 @@ pub fn vreinterpret_f16_s64(a: int64x1_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_s64(a: int64x1_t) -> float16x4_t {
     unsafe {
@@ -43092,7 +44128,14 @@ pub fn vreinterpret_f16_s64(a: int64x1_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s64(a: int64x2_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43108,7 +44151,14 @@ pub fn vreinterpretq_f16_s64(a: int64x2_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_s64(a: int64x2_t) -> float16x8_t {
     let a: int64x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
@@ -43128,7 +44178,14 @@ pub fn vreinterpretq_f16_s64(a: int64x2_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u8(a: uint8x8_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43144,7 +44201,14 @@ pub fn vreinterpret_f16_u8(a: uint8x8_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u8(a: uint8x8_t) -> float16x4_t {
     let a: uint8x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -43164,7 +44228,14 @@ pub fn vreinterpret_f16_u8(a: uint8x8_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u8(a: uint8x16_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43180,7 +44251,14 @@ pub fn vreinterpretq_f16_u8(a: uint8x16_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u8(a: uint8x16_t) -> float16x8_t {
     let a: uint8x16_t =
@@ -43201,7 +44279,14 @@ pub fn vreinterpretq_f16_u8(a: uint8x16_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u16(a: uint16x4_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43217,7 +44302,14 @@ pub fn vreinterpret_f16_u16(a: uint16x4_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u16(a: uint16x4_t) -> float16x4_t {
     let a: uint16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -43237,7 +44329,14 @@ pub fn vreinterpret_f16_u16(a: uint16x4_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u16(a: uint16x8_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43253,7 +44352,14 @@ pub fn vreinterpretq_f16_u16(a: uint16x8_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u16(a: uint16x8_t) -> float16x8_t {
     let a: uint16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -43273,7 +44379,14 @@ pub fn vreinterpretq_f16_u16(a: uint16x8_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u32(a: uint32x2_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43289,7 +44402,14 @@ pub fn vreinterpret_f16_u32(a: uint32x2_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u32(a: uint32x2_t) -> float16x4_t {
     let a: uint32x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
@@ -43309,7 +44429,14 @@ pub fn vreinterpret_f16_u32(a: uint32x2_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u32(a: uint32x4_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43325,7 +44452,14 @@ pub fn vreinterpretq_f16_u32(a: uint32x4_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u32(a: uint32x4_t) -> float16x8_t {
     let a: uint32x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -43345,7 +44479,14 @@ pub fn vreinterpretq_f16_u32(a: uint32x4_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u64(a: uint64x1_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43361,7 +44502,14 @@ pub fn vreinterpret_f16_u64(a: uint64x1_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_u64(a: uint64x1_t) -> float16x4_t {
     unsafe {
@@ -43380,7 +44528,14 @@ pub fn vreinterpret_f16_u64(a: uint64x1_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u64(a: uint64x2_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43396,7 +44551,14 @@ pub fn vreinterpretq_f16_u64(a: uint64x2_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_u64(a: uint64x2_t) -> float16x8_t {
     let a: uint64x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
@@ -43416,7 +44578,14 @@ pub fn vreinterpretq_f16_u64(a: uint64x2_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_p8(a: poly8x8_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43432,7 +44601,14 @@ pub fn vreinterpret_f16_p8(a: poly8x8_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_p8(a: poly8x8_t) -> float16x4_t {
     let a: poly8x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -43452,7 +44628,14 @@ pub fn vreinterpret_f16_p8(a: poly8x8_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p8(a: poly8x16_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43468,7 +44651,14 @@ pub fn vreinterpretq_f16_p8(a: poly8x16_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p8(a: poly8x16_t) -> float16x8_t {
     let a: poly8x16_t =
@@ -43489,7 +44679,14 @@ pub fn vreinterpretq_f16_p8(a: poly8x16_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_p16(a: poly16x4_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43505,7 +44702,14 @@ pub fn vreinterpret_f16_p16(a: poly16x4_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_p16(a: poly16x4_t) -> float16x4_t {
     let a: poly16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -43525,7 +44729,14 @@ pub fn vreinterpret_f16_p16(a: poly16x4_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p16(a: poly16x8_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43541,7 +44752,14 @@ pub fn vreinterpretq_f16_p16(a: poly16x8_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p16(a: poly16x8_t) -> float16x8_t {
     let a: poly16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -43561,7 +44779,14 @@ pub fn vreinterpretq_f16_p16(a: poly16x8_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p128(a: p128) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43577,7 +44802,14 @@ pub fn vreinterpretq_f16_p128(a: p128) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p128(a: p128) -> float16x8_t {
     unsafe {
@@ -43596,7 +44828,14 @@ pub fn vreinterpretq_f16_p128(a: p128) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_p64_f16(a: float16x4_t) -> poly64x1_t {
     unsafe { transmute(a) }
@@ -43612,7 +44851,14 @@ pub fn vreinterpret_p64_f16(a: float16x4_t) -> poly64x1_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_p64_f16(a: float16x4_t) -> poly64x1_t {
     let a: float16x4_t = unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) };
@@ -43629,7 +44875,14 @@ pub fn vreinterpret_p64_f16(a: float16x4_t) -> poly64x1_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p128_f16(a: float16x8_t) -> p128 {
     unsafe { transmute(a) }
@@ -43645,7 +44898,14 @@ pub fn vreinterpretq_p128_f16(a: float16x8_t) -> p128 {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p128_f16(a: float16x8_t) -> p128 {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -43662,7 +44922,14 @@ pub fn vreinterpretq_p128_f16(a: float16x8_t) -> p128 {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p64_f16(a: float16x8_t) -> poly64x2_t {
     unsafe { transmute(a) }
@@ -43678,7 +44945,14 @@ pub fn vreinterpretq_p64_f16(a: float16x8_t) -> poly64x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_p64_f16(a: float16x8_t) -> poly64x2_t {
     let a: float16x8_t = unsafe { simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]) };
@@ -43698,7 +44972,14 @@ pub fn vreinterpretq_p64_f16(a: float16x8_t) -> poly64x2_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_p64(a: poly64x1_t) -> float16x4_t {
     unsafe { transmute(a) }
@@ -43714,7 +44995,14 @@ pub fn vreinterpret_f16_p64(a: poly64x1_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpret_f16_p64(a: poly64x1_t) -> float16x4_t {
     unsafe {
@@ -43733,7 +45021,14 @@ pub fn vreinterpret_f16_p64(a: poly64x1_t) -> float16x4_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p64(a: poly64x2_t) -> float16x8_t {
     unsafe { transmute(a) }
@@ -43749,7 +45044,14 @@ pub fn vreinterpretq_f16_p64(a: poly64x2_t) -> float16x8_t {
     assert_instr(nop)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vreinterpretq_f16_p64(a: poly64x2_t) -> float16x8_t {
     let a: poly64x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
@@ -57746,7 +59048,14 @@ pub fn vrev64q_u8(a: uint8x16_t) -> uint8x16_t {
     assert_instr(rev64)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrev64_f16(a: float16x4_t) -> float16x4_t {
     unsafe { simd_shuffle!(a, a, [3, 2, 1, 0]) }
@@ -57761,7 +59070,14 @@ pub fn vrev64_f16(a: float16x4_t) -> float16x4_t {
     assert_instr(rev64)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrev64q_f16(a: float16x8_t) -> float16x8_t {
     unsafe { simd_shuffle!(a, a, [3, 2, 1, 0, 7, 6, 5, 4]) }
@@ -58124,7 +59440,14 @@ pub fn vrhaddq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
     assert_instr(frintn)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrndn_f16(a: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -58146,7 +59469,14 @@ pub fn vrndn_f16(a: float16x4_t) -> float16x4_t {
     assert_instr(frintn)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrndnq_f16(a: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -59230,7 +60560,14 @@ pub fn vrshrn_n_u64<const N: i32>(a: uint64x2_t) -> uint32x2_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(frsqrte)
 )]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrsqrte_f16(a: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -59253,7 +60590,14 @@ pub fn vrsqrte_f16(a: float16x4_t) -> float16x4_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(frsqrte)
 )]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrsqrteq_f16(a: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -59392,7 +60736,14 @@ pub fn vrsqrteq_u32(a: uint32x4_t) -> uint32x4_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(frsqrts)
 )]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrsqrts_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe extern "unadjusted" {
@@ -59415,7 +60766,14 @@ pub fn vrsqrts_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(frsqrts)
 )]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vrsqrtsq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe extern "unadjusted" {
@@ -66926,7 +68284,7 @@ unsafe fn vst1q_v8i16<const ALIGN: i32>(addr: *const i8, val: int16x8_t) {
 #[cfg(target_arch = "arm")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vst1.16"))]
 unsafe fn vst1_v4f16(addr: *const i8, val: float16x4_t, align: i32) {
@@ -66944,7 +68302,7 @@ unsafe fn vst1_v4f16(addr: *const i8, val: float16x4_t, align: i32) {
 #[cfg(target_arch = "arm")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
 #[cfg(not(target_arch = "arm64ec"))]
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vst1.16"))]
 unsafe fn vst1q_v8f16(addr: *const i8, val: float16x8_t, align: i32) {
@@ -70962,7 +72320,14 @@ pub unsafe fn vstrq_p128(a: *mut p128, b: p128) {
     assert_instr(fsub)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vsub_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     unsafe { simd_sub(a, b) }
@@ -70977,7 +72342,14 @@ pub fn vsub_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
     assert_instr(fsub)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vsubq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unsafe { simd_sub(a, b) }
@@ -72910,7 +74282,14 @@ pub fn vtbx4_p8(a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t) -> poly8x8_t {
     assert_instr(trn2)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vtrn_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
     unsafe {
@@ -72933,7 +74312,14 @@ pub fn vtrn_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
     assert_instr(trn2)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vtrnq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t {
     unsafe {
@@ -74112,7 +75498,14 @@ pub fn vusmmlaq_s32(a: int32x4_t, b: uint8x16_t, c: int8x16_t) -> int32x4_t {
     assert_instr(uzp2)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vuzp_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
     unsafe {
@@ -74135,7 +75528,14 @@ pub fn vuzp_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
     assert_instr(uzp2)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vuzpq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t {
     unsafe {
@@ -74704,7 +76104,14 @@ pub fn vuzpq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
     assert_instr(zip2)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vzip_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
     unsafe {
@@ -74727,7 +76134,14 @@ pub fn vzip_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
     assert_instr(zip2)
 )]
 #[target_feature(enable = "neon,fp16")]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 #[cfg(not(target_arch = "arm64ec"))]
 pub fn vzipq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t {
     unsafe {

--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -104,7 +104,8 @@ types! {
 }
 
 types! {
-    #![unstable(feature = "stdarch_neon_f16", issue = "136306")]
+    #![cfg_attr(not(target_arch = "arm"), stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION"))]
+    #![cfg_attr(target_arch = "arm", unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800"))]
 
     /// Arm-specific 64-bit wide vector of four packed `f16`.
     pub struct float16x4_t(4 x pub(crate) f16);
@@ -747,19 +748,40 @@ pub struct uint32x4x4_t(
 /// Arm-specific type containing two `float16x4_t` vectors.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub struct float16x4x2_t(pub float16x4_t, pub float16x4_t);
 
 /// Arm-specific type containing three `float16x4_t` vectors.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub struct float16x4x3_t(pub float16x4_t, pub float16x4_t, pub float16x4_t);
 
 /// Arm-specific type containing four `float16x4_t` vectors.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub struct float16x4x4_t(
     pub float16x4_t,
     pub float16x4_t,
@@ -770,19 +792,40 @@ pub struct float16x4x4_t(
 /// Arm-specific type containing two `float16x8_t` vectors.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub struct float16x8x2_t(pub float16x8_t, pub float16x8_t);
 
 /// Arm-specific type containing three `float16x8_t` vectors.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub struct float16x8x3_t(pub float16x8_t, pub float16x8_t, pub float16x8_t);
 
 /// Arm-specific type containing four `float16x8_t` vectors.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub struct float16x8x4_t(
     pub float16x8_t,
     pub float16x8_t,

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13,6 +13,10 @@ auto_llvm_sign_conversion: false
 neon-stable: &neon-stable
   FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
 
+# #[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
+neon-stable-fp16: &neon-stable-fp16
+  FnCall: [stable, ['feature = "stdarch_neon_fp16"', 'since = "CURRENT_RUSTC_VERSION"']]
+
 # #[cfg(not(target_arch = "arm64ec"))]
 target-not-arm64ec: &target-not-arm64ec
   FnCall: [cfg, [{ FnCall: [not, ['target_arch = "arm64ec"']]}]]
@@ -1506,7 +1510,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtn2]]}]]
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1523,7 +1527,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtl2]]}]]
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1807,7 +1811,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtas]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1977,7 +1981,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtns]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1998,7 +2002,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtnu]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -2112,7 +2116,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtms]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -2133,7 +2137,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtmu]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -2328,7 +2332,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtps]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -2349,7 +2353,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtpu]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -3032,7 +3036,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [frintx]
     safety: safe
@@ -3081,7 +3085,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [frinta]
     safety: safe
@@ -3181,7 +3185,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [frintm]
     safety: safe
@@ -3231,7 +3235,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [frintp]
     safety: safe
@@ -3277,7 +3281,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [frintz]
     safety: safe
@@ -3330,7 +3334,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [frinti]
     safety: safe
@@ -5268,7 +5272,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmulx]
     safety: safe
@@ -5450,7 +5454,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fmulx, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['2']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -5651,7 +5655,7 @@ intrinsics:
     return_type: "{neon_type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fdiv]
     safety: safe
@@ -6000,7 +6004,7 @@ intrinsics:
     attr:
       - *neon-fp16
       - *enable-fcma
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     assert_instr: [fcadd]
     safety: safe
@@ -6021,7 +6025,7 @@ intrinsics:
     attr:
       - *neon-fp16
       - *enable-fcma
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     assert_instr: [fcadd]
     safety: safe
@@ -6062,7 +6066,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "neon,fcma"']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     assert_instr: [fcmla]
     safety: safe
@@ -6103,7 +6107,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "neon,fcma"']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     assert_instr: [fcmla]
     safety: safe
@@ -6145,7 +6149,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "neon,fcma"']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     assert_instr: [fcmla]
     safety: safe
@@ -6190,7 +6194,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6236,7 +6240,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6282,7 +6286,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6325,7 +6329,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "neon,fcma"']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     assert_instr: [fcmla]
     safety: safe
@@ -6371,7 +6375,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6419,7 +6423,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6467,7 +6471,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6514,7 +6518,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6558,7 +6562,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-unstable-fcma
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6969,7 +6973,7 @@ intrinsics:
     return_type: "{type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [faddp]
     safety: safe
@@ -6989,7 +6993,7 @@ intrinsics:
     return_type: "{type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmaxp]
     safety: safe
@@ -7010,7 +7014,7 @@ intrinsics:
     return_type: "{type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmaxnmp]
     safety: safe
@@ -7031,7 +7035,7 @@ intrinsics:
     return_type: "{type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fminp]
     safety: safe
@@ -7052,7 +7056,7 @@ intrinsics:
     return_type: "{type}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fminnmp]
     safety: safe
@@ -8478,7 +8482,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fsqrt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8791,7 +8795,7 @@ intrinsics:
     arguments: ["a: {type[0]}"]
     return_type: "{type[1]}"
     attr:
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [nop]
     safety: safe
@@ -9691,7 +9695,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [trn1]]}]]
     safety: safe
@@ -9753,7 +9757,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [trn2]]}]]
     safety: safe
@@ -9822,7 +9826,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [zip2]]}]]
     safety: safe
@@ -9873,7 +9877,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [zip1]]}]]
     safety: safe
@@ -9935,7 +9939,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [uzp1]]}]]
     safety: safe
@@ -10001,7 +10005,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [uzp2]]}]]
     safety: safe
@@ -10291,7 +10295,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fmla, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe
@@ -10318,7 +10322,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fmls, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe
@@ -10658,7 +10662,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcmeq]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11248,7 +11252,7 @@ intrinsics:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fmul, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['2']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe
@@ -11862,7 +11866,7 @@ intrinsics:
     attr:
       - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtau]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     safety: safe
     types:
@@ -13770,7 +13774,7 @@ intrinsics:
     attr:
       - *neon-fp16
       - *enable-fhm
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmlal2]
     safety: safe
@@ -13794,7 +13798,7 @@ intrinsics:
       - *neon-fp16
       - *enable-fhm
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe
@@ -13819,7 +13823,7 @@ intrinsics:
     attr:
       - *neon-fp16
       - *enable-fhm
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmlal]
     safety: safe
@@ -13843,7 +13847,7 @@ intrinsics:
       - *neon-fp16
       - *enable-fhm
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe
@@ -13868,7 +13872,7 @@ intrinsics:
     attr:
       - *neon-fp16
       - *enable-fhm
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmlsl2]
     safety: safe
@@ -13891,7 +13895,7 @@ intrinsics:
       - *neon-fp16
       - *enable-fhm
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe
@@ -13916,7 +13920,7 @@ intrinsics:
     attr:
       - *neon-fp16
       - *enable-fhm
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     assert_instr: [fmlsl]
     safety: safe
@@ -13939,7 +13943,7 @@ intrinsics:
       - *neon-fp16
       - *enable-fhm
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - *neon-unstable-f16
+      - *neon-stable-fp16
       - *target-not-arm64ec
     static_defs: ['const LANE: i32']
     safety: safe

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -10,6 +10,10 @@ auto_big_endian: true
 neon-stable: &neon-stable
   FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
 
+# #[stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION")]
+neon-stable-fp16: &neon-stable-fp16
+  FnCall: [stable, ['feature = "stdarch_neon_fp16"', 'since = "CURRENT_RUSTC_VERSION"']]
+
 # #[cfg_attr(target_arch = "arm", unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800"))]
 neon-cfg-arm-unstable: &neon-cfg-arm-unstable
   FnCall: ['cfg_attr', ['target_arch = "arm"', {FnCall: ['unstable', ['feature = "stdarch_arm_neon_intrinsics"', 'issue = "111800"']]}]]
@@ -50,6 +54,10 @@ neon-target-aarch64-arm64ec: &neon-target-aarch64-arm64ec
 # #[cfg_attr(not(target_arch = "arm"), stable(feature = "neon_intrinsics", since = "1.59.0"))]
 neon-not-arm-stable: &neon-not-arm-stable
   FnCall: [cfg_attr, [{ FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]}]]
+
+# #[cfg_attr(not(target_arch = "arm"), stable(feature = "stdarch_neon_fp16", since = "CURRENT_RUSTC_VERSION"))]
+neon-not-arm-stable-fp16: &neon-not-arm-stable-fp16
+  FnCall: [cfg_attr, [{ FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [stable, ['feature = "stdarch_neon_fp16"', 'since = "CURRENT_RUSTC_VERSION"']]}]]
 
 # #[cfg_attr(all(test, not(target_env = "msvc"))]
 msvc-disabled: &msvc-disabled
@@ -285,7 +293,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vabd.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fabd]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -404,7 +413,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vceq.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmeq]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -466,7 +476,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vabs]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fabs]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -566,7 +577,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcgt.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmgt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -585,7 +597,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcgt.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmgt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -664,7 +677,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcge.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmge]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -682,7 +696,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcle.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmle]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -864,7 +879,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vacgt.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [facgt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -911,7 +927,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vacge.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [facge]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -952,7 +969,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vacgt.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [facgt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -988,7 +1006,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vacge.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [facge]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1023,7 +1042,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [scvtf]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1058,7 +1078,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [ucvtf]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -1130,7 +1151,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [ucvtf, 'N = 1']]}]]
       - FnCall: [rustc_legacy_const_generics, ['1']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1162,7 +1184,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtzs, 'N = 1']]}]]
       - FnCall: [rustc_legacy_const_generics, ['1']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1194,7 +1217,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtzu, 'N = 1']]}]]
       - FnCall: [rustc_legacy_const_generics, ['1']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1253,7 +1277,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [scvtf, 'N = 1']]}]]
       - FnCall: [rustc_legacy_const_generics, ['1']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1507,7 +1532,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [dup, 'N = 4']]}]]
       - FnCall: [rustc_legacy_const_generics, ['1']]
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1546,7 +1572,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [dup, 'N = 2']]}]]
       - FnCall: [rustc_legacy_const_generics, ['1']]
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1768,7 +1795,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [ext, 'N = 3']]}]]
       - FnCall: [rustc_legacy_const_generics, ['2']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -1787,7 +1815,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [ext, 'N = 7']]}]]
       - FnCall: [rustc_legacy_const_generics, ['2']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ['const N: i32']
     safety: safe
@@ -2237,7 +2266,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vneg.{type[1]}"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fneg]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -2501,7 +2531,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vrintn]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [frintn]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -6368,7 +6399,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vmul.{type[0]}"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmul]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -6418,7 +6450,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmul, 'LANE = 1']]}]]
       - FnCall: [rustc_legacy_const_generics, ['2']]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     static_defs: ["const LANE: i32"]
     safety: safe
@@ -6622,7 +6655,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vfma]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmla]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -6732,7 +6766,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vsub.{type[0]}"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fsub]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -6751,7 +6786,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vadd.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fadd]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -7253,7 +7289,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vmax]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmax]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -7296,7 +7333,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vmaxnm]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmaxnm]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -7315,7 +7353,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vminnm]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fminnm]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -7402,7 +7441,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vmin]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmin]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -7467,7 +7507,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vpadd]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [faddp]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8311,7 +8352,8 @@ intrinsics:
       - *neon-fp16
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vrsqrts]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [frsqrts]]}]]
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8360,7 +8402,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vrecpe]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [frecpe]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8409,7 +8452,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vrecps]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [frecps]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8742,7 +8786,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [nop]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8805,7 +8850,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [nop]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -8828,7 +8874,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vrev64]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [rev64]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -9144,7 +9191,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [nop]]}]]
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -9650,7 +9698,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn1]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn2]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -9806,7 +9855,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -9877,7 +9927,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp1]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp2]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -10456,7 +10507,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcge.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmge]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -10475,7 +10527,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcge.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmge]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -10715,7 +10768,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtzu]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -10735,7 +10789,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtn]]}]]
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -10752,7 +10807,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtl]]}]]
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11227,7 +11283,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vcgt.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmgt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11246,7 +11303,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vclt.f16"']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcmlt]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11359,7 +11417,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [nop]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fmls]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11475,7 +11534,8 @@ intrinsics:
       - *neon-fp16
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vrsqrte]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [frsqrte]]}]]
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11589,7 +11649,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtzs]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:
@@ -11839,7 +11900,7 @@ intrinsics:
       - *enable-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [nop]]}]]
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-arm-unstable
       - *target-not-arm64ec
     safety:
       unsafe: [neon]
@@ -13784,7 +13845,7 @@ intrinsics:
       - *target-is-arm
       - *neon-v7
       - *neon-fp16
-      - *neon-unstable-f16
+      - *neon-arm-unstable
       - *target-not-arm64ec
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vst1.{type[4]}"']]}]]
     types:
@@ -14060,7 +14121,8 @@ intrinsics:
     attr:
       - *neon-v7
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     assert_instr: [nop]
     safety: safe
@@ -14076,7 +14138,8 @@ intrinsics:
     attr:
       - *neon-v7
       - *arm-fp16
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     assert_instr: [nop]
     safety: safe
@@ -14731,7 +14794,8 @@ intrinsics:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, { FnCall: [assert_instr, ['vbsl']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, ['bsl']]}]]
-      - *neon-unstable-f16
+      - *neon-not-arm-stable-fp16
+      - *neon-cfg-arm-unstable
       - *target-not-arm64ec
     safety: safe
     types:


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/136306 ~(blocked on https://github.com/rust-lang/rust/issues/149654)~

1. The feature gate of stablized items is `stdarch_neon_fp16`.
2. `stdarch_neon_f16` types are still unstable on arm. They're gated by `stdarch_arm_neon_intrinsics` now.
3. `stdarch_neon_f16` intrinsics are still unstable on arm. They're gated by `stdarch_arm_neon_intrinsics` now.
4. `stdarch_neon_f16` intrinsics that requires `fhm` are stable.
5. `stdarch_neon_f16` intrinsics that requires `fcma` are still unstable. They're gated by `stdarch_neon_fcma` now.
6. `stdarch_neon_f16` intrinsics that requires `lut` are still unstable. They're gated by `stdarch_neon_feat_lut` before and after this pull request.
7. `stdarch_neon_f16` intrinsics that takes or returns `f16`, `*const f16` or `*mut f16` are still unstable.

<details>
<summary> List of stablized intrinsics. </summary>

```rust
extern {
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vabd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vabdq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vabs_f16(a: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vabsq_f16(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vadd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vaddq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vbsl_f16(a: uint16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vbslq_f16(a: uint16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcage_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcageq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcagt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcagtq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcale_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcaleq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcalt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcaltq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vceq_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vceqq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcge_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgeq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgez_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgezq_f16(a: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgtq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgtz_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgtzq_f16(a: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcle_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcleq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vclez_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vclezq_f16(a: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vclt_f16(a: float16x4_t, b: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcltq_f16(a: float16x8_t, b: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcltz_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcltzq_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcombine_f16(a: float16x4_t, b: float16x4_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcreate_f16(a: u64) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcreate_f16(a: u64) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_f16_f32(a: float32x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_f16_s16(a: int16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_f16_s16(a: int16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_f16_u16(a: uint16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_f16_u16(a: uint16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_f32_f16(a: float16x4_t) -> float32x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_n_f16_s16<const N: i32>(a: int16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_n_f16_s16<const N: i32>(a: int16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_n_f16_u16<const N: i32>(a: uint16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_n_f16_u16<const N: i32>(a: uint16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_n_s16_f16<const N: i32>(a: float16x4_t) -> int16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_n_s16_f16<const N: i32>(a: float16x8_t) -> int16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_n_u16_f16<const N: i32>(a: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_n_u16_f16<const N: i32>(a: float16x8_t) -> uint16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_s16_f16(a: float16x4_t) -> int16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(1)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdup_lane_f16<const N: i32>(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(1)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdupq_lane_f16<const N: i32>(a: float16x4_t) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(1)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdup_laneq_f16<const N: i32>(a: float16x8_t) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(1)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdupq_laneq_f16<const N: i32>(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vext_f16<const N: i32>(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vextq_f16<const N: i32>(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "vfp4"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfma_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "vfp4"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "vfp4"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfms_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "vfp4"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vget_high_f16(a: float16x8_t) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vget_low_f16(a: float16x8_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmax_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp-armv8,v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp-armv8,v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmin_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp-armv8,v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp-armv8,v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmul_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmul_lane_f16<const LANE: i32>(a: float16x4_t, v: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulq_lane_f16<const LANE: i32>(
        a: float16x8_t,
        v: float16x4_t,
    ) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vneg_f16(a: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vnegq_f16(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpadd_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecpe_f16(a: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecpeq_f16(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecps_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecpsq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f32_f16(a: float16x4_t) -> float32x2_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f32_f16(a: float16x4_t) -> float32x2_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s8_f16(a: float16x4_t) -> int8x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s8_f16(a: float16x4_t) -> int8x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s16_f16(a: float16x4_t) -> int16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s16_f16(a: float16x4_t) -> int16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s32_f16(a: float16x4_t) -> int32x2_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s32_f16(a: float16x4_t) -> int32x2_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s64_f16(a: float16x4_t) -> int64x1_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_s64_f16(a: float16x4_t) -> int64x1_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u8_f16(a: float16x4_t) -> uint8x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u8_f16(a: float16x4_t) -> uint8x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u32_f16(a: float16x4_t) -> uint32x2_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u32_f16(a: float16x4_t) -> uint32x2_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u64_f16(a: float16x4_t) -> uint64x1_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_u64_f16(a: float16x4_t) -> uint64x1_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_p8_f16(a: float16x4_t) -> poly8x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_p8_f16(a: float16x4_t) -> poly8x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_p16_f16(a: float16x4_t) -> poly16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_p16_f16(a: float16x4_t) -> poly16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f32_f16(a: float16x8_t) -> float32x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f32_f16(a: float16x8_t) -> float32x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s8_f16(a: float16x8_t) -> int8x16_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s8_f16(a: float16x8_t) -> int8x16_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s32_f16(a: float16x8_t) -> int32x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s32_f16(a: float16x8_t) -> int32x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s64_f16(a: float16x8_t) -> int64x2_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_s64_f16(a: float16x8_t) -> int64x2_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u8_f16(a: float16x8_t) -> uint8x16_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u8_f16(a: float16x8_t) -> uint8x16_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u32_f16(a: float16x8_t) -> uint32x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u32_f16(a: float16x8_t) -> uint32x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u64_f16(a: float16x8_t) -> uint64x2_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_u64_f16(a: float16x8_t) -> uint64x2_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p8_f16(a: float16x8_t) -> poly8x16_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p8_f16(a: float16x8_t) -> poly8x16_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p16_f16(a: float16x8_t) -> poly16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p16_f16(a: float16x8_t) -> poly16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_f32(a: float32x2_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_f32(a: float32x2_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_f32(a: float32x4_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_f32(a: float32x4_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s8(a: int8x8_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s8(a: int8x8_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s8(a: int8x16_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s8(a: int8x16_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s16(a: int16x4_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s16(a: int16x4_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s16(a: int16x8_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s16(a: int16x8_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s32(a: int32x2_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s32(a: int32x2_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s32(a: int32x4_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s32(a: int32x4_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s64(a: int64x1_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_s64(a: int64x1_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s64(a: int64x2_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_s64(a: int64x2_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u8(a: uint8x8_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u8(a: uint8x8_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u8(a: uint8x16_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u8(a: uint8x16_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u16(a: uint16x4_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u16(a: uint16x4_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u16(a: uint16x8_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u16(a: uint16x8_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u32(a: uint32x2_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u32(a: uint32x2_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u32(a: uint32x4_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u32(a: uint32x4_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u64(a: uint64x1_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_u64(a: uint64x1_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u64(a: uint64x2_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_u64(a: uint64x2_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_p8(a: poly8x8_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_p8(a: poly8x8_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p8(a: poly8x16_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p8(a: poly8x16_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_p16(a: poly16x4_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_p16(a: poly16x4_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p16(a: poly16x8_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p16(a: poly16x8_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p128(a: p128) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p128(a: p128) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_p64_f16(a: float16x4_t) -> poly64x1_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_p64_f16(a: float16x4_t) -> poly64x1_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p128_f16(a: float16x8_t) -> p128;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p128_f16(a: float16x8_t) -> p128;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p64_f16(a: float16x8_t) -> poly64x2_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_p64_f16(a: float16x8_t) -> poly64x2_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_p64(a: poly64x1_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_p64(a: poly64x1_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p64(a: poly64x2_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_p64(a: poly64x2_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrev64_f16(a: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrev64q_f16(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp-armv8,v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndn_f16(a: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp-armv8,v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndnq_f16(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrsqrte_f16(a: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrsqrteq_f16(a: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrsqrts_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrsqrtsq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsub_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsubq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vtrn_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vtrnq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vuzp_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vuzpq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vzip_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vzipq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vceqz_f16(a: float16x4_t) -> uint16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vceqzq_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_high_f16_f32(a: float16x4_t, b: float32x4_t) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvt_high_f32_f16(a: float16x8_t) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvta_s16_f16(a: float16x4_t) -> int16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtaq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvta_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtaq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtm_s16_f16(a: float16x4_t) -> int16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtm_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtn_s16_f16(a: float16x4_t) -> int16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtn_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtp_s16_f16(a: float16x4_t) -> int16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtpq_s16_f16(a: float16x8_t) -> int16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtp_u16_f16(a: float16x4_t) -> uint16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtpq_u16_f16(a: float16x8_t) -> uint16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdiv_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdivq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfma_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfma_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x8_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmaq_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x4_t,
    ) -> float16x8_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmaq_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlal_high_f16(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x4_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlalq_high_f16(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlal_lane_high_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x4_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlal_laneq_high_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x8_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlalq_lane_high_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x4_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlalq_laneq_high_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlal_lane_low_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x4_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlal_laneq_low_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x8_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlalq_lane_low_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x4_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlalq_laneq_low_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlal_low_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlalq_low_f16(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlsl_high_f16(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x4_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlslq_high_f16(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlsl_lane_high_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x4_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlsl_laneq_high_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x8_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlslq_lane_high_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x4_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlslq_laneq_high_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlsl_lane_low_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x4_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlsl_laneq_low_f16<const LANE: i32>(
        r: float32x2_t,
        a: float16x4_t,
        b: float16x8_t,
    ) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlslq_lane_low_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x4_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[rustc_legacy_const_generics(3)]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlslq_laneq_low_f16<const LANE: i32>(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlsl_low_f16(r: float32x2_t, a: float16x4_t, b: float16x4_t) -> float32x2_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fhm"))]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmlslq_low_f16(
        r: float32x4_t,
        a: float16x8_t,
        b: float16x8_t,
    ) -> float32x4_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfms_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfms_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x8_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsq_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x4_t,
    ) -> float16x8_t;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsq_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmul_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x8_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulq_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulx_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulx_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulx_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x8_t,
    ) -> float16x4_t;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxq_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x4_t,
    ) -> float16x8_t;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxq_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpaddq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpmax_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpmaxq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpmin_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpminq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vpminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f64_f16(a: float16x4_t) -> float64x1_t;
    #[cfg(target_endian = "big")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f64_f16(a: float16x4_t) -> float64x1_t;
    #[cfg(target_endian = "little")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f64_f16(a: float16x8_t) -> float64x2_t;
    #[cfg(target_endian = "big")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f64_f16(a: float16x8_t) -> float64x2_t;
    #[cfg(target_endian = "little")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_f64(a: float64x1_t) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpret_f16_f64(a: float64x1_t) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_f64(a: float64x2_t) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vreinterpretq_f16_f64(a: float64x2_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrnd_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrnda_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndaq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndi_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndiq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndm_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndmq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndp_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndpq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndx_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndxq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsqrt_f16(a: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsqrtq_f16(a: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vtrn1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vtrn1q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vtrn2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vtrn2q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vuzp1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vuzp1q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vuzp2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vuzp2q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vzip1_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vzip1q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vzip2_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vzip2q_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
}
```

</details>

<details>
<summary> List of unstable intrinsics. </summary>

```rust
extern {
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vabsh_f16(a: f16) -> f16;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vaddh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdup_n_f16(a: f16) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdupq_n_f16(a: f16) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(1)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vget_lane_f16<const LANE: i32>(a: float16x4_t) -> f16;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(1)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vgetq_lane_f16<const LANE: i32>(a: float16x8_t) -> f16;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_dup_f16(ptr: *const f16) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_dup_f16(ptr: *const f16) -> float16x8_t;
    #[cfg(target_endian = "little")]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,v7")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_f16(ptr: *const f16) -> float16x4_t;
    #[cfg(target_endian = "big")]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,v7")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_f16(ptr: *const f16) -> float16x4_t;
    #[cfg(target_endian = "little")]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,v7")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t;
    #[cfg(target_endian = "big")]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,v7")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_f16_x2(a: *const f16) -> float16x4x2_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_f16_x3(a: *const f16) -> float16x4x3_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_f16_x4(a: *const f16) -> float16x4x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_f16_x2(a: *const f16) -> float16x8x2_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_f16_x3(a: *const f16) -> float16x8x3_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_f16_x4(a: *const f16) -> float16x8x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_lane_f16<const LANE: i32>(
        ptr: *const f16,
        src: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_lane_f16<const LANE: i32>(
        ptr: *const f16,
        src: float16x8_t,
    ) -> float16x8_t;
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,v7")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
    #[cfg(not(target_arch = "arm64ec"))]
    unsafe fn vld1_v4f16(a: *const i8, b: i32) -> float16x4_t;
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,v7")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
    #[cfg(not(target_arch = "arm64ec"))]
    unsafe fn vld1q_v8f16(a: *const i8, b: i32) -> float16x8_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2_dup_f16(a: *const f16) -> float16x4x2_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2q_dup_f16(a: *const f16) -> float16x8x2_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2_dup_f16(a: *const f16) -> float16x4x2_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2q_dup_f16(a: *const f16) -> float16x8x2_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2_f16(a: *const f16) -> float16x4x2_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2q_f16(a: *const f16) -> float16x8x2_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2_f16(a: *const f16) -> float16x4x2_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2q_f16(a: *const f16) -> float16x8x2_t;
    #[target_feature(enable = "neon,v7")]
    #[cfg(target_arch = "arm")]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x4x2_t,
    ) -> float16x4x2_t;
    #[target_feature(enable = "neon,v7")]
    #[cfg(target_arch = "arm")]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2q_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x8x2_t,
    ) -> float16x8x2_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x4x2_t,
    ) -> float16x4x2_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld2q_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x8x2_t,
    ) -> float16x8x2_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3_dup_f16(a: *const f16) -> float16x4x3_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3q_dup_f16(a: *const f16) -> float16x8x3_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3_dup_f16(a: *const f16) -> float16x4x3_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3q_dup_f16(a: *const f16) -> float16x8x3_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3_f16(a: *const f16) -> float16x4x3_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3q_f16(a: *const f16) -> float16x8x3_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3_f16(a: *const f16) -> float16x4x3_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3q_f16(a: *const f16) -> float16x8x3_t;
    #[target_feature(enable = "neon,v7")]
    #[cfg(target_arch = "arm")]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x4x3_t,
    ) -> float16x4x3_t;
    #[target_feature(enable = "neon,v7")]
    #[cfg(target_arch = "arm")]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3q_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x8x3_t,
    ) -> float16x8x3_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x4x3_t,
    ) -> float16x4x3_t;
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld3q_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x8x3_t,
    ) -> float16x8x3_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4_dup_f16(a: *const f16) -> float16x4x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4q_dup_f16(a: *const f16) -> float16x8x4_t;
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4_dup_f16(a: *const f16) -> float16x4x4_t;
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4q_dup_f16(a: *const f16) -> float16x8x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4_f16(a: *const f16) -> float16x4x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg(target_arch = "arm")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4q_f16(a: *const f16) -> float16x8x4_t;
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4_f16(a: *const f16) -> float16x4x4_t;
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4q_f16(a: *const f16) -> float16x8x4_t;
    #[target_feature(enable = "neon,v7")]
    #[cfg(target_arch = "arm")]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x4x4_t,
    ) -> float16x4x4_t;
    #[target_feature(enable = "neon,v7")]
    #[cfg(target_arch = "arm")]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4q_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x8x4_t,
    ) -> float16x8x4_t;
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x4x4_t,
    ) -> float16x4x4_t;
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld4q_lane_f16<const LANE: i32>(
        a: *const f16,
        b: float16x8x4_t,
    ) -> float16x8x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmov_n_f16(a: f16) -> float16x4_t;
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmovq_n_f16(a: f16) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmul_n_f16(a: float16x4_t, b: f16) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulq_n_f16(a: float16x8_t, b: f16) -> float16x8_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vset_lane_f16<const LANE: i32>(a: f16, b: float16x4_t) -> float16x4_t;
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsetq_lane_f16<const LANE: i32>(a: f16, b: float16x8_t) -> float16x8_t;
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16(ptr: *mut f16, a: float16x4_t);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16(ptr: *mut f16, a: float16x8_t);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16_x2(a: *mut f16, b: float16x4x2_t);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16_x2(a: *mut f16, b: float16x8x2_t);
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16_x2(a: *mut f16, b: float16x4x2_t);
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16_x2(a: *mut f16, b: float16x8x2_t);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16_x3(a: *mut f16, b: float16x4x3_t);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16_x3(a: *mut f16, b: float16x8x3_t);
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16_x3(a: *mut f16, b: float16x4x3_t);
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16_x3(a: *mut f16, b: float16x8x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16_x4(a: *mut f16, b: float16x4x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16_x4(a: *mut f16, b: float16x8x4_t);
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16_x4(a: *mut f16, b: float16x4x4_t);
    #[cfg(not(target_arch = "arm"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16_x4(a: *mut f16, b: float16x8x4_t);
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4_t);
    #[target_feature(enable = "neon")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8_t);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
    #[cfg(not(target_arch = "arm64ec"))]
    unsafe fn vst1_v4f16(addr: *const i8, val: float16x4_t, align: i32);
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")]
    #[cfg(not(target_arch = "arm64ec"))]
    unsafe fn vst1q_v8f16(addr: *const i8, val: float16x8_t, align: i32);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2_f16(a: *mut f16, b: float16x4x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2q_f16(a: *mut f16, b: float16x8x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2_f16(a: *mut f16, b: float16x4x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2q_f16(a: *mut f16, b: float16x8x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst2q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x2_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3_f16(a: *mut f16, b: float16x4x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3q_f16(a: *mut f16, b: float16x8x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3_f16(a: *mut f16, b: float16x4x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3q_f16(a: *mut f16, b: float16x8x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst3q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x3_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4_f16(a: *mut f16, b: float16x4x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4q_f16(a: *mut f16, b: float16x8x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4_f16(a: *mut f16, b: float16x4x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4q_f16(a: *mut f16, b: float16x8x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(target_arch = "arm")]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4_lane_f16<const LANE: i32>(a: *mut f16, b: float16x4x4_t);
    #[target_feature(enable = "neon")]
    #[cfg(not(target_arch = "arm"))]
    #[rustc_legacy_const_generics(2)]
    #[cfg_attr(target_arch = "arm", target_feature(enable = "fp16"))]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst4q_lane_f16<const LANE: i32>(a: *mut f16, b: float16x8x4_t);
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vabdh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcadd_rot270_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcaddq_rot270_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcadd_rot90_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[cfg_attr(not(target_arch = "arm"), target_feature(enable = "fcma"))]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcaddq_rot90_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcageh_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcagth_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcaleh_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcalth_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vceqh_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vceqzh_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgeh_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgezh_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgth_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcgtzh_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcleh_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vclezh_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vclth_f16(a: f16, b: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcltzh_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_f16(a: float16x4_t, b: float16x4_t, c: float16x4_t) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x4_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x8_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot180_f16(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot180_f16(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot180_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot180_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x4_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot180_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x8_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot180_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot270_f16(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot270_f16(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot270_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot270_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x4_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot270_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x8_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot270_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot90_f16(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot90_f16(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot90_lane_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x4_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot90_lane_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x4_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmla_rot90_laneq_f16<const LANE: i32>(
        a: float16x4_t,
        b: float16x4_t,
        c: float16x8_t,
    ) -> float16x4_t;
    #[target_feature(enable = "neon,fcma")]
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_fcma", issue = "117222")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcmlaq_rot90_laneq_f16<const LANE: i32>(
        a: float16x8_t,
        b: float16x8_t,
        c: float16x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtah_s16_f16(a: f16) -> i16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtah_s32_f16(a: f16) -> i32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtah_s64_f16(a: f16) -> i64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtah_u16_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtah_u32_f16(a: f16) -> u32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtah_u64_f16(a: f16) -> u64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_f16_s16(a: i16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_f16_s32(a: i32) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_f16_s64(a: i64) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_f16_u16(a: u16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_f16_u32(a: u32) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_f16_u64(a: u64) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_f16_s16<const N: i32>(a: i16) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_f16_s32<const N: i32>(a: i32) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_f16_s64<const N: i32>(a: i64) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_f16_u16<const N: i32>(a: u16) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_f16_u32<const N: i32>(a: u32) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_f16_u64<const N: i32>(a: u64) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_s16_f16<const N: i32>(a: f16) -> i16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_s32_f16<const N: i32>(a: f16) -> i32;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_s64_f16<const N: i32>(a: f16) -> i64;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_u16_f16<const N: i32>(a: f16) -> u16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_u32_f16<const N: i32>(a: f16) -> u32;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_n_u64_f16<const N: i32>(a: f16) -> u64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_s16_f16(a: f16) -> i16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_s32_f16(a: f16) -> i32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_s64_f16(a: f16) -> i64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_u16_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_u32_f16(a: f16) -> u32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvth_u64_f16(a: f16) -> u64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmh_s16_f16(a: f16) -> i16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmh_s32_f16(a: f16) -> i32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmh_s64_f16(a: f16) -> i64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmh_u16_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmh_u32_f16(a: f16) -> u32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtmh_u64_f16(a: f16) -> u64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnh_s16_f16(a: f16) -> i16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnh_s32_f16(a: f16) -> i32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnh_s64_f16(a: f16) -> i64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnh_u16_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnh_u32_f16(a: f16) -> u32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtnh_u64_f16(a: f16) -> u64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtph_s16_f16(a: f16) -> i16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtph_s32_f16(a: f16) -> i32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtph_s64_f16(a: f16) -> i64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtph_u16_f16(a: f16) -> u16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtph_u32_f16(a: f16) -> u32;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vcvtph_u64_f16(a: f16) -> u64;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vdivh_f16(a: f16, b: f16) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vduph_lane_f16<const N: i32>(a: float16x4_t) -> f16;
    #[rustc_legacy_const_generics(1)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vduph_laneq_f16<const N: i32>(a: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfma_n_f16(a: float16x4_t, b: float16x4_t, c: f16) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmaq_n_f16(a: float16x8_t, b: float16x8_t, c: f16) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmah_f16(a: f16, b: f16, c: f16) -> f16;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmah_lane_f16<const LANE: i32>(a: f16, b: f16, v: float16x4_t) -> f16;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmah_laneq_f16<const LANE: i32>(a: f16, b: f16, v: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfms_n_f16(a: float16x4_t, b: float16x4_t, c: f16) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsq_n_f16(a: float16x8_t, b: float16x8_t, c: f16) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsh_f16(a: f16, b: f16, c: f16) -> f16;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsh_lane_f16<const LANE: i32>(a: f16, b: f16, v: float16x4_t) -> f16;
    #[rustc_legacy_const_generics(3)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vfmsh_laneq_f16<const LANE: i32>(a: f16, b: f16, v: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1_f16(ptr: *const f16) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t;
    #[target_feature(enable = "neon,lut,fp16")]
    #[unstable(feature = "stdarch_neon_feat_lut", issue = "138050")]
    #[rustc_legacy_const_generics(2)]
    pub unsafe fn vluti4q_lane_f16_x2<const LANE: i32>(
        a: float16x8x2_t,
        b: uint8x8_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,lut,fp16")]
    #[unstable(feature = "stdarch_neon_feat_lut", issue = "138050")]
    #[rustc_legacy_const_generics(2)]
    pub unsafe fn vluti4q_laneq_f16_x2<const LANE: i32>(
        a: float16x8x2_t,
        b: uint8x16_t,
    ) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxnmh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxnmv_f16(a: float16x4_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxnmvq_f16(a: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxv_f16(a: float16x4_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmaxvq_f16(a: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminnmh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminnmv_f16(a: float16x4_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminnmvq_f16(a: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminv_f16(a: float16x4_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vminvq_f16(a: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulh_f16(a: f16, b: f16) -> f16;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulh_lane_f16<const LANE: i32>(a: f16, b: float16x4_t) -> f16;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulh_laneq_f16<const LANE: i32>(a: f16, b: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulx_n_f16(a: float16x4_t, b: f16) -> float16x4_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxq_n_f16(a: float16x8_t, b: f16) -> float16x8_t;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxh_f16(a: f16, b: f16) -> f16;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxh_lane_f16<const LANE: i32>(a: f16, b: float16x4_t) -> f16;
    #[rustc_legacy_const_generics(2)]
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vmulxh_laneq_f16<const LANE: i32>(a: f16, b: float16x8_t) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vnegh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecpeh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecpsh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrecpxh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndah_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndih_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndmh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndnh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndph_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrndxh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrsqrteh_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vrsqrtsh_f16(a: f16, b: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsqrth_f16(a: f16) -> f16;
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1_f16(ptr: *mut f16, a: float16x4_t);
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub unsafe fn vst1q_f16(ptr: *mut f16, a: float16x8_t);
    #[target_feature(enable = "neon,fp16")]
    #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
    #[cfg(not(target_arch = "arm64ec"))]
    pub fn vsubh_f16(a: f16, b: f16) -> f16;
}
```

</details>