### PR TITLE
remove a use of `core::intrinsics::size_of`

### DIFF
--- a/crates/core_arch/src/x86/gfni.rs
+++ b/crates/core_arch/src/x86/gfni.rs
@@ -745,7 +745,6 @@ mod tests {
     #![allow(overflowing_literals)]
 
     use core::hint::black_box;
-    use core::intrinsics::size_of;
     use stdarch_test::simd_test;
 
     use crate::core_arch::x86::*;


### PR DESCRIPTION
use of the intrinsic, rather than the stable function, is probably an accident.

This import was unused since https://github.com/rust-lang/stdarch/pull/1945. That fix was needed because we ran into https://github.com/rust-lang/rust/issues/148104. That makes sense in retrospect, the intrinsic should not be used in normal code where `core::mem::size_of` is available.