### PR TITLE
improve ternary logic tests

### DIFF
--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -46240,22 +46240,25 @@ mod tests {
 
     #[simd_test(enable = "avx512f")]
     unsafe fn test_mm512_ternarylogic_epi32() {
+        use core::intrinsics::simd::simd_xor;
+
         let a = _mm512_set4_epi32(0b100, 0b110, 0b001, 0b101);
-        let b = _mm512_set4_epi32(0b010, 0b011, 0b001, 0b101);
-        let c = _mm512_set4_epi32(0b001, 0b000, 0b001, 0b101);
+        let b = _mm512_set4_epi32(0b010, 0b011, 0b001, 0b110);
+        let c = _mm512_set4_epi32(0b001, 0b000, 0b001, 0b111);
 
         // Identity of A.
         let r = _mm512_ternarylogic_epi32::<0b1111_0000>(a, b, c);
         assert_eq_m512i(r, a);
 
-        // Bitwise or.
-        let r = _mm512_ternarylogic_epi32::<0b1111_1110>(a, b, c);
-        let e = _mm512_set4_epi32(0b111, 0b111, 0b001, 0b101);
+        // Bitwise xor.
+        let r = _mm512_ternarylogic_epi32::<0b10010110>(a, b, c);
+        let e = _mm512_set4_epi32(0b111, 0b101, 0b001, 0b100);
         assert_eq_m512i(r, e);
+        assert_eq_m512i(r, simd_xor(simd_xor(a, b), c));
 
-        // Majority.
+        // Majority (2 or more bits set).
         let r = _mm512_ternarylogic_epi32::<0b1110_1000>(a, b, c);
-        let e = _mm512_set4_epi32(0b000, 0b010, 0b001, 0b101);
+        let e = _mm512_set4_epi32(0b000, 0b010, 0b001, 0b111);
         assert_eq_m512i(r, e);
     }
 
@@ -46285,24 +46288,27 @@ mod tests {
 
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm256_ternarylogic_epi32() {
+        use core::intrinsics::simd::simd_xor;
+
         let _mm256_set4_epi32 = |a, b, c, d| _mm256_setr_epi32(a, b, c, d, a, b, c, d);
 
         let a = _mm256_set4_epi32(0b100, 0b110, 0b001, 0b101);
-        let b = _mm256_set4_epi32(0b010, 0b011, 0b001, 0b101);
-        let c = _mm256_set4_epi32(0b001, 0b000, 0b001, 0b101);
+        let b = _mm256_set4_epi32(0b010, 0b011, 0b001, 0b110);
+        let c = _mm256_set4_epi32(0b001, 0b000, 0b001, 0b111);
 
         // Identity of A.
         let r = _mm256_ternarylogic_epi32::<0b1111_0000>(a, b, c);
         assert_eq_m256i(r, a);
 
-        // Bitwise or.
-        let r = _mm256_ternarylogic_epi32::<0b1111_1110>(a, b, c);
-        let e = _mm256_set4_epi32(0b111, 0b111, 0b001, 0b101);
+        // Bitwise xor.
+        let r = _mm256_ternarylogic_epi32::<0b10010110>(a, b, c);
+        let e = _mm256_set4_epi32(0b111, 0b101, 0b001, 0b100);
         assert_eq_m256i(r, e);
+        assert_eq_m256i(r, simd_xor(simd_xor(a, b), c));
 
-        // Majority.
+        // Majority (2 or more bits set).
         let r = _mm256_ternarylogic_epi32::<0b1110_1000>(a, b, c);
-        let e = _mm256_set4_epi32(0b000, 0b010, 0b001, 0b101);
+        let e = _mm256_set4_epi32(0b000, 0b010, 0b001, 0b111);
         assert_eq_m256i(r, e);
     }
 
@@ -46332,22 +46338,25 @@ mod tests {
 
     #[simd_test(enable = "avx512f,avx512vl")]
     unsafe fn test_mm_ternarylogic_epi32() {
+        use core::intrinsics::simd::simd_xor;
+
         let a = _mm_setr_epi32(0b100, 0b110, 0b001, 0b101);
-        let b = _mm_setr_epi32(0b010, 0b011, 0b001, 0b101);
-        let c = _mm_setr_epi32(0b001, 0b000, 0b001, 0b101);
+        let b = _mm_setr_epi32(0b010, 0b011, 0b001, 0b110);
+        let c = _mm_setr_epi32(0b001, 0b000, 0b001, 0b111);
 
         // Identity of A.
         let r = _mm_ternarylogic_epi32::<0b1111_0000>(a, b, c);
         assert_eq_m128i(r, a);
 
-        // Bitwise or.
-        let r = _mm_ternarylogic_epi32::<0b1111_1110>(a, b, c);
-        let e = _mm_setr_epi32(0b111, 0b111, 0b001, 0b101);
+        // Bitwise xor.
+        let r = _mm_ternarylogic_epi32::<0b10010110>(a, b, c);
+        let e = _mm_setr_epi32(0b111, 0b101, 0b001, 0b100);
         assert_eq_m128i(r, e);
+        assert_eq_m128i(r, simd_xor(simd_xor(a, b), c));
 
-        // Majority.
+        // Majority (2 or more bits set).
         let r = _mm_ternarylogic_epi32::<0b1110_1000>(a, b, c);
-        let e = _mm_setr_epi32(0b000, 0b010, 0b001, 0b101);
+        let e = _mm_setr_epi32(0b000, 0b010, 0b001, 0b111);
         assert_eq_m128i(r, e);
     }
 


### PR DESCRIPTION
follow-up to https://github.com/rust-lang/stdarch/pull/1958

r? @sayantn when Ralf approves