### PR TITLE
thread, grid, and block dim/idx can only return non-negative values

### DIFF
--- a/crates/core_arch/src/nvptx/mod.rs
+++ b/crates/core_arch/src/nvptx/mod.rs
@@ -23,29 +23,29 @@ unsafe extern "C" {
     #[link_name = "llvm.nvvm.barrier0"]
     fn syncthreads() -> ();
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.x"]
-    fn block_dim_x() -> i32;
+    fn block_dim_x() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.y"]
-    fn block_dim_y() -> i32;
+    fn block_dim_y() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.z"]
-    fn block_dim_z() -> i32;
+    fn block_dim_z() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.x"]
-    fn block_idx_x() -> i32;
+    fn block_idx_x() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.y"]
-    fn block_idx_y() -> i32;
+    fn block_idx_y() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.z"]
-    fn block_idx_z() -> i32;
+    fn block_idx_z() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.nctaid.x"]
-    fn grid_dim_x() -> i32;
+    fn grid_dim_x() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.nctaid.y"]
-    fn grid_dim_y() -> i32;
+    fn grid_dim_y() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.nctaid.z"]
-    fn grid_dim_z() -> i32;
+    fn grid_dim_z() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.tid.x"]
-    fn thread_idx_x() -> i32;
+    fn thread_idx_x() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.tid.y"]
-    fn thread_idx_y() -> i32;
+    fn thread_idx_y() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.tid.z"]
-    fn thread_idx_z() -> i32;
+    fn thread_idx_z() -> u32;
 }
 
 /// Synchronizes all threads in the block.
@@ -58,84 +58,84 @@ pub unsafe fn _syncthreads() -> () {
 /// x-th thread-block dimension.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _block_dim_x() -> i32 {
+pub unsafe fn _block_dim_x() -> u32 {
     block_dim_x()
 }
 
 /// y-th thread-block dimension.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _block_dim_y() -> i32 {
+pub unsafe fn _block_dim_y() -> u32 {
     block_dim_y()
 }
 
 /// z-th thread-block dimension.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _block_dim_z() -> i32 {
+pub unsafe fn _block_dim_z() -> u32 {
     block_dim_z()
 }
 
 /// x-th thread-block index.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _block_idx_x() -> i32 {
+pub unsafe fn _block_idx_x() -> u32 {
     block_idx_x()
 }
 
 /// y-th thread-block index.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _block_idx_y() -> i32 {
+pub unsafe fn _block_idx_y() -> u32 {
     block_idx_y()
 }
 
 /// z-th thread-block index.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _block_idx_z() -> i32 {
+pub unsafe fn _block_idx_z() -> u32 {
     block_idx_z()
 }
 
 /// x-th block-grid dimension.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _grid_dim_x() -> i32 {
+pub unsafe fn _grid_dim_x() -> u32 {
     grid_dim_x()
 }
 
 /// y-th block-grid dimension.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _grid_dim_y() -> i32 {
+pub unsafe fn _grid_dim_y() -> u32 {
     grid_dim_y()
 }
 
 /// z-th block-grid dimension.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _grid_dim_z() -> i32 {
+pub unsafe fn _grid_dim_z() -> u32 {
     grid_dim_z()
 }
 
 /// x-th thread index.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _thread_idx_x() -> i32 {
+pub unsafe fn _thread_idx_x() -> u32 {
     thread_idx_x()
 }
 
 /// y-th thread index.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _thread_idx_y() -> i32 {
+pub unsafe fn _thread_idx_y() -> u32 {
     thread_idx_y()
 }
 
 /// z-th thread index.
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
-pub unsafe fn _thread_idx_z() -> i32 {
+pub unsafe fn _thread_idx_z() -> u32 {
     thread_idx_z()
 }
 


### PR DESCRIPTION
Based on the previous discussion in
https://rust-lang.zulipchat.com/#narrow/channel/422870-t-compiler.2Fgpgpu-backend/topic/Return.20type.20of.20NVPTX.20index.20and.20dimension.20intrinsics

Also matching amdgpu: https://doc.rust-lang.org/nightly/core/arch/amdgpu/fn.workitem_id_x.html

r? @workingjubilee
