### PR TITLE
Make `__cpuid_count()` a pure function

### DIFF
--- a/crates/core_arch/src/x86/cpuid.rs
+++ b/crates/core_arch/src/x86/cpuid.rs
@@ -67,7 +67,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             inout("eax") leaf => eax,
             inout("ecx") sub_leaf => ecx,
             out("edx") edx,
-            options(nostack, preserves_flags),
+            options(nostack, nomem, pure, preserves_flags),
         );
     }
     #[cfg(target_arch = "x86_64")]
@@ -80,7 +80,7 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
             inout("eax") leaf => eax,
             inout("ecx") sub_leaf => ecx,
             out("edx") edx,
-            options(nostack, preserves_flags),
+            options(nostack, nomem, pure, preserves_flags),
         );
     }
     CpuidResult { eax, ebx, ecx, edx }


### PR DESCRIPTION
Refiled from <https://github.com/rust-lang/rust/pull/147961>.

Crates like [`raw_cpuid`](https://docs.rs/raw_cpuid) use `core::arch::x86_64::__cpuid_count()` to determine x86 CPU information.  It's great that core provides such a function, instead of having to write inline assembly everywhere; but core's implementation does not use the `asm!` attributes `pure` and `nomem`.  This means that calls to `__cpuid_count()` can't be elided or deduplicated.  I'm writing some target-feature enhancement code (akin to [`multiversion`](https://docs.rs/multiversion)), and I'd like to rely on CPUID getting optimized away appropriately.

While CPUID is a serializing instruction, that's not the primary use case for it.  There are several possible approaches to separating the primary use case (where it can be treated as a pure function) from secondary use cases (where it needs to be impure):

1. Make `__cpuid_count()` pure and require inline assembly for secondary use cases.  _(implemented in this PR)_

   Secondary use cases are IMO quite rare and their users probably don't mind using inline assembly manually, in order to control LLVM thoroughly.  But this is might be considered a breaking change.
 
2. Make `__cpuid_count()` pure and introduce `__impure_cpuid_count()` for secondary use cases.

   This would simplify the updating of secondary use cases, but might still be considered a breaking change.  It would also require replicating `__cpuid()` and __get_cpuid_max()`.
  
3. Leave `__cpuid_count()` as-is and introduce `__pure_cpuid_count()`.

   This would not be a breaking change; however, I find it unfortunate that the primary use case for this function would be relegated to a more inconvenient function name.  Once an approach is stabilized, it would be harder to transition to an (IMO) ideal world where `__cpuid_count()` is pure.

I think approach 1 is ideal, but it's a (minor?) breaking change, and I'll leave that judgement to the reviewer.