### PR TITLE
use `wrapping_add` for `_kadd` intrinsics

### DIFF
--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -10254,7 +10254,7 @@ pub fn _cvtu32_mask32(a: u32) -> __mmask32 {
 #[target_feature(enable = "avx512bw")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kadd_mask32(a: __mmask32, b: __mmask32) -> __mmask32 {
-    a + b
+    a.wrapping_add(b)
 }
 
 /// Add 64-bit masks in a and b, and store the result in k.
@@ -10264,7 +10264,7 @@ pub fn _kadd_mask32(a: __mmask32, b: __mmask32) -> __mmask32 {
 #[target_feature(enable = "avx512bw")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kadd_mask64(a: __mmask64, b: __mmask64) -> __mmask64 {
-    a + b
+    a.wrapping_add(b)
 }
 
 /// Compute the bitwise AND of 32-bit masks a and b, and store the result in k.

--- a/crates/core_arch/src/x86/avx512dq.rs
+++ b/crates/core_arch/src/x86/avx512dq.rs
@@ -4486,7 +4486,7 @@ pub fn _cvtu32_mask8(a: u32) -> __mmask8 {
 #[target_feature(enable = "avx512dq")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kadd_mask16(a: __mmask16, b: __mmask16) -> __mmask16 {
-    a + b
+    a.wrapping_add(b)
 }
 
 /// Add 8-bit masks a and b, and store the result in dst.
@@ -4496,7 +4496,7 @@ pub fn _kadd_mask16(a: __mmask16, b: __mmask16) -> __mmask16 {
 #[target_feature(enable = "avx512dq")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _kadd_mask8(a: __mmask8, b: __mmask8) -> __mmask8 {
-    a + b
+    a.wrapping_add(b)
 }
 
 /// Bitwise AND of 8-bit masks a and b, and store the result in dst.


### PR DESCRIPTION
Intel specifies these as follows (e.g. for `_kadd_mask16`)
```
k[15:0] := a[15:0] + b[15:0]
k[MAX:16] := 0
```
so these should use `wrapping_add`