### PR TITLE
Remove `[no-mentions]` handler in our triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -56,7 +56,3 @@ Thanks!
 # Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
 [issue-links]
 check-commits = false
-
-# Prevents mentions in commits to avoid users being spammed
-# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
-[no-mentions]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in our triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225