### PR TITLE
crc32: remove `#[cfg(not(target_arch = "arm"))]` from aarch64 crc functions

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -16,7 +16,6 @@ use super::*;
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32cd)"]
 #[inline]
 #[target_feature(enable = "crc")]
-#[cfg(not(target_arch = "arm"))]
 #[cfg_attr(test, assert_instr(crc32cx))]
 #[stable(feature = "stdarch_aarch64_crc32", since = "1.80.0")]
 pub fn __crc32cd(crc: u32, data: u64) -> u32 {
@@ -33,7 +32,6 @@ pub fn __crc32cd(crc: u32, data: u64) -> u32 {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/__crc32d)"]
 #[inline]
 #[target_feature(enable = "crc")]
-#[cfg(not(target_arch = "arm"))]
 #[cfg_attr(test, assert_instr(crc32x))]
 #[stable(feature = "stdarch_aarch64_crc32", since = "1.80.0")]
 pub fn __crc32d(crc: u32, data: u64) -> u32 {

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13,10 +13,6 @@ auto_llvm_sign_conversion: false
 neon-stable: &neon-stable
   FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
 
-# #[cfg(not(target_arch = "arm"))]
-target-not-arm: &target-not-arm
-  FnCall: [cfg, [{ FnCall: [not, ['target_arch = "arm"']]}]]
-
 # #[cfg(not(target_arch = "arm64ec"))]
 target-not-arm64ec: &target-not-arm64ec
   FnCall: [cfg, [{ FnCall: [not, ['target_arch = "arm64ec"']]}]]
@@ -13082,7 +13078,6 @@ intrinsics:
     return_type: "{type[0]}"
     attr:
       - FnCall: [target_feature, ['enable = "crc"']]
-      - *target-not-arm
       - FnCall: [cfg_attr, [test, { FnCall: [assert_instr, ["crc32x"]] }]]
       - *aarch64-crc-stable
     safety: safe
@@ -13104,7 +13099,6 @@ intrinsics:
     return_type: "{type[0]}"
     attr:
       - FnCall: [target_feature, ['enable = "crc"']]
-      - *target-not-arm
       - FnCall: [cfg_attr, [test, { FnCall: [assert_instr, ["crc32cx"]] }]]
       - *aarch64-crc-stable
     safety: safe


### PR DESCRIPTION
They are defined in the aarch64 module, so this cfg is pointless. These two instructions, operating on 64-bit input, are only available on aarch64, not on arm.

