### PR TITLE
Enable assert_instr for wasm32 throw

### DIFF
--- a/ci/docker/wasm32-wasip1/Dockerfile
+++ b/ci/docker/wasm32-wasip1/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   clang
 
-ENV VERSION=v34.0.1
+ENV VERSION=v38.0.3
 
 RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz | tar xJf -
 ENV PATH=$PATH:/wasmtime-${VERSION}-x86_64-linux
 
-ENV CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime --dir /checkout/target/wasm32-wasip1/release/deps::."
+ENV CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime -Wexceptions --dir /checkout/target/wasm32-wasip1/release/deps::."

--- a/crates/core_arch/src/wasm32/mod.rs
+++ b/crates/core_arch/src/wasm32/mod.rs
@@ -185,10 +185,7 @@ unsafe extern "C-unwind" {
 ///
 /// [`throw`]: https://webassembly.github.io/exception-handling/core/syntax/instructions.html#syntax-instr-control
 /// [exception-handling proposal]: https://github.com/WebAssembly/exception-handling
-// FIXME: wasmtime does not currently support exception-handling, so cannot execute
-//        a wasm module with the throw instruction in it. once it does, we can
-//        reenable this attribute.
-// #[cfg_attr(test, assert_instr(throw, TAG = 0, ptr = core::ptr::null_mut()))]
+#[cfg_attr(test, assert_instr(throw, TAG = 0, ptr = core::ptr::null_mut()))]
 #[inline]
 #[unstable(feature = "wasm_exception_handling_intrinsics", issue = "122465")]
 // FIXME: Since this instruction unwinds, `core` built with `-C panic=unwind`


### PR DESCRIPTION
As of [`wasmtime` 37.0](https://github.com/bytecodealliance/wasmtime/blob/release-37.0.0/RELEASES.md#3700) wasmtime supports the exception-handling proposal, which means we can uncomment the `assert_instr` for the `throw` intrinsic.