### PR TITLE
rename default branch to main

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -16,7 +16,7 @@ jobs:
       # https://rust-lang.zulipchat.com/#narrow/channel/208962-t-libs.2Fstdarch/topic/Subtree.20sync.20automation/with/528461782
       zulip-stream-id: 208962
       zulip-bot-email:  "stdarch-ci-bot@rust-lang.zulipchat.com"
-      pr-base-branch: master
+      pr-base-branch: main
       branch-name: rustc-pull
     secrets:
       zulip-api-token: ${{ secrets.ZULIP_API_TOKEN }}

--- a/crates/core_arch/README.md
+++ b/crates/core_arch/README.md
@@ -3,7 +3,7 @@
 
 The `core::arch` module implements architecture-dependent intrinsics (e.g. SIMD).
 
-# Usage 
+# Usage
 
 `core::arch` is available as part of `libcore` and it is re-exported by
 `libstd`. Prefer using it via `core::arch` or `std::arch` than via this crate.
@@ -17,7 +17,7 @@ are:
   you need to re-compile it for a non-standard target, please prefer using
   `xargo` and re-compiling `libcore`/`libstd` as appropriate instead of using
   this crate.
-  
+
 * using some features that might not be available even behind unstable Rust
   features. We try to keep these to a minimum. If you need to use some of these
   features, please open an issue so that we can expose them in nightly Rust and
@@ -34,7 +34,7 @@ are:
 * [How to get started][contrib]
 * [How to help implement intrinsics][help-implement]
 
-[contrib]: https://github.com/rust-lang/stdarch/blob/master/CONTRIBUTING.md
+[contrib]: https://github.com/rust-lang/stdarch/blob/HEAD/CONTRIBUTING.md
 [help-implement]: https://github.com/rust-lang/stdarch/issues/40
 [i686]: https://rust-lang.github.io/stdarch/i686/core_arch/
 [x86_64]: https://rust-lang.github.io/stdarch/x86_64/core_arch/


### PR DESCRIPTION
Related to https://github.com/rust-lang/infra-team/issues/227

Migration guide:
- [x] confirm that no other rust-lang projects hardcode the `master` branch name (stdarch maintainer)
- [x] approve this PR (stdarch maintainer)
- [x] approve team PR https://github.com/rust-lang/team/pull/2068 (another infra admin)
- [x] Change the branch name in the GitHub settings of the repo (Marco)
- [x] merge this PR (Marco)
- [x] merge team PR https://github.com/rust-lang/team/pull/2068 (Marco)