### PR TITLE
use `byte_add` in gfni tests

### DIFF
--- a/crates/core_arch/src/x86/gfni.rs
+++ b/crates/core_arch/src/x86/gfni.rs
@@ -881,26 +881,20 @@ mod tests {
     }
 
     #[target_feature(enable = "sse2")]
-    #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
     unsafe fn load_m128i_word<T>(data: &[T], word_index: usize) -> __m128i {
-        let byte_offset = word_index * 16 / size_of::<T>();
-        let pointer = data.as_ptr().add(byte_offset) as *const __m128i;
+        let pointer = data.as_ptr().byte_add(word_index * 16) as *const __m128i;
         _mm_loadu_si128(black_box(pointer))
     }
 
     #[target_feature(enable = "avx")]
-    #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
     unsafe fn load_m256i_word<T>(data: &[T], word_index: usize) -> __m256i {
-        let byte_offset = word_index * 32 / size_of::<T>();
-        let pointer = data.as_ptr().add(byte_offset) as *const __m256i;
+        let pointer = data.as_ptr().byte_add(word_index * 32) as *const __m256i;
         _mm256_loadu_si256(black_box(pointer))
     }
 
     #[target_feature(enable = "avx512f")]
-    #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
     unsafe fn load_m512i_word<T>(data: &[T], word_index: usize) -> __m512i {
-        let byte_offset = word_index * 64 / size_of::<T>();
-        let pointer = data.as_ptr().add(byte_offset) as *const _;
+        let pointer = data.as_ptr().byte_add(word_index * 64) as *const __m512i;
         _mm512_loadu_si512(black_box(pointer))
     }
 


### PR DESCRIPTION
looking at https://github.com/rust-lang/stdarch/pull/1944 CI hit an error in these functions. That is a problem, but I think this implementation is just clearer. I'm not sure how these helper functions got the `#[stable]` attribute, that does not seem useful.