### PR TITLE
Remove fp16 target feature from some intrinsics

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -9487,7 +9487,7 @@ pub fn vdivq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg(not(target_arch = "arm64ec"))]
-#[cfg_attr(test, assert_instr(nop))]
+#[cfg_attr(test, assert_instr(fdiv))]
 pub fn vdivh_f16(a: f16, b: f16) -> f16 {
     a / b
 }
@@ -14829,7 +14829,7 @@ pub fn vmuld_lane_f64<const LANE: i32>(a: f64, b: float64x1_t) -> f64 {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg(not(target_arch = "arm64ec"))]
-#[cfg_attr(test, assert_instr(nop))]
+#[cfg_attr(test, assert_instr(fmul))]
 pub fn vmulh_f16(a: f16, b: f16) -> f16 {
     a * b
 }
@@ -26719,7 +26719,7 @@ pub fn vsubq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(nop))]
+#[cfg_attr(test, assert_instr(sub))]
 pub fn vsubd_s64(a: i64, b: i64) -> i64 {
     a.wrapping_sub(b)
 }
@@ -26728,7 +26728,7 @@ pub fn vsubd_s64(a: i64, b: i64) -> i64 {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(nop))]
+#[cfg_attr(test, assert_instr(sub))]
 pub fn vsubd_u64(a: u64, b: u64) -> u64 {
     a.wrapping_sub(b)
 }
@@ -26738,7 +26738,7 @@ pub fn vsubd_u64(a: u64, b: u64) -> u64 {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg(not(target_arch = "arm64ec"))]
-#[cfg_attr(test, assert_instr(nop))]
+#[cfg_attr(test, assert_instr(fsub))]
 pub fn vsubh_f16(a: f16, b: f16) -> f16 {
     a - b
 }

--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -8310,7 +8310,7 @@ pub fn vcreate_p64(a: u64) -> poly64x1_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
-# [cfg_attr (all (test , target_arch = "arm") , assert_instr (vcvt . f16 . f32))]
+#[cfg_attr(all(test, target_arch = "arm"), assert_instr(vcvt))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
     assert_instr(fcvtn)

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -5669,7 +5669,7 @@ intrinsics:
       - *neon-fp16
       - *neon-unstable-f16
       - *target-not-arm64ec
-    assert_instr: [nop]
+    assert_instr: [fdiv]
     safety: safe
     types:
       - [f16, 'h']
@@ -5694,7 +5694,7 @@ intrinsics:
     arguments: ["a: {type[1]}", "b: {type[1]}"]
     return_type: "{type[1]}"
     attr: [*neon-stable]
-    assert_instr: [nop]
+    assert_instr: [sub]
     safety: safe
     types:
       - ['d_s64', 'i64']
@@ -5710,7 +5710,7 @@ intrinsics:
       - *neon-fp16
       - *neon-unstable-f16
       - *target-not-arm64ec
-    assert_instr: [nop]
+    assert_instr: [fsub]
     safety: safe
     types:
       - ['h_f16', 'f16']
@@ -11271,7 +11271,7 @@ intrinsics:
       - *neon-fp16
       - *neon-unstable-f16
       - *target-not-arm64ec
-    assert_instr: [nop]
+    assert_instr: [fmul]
     safety: safe
     types:
       - [f16, 'h']

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -10732,7 +10732,7 @@ intrinsics:
     return_type: "{neon_type[1]}"
     attr:
       - *neon-v7
-      - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt.f16.f32]]}]]
+      - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vcvt]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [fcvtn]]}]]
       - *arm-fp16
       - *neon-unstable-f16


### PR DESCRIPTION
The instructions for some f16 intrinsics are available in the base neon feature (DUP/INS variants, store/loads and the fp conversion instructions FCVTL/FCVTN). This relaxes the requirement for the fp16 target feature on aarch64 for these intrinsics, which doesn't affect codegen/ABI.

This change makes it possible to create the Neon types on non-fp16 hardware, but since there's very little that can be done with these types outside of the intrinsics this shouldn't require the compiler to handle fallback implementations operations like it does with the scalar f16 type.