### PR TITLE
Implement fjcvtzs under the name __jcvt like the C intrinsic

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -46,6 +46,22 @@ pub fn __crc32d(crc: u32, data: u64) -> u32 {
     }
     unsafe { ___crc32d(crc, data) }
 }
+#[doc = "Floating-point JavaScript convert to signed fixed-point, rounding toward zero"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__jcvt)"]
+#[inline]
+#[target_feature(enable = "jsconv")]
+#[cfg_attr(test, assert_instr(fjcvtzs))]
+#[unstable(feature = "stdarch_aarch64_jscvt", issue = "147555")]
+pub fn __jcvt(a: f64) -> i32 {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            any(target_arch = "aarch64", target_arch = "arm64ec"),
+            link_name = "llvm.aarch64.fjcvtzs"
+        )]
+        fn ___jcvt(a: f64) -> i32;
+    }
+    unsafe { ___jcvt(a) }
+}
 #[doc = "Signed Absolute difference and Accumulate Long"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabal_high_s8)"]
 #[inline]

--- a/crates/intrinsic-test/src/arm/config.rs
+++ b/crates/intrinsic-test/src/arm/config.rs
@@ -121,6 +121,7 @@ pub const AARCH_CONFIGURATIONS: &str = r#"
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_i8mm))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sm4))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_ftts))]
+#![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_aarch64_jscvt))]
 #![feature(fmt_helpers_for_derive)]
 #![feature(stdarch_neon_f16)]
 

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -63,6 +63,9 @@ neon-unstable-f16: &neon-unstable-f16
 neon-unstable-feat-lut: &neon-unstable-feat-lut
   FnCall: [unstable, ['feature = "stdarch_neon_feat_lut"', 'issue = "138050"']]
 
+aarch64-unstable-jscvt: &aarch64-unstable-jscvt
+  FnCall: [unstable, ['feature = "stdarch_aarch64_jscvt"', 'issue = "147555"']]
+
 # #[cfg(target_endian = "little")]
 little-endian: &little-endian
   FnCall: [cfg, ['target_endian = "little"']]
@@ -14265,3 +14268,21 @@ intrinsics:
                 - 'vluti4q_laneq_{neon_type[5]}_x2::<LANE>'
                 - - FnCall: [transmute, [a]]
                   - b
+
+  - name: "__jcvt"
+    doc: "Floating-point JavaScript convert to signed fixed-point, rounding toward zero"
+    arguments: ["a: {type}"]
+    return_type: "i32"
+    attr:
+      - FnCall: [target_feature, ['enable = "jsconv"']]
+      - FnCall: [cfg_attr, [test, { FnCall: [assert_instr, ["fjcvtzs"]] }]]
+      - *aarch64-unstable-jscvt
+    safety: safe
+    types:
+      - f64
+    compose:
+      - LLVMLink:
+          name: "fjcvtzs"
+          links:
+            - link: "llvm.aarch64.fjcvtzs"
+              arch: aarch64,arm64ec

--- a/intrinsics_data/arm_intrinsics.json
+++ b/intrinsics_data/arm_intrinsics.json
@@ -119753,5 +119753,28 @@
         "LUTI4"
       ]
     ]
+  },
+  {
+    "SIMD_ISA": "Neon",
+    "name": "__jcvt",
+    "arguments": [
+      "float64_t a"
+    ],
+    "return_type": {
+      "value": "int32_t"
+    },
+    "Arguments_Preparation": {
+      "a": {
+        "register": "Dn"
+      }
+    },
+    "Architectures": [
+      "A64"
+    ],
+    "instructions": [
+      [
+        "FJCVTZS"
+      ]
+    ]
   }
 ]


### PR DESCRIPTION
This instruction is only available when the `jsconv` target_feature is available, so on ARMv8.3 or higher.

It is used e.g. by [Ruffle](https://github.com/ruffle-rs/ruffle/pull/21780) to speed up its conversion from `f64` to `i32`, or by any JS engine probably.

I got redirected to this repository from https://github.com/rust-lang/rust/pull/147517