### PR TITLE
`core_arch::x86` : Fix the implementation of `_kshift` instructions

### DIFF
--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -10440,7 +10440,7 @@ pub fn _kortestz_mask64_u8(a: __mmask64, b: __mmask64) -> u8 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftli_mask32<const COUNT: u32>(a: __mmask32) -> __mmask32 {
-    a << COUNT
+    a.unbounded_shl(COUNT)
 }
 
 /// Shift the bits of 64-bit mask a left by count while shifting in zeros, and store the least significant 32 bits of the result in k.
@@ -10451,7 +10451,7 @@ pub fn _kshiftli_mask32<const COUNT: u32>(a: __mmask32) -> __mmask32 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftli_mask64<const COUNT: u32>(a: __mmask64) -> __mmask64 {
-    a << COUNT
+    a.unbounded_shl(COUNT)
 }
 
 /// Shift the bits of 32-bit mask a right by count while shifting in zeros, and store the least significant 32 bits of the result in k.
@@ -10462,7 +10462,7 @@ pub fn _kshiftli_mask64<const COUNT: u32>(a: __mmask64) -> __mmask64 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftri_mask32<const COUNT: u32>(a: __mmask32) -> __mmask32 {
-    a >> COUNT
+    a.unbounded_shr(COUNT)
 }
 
 /// Shift the bits of 64-bit mask a right by count while shifting in zeros, and store the least significant 32 bits of the result in k.
@@ -10473,7 +10473,7 @@ pub fn _kshiftri_mask32<const COUNT: u32>(a: __mmask32) -> __mmask32 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftri_mask64<const COUNT: u32>(a: __mmask64) -> __mmask64 {
-    a >> COUNT
+    a.unbounded_shr(COUNT)
 }
 
 /// Compute the bitwise AND of 32-bit masks a and b, and if the result is all zeros, store 1 in dst,
@@ -20315,6 +20315,18 @@ mod tests {
         let r = _kshiftli_mask32::<3>(a);
         let e: __mmask32 = 0b0100101101001011_0100101101001000;
         assert_eq!(r, e);
+
+        let r = _kshiftli_mask32::<31>(a);
+        let e: __mmask32 = 0b1000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask32::<32>(a);
+        let e: __mmask32 = 0b0000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask32::<33>(a);
+        let e: __mmask32 = 0b0000000000000000_0000000000000000;
+        assert_eq!(r, e);
     }
 
     #[simd_test(enable = "avx512bw")]
@@ -20323,21 +20335,61 @@ mod tests {
         let r = _kshiftli_mask64::<3>(a);
         let e: __mmask64 = 0b0110100101101001011_0100101101001000;
         assert_eq!(r, e);
+
+        let r = _kshiftli_mask64::<63>(a);
+        let e: __mmask64 = 0b1000000000000000_0000000000000000_0000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask64::<64>(a);
+        let e: __mmask64 = 0b0000000000000000_0000000000000000_0000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask64::<65>(a);
+        let e: __mmask64 = 0b0000000000000000_0000000000000000_0000000000000000_0000000000000000;
+        assert_eq!(r, e);
     }
 
     #[simd_test(enable = "avx512bw")]
     unsafe fn test_kshiftri_mask32() {
-        let a: __mmask32 = 0b0110100101101001_0110100101101001;
+        let a: __mmask32 = 0b1010100101101001_0110100101101001;
         let r = _kshiftri_mask32::<3>(a);
-        let e: __mmask32 = 0b0000110100101101_0010110100101101;
+        let e: __mmask32 = 0b0001010100101101_0010110100101101;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask32::<31>(a);
+        let e: __mmask32 = 0b0000000000000000_0000000000000001;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask32::<32>(a);
+        let e: __mmask32 = 0b0000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask32::<33>(a);
+        let e: __mmask32 = 0b0000000000000000_0000000000000000;
         assert_eq!(r, e);
     }
 
     #[simd_test(enable = "avx512bw")]
     unsafe fn test_kshiftri_mask64() {
-        let a: __mmask64 = 0b0110100101101001011_0100101101001000;
+        let a: __mmask64 = 0b1010100101101001011_0100101101001000;
         let r = _kshiftri_mask64::<3>(a);
-        let e: __mmask64 = 0b0110100101101001_0110100101101001;
+        let e: __mmask64 = 0b1010100101101001_0110100101101001;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask64::<34>(a);
+        let e: __mmask64 = 0b0000000000000000_0000000000000000_0000000000000000_0000000000000001;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask64::<35>(a);
+        let e: __mmask64 = 0b0000000000000000_0000000000000000_0000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask64::<64>(a);
+        let e: __mmask64 = 0b0000000000000000_0000000000000000_0000000000000000_0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask64::<65>(a);
+        let e: __mmask64 = 0b0000000000000000_0000000000000000_0000000000000000_0000000000000000;
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/x86/avx512dq.rs
+++ b/crates/core_arch/src/x86/avx512dq.rs
@@ -4602,7 +4602,7 @@ pub fn _kortestz_mask8_u8(a: __mmask8, b: __mmask8) -> u8 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftli_mask8<const COUNT: u32>(a: __mmask8) -> __mmask8 {
-    a << COUNT
+    a.unbounded_shl(COUNT)
 }
 
 /// Shift 8-bit mask a right by count bits while shifting in zeros, and store the result in dst.
@@ -4613,7 +4613,7 @@ pub fn _kshiftli_mask8<const COUNT: u32>(a: __mmask8) -> __mmask8 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftri_mask8<const COUNT: u32>(a: __mmask8) -> __mmask8 {
-    a >> COUNT
+    a.unbounded_shr(COUNT)
 }
 
 /// Compute the bitwise AND of 16-bit masks a and b, and if the result is all zeros, store 1 in dst,
@@ -9856,13 +9856,37 @@ mod tests {
         let r = _kshiftli_mask8::<3>(a);
         let e: __mmask8 = 0b01001000;
         assert_eq!(r, e);
+
+        let r = _kshiftli_mask8::<7>(a);
+        let e: __mmask8 = 0b10000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask8::<8>(a);
+        let e: __mmask8 = 0b00000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask8::<9>(a);
+        let e: __mmask8 = 0b00000000;
+        assert_eq!(r, e);
     }
 
     #[simd_test(enable = "avx512dq")]
     unsafe fn test_kshiftri_mask8() {
-        let a: __mmask8 = 0b01101001;
+        let a: __mmask8 = 0b10101001;
         let r = _kshiftri_mask8::<3>(a);
-        let e: __mmask8 = 0b00001101;
+        let e: __mmask8 = 0b00010101;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask8::<7>(a);
+        let e: __mmask8 = 0b00000001;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask8::<8>(a);
+        let e: __mmask8 = 0b00000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask8::<9>(a);
+        let e: __mmask8 = 0b00000000;
         assert_eq!(r, e);
     }
 

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -29090,7 +29090,7 @@ pub fn _kortestz_mask16_u8(a: __mmask16, b: __mmask16) -> u8 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftli_mask16<const COUNT: u32>(a: __mmask16) -> __mmask16 {
-    a << COUNT
+    a.unbounded_shl(COUNT)
 }
 
 /// Shift 16-bit mask a right by count bits while shifting in zeros, and store the result in dst.
@@ -29101,7 +29101,7 @@ pub fn _kshiftli_mask16<const COUNT: u32>(a: __mmask16) -> __mmask16 {
 #[rustc_legacy_const_generics(1)]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kshiftri_mask16<const COUNT: u32>(a: __mmask16) -> __mmask16 {
-    a >> COUNT
+    a.unbounded_shr(COUNT)
 }
 
 /// Load 16-bit mask from memory
@@ -56001,13 +56001,37 @@ mod tests {
         let r = _kshiftli_mask16::<3>(a);
         let e: __mmask16 = 0b1011011000011000;
         assert_eq!(r, e);
+
+        let r = _kshiftli_mask16::<15>(a);
+        let e: __mmask16 = 0b1000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask16::<16>(a);
+        let e: __mmask16 = 0b0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftli_mask16::<17>(a);
+        let e: __mmask16 = 0b0000000000000000;
+        assert_eq!(r, e);
     }
 
     #[simd_test(enable = "avx512dq")]
     unsafe fn test_kshiftri_mask16() {
-        let a: __mmask16 = 0b0110100100111100;
+        let a: __mmask16 = 0b1010100100111100;
         let r = _kshiftri_mask16::<3>(a);
-        let e: __mmask16 = 0b0000110100100111;
+        let e: __mmask16 = 0b0001010100100111;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask16::<15>(a);
+        let e: __mmask16 = 0b0000000000000001;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask16::<16>(a);
+        let e: __mmask16 = 0b0000000000000000;
+        assert_eq!(r, e);
+
+        let r = _kshiftri_mask16::<17>(a);
+        let e: __mmask16 = 0b0000000000000000;
         assert_eq!(r, e);
     }
 


### PR DESCRIPTION
# Summary
The `_kshiftri_mask32`, `_kshiftri_mask64`, `_kshiftli_mask32` and `_kshiftli_mask64` intrinsics in `core_arch::x86` module do not handle a critical edge case when the shift amount exceeds the bit-length of the input argument. 

EDIT: updated the 8-bit and 16-bit versions of the same.

# Current behaviour
For `_kshiftri_mask32` and `_kshiftli_mask32` intrinsics, when the shift amount (passed as a const-generic argument) exceeds 32, the shift amount applied to the argument becomes `shift % 32`.

Similar is the case with the 8-bit, 16-bit and 64-bit variants of the same.

[Godbolt link for the 32-bit variant with minimal replication](https://godbolt.org/z/oKea3d55f).
[Godbolt link for the 64-bit variant with minimal replication](https://godbolt.org/z/EbGhh7eo8).

# Expected behaviour
When the shift amount exceeds 32 (for the 32-bit versions) or 64 (for the 64-bit versions) the result becomes zero, in line with Intel's [documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_kshiftli_mask32&ig_expand=3943) on the same.

Similar is the case with 8-bit and 16-bit versions.

# Fix
Use `unbounded_shr()` and `unbounded_shl()` functions instead of `>>` and `<<` operations.

[Godbolt link that shows the corrected version of the 32-bit implementation](https://godbolt.org/z/x1jfh1G9n).
[Godbolt link that shows the corrected version of the 64-bit implementation](https://godbolt.org/z/EbGhh7eo8)

r? @sayantn 
cc: @folkertdev