### PR TITLE
Fix xsave segfaults

### DIFF
--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -14,5 +14,3 @@ RUN tar -xJf sde.tar.xz --strip-components=1 -C intel-sde
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/intel-sde/sde64 \
             -cpuid-in /checkout/ci/docker/x86_64-unknown-linux-gnu/cpuid.def \
             -rtm-mode full -tsx --"
-# These tests fail with SDE as it doesn't support saving register data
-ENV STDARCH_TEST_SKIP_FUNCTION="xsave,xsaveopt,xsave64,xsaveopt64"

--- a/crates/core_arch/src/x86_64/xsave.rs
+++ b/crates/core_arch/src/x86_64/xsave.rs
@@ -126,28 +126,9 @@ pub unsafe fn _xrstors64(mem_addr: *const u8, rs_mask: u64) {
 
 #[cfg(test)]
 mod tests {
-    use crate::core_arch::x86_64::xsave;
-    use std::fmt;
+    use crate::core_arch::x86::*;
+    use crate::core_arch::x86_64::*;
     use stdarch_test::simd_test;
-
-    #[repr(align(64))]
-    #[derive(Debug)]
-    struct XsaveArea {
-        // max size for 256-bit registers is 800 bytes:
-        // see https://software.intel.com/en-us/node/682996
-        // max size for 512-bit registers is 2560 bytes:
-        // FIXME: add source
-        data: [u8; 2560],
-    }
-
-    impl XsaveArea {
-        fn new() -> XsaveArea {
-            XsaveArea { data: [0; 2560] }
-        }
-        fn ptr(&mut self) -> *mut u8 {
-            self.data.as_mut_ptr()
-        }
-    }
 
     #[simd_test(enable = "xsave")]
     #[cfg_attr(miri, ignore)] // Register saving/restoring is not supported in Miri
@@ -156,9 +137,9 @@ mod tests {
         let mut a = XsaveArea::new();
         let mut b = XsaveArea::new();
 
-        xsave::_xsave64(a.ptr(), m);
-        xsave::_xrstor64(a.ptr(), m);
-        xsave::_xsave64(b.ptr(), m);
+        _xsave64(a.ptr(), m);
+        _xrstor64(a.ptr(), m);
+        _xsave64(b.ptr(), m);
     }
 
     #[simd_test(enable = "xsave,xsaveopt")]
@@ -168,9 +149,9 @@ mod tests {
         let mut a = XsaveArea::new();
         let mut b = XsaveArea::new();
 
-        xsave::_xsaveopt64(a.ptr(), m);
-        xsave::_xrstor64(a.ptr(), m);
-        xsave::_xsaveopt64(b.ptr(), m);
+        _xsaveopt64(a.ptr(), m);
+        _xrstor64(a.ptr(), m);
+        _xsaveopt64(b.ptr(), m);
     }
 
     #[simd_test(enable = "xsave,xsavec")]
@@ -180,8 +161,8 @@ mod tests {
         let mut a = XsaveArea::new();
         let mut b = XsaveArea::new();
 
-        xsave::_xsavec64(a.ptr(), m);
-        xsave::_xrstor64(a.ptr(), m);
-        xsave::_xsavec64(b.ptr(), m);
+        _xsavec64(a.ptr(), m);
+        _xrstor64(a.ptr(), m);
+        _xsavec64(b.ptr(), m);
     }
 }


### PR DESCRIPTION
It turns out that MSVC was right, and we were wrong (such a weird thing to say).

Our `xsave` tests used a fixed-size 2560 byte buffer for saving all register data. But the problem is that the required size for xsave is not fixed, it depends on the CPU. This piece of code is ancient, and when it was written the authors calculated this limit based on the typical size. But currently, the maximum size required for xsave can be as high as 11892 bytes (heck on my laptop it is 2696 bytes, if anyone wants to try it out the code is in [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=98d5ba7f35621ded6d71e191ae5cb999)), for our SDE run it is 11008 bytes (which also explains why these tests were disabled in the `x86_64-unknown-linux-gnu` run, due to such a huge discrepancy in size, it always generated a segfault). So in a way, MSVC helped us detect this bug.

See rust-lang/stdarch#1933 for some more context

As for why we are only seeing this now, if the CPU only supports up to AVX, 2560 bytes is enough space, but my guess is that GH introduced some better (windows?) runners, with AVX512 or AMX support, and both of those are capable of skyrocketing the XSAVE area size.

I will still rerun the CI a few times to ensure no weird random behavior is snooping around.