### PR TITLE
RISC-V: Use symbolic instructions on inline assembly (part 1)

### DIFF
--- a/crates/core_arch/src/riscv_shared/mod.rs
+++ b/crates/core_arch/src/riscv_shared/mod.rs
@@ -44,9 +44,14 @@ use crate::arch::asm;
 #[inline]
 #[unstable(feature = "riscv_ext_intrinsics", issue = "114544")]
 pub fn pause() {
+    // Use `.option` directives to expose this HINT instruction
+    // (no-op if not supported by the hardware) without `#[target_feature]`.
     unsafe {
         asm!(
-            ".insn i 0x0F, 0, x0, x0, 0x010",
+            ".option push",
+            ".option arch, +zihintpause",
+            "pause",
+            ".option pop",
             options(nomem, nostack, preserves_flags)
         );
     }


### PR DESCRIPTION
While many intrinsics use `.insn` to generate raw machine code from numbers, all ratified instructions can be symbolic using `.option` directives.

By saving the assembler environment with `.option push` then modifying the architecture with `.option arch`, we can temporarily enable certain extensions (as we use `.option pop` immediately after the target instruction, surrounding environment is completely intact in this commit; *almost* completely intact in general).

This PR (part 1) modifies the `pause` *hint* intrinsic to use symbolic *instruction* because we want to expose it even if the Zihintpause extension is unavailable on the target.

----

This is the technique as the author used in rust-lang/rust#146798.