### PR TITLE
x86: remove "unsafe" from tests that do not need it

### DIFF
--- a/crates/core_arch/src/x86/abm.rs
+++ b/crates/core_arch/src/x86/abm.rs
@@ -54,12 +54,12 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "lzcnt")]
-    const unsafe fn test_lzcnt_u32() {
+    const fn test_lzcnt_u32() {
         assert_eq!(_lzcnt_u32(0b0101_1010), 25);
     }
 
     #[simd_test(enable = "popcnt")]
-    const unsafe fn test_popcnt32() {
+    const fn test_popcnt32() {
         assert_eq!(_popcnt32(0b0101_1010), 4);
     }
 }

--- a/crates/core_arch/src/x86/aes.rs
+++ b/crates/core_arch/src/x86/aes.rs
@@ -112,7 +112,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "aes")]
-    unsafe fn test_mm_aesdec_si128() {
+    fn test_mm_aesdec_si128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
@@ -122,7 +122,7 @@ mod tests {
     }
 
     #[simd_test(enable = "aes")]
-    unsafe fn test_mm_aesdeclast_si128() {
+    fn test_mm_aesdeclast_si128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714178.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "aes")]
-    unsafe fn test_mm_aesenc_si128() {
+    fn test_mm_aesenc_si128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664810.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[simd_test(enable = "aes")]
-    unsafe fn test_mm_aesenclast_si128() {
+    fn test_mm_aesenclast_si128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714136.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "aes")]
-    unsafe fn test_mm_aesimc_si128() {
+    fn test_mm_aesimc_si128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714195.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let e = _mm_set_epi64x(0xc66c82284ee40aa0, 0x6633441122770055);
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[simd_test(enable = "aes")]
-    unsafe fn test_mm_aeskeygenassist_si128() {
+    fn test_mm_aeskeygenassist_si128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714138.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let e = _mm_set_epi64x(0x857c266b7c266e85, 0xeac4eea9c4eeacea);

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -3364,7 +3364,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_add_pd() {
+    const fn test_mm256_add_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_add_pd(a, b);
@@ -3373,7 +3373,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_add_ps() {
+    const fn test_mm256_add_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm256_add_ps(a, b);
@@ -3382,7 +3382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_and_pd() {
+    const fn test_mm256_and_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set1_pd(0.6);
         let r = _mm256_and_pd(a, b);
@@ -3391,7 +3391,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_and_ps() {
+    const fn test_mm256_and_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set1_ps(0.6);
         let r = _mm256_and_ps(a, b);
@@ -3400,7 +3400,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_or_pd() {
+    const fn test_mm256_or_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set1_pd(0.6);
         let r = _mm256_or_pd(a, b);
@@ -3409,7 +3409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_or_ps() {
+    const fn test_mm256_or_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set1_ps(0.6);
         let r = _mm256_or_ps(a, b);
@@ -3418,7 +3418,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_shuffle_pd() {
+    const fn test_mm256_shuffle_pd() {
         let a = _mm256_setr_pd(1., 4., 5., 8.);
         let b = _mm256_setr_pd(2., 3., 6., 7.);
         let r = _mm256_shuffle_pd::<0b11_11_11_11>(a, b);
@@ -3427,7 +3427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_shuffle_ps() {
+    const fn test_mm256_shuffle_ps() {
         let a = _mm256_setr_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_setr_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_shuffle_ps::<0b00_00_11_11>(a, b);
@@ -3436,7 +3436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_andnot_pd() {
+    const fn test_mm256_andnot_pd() {
         let a = _mm256_set1_pd(0.);
         let b = _mm256_set1_pd(0.6);
         let r = _mm256_andnot_pd(a, b);
@@ -3444,7 +3444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_andnot_ps() {
+    const fn test_mm256_andnot_ps() {
         let a = _mm256_set1_ps(0.);
         let b = _mm256_set1_ps(0.6);
         let r = _mm256_andnot_ps(a, b);
@@ -3556,7 +3556,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_mul_pd() {
+    const fn test_mm256_mul_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_mul_pd(a, b);
@@ -3565,7 +3565,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_mul_ps() {
+    const fn test_mm256_mul_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm256_mul_ps(a, b);
@@ -3574,7 +3574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_addsub_pd() {
+    const fn test_mm256_addsub_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_addsub_pd(a, b);
@@ -3583,7 +3583,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_addsub_ps() {
+    const fn test_mm256_addsub_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 1., 2., 3., 4.);
         let b = _mm256_setr_ps(5., 6., 7., 8., 5., 6., 7., 8.);
         let r = _mm256_addsub_ps(a, b);
@@ -3592,7 +3592,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_sub_pd() {
+    const fn test_mm256_sub_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_sub_pd(a, b);
@@ -3601,7 +3601,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_sub_ps() {
+    const fn test_mm256_sub_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., -1., -2., -3., -4.);
         let b = _mm256_setr_ps(5., 6., 7., 8., 3., 2., 1., 0.);
         let r = _mm256_sub_ps(a, b);
@@ -3610,7 +3610,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_round_pd() {
+    fn test_mm256_round_pd() {
         let a = _mm256_setr_pd(1.55, 2.2, 3.99, -1.2);
         let result_closest = _mm256_round_pd::<0b0000>(a);
         let result_down = _mm256_round_pd::<0b0001>(a);
@@ -3624,7 +3624,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_floor_pd() {
+    const fn test_mm256_floor_pd() {
         let a = _mm256_setr_pd(1.55, 2.2, 3.99, -1.2);
         let result_down = _mm256_floor_pd(a);
         let expected_down = _mm256_setr_pd(1., 2., 3., -2.);
@@ -3632,7 +3632,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_ceil_pd() {
+    const fn test_mm256_ceil_pd() {
         let a = _mm256_setr_pd(1.55, 2.2, 3.99, -1.2);
         let result_up = _mm256_ceil_pd(a);
         let expected_up = _mm256_setr_pd(2., 3., 4., -1.);
@@ -3640,7 +3640,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_round_ps() {
+    fn test_mm256_round_ps() {
         let a = _mm256_setr_ps(1.55, 2.2, 3.99, -1.2, 1.55, 2.2, 3.99, -1.2);
         let result_closest = _mm256_round_ps::<0b0000>(a);
         let result_down = _mm256_round_ps::<0b0001>(a);
@@ -3654,7 +3654,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_floor_ps() {
+    const fn test_mm256_floor_ps() {
         let a = _mm256_setr_ps(1.55, 2.2, 3.99, -1.2, 1.55, 2.2, 3.99, -1.2);
         let result_down = _mm256_floor_ps(a);
         let expected_down = _mm256_setr_ps(1., 2., 3., -2., 1., 2., 3., -2.);
@@ -3662,7 +3662,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_ceil_ps() {
+    const fn test_mm256_ceil_ps() {
         let a = _mm256_setr_ps(1.55, 2.2, 3.99, -1.2, 1.55, 2.2, 3.99, -1.2);
         let result_up = _mm256_ceil_ps(a);
         let expected_up = _mm256_setr_ps(2., 3., 4., -1., 2., 3., 4., -1.);
@@ -3670,7 +3670,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_sqrt_pd() {
+    fn test_mm256_sqrt_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let r = _mm256_sqrt_pd(a);
         let e = _mm256_setr_pd(2., 3., 4., 5.);
@@ -3678,7 +3678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_sqrt_ps() {
+    fn test_mm256_sqrt_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let r = _mm256_sqrt_ps(a);
         let e = _mm256_setr_ps(2., 3., 4., 5., 2., 3., 4., 5.);
@@ -3686,7 +3686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_div_ps() {
+    const fn test_mm256_div_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_div_ps(a, b);
@@ -3695,7 +3695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_div_pd() {
+    const fn test_mm256_div_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let b = _mm256_setr_pd(4., 3., 2., 5.);
         let r = _mm256_div_pd(a, b);
@@ -3704,7 +3704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_blend_pd() {
+    const fn test_mm256_blend_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let b = _mm256_setr_pd(4., 3., 2., 5.);
         let r = _mm256_blend_pd::<0x0>(a, b);
@@ -3716,7 +3716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_blend_ps() {
+    const fn test_mm256_blend_ps() {
         let a = _mm256_setr_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_setr_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_blend_ps::<0x0>(a, b);
@@ -3728,7 +3728,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_blendv_pd() {
+    const fn test_mm256_blendv_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let b = _mm256_setr_pd(4., 3., 2., 5.);
         let c = _mm256_setr_pd(0., 0., !0 as f64, !0 as f64);
@@ -3738,7 +3738,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_blendv_ps() {
+    const fn test_mm256_blendv_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         #[rustfmt::skip]
@@ -3751,7 +3751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_dp_ps() {
+    fn test_mm256_dp_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_dp_ps::<0xFF>(a, b);
@@ -3760,7 +3760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_hadd_pd() {
+    const fn test_mm256_hadd_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let b = _mm256_setr_pd(4., 3., 2., 5.);
         let r = _mm256_hadd_pd(a, b);
@@ -3775,7 +3775,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_hadd_ps() {
+    const fn test_mm256_hadd_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_hadd_ps(a, b);
@@ -3790,7 +3790,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_hsub_pd() {
+    const fn test_mm256_hsub_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let b = _mm256_setr_pd(4., 3., 2., 5.);
         let r = _mm256_hsub_pd(a, b);
@@ -3805,7 +3805,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_hsub_ps() {
+    const fn test_mm256_hsub_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_hsub_ps(a, b);
@@ -3820,7 +3820,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_xor_pd() {
+    const fn test_mm256_xor_pd() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let b = _mm256_set1_pd(0.);
         let r = _mm256_xor_pd(a, b);
@@ -3828,7 +3828,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_xor_ps() {
+    const fn test_mm256_xor_ps() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_set1_ps(0.);
         let r = _mm256_xor_ps(a, b);
@@ -3836,7 +3836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_cmp_pd() {
+    fn test_mm_cmp_pd() {
         let a = _mm_setr_pd(4., 9.);
         let b = _mm_setr_pd(4., 3.);
         let r = _mm_cmp_pd::<_CMP_GE_OS>(a, b);
@@ -3845,7 +3845,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_cmp_pd() {
+    fn test_mm256_cmp_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_cmp_pd::<_CMP_GE_OS>(a, b);
@@ -3854,7 +3854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_cmp_ps() {
+    fn test_mm_cmp_ps() {
         let a = _mm_setr_ps(4., 3., 2., 5.);
         let b = _mm_setr_ps(4., 9., 16., 25.);
         let r = _mm_cmp_ps::<_CMP_GE_OS>(a, b);
@@ -3865,7 +3865,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_cmp_ps() {
+    fn test_mm256_cmp_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 1., 2., 3., 4.);
         let b = _mm256_setr_ps(5., 6., 7., 8., 5., 6., 7., 8.);
         let r = _mm256_cmp_ps::<_CMP_GE_OS>(a, b);
@@ -3874,7 +3874,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_cmp_sd() {
+    fn test_mm_cmp_sd() {
         let a = _mm_setr_pd(4., 9.);
         let b = _mm_setr_pd(4., 3.);
         let r = _mm_cmp_sd::<_CMP_GE_OS>(a, b);
@@ -3883,7 +3883,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_cmp_ss() {
+    fn test_mm_cmp_ss() {
         let a = _mm_setr_ps(4., 3., 2., 5.);
         let b = _mm_setr_ps(4., 9., 16., 25.);
         let r = _mm_cmp_ss::<_CMP_GE_OS>(a, b);
@@ -3894,7 +3894,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtepi32_pd() {
+    const fn test_mm256_cvtepi32_pd() {
         let a = _mm_setr_epi32(4, 9, 16, 25);
         let r = _mm256_cvtepi32_pd(a);
         let e = _mm256_setr_pd(4., 9., 16., 25.);
@@ -3902,7 +3902,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtepi32_ps() {
+    const fn test_mm256_cvtepi32_ps() {
         let a = _mm256_setr_epi32(4, 9, 16, 25, 4, 9, 16, 25);
         let r = _mm256_cvtepi32_ps(a);
         let e = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
@@ -3910,7 +3910,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtpd_ps() {
+    const fn test_mm256_cvtpd_ps() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let r = _mm256_cvtpd_ps(a);
         let e = _mm_setr_ps(4., 9., 16., 25.);
@@ -3918,7 +3918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_cvtps_epi32() {
+    fn test_mm256_cvtps_epi32() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let r = _mm256_cvtps_epi32(a);
         let e = _mm256_setr_epi32(4, 9, 16, 25, 4, 9, 16, 25);
@@ -3926,7 +3926,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtps_pd() {
+    const fn test_mm256_cvtps_pd() {
         let a = _mm_setr_ps(4., 9., 16., 25.);
         let r = _mm256_cvtps_pd(a);
         let e = _mm256_setr_pd(4., 9., 16., 25.);
@@ -3934,14 +3934,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtsd_f64() {
+    const fn test_mm256_cvtsd_f64() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let r = _mm256_cvtsd_f64(a);
         assert_eq!(r, 1.);
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_cvttpd_epi32() {
+    fn test_mm256_cvttpd_epi32() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let r = _mm256_cvttpd_epi32(a);
         let e = _mm_setr_epi32(4, 9, 16, 25);
@@ -3949,7 +3949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_cvtpd_epi32() {
+    fn test_mm256_cvtpd_epi32() {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let r = _mm256_cvtpd_epi32(a);
         let e = _mm_setr_epi32(4, 9, 16, 25);
@@ -3957,7 +3957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_cvttps_epi32() {
+    fn test_mm256_cvttps_epi32() {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let r = _mm256_cvttps_epi32(a);
         let e = _mm256_setr_epi32(4, 9, 16, 25, 4, 9, 16, 25);
@@ -3965,7 +3965,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_extractf128_ps() {
+    const fn test_mm256_extractf128_ps() {
         let a = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_extractf128_ps::<0>(a);
         let e = _mm_setr_ps(4., 3., 2., 5.);
@@ -3973,7 +3973,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_extractf128_pd() {
+    const fn test_mm256_extractf128_pd() {
         let a = _mm256_setr_pd(4., 3., 2., 5.);
         let r = _mm256_extractf128_pd::<0>(a);
         let e = _mm_setr_pd(4., 3.);
@@ -3981,7 +3981,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_extractf128_si256() {
+    const fn test_mm256_extractf128_si256() {
         let a = _mm256_setr_epi64x(4, 3, 2, 5);
         let r = _mm256_extractf128_si256::<0>(a);
         let e = _mm_setr_epi64x(4, 3);
@@ -3989,7 +3989,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_extract_epi32() {
+    const fn test_mm256_extract_epi32() {
         let a = _mm256_setr_epi32(-1, 1, 2, 3, 4, 5, 6, 7);
         let r1 = _mm256_extract_epi32::<0>(a);
         let r2 = _mm256_extract_epi32::<3>(a);
@@ -3998,7 +3998,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtsi256_si32() {
+    const fn test_mm256_cvtsi256_si32() {
         let a = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_cvtsi256_si32(a);
         assert_eq!(r, 1);
@@ -4006,18 +4006,18 @@ mod tests {
 
     #[simd_test(enable = "avx")]
     #[cfg_attr(miri, ignore)] // Register-level operation not supported by Miri
-    unsafe fn test_mm256_zeroall() {
+    fn test_mm256_zeroall() {
         _mm256_zeroall();
     }
 
     #[simd_test(enable = "avx")]
     #[cfg_attr(miri, ignore)] // Register-level operation not supported by Miri
-    unsafe fn test_mm256_zeroupper() {
+    fn test_mm256_zeroupper() {
         _mm256_zeroupper();
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_permutevar_ps() {
+    fn test_mm256_permutevar_ps() {
         let a = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_permutevar_ps(a, b);
@@ -4026,7 +4026,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_permutevar_ps() {
+    fn test_mm_permutevar_ps() {
         let a = _mm_setr_ps(4., 3., 2., 5.);
         let b = _mm_setr_epi32(1, 2, 3, 4);
         let r = _mm_permutevar_ps(a, b);
@@ -4035,7 +4035,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_permute_ps() {
+    const fn test_mm256_permute_ps() {
         let a = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_permute_ps::<0x1b>(a);
         let e = _mm256_setr_ps(5., 2., 3., 4., 50., 64., 9., 8.);
@@ -4043,7 +4043,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_permute_ps() {
+    const fn test_mm_permute_ps() {
         let a = _mm_setr_ps(4., 3., 2., 5.);
         let r = _mm_permute_ps::<0x1b>(a);
         let e = _mm_setr_ps(5., 2., 3., 4.);
@@ -4051,7 +4051,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_permutevar_pd() {
+    fn test_mm256_permutevar_pd() {
         let a = _mm256_setr_pd(4., 3., 2., 5.);
         let b = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_permutevar_pd(a, b);
@@ -4060,7 +4060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_permutevar_pd() {
+    fn test_mm_permutevar_pd() {
         let a = _mm_setr_pd(4., 3.);
         let b = _mm_setr_epi64x(3, 0);
         let r = _mm_permutevar_pd(a, b);
@@ -4069,7 +4069,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_permute_pd() {
+    const fn test_mm256_permute_pd() {
         let a = _mm256_setr_pd(4., 3., 2., 5.);
         let r = _mm256_permute_pd::<5>(a);
         let e = _mm256_setr_pd(3., 4., 5., 2.);
@@ -4077,7 +4077,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_permute_pd() {
+    const fn test_mm_permute_pd() {
         let a = _mm_setr_pd(4., 3.);
         let r = _mm_permute_pd::<1>(a);
         let e = _mm_setr_pd(3., 4.);
@@ -4085,7 +4085,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_permute2f128_ps() {
+    const fn test_mm256_permute2f128_ps() {
         let a = _mm256_setr_ps(11., 12., 13., 14., 15., 16., 17., 18.);
         let b = _mm256_setr_ps(21., 22., 23., 24., 25., 26., 27., 28.);
         let r = _mm256_permute2f128_ps::<0b0001_0011>(a, b);
@@ -4099,7 +4099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_permute2f128_pd() {
+    const fn test_mm256_permute2f128_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_permute2f128_pd::<0b0011_0001>(a, b);
@@ -4113,7 +4113,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_permute2f128_si256() {
+    const fn test_mm256_permute2f128_si256() {
         let a = _mm256_setr_epi32(11, 12, 13, 14, 15, 16, 17, 18);
         let b = _mm256_setr_epi32(21, 22, 23, 24, 25, 26, 27, 28);
         let r = _mm256_permute2f128_si256::<0b0010_0000>(a, b);
@@ -4127,28 +4127,28 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_broadcast_ss() {
+    const fn test_mm256_broadcast_ss() {
         let r = _mm256_broadcast_ss(&3.);
         let e = _mm256_set1_ps(3.);
         assert_eq_m256(r, e);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_broadcast_ss() {
+    const fn test_mm_broadcast_ss() {
         let r = _mm_broadcast_ss(&3.);
         let e = _mm_set1_ps(3.);
         assert_eq_m128(r, e);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_broadcast_sd() {
+    const fn test_mm256_broadcast_sd() {
         let r = _mm256_broadcast_sd(&3.);
         let e = _mm256_set1_pd(3.);
         assert_eq_m256d(r, e);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_broadcast_ps() {
+    const fn test_mm256_broadcast_ps() {
         let a = _mm_setr_ps(4., 3., 2., 5.);
         let r = _mm256_broadcast_ps(&a);
         let e = _mm256_setr_ps(4., 3., 2., 5., 4., 3., 2., 5.);
@@ -4156,7 +4156,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_broadcast_pd() {
+    const fn test_mm256_broadcast_pd() {
         let a = _mm_setr_pd(4., 3.);
         let r = _mm256_broadcast_pd(&a);
         let e = _mm256_setr_pd(4., 3., 4., 3.);
@@ -4164,7 +4164,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insertf128_ps() {
+    const fn test_mm256_insertf128_ps() {
         let a = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let b = _mm_setr_ps(4., 9., 16., 25.);
         let r = _mm256_insertf128_ps::<0>(a, b);
@@ -4173,7 +4173,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insertf128_pd() {
+    const fn test_mm256_insertf128_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm_setr_pd(5., 6.);
         let r = _mm256_insertf128_pd::<0>(a, b);
@@ -4182,7 +4182,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insertf128_si256() {
+    const fn test_mm256_insertf128_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let b = _mm_setr_epi64x(5, 6);
         let r = _mm256_insertf128_si256::<0>(a, b);
@@ -4191,7 +4191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insert_epi8() {
+    const fn test_mm256_insert_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -4211,7 +4211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insert_epi16() {
+    const fn test_mm256_insert_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4227,7 +4227,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insert_epi32() {
+    const fn test_mm256_insert_epi32() {
         let a = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_insert_epi32::<7>(a, 0);
         let e = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 0);
@@ -4417,7 +4417,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_movehdup_ps() {
+    const fn test_mm256_movehdup_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_movehdup_ps(a);
         let e = _mm256_setr_ps(2., 2., 4., 4., 6., 6., 8., 8.);
@@ -4425,7 +4425,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_moveldup_ps() {
+    const fn test_mm256_moveldup_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_moveldup_ps(a);
         let e = _mm256_setr_ps(1., 1., 3., 3., 5., 5., 7., 7.);
@@ -4433,7 +4433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_movedup_pd() {
+    const fn test_mm256_movedup_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let r = _mm256_movedup_pd(a);
         let e = _mm256_setr_pd(1., 1., 3., 3.);
@@ -4506,7 +4506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_rcp_ps() {
+    fn test_mm256_rcp_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_rcp_ps(a);
         #[rustfmt::skip]
@@ -4521,7 +4521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_rsqrt_ps() {
+    fn test_mm256_rsqrt_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_rsqrt_ps(a);
         #[rustfmt::skip]
@@ -4536,7 +4536,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_unpackhi_pd() {
+    const fn test_mm256_unpackhi_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_unpackhi_pd(a, b);
@@ -4545,7 +4545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_unpackhi_ps() {
+    const fn test_mm256_unpackhi_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm256_unpackhi_ps(a, b);
@@ -4554,7 +4554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_unpacklo_pd() {
+    const fn test_mm256_unpacklo_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_unpacklo_pd(a, b);
@@ -4563,7 +4563,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_unpacklo_ps() {
+    const fn test_mm256_unpacklo_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm256_unpacklo_ps(a, b);
@@ -4572,7 +4572,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_testz_si256() {
+    const fn test_mm256_testz_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let b = _mm256_setr_epi64x(5, 6, 7, 8);
         let r = _mm256_testz_si256(a, b);
@@ -4583,7 +4583,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_testc_si256() {
+    const fn test_mm256_testc_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let b = _mm256_setr_epi64x(5, 6, 7, 8);
         let r = _mm256_testc_si256(a, b);
@@ -4594,7 +4594,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testnzc_si256() {
+    fn test_mm256_testnzc_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let b = _mm256_setr_epi64x(5, 6, 7, 8);
         let r = _mm256_testnzc_si256(a, b);
@@ -4606,7 +4606,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testz_pd() {
+    fn test_mm256_testz_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_testz_pd(a, b);
@@ -4617,7 +4617,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testc_pd() {
+    fn test_mm256_testc_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_testc_pd(a, b);
@@ -4629,7 +4629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testnzc_pd() {
+    fn test_mm256_testnzc_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 6., 7., 8.);
         let r = _mm256_testnzc_pd(a, b);
@@ -4641,7 +4641,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_testz_pd() {
+    const fn test_mm_testz_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 6.);
         let r = _mm_testz_pd(a, b);
@@ -4652,7 +4652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_testc_pd() {
+    const fn test_mm_testc_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 6.);
         let r = _mm_testc_pd(a, b);
@@ -4664,7 +4664,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_testnzc_pd() {
+    fn test_mm_testnzc_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 6.);
         let r = _mm_testnzc_pd(a, b);
@@ -4676,7 +4676,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testz_ps() {
+    fn test_mm256_testz_ps() {
         let a = _mm256_set1_ps(1.);
         let r = _mm256_testz_ps(a, a);
         assert_eq!(r, 1);
@@ -4686,7 +4686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testc_ps() {
+    fn test_mm256_testc_ps() {
         let a = _mm256_set1_ps(1.);
         let r = _mm256_testc_ps(a, a);
         assert_eq!(r, 1);
@@ -4696,7 +4696,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm256_testnzc_ps() {
+    fn test_mm256_testnzc_ps() {
         let a = _mm256_set1_ps(1.);
         let r = _mm256_testnzc_ps(a, a);
         assert_eq!(r, 0);
@@ -4707,7 +4707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_testz_ps() {
+    const fn test_mm_testz_ps() {
         let a = _mm_set1_ps(1.);
         let r = _mm_testz_ps(a, a);
         assert_eq!(r, 1);
@@ -4717,7 +4717,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm_testc_ps() {
+    const fn test_mm_testc_ps() {
         let a = _mm_set1_ps(1.);
         let r = _mm_testc_ps(a, a);
         assert_eq!(r, 1);
@@ -4727,7 +4727,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    unsafe fn test_mm_testnzc_ps() {
+    fn test_mm_testnzc_ps() {
         let a = _mm_set1_ps(1.);
         let r = _mm_testnzc_ps(a, a);
         assert_eq!(r, 0);
@@ -4738,51 +4738,51 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_movemask_pd() {
+    const fn test_mm256_movemask_pd() {
         let a = _mm256_setr_pd(1., -2., 3., -4.);
         let r = _mm256_movemask_pd(a);
         assert_eq!(r, 0xA);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_movemask_ps() {
+    const fn test_mm256_movemask_ps() {
         let a = _mm256_setr_ps(1., -2., 3., -4., 1., -2., 3., -4.);
         let r = _mm256_movemask_ps(a);
         assert_eq!(r, 0xAA);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setzero_pd() {
+    const fn test_mm256_setzero_pd() {
         let r = _mm256_setzero_pd();
         assert_eq_m256d(r, _mm256_set1_pd(0.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setzero_ps() {
+    const fn test_mm256_setzero_ps() {
         let r = _mm256_setzero_ps();
         assert_eq_m256(r, _mm256_set1_ps(0.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setzero_si256() {
+    const fn test_mm256_setzero_si256() {
         let r = _mm256_setzero_si256();
         assert_eq_m256i(r, _mm256_set1_epi8(0));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_pd() {
+    const fn test_mm256_set_pd() {
         let r = _mm256_set_pd(1., 2., 3., 4.);
         assert_eq_m256d(r, _mm256_setr_pd(4., 3., 2., 1.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_ps() {
+    const fn test_mm256_set_ps() {
         let r = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         assert_eq_m256(r, _mm256_setr_ps(8., 7., 6., 5., 4., 3., 2., 1.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_epi8() {
+    const fn test_mm256_set_epi8() {
         #[rustfmt::skip]
         let r = _mm256_set_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -4801,7 +4801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_epi16() {
+    const fn test_mm256_set_epi16() {
         #[rustfmt::skip]
         let r = _mm256_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -4816,31 +4816,31 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_epi32() {
+    const fn test_mm256_set_epi32() {
         let r = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         assert_eq_m256i(r, _mm256_setr_epi32(8, 7, 6, 5, 4, 3, 2, 1));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_epi64x() {
+    const fn test_mm256_set_epi64x() {
         let r = _mm256_set_epi64x(1, 2, 3, 4);
         assert_eq_m256i(r, _mm256_setr_epi64x(4, 3, 2, 1));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_pd() {
+    const fn test_mm256_setr_pd() {
         let r = _mm256_setr_pd(1., 2., 3., 4.);
         assert_eq_m256d(r, _mm256_setr_pd(1., 2., 3., 4.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_ps() {
+    const fn test_mm256_setr_ps() {
         let r = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         assert_eq_m256(r, _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_epi8() {
+    const fn test_mm256_setr_epi8() {
         #[rustfmt::skip]
         let r = _mm256_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -4860,7 +4860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_epi16() {
+    const fn test_mm256_setr_epi16() {
         #[rustfmt::skip]
         let r = _mm256_setr_epi16(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -4875,55 +4875,55 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_epi32() {
+    const fn test_mm256_setr_epi32() {
         let r = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         assert_eq_m256i(r, _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_epi64x() {
+    const fn test_mm256_setr_epi64x() {
         let r = _mm256_setr_epi64x(1, 2, 3, 4);
         assert_eq_m256i(r, _mm256_setr_epi64x(1, 2, 3, 4));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set1_pd() {
+    const fn test_mm256_set1_pd() {
         let r = _mm256_set1_pd(1.);
         assert_eq_m256d(r, _mm256_set1_pd(1.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set1_ps() {
+    const fn test_mm256_set1_ps() {
         let r = _mm256_set1_ps(1.);
         assert_eq_m256(r, _mm256_set1_ps(1.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set1_epi8() {
+    const fn test_mm256_set1_epi8() {
         let r = _mm256_set1_epi8(1);
         assert_eq_m256i(r, _mm256_set1_epi8(1));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set1_epi16() {
+    const fn test_mm256_set1_epi16() {
         let r = _mm256_set1_epi16(1);
         assert_eq_m256i(r, _mm256_set1_epi16(1));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set1_epi32() {
+    const fn test_mm256_set1_epi32() {
         let r = _mm256_set1_epi32(1);
         assert_eq_m256i(r, _mm256_set1_epi32(1));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set1_epi64x() {
+    const fn test_mm256_set1_epi64x() {
         let r = _mm256_set1_epi64x(1);
         assert_eq_m256i(r, _mm256_set1_epi64x(1));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castpd_ps() {
+    const fn test_mm256_castpd_ps() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let r = _mm256_castpd_ps(a);
         let e = _mm256_setr_ps(0., 1.875, 0., 2., 0., 2.125, 0., 2.25);
@@ -4931,7 +4931,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castps_pd() {
+    const fn test_mm256_castps_pd() {
         let a = _mm256_setr_ps(0., 1.875, 0., 2., 0., 2.125, 0., 2.25);
         let r = _mm256_castps_pd(a);
         let e = _mm256_setr_pd(1., 2., 3., 4.);
@@ -4939,7 +4939,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castps_si256() {
+    const fn test_mm256_castps_si256() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_castps_si256(a);
         #[rustfmt::skip]
@@ -4953,7 +4953,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castsi256_ps() {
+    const fn test_mm256_castsi256_ps() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 0, -128, 63, 0, 0, 0, 64,
@@ -4967,63 +4967,63 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castpd_si256() {
+    const fn test_mm256_castpd_si256() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let r = _mm256_castpd_si256(a);
-        assert_eq_m256d(transmute(r), a);
+        assert_eq_m256d(unsafe { transmute(r) }, a);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castsi256_pd() {
+    const fn test_mm256_castsi256_pd() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_castsi256_pd(a);
-        assert_eq_m256d(r, transmute(a));
+        assert_eq_m256d(r, unsafe { transmute(a) });
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castps256_ps128() {
+    const fn test_mm256_castps256_ps128() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_castps256_ps128(a);
         assert_eq_m128(r, _mm_setr_ps(1., 2., 3., 4.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castpd256_pd128() {
+    const fn test_mm256_castpd256_pd128() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let r = _mm256_castpd256_pd128(a);
         assert_eq_m128d(r, _mm_setr_pd(1., 2.));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castsi256_si128() {
+    const fn test_mm256_castsi256_si128() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_castsi256_si128(a);
         assert_eq_m128i(r, _mm_setr_epi64x(1, 2));
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castps128_ps256() {
+    const fn test_mm256_castps128_ps256() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let r = _mm256_castps128_ps256(a);
         assert_eq_m128(_mm256_castps256_ps128(r), a);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castpd128_pd256() {
+    const fn test_mm256_castpd128_pd256() {
         let a = _mm_setr_pd(1., 2.);
         let r = _mm256_castpd128_pd256(a);
         assert_eq_m128d(_mm256_castpd256_pd128(r), a);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_castsi128_si256() {
+    const fn test_mm256_castsi128_si256() {
         let a = _mm_setr_epi32(1, 2, 3, 4);
         let r = _mm256_castsi128_si256(a);
         assert_eq_m128i(_mm256_castsi256_si128(r), a);
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_zextps128_ps256() {
+    const fn test_mm256_zextps128_ps256() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let r = _mm256_zextps128_ps256(a);
         let e = _mm256_setr_ps(1., 2., 3., 4., 0., 0., 0., 0.);
@@ -5031,7 +5031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_zextsi128_si256() {
+    const fn test_mm256_zextsi128_si256() {
         let a = _mm_setr_epi64x(1, 2);
         let r = _mm256_zextsi128_si256(a);
         let e = _mm256_setr_epi64x(1, 2, 0, 0);
@@ -5039,7 +5039,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_zextpd128_pd256() {
+    const fn test_mm256_zextpd128_pd256() {
         let a = _mm_setr_pd(1., 2.);
         let r = _mm256_zextpd128_pd256(a);
         let e = _mm256_setr_pd(1., 2., 0., 0.);
@@ -5047,7 +5047,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_m128() {
+    const fn test_mm256_set_m128() {
         let hi = _mm_setr_ps(5., 6., 7., 8.);
         let lo = _mm_setr_ps(1., 2., 3., 4.);
         let r = _mm256_set_m128(hi, lo);
@@ -5056,7 +5056,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_m128d() {
+    const fn test_mm256_set_m128d() {
         let hi = _mm_setr_pd(3., 4.);
         let lo = _mm_setr_pd(1., 2.);
         let r = _mm256_set_m128d(hi, lo);
@@ -5065,7 +5065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_set_m128i() {
+    const fn test_mm256_set_m128i() {
         #[rustfmt::skip]
         let hi = _mm_setr_epi8(
             17, 18, 19, 20,
@@ -5092,7 +5092,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_m128() {
+    const fn test_mm256_setr_m128() {
         let lo = _mm_setr_ps(1., 2., 3., 4.);
         let hi = _mm_setr_ps(5., 6., 7., 8.);
         let r = _mm256_setr_m128(lo, hi);
@@ -5101,7 +5101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_m128d() {
+    const fn test_mm256_setr_m128d() {
         let lo = _mm_setr_pd(1., 2.);
         let hi = _mm_setr_pd(3., 4.);
         let r = _mm256_setr_m128d(lo, hi);
@@ -5110,7 +5110,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_setr_m128i() {
+    const fn test_mm256_setr_m128i() {
         #[rustfmt::skip]
         let lo = _mm_setr_epi8(
             1, 2, 3, 4,
@@ -5235,7 +5235,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_cvtss_f32() {
+    const fn test_mm256_cvtss_f32() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_cvtss_f32(a);
         assert_eq!(r, 1.);

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3914,7 +3914,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_abs_epi32() {
+    const fn test_mm256_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -3930,7 +3930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_abs_epi16() {
+    const fn test_mm256_abs_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0,  1, -1, 2, -2, 3, -3, 4,
@@ -3946,7 +3946,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_abs_epi8() {
+    const fn test_mm256_abs_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 1, -1, 2, -2, 3, -3, 4,
@@ -3966,7 +3966,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_add_epi64() {
+    const fn test_mm256_add_epi64() {
         let a = _mm256_setr_epi64x(-10, 0, 100, 1_000_000_000);
         let b = _mm256_setr_epi64x(-1, 0, 1, 2);
         let r = _mm256_add_epi64(a, b);
@@ -3975,7 +3975,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_add_epi32() {
+    const fn test_mm256_add_epi32() {
         let a = _mm256_setr_epi32(-1, 0, 1, 2, 3, 4, 5, 6);
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_add_epi32(a, b);
@@ -3984,7 +3984,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_add_epi16() {
+    const fn test_mm256_add_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4005,7 +4005,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_add_epi8() {
+    const fn test_mm256_add_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4032,7 +4032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_adds_epi8() {
+    const fn test_mm256_adds_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4059,7 +4059,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_adds_epi8_saturate_positive() {
+    fn test_mm256_adds_epi8_saturate_positive() {
         let a = _mm256_set1_epi8(0x7F);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_adds_epi8(a, b);
@@ -4067,7 +4067,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_adds_epi8_saturate_negative() {
+    fn test_mm256_adds_epi8_saturate_negative() {
         let a = _mm256_set1_epi8(-0x80);
         let b = _mm256_set1_epi8(-1);
         let r = _mm256_adds_epi8(a, b);
@@ -4075,7 +4075,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_adds_epi16() {
+    const fn test_mm256_adds_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4097,7 +4097,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_adds_epi16_saturate_positive() {
+    fn test_mm256_adds_epi16_saturate_positive() {
         let a = _mm256_set1_epi16(0x7FFF);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_adds_epi16(a, b);
@@ -4105,7 +4105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_adds_epi16_saturate_negative() {
+    fn test_mm256_adds_epi16_saturate_negative() {
         let a = _mm256_set1_epi16(-0x8000);
         let b = _mm256_set1_epi16(-1);
         let r = _mm256_adds_epi16(a, b);
@@ -4113,7 +4113,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_adds_epu8() {
+    const fn test_mm256_adds_epu8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4140,7 +4140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_adds_epu8_saturate() {
+    fn test_mm256_adds_epu8_saturate() {
         let a = _mm256_set1_epi8(!0);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_adds_epu8(a, b);
@@ -4148,7 +4148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_adds_epu16() {
+    const fn test_mm256_adds_epu16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4170,7 +4170,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_adds_epu16_saturate() {
+    fn test_mm256_adds_epu16_saturate() {
         let a = _mm256_set1_epi16(!0);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_adds_epu16(a, b);
@@ -4178,7 +4178,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_and_si256() {
+    const fn test_mm256_and_si256() {
         let a = _mm256_set1_epi8(5);
         let b = _mm256_set1_epi8(3);
         let got = _mm256_and_si256(a, b);
@@ -4186,7 +4186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_andnot_si256() {
+    const fn test_mm256_andnot_si256() {
         let a = _mm256_set1_epi8(5);
         let b = _mm256_set1_epi8(3);
         let got = _mm256_andnot_si256(a, b);
@@ -4194,21 +4194,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_avg_epu8() {
+    const fn test_mm256_avg_epu8() {
         let (a, b) = (_mm256_set1_epi8(3), _mm256_set1_epi8(9));
         let r = _mm256_avg_epu8(a, b);
         assert_eq_m256i(r, _mm256_set1_epi8(6));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_avg_epu16() {
+    const fn test_mm256_avg_epu16() {
         let (a, b) = (_mm256_set1_epi16(3), _mm256_set1_epi16(9));
         let r = _mm256_avg_epu16(a, b);
         assert_eq_m256i(r, _mm256_set1_epi16(6));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_blend_epi32() {
+    const fn test_mm_blend_epi32() {
         let (a, b) = (_mm_set1_epi32(3), _mm_set1_epi32(9));
         let e = _mm_setr_epi32(9, 3, 3, 3);
         let r = _mm_blend_epi32::<0x01>(a, b);
@@ -4219,7 +4219,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_blend_epi32() {
+    const fn test_mm256_blend_epi32() {
         let (a, b) = (_mm256_set1_epi32(3), _mm256_set1_epi32(9));
         let e = _mm256_setr_epi32(9, 3, 3, 3, 3, 3, 3, 3);
         let r = _mm256_blend_epi32::<0x01>(a, b);
@@ -4235,7 +4235,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_blend_epi16() {
+    const fn test_mm256_blend_epi16() {
         let (a, b) = (_mm256_set1_epi16(3), _mm256_set1_epi16(9));
         let e = _mm256_setr_epi16(9, 3, 3, 3, 3, 3, 3, 3, 9, 3, 3, 3, 3, 3, 3, 3);
         let r = _mm256_blend_epi16::<0x01>(a, b);
@@ -4246,7 +4246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_blendv_epi8() {
+    const fn test_mm256_blendv_epi8() {
         let (a, b) = (_mm256_set1_epi8(4), _mm256_set1_epi8(2));
         let mask = _mm256_insert_epi8::<2>(_mm256_set1_epi8(0), -1);
         let e = _mm256_insert_epi8::<2>(_mm256_set1_epi8(4), 2);
@@ -4255,63 +4255,63 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastb_epi8() {
+    const fn test_mm_broadcastb_epi8() {
         let a = _mm_insert_epi8::<0>(_mm_set1_epi8(0x00), 0x2a);
         let res = _mm_broadcastb_epi8(a);
         assert_eq_m128i(res, _mm_set1_epi8(0x2a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastb_epi8() {
+    const fn test_mm256_broadcastb_epi8() {
         let a = _mm_insert_epi8::<0>(_mm_set1_epi8(0x00), 0x2a);
         let res = _mm256_broadcastb_epi8(a);
         assert_eq_m256i(res, _mm256_set1_epi8(0x2a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastd_epi32() {
+    const fn test_mm_broadcastd_epi32() {
         let a = _mm_setr_epi32(0x2a, 0x8000000, 0, 0);
         let res = _mm_broadcastd_epi32(a);
         assert_eq_m128i(res, _mm_set1_epi32(0x2a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastd_epi32() {
+    const fn test_mm256_broadcastd_epi32() {
         let a = _mm_setr_epi32(0x2a, 0x8000000, 0, 0);
         let res = _mm256_broadcastd_epi32(a);
         assert_eq_m256i(res, _mm256_set1_epi32(0x2a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastq_epi64() {
+    const fn test_mm_broadcastq_epi64() {
         let a = _mm_setr_epi64x(0x1ffffffff, 0);
         let res = _mm_broadcastq_epi64(a);
         assert_eq_m128i(res, _mm_set1_epi64x(0x1ffffffff));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastq_epi64() {
+    const fn test_mm256_broadcastq_epi64() {
         let a = _mm_setr_epi64x(0x1ffffffff, 0);
         let res = _mm256_broadcastq_epi64(a);
         assert_eq_m256i(res, _mm256_set1_epi64x(0x1ffffffff));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastsd_pd() {
+    const fn test_mm_broadcastsd_pd() {
         let a = _mm_setr_pd(6.88, 3.44);
         let res = _mm_broadcastsd_pd(a);
         assert_eq_m128d(res, _mm_set1_pd(6.88));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastsd_pd() {
+    const fn test_mm256_broadcastsd_pd() {
         let a = _mm_setr_pd(6.88, 3.44);
         let res = _mm256_broadcastsd_pd(a);
         assert_eq_m256d(res, _mm256_set1_pd(6.88f64));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastsi128_si256() {
+    const fn test_mm_broadcastsi128_si256() {
         let a = _mm_setr_epi64x(0x0987654321012334, 0x5678909876543210);
         let res = _mm_broadcastsi128_si256(a);
         let retval = _mm256_setr_epi64x(
@@ -4324,7 +4324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastsi128_si256() {
+    const fn test_mm256_broadcastsi128_si256() {
         let a = _mm_setr_epi64x(0x0987654321012334, 0x5678909876543210);
         let res = _mm256_broadcastsi128_si256(a);
         let retval = _mm256_setr_epi64x(
@@ -4337,35 +4337,35 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastss_ps() {
+    const fn test_mm_broadcastss_ps() {
         let a = _mm_setr_ps(6.88, 3.44, 0.0, 0.0);
         let res = _mm_broadcastss_ps(a);
         assert_eq_m128(res, _mm_set1_ps(6.88));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastss_ps() {
+    const fn test_mm256_broadcastss_ps() {
         let a = _mm_setr_ps(6.88, 3.44, 0.0, 0.0);
         let res = _mm256_broadcastss_ps(a);
         assert_eq_m256(res, _mm256_set1_ps(6.88));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_broadcastw_epi16() {
+    const fn test_mm_broadcastw_epi16() {
         let a = _mm_insert_epi16::<0>(_mm_set1_epi16(0x2a), 0x22b);
         let res = _mm_broadcastw_epi16(a);
         assert_eq_m128i(res, _mm_set1_epi16(0x22b));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_broadcastw_epi16() {
+    const fn test_mm256_broadcastw_epi16() {
         let a = _mm_insert_epi16::<0>(_mm_set1_epi16(0x2a), 0x22b);
         let res = _mm256_broadcastw_epi16(a);
         assert_eq_m256i(res, _mm256_set1_epi16(0x22b));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpeq_epi8() {
+    const fn test_mm256_cmpeq_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4385,7 +4385,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpeq_epi16() {
+    const fn test_mm256_cmpeq_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4401,7 +4401,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpeq_epi32() {
+    const fn test_mm256_cmpeq_epi32() {
         let a = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_setr_epi32(7, 6, 2, 4, 3, 2, 1, 0);
         let r = _mm256_cmpeq_epi32(a, b);
@@ -4411,7 +4411,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpeq_epi64() {
+    const fn test_mm256_cmpeq_epi64() {
         let a = _mm256_setr_epi64x(0, 1, 2, 3);
         let b = _mm256_setr_epi64x(3, 2, 2, 0);
         let r = _mm256_cmpeq_epi64(a, b);
@@ -4419,7 +4419,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpgt_epi8() {
+    const fn test_mm256_cmpgt_epi8() {
         let a = _mm256_insert_epi8::<0>(_mm256_set1_epi8(0), 5);
         let b = _mm256_set1_epi8(0);
         let r = _mm256_cmpgt_epi8(a, b);
@@ -4427,7 +4427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpgt_epi16() {
+    const fn test_mm256_cmpgt_epi16() {
         let a = _mm256_insert_epi16::<0>(_mm256_set1_epi16(0), 5);
         let b = _mm256_set1_epi16(0);
         let r = _mm256_cmpgt_epi16(a, b);
@@ -4435,7 +4435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpgt_epi32() {
+    const fn test_mm256_cmpgt_epi32() {
         let a = _mm256_insert_epi32::<0>(_mm256_set1_epi32(0), 5);
         let b = _mm256_set1_epi32(0);
         let r = _mm256_cmpgt_epi32(a, b);
@@ -4443,7 +4443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cmpgt_epi64() {
+    const fn test_mm256_cmpgt_epi64() {
         let a = _mm256_insert_epi64::<0>(_mm256_set1_epi64x(0), 5);
         let b = _mm256_set1_epi64x(0);
         let r = _mm256_cmpgt_epi64(a, b);
@@ -4451,7 +4451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepi8_epi16() {
+    const fn test_mm256_cvtepi8_epi16() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 0, -1, 1, -2, 2, -3, 3,
@@ -4466,7 +4466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepi8_epi32() {
+    const fn test_mm256_cvtepi8_epi32() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 0, -1, 1, -2, 2, -3, 3,
@@ -4477,7 +4477,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepi8_epi64() {
+    const fn test_mm256_cvtepi8_epi64() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 0, -1, 1, -2, 2, -3, 3,
@@ -4488,49 +4488,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepi16_epi32() {
+    const fn test_mm256_cvtepi16_epi32() {
         let a = _mm_setr_epi16(0, 0, -1, 1, -2, 2, -3, 3);
         let r = _mm256_setr_epi32(0, 0, -1, 1, -2, 2, -3, 3);
         assert_eq_m256i(r, _mm256_cvtepi16_epi32(a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepi16_epi64() {
+    const fn test_mm256_cvtepi16_epi64() {
         let a = _mm_setr_epi16(0, 0, -1, 1, -2, 2, -3, 3);
         let r = _mm256_setr_epi64x(0, 0, -1, 1);
         assert_eq_m256i(r, _mm256_cvtepi16_epi64(a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepi32_epi64() {
+    const fn test_mm256_cvtepi32_epi64() {
         let a = _mm_setr_epi32(0, 0, -1, 1);
         let r = _mm256_setr_epi64x(0, 0, -1, 1);
         assert_eq_m256i(r, _mm256_cvtepi32_epi64(a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepu16_epi32() {
+    const fn test_mm256_cvtepu16_epi32() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         assert_eq_m256i(r, _mm256_cvtepu16_epi32(a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepu16_epi64() {
+    const fn test_mm256_cvtepu16_epi64() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_setr_epi64x(0, 1, 2, 3);
         assert_eq_m256i(r, _mm256_cvtepu16_epi64(a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepu32_epi64() {
+    const fn test_mm256_cvtepu32_epi64() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let r = _mm256_setr_epi64x(0, 1, 2, 3);
         assert_eq_m256i(r, _mm256_cvtepu32_epi64(a));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepu8_epi16() {
+    const fn test_mm256_cvtepu8_epi16() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4545,7 +4545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepu8_epi32() {
+    const fn test_mm256_cvtepu8_epi32() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4556,7 +4556,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_cvtepu8_epi64() {
+    const fn test_mm256_cvtepu8_epi64() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4567,7 +4567,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_extracti128_si256() {
+    const fn test_mm256_extracti128_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_extracti128_si256::<1>(a);
         let e = _mm_setr_epi64x(3, 4);
@@ -4575,7 +4575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_hadd_epi16() {
+    const fn test_mm256_hadd_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hadd_epi16(a, b);
@@ -4584,7 +4584,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_hadd_epi32() {
+    const fn test_mm256_hadd_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_hadd_epi32(a, b);
@@ -4593,7 +4593,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_hadds_epi16() {
+    fn test_mm256_hadds_epi16() {
         let a = _mm256_set1_epi16(2);
         let a = _mm256_insert_epi16::<0>(a, 0x7fff);
         let a = _mm256_insert_epi16::<1>(a, 1);
@@ -4608,7 +4608,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_hsub_epi16() {
+    const fn test_mm256_hsub_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hsub_epi16(a, b);
@@ -4617,7 +4617,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_hsub_epi32() {
+    const fn test_mm256_hsub_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_hsub_epi32(a, b);
@@ -4626,7 +4626,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_hsubs_epi16() {
+    fn test_mm256_hsubs_epi16() {
         let a = _mm256_set1_epi16(2);
         let a = _mm256_insert_epi16::<0>(a, 0x7fff);
         let a = _mm256_insert_epi16::<1>(a, -1);
@@ -4637,7 +4637,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_madd_epi16() {
+    const fn test_mm256_madd_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_madd_epi16(a, b);
@@ -4646,7 +4646,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_inserti128_si256() {
+    const fn test_mm256_inserti128_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let b = _mm_setr_epi64x(7, 8);
         let r = _mm256_inserti128_si256::<1>(a, b);
@@ -4655,7 +4655,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_maddubs_epi16() {
+    fn test_mm256_maddubs_epi16() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_maddubs_epi16(a, b);
@@ -4744,7 +4744,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_max_epi16() {
+    const fn test_mm256_max_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_max_epi16(a, b);
@@ -4752,7 +4752,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_max_epi32() {
+    const fn test_mm256_max_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_max_epi32(a, b);
@@ -4760,7 +4760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_max_epi8() {
+    const fn test_mm256_max_epi8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_max_epi8(a, b);
@@ -4768,7 +4768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_max_epu16() {
+    const fn test_mm256_max_epu16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_max_epu16(a, b);
@@ -4776,7 +4776,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_max_epu32() {
+    const fn test_mm256_max_epu32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_max_epu32(a, b);
@@ -4784,7 +4784,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_max_epu8() {
+    const fn test_mm256_max_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_max_epu8(a, b);
@@ -4792,7 +4792,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_min_epi16() {
+    const fn test_mm256_min_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_min_epi16(a, b);
@@ -4800,7 +4800,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_min_epi32() {
+    const fn test_mm256_min_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_min_epi32(a, b);
@@ -4808,7 +4808,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_min_epi8() {
+    const fn test_mm256_min_epi8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_min_epi8(a, b);
@@ -4816,7 +4816,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_min_epu16() {
+    const fn test_mm256_min_epu16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_min_epu16(a, b);
@@ -4824,7 +4824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_min_epu32() {
+    const fn test_mm256_min_epu32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_min_epu32(a, b);
@@ -4832,7 +4832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_min_epu8() {
+    const fn test_mm256_min_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_min_epu8(a, b);
@@ -4840,7 +4840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_movemask_epi8() {
+    const fn test_mm256_movemask_epi8() {
         let a = _mm256_set1_epi8(-1);
         let r = _mm256_movemask_epi8(a);
         let e = -1;
@@ -4848,7 +4848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_mpsadbw_epu8() {
+    fn test_mm256_mpsadbw_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_mpsadbw_epu8::<0>(a, b);
@@ -4857,7 +4857,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_mul_epi32() {
+    const fn test_mm256_mul_epi32() {
         let a = _mm256_setr_epi32(0, 0, 0, 0, 2, 2, 2, 2);
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_mul_epi32(a, b);
@@ -4866,7 +4866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_mul_epu32() {
+    const fn test_mm256_mul_epu32() {
         let a = _mm256_setr_epi32(0, 0, 0, 0, 2, 2, 2, 2);
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_mul_epu32(a, b);
@@ -4875,7 +4875,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_mulhi_epi16() {
+    const fn test_mm256_mulhi_epi16() {
         let a = _mm256_set1_epi16(6535);
         let b = _mm256_set1_epi16(6535);
         let r = _mm256_mulhi_epi16(a, b);
@@ -4884,7 +4884,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_mulhi_epu16() {
+    const fn test_mm256_mulhi_epu16() {
         let a = _mm256_set1_epi16(6535);
         let b = _mm256_set1_epi16(6535);
         let r = _mm256_mulhi_epu16(a, b);
@@ -4893,7 +4893,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_mullo_epi16() {
+    const fn test_mm256_mullo_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_mullo_epi16(a, b);
@@ -4902,7 +4902,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_mullo_epi32() {
+    const fn test_mm256_mullo_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_mullo_epi32(a, b);
@@ -4911,7 +4911,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_mulhrs_epi16() {
+    fn test_mm256_mulhrs_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_mullo_epi16(a, b);
@@ -4920,7 +4920,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_or_si256() {
+    const fn test_mm256_or_si256() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(0);
         let r = _mm256_or_si256(a, b);
@@ -4928,7 +4928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_packs_epi16() {
+    fn test_mm256_packs_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_packs_epi16(a, b);
@@ -4944,7 +4944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_packs_epi32() {
+    fn test_mm256_packs_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_packs_epi32(a, b);
@@ -4954,7 +4954,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_packus_epi16() {
+    fn test_mm256_packus_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_packus_epi16(a, b);
@@ -4970,7 +4970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_packus_epi32() {
+    fn test_mm256_packus_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_packus_epi32(a, b);
@@ -4980,7 +4980,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sad_epu8() {
+    fn test_mm256_sad_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_sad_epu8(a, b);
@@ -4989,7 +4989,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_shufflehi_epi16() {
+    const fn test_mm256_shufflehi_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             0, 1, 2, 3, 11, 22, 33, 44,
@@ -5005,7 +5005,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_shufflelo_epi16() {
+    const fn test_mm256_shufflelo_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             11, 22, 33, 44, 0, 1, 2, 3,
@@ -5021,7 +5021,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sign_epi16() {
+    fn test_mm256_sign_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(-1);
         let r = _mm256_sign_epi16(a, b);
@@ -5030,7 +5030,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sign_epi32() {
+    fn test_mm256_sign_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(-1);
         let r = _mm256_sign_epi32(a, b);
@@ -5039,7 +5039,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sign_epi8() {
+    fn test_mm256_sign_epi8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(-1);
         let r = _mm256_sign_epi8(a, b);
@@ -5048,7 +5048,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sll_epi16() {
+    fn test_mm256_sll_epi16() {
         let a = _mm256_set1_epi16(0xFF);
         let b = _mm_insert_epi16::<0>(_mm_set1_epi16(0), 4);
         let r = _mm256_sll_epi16(a, b);
@@ -5056,7 +5056,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sll_epi32() {
+    fn test_mm256_sll_epi32() {
         let a = _mm256_set1_epi32(0xFFFF);
         let b = _mm_insert_epi32::<0>(_mm_set1_epi32(0), 4);
         let r = _mm256_sll_epi32(a, b);
@@ -5064,7 +5064,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sll_epi64() {
+    fn test_mm256_sll_epi64() {
         let a = _mm256_set1_epi64x(0xFFFFFFFF);
         let b = _mm_insert_epi64::<0>(_mm_set1_epi64x(0), 4);
         let r = _mm256_sll_epi64(a, b);
@@ -5072,7 +5072,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_slli_epi16() {
+    const fn test_mm256_slli_epi16() {
         assert_eq_m256i(
             _mm256_slli_epi16::<4>(_mm256_set1_epi16(0xFF)),
             _mm256_set1_epi16(0xFF0),
@@ -5080,7 +5080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_slli_epi32() {
+    const fn test_mm256_slli_epi32() {
         assert_eq_m256i(
             _mm256_slli_epi32::<4>(_mm256_set1_epi32(0xFFFF)),
             _mm256_set1_epi32(0xFFFF0),
@@ -5088,7 +5088,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_slli_epi64() {
+    const fn test_mm256_slli_epi64() {
         assert_eq_m256i(
             _mm256_slli_epi64::<4>(_mm256_set1_epi64x(0xFFFFFFFF)),
             _mm256_set1_epi64x(0xFFFFFFFF0),
@@ -5096,14 +5096,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_slli_si256() {
+    const fn test_mm256_slli_si256() {
         let a = _mm256_set1_epi64x(0xFFFFFFFF);
         let r = _mm256_slli_si256::<3>(a);
         assert_eq_m256i(r, _mm256_set1_epi64x(0xFFFFFFFF000000));
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_sllv_epi32() {
+    const fn test_mm_sllv_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(1);
         let r = _mm_sllv_epi32(a, b);
@@ -5112,7 +5112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_sllv_epi32() {
+    const fn test_mm256_sllv_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_sllv_epi32(a, b);
@@ -5121,7 +5121,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_sllv_epi64() {
+    const fn test_mm_sllv_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(1);
         let r = _mm_sllv_epi64(a, b);
@@ -5130,7 +5130,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_sllv_epi64() {
+    const fn test_mm256_sllv_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_sllv_epi64(a, b);
@@ -5139,7 +5139,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sra_epi16() {
+    fn test_mm256_sra_epi16() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm_setr_epi16(1, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm256_sra_epi16(a, b);
@@ -5147,7 +5147,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_sra_epi32() {
+    fn test_mm256_sra_epi32() {
         let a = _mm256_set1_epi32(-1);
         let b = _mm_insert_epi32::<0>(_mm_set1_epi32(0), 1);
         let r = _mm256_sra_epi32(a, b);
@@ -5155,7 +5155,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srai_epi16() {
+    const fn test_mm256_srai_epi16() {
         assert_eq_m256i(
             _mm256_srai_epi16::<1>(_mm256_set1_epi16(-1)),
             _mm256_set1_epi16(-1),
@@ -5163,7 +5163,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srai_epi32() {
+    const fn test_mm256_srai_epi32() {
         assert_eq_m256i(
             _mm256_srai_epi32::<1>(_mm256_set1_epi32(-1)),
             _mm256_set1_epi32(-1),
@@ -5171,7 +5171,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_srav_epi32() {
+    const fn test_mm_srav_epi32() {
         let a = _mm_set1_epi32(4);
         let count = _mm_set1_epi32(1);
         let r = _mm_srav_epi32(a, count);
@@ -5180,7 +5180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srav_epi32() {
+    const fn test_mm256_srav_epi32() {
         let a = _mm256_set1_epi32(4);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_srav_epi32(a, count);
@@ -5189,7 +5189,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srli_si256() {
+    const fn test_mm256_srli_si256() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -5209,7 +5209,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_srl_epi16() {
+    fn test_mm256_srl_epi16() {
         let a = _mm256_set1_epi16(0xFF);
         let b = _mm_insert_epi16::<0>(_mm_set1_epi16(0), 4);
         let r = _mm256_srl_epi16(a, b);
@@ -5217,7 +5217,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_srl_epi32() {
+    fn test_mm256_srl_epi32() {
         let a = _mm256_set1_epi32(0xFFFF);
         let b = _mm_insert_epi32::<0>(_mm_set1_epi32(0), 4);
         let r = _mm256_srl_epi32(a, b);
@@ -5225,7 +5225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_srl_epi64() {
+    fn test_mm256_srl_epi64() {
         let a = _mm256_set1_epi64x(0xFFFFFFFF);
         let b = _mm_setr_epi64x(4, 0);
         let r = _mm256_srl_epi64(a, b);
@@ -5233,7 +5233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srli_epi16() {
+    const fn test_mm256_srli_epi16() {
         assert_eq_m256i(
             _mm256_srli_epi16::<4>(_mm256_set1_epi16(0xFF)),
             _mm256_set1_epi16(0xF),
@@ -5241,7 +5241,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srli_epi32() {
+    const fn test_mm256_srli_epi32() {
         assert_eq_m256i(
             _mm256_srli_epi32::<4>(_mm256_set1_epi32(0xFFFF)),
             _mm256_set1_epi32(0xFFF),
@@ -5249,7 +5249,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srli_epi64() {
+    const fn test_mm256_srli_epi64() {
         assert_eq_m256i(
             _mm256_srli_epi64::<4>(_mm256_set1_epi64x(0xFFFFFFFF)),
             _mm256_set1_epi64x(0xFFFFFFF),
@@ -5257,7 +5257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_srlv_epi32() {
+    const fn test_mm_srlv_epi32() {
         let a = _mm_set1_epi32(2);
         let count = _mm_set1_epi32(1);
         let r = _mm_srlv_epi32(a, count);
@@ -5266,7 +5266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srlv_epi32() {
+    const fn test_mm256_srlv_epi32() {
         let a = _mm256_set1_epi32(2);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_srlv_epi32(a, count);
@@ -5275,7 +5275,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm_srlv_epi64() {
+    const fn test_mm_srlv_epi64() {
         let a = _mm_set1_epi64x(2);
         let count = _mm_set1_epi64x(1);
         let r = _mm_srlv_epi64(a, count);
@@ -5284,7 +5284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_srlv_epi64() {
+    const fn test_mm256_srlv_epi64() {
         let a = _mm256_set1_epi64x(2);
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_srlv_epi64(a, count);
@@ -5300,7 +5300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_sub_epi16() {
+    const fn test_mm256_sub_epi16() {
         let a = _mm256_set1_epi16(4);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_sub_epi16(a, b);
@@ -5308,7 +5308,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_sub_epi32() {
+    const fn test_mm256_sub_epi32() {
         let a = _mm256_set1_epi32(4);
         let b = _mm256_set1_epi32(2);
         let r = _mm256_sub_epi32(a, b);
@@ -5316,7 +5316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_sub_epi64() {
+    const fn test_mm256_sub_epi64() {
         let a = _mm256_set1_epi64x(4);
         let b = _mm256_set1_epi64x(2);
         let r = _mm256_sub_epi64(a, b);
@@ -5324,7 +5324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_sub_epi8() {
+    const fn test_mm256_sub_epi8() {
         let a = _mm256_set1_epi8(4);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_sub_epi8(a, b);
@@ -5332,7 +5332,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_subs_epi16() {
+    const fn test_mm256_subs_epi16() {
         let a = _mm256_set1_epi16(4);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_subs_epi16(a, b);
@@ -5340,7 +5340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_subs_epi8() {
+    const fn test_mm256_subs_epi8() {
         let a = _mm256_set1_epi8(4);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_subs_epi8(a, b);
@@ -5348,7 +5348,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_subs_epu16() {
+    const fn test_mm256_subs_epu16() {
         let a = _mm256_set1_epi16(4);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_subs_epu16(a, b);
@@ -5356,7 +5356,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_subs_epu8() {
+    const fn test_mm256_subs_epu8() {
         let a = _mm256_set1_epi8(4);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_subs_epu8(a, b);
@@ -5364,7 +5364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_xor_si256() {
+    const fn test_mm256_xor_si256() {
         let a = _mm256_set1_epi8(5);
         let b = _mm256_set1_epi8(3);
         let r = _mm256_xor_si256(a, b);
@@ -5372,7 +5372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_alignr_epi8() {
+    const fn test_mm256_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -5428,7 +5428,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_shuffle_epi8() {
+    fn test_mm256_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -5455,7 +5455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_permutevar8x32_epi32() {
+    fn test_mm256_permutevar8x32_epi32() {
         let a = _mm256_setr_epi32(100, 200, 300, 400, 500, 600, 700, 800);
         let b = _mm256_setr_epi32(5, 0, 5, 1, 7, 6, 3, 4);
         let expected = _mm256_setr_epi32(600, 100, 600, 200, 800, 700, 400, 500);
@@ -5464,7 +5464,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_permute4x64_epi64() {
+    const fn test_mm256_permute4x64_epi64() {
         let a = _mm256_setr_epi64x(100, 200, 300, 400);
         let expected = _mm256_setr_epi64x(400, 100, 200, 100);
         let r = _mm256_permute4x64_epi64::<0b00010011>(a);
@@ -5472,7 +5472,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_permute2x128_si256() {
+    const fn test_mm256_permute2x128_si256() {
         let a = _mm256_setr_epi64x(100, 200, 500, 600);
         let b = _mm256_setr_epi64x(300, 400, 700, 800);
         let r = _mm256_permute2x128_si256::<0b00_01_00_11>(a, b);
@@ -5481,7 +5481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_permute4x64_pd() {
+    const fn test_mm256_permute4x64_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let r = _mm256_permute4x64_pd::<0b00_01_00_11>(a);
         let e = _mm256_setr_pd(4., 1., 2., 1.);
@@ -5489,7 +5489,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    unsafe fn test_mm256_permutevar8x32_ps() {
+    fn test_mm256_permutevar8x32_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_epi32(5, 0, 5, 1, 7, 6, 3, 4);
         let r = _mm256_permutevar8x32_ps(a, b);
@@ -5839,7 +5839,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_extract_epi8() {
+    const fn test_mm256_extract_epi8() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi8(
             -1, 1, 2, 3, 4, 5, 6, 7,
@@ -5854,7 +5854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx2")]
-    const unsafe fn test_mm256_extract_epi16() {
+    const fn test_mm256_extract_epi16() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi16(
             -1, 1, 2, 3, 4, 5, 6, 7,

--- a/crates/core_arch/src/x86/avx512bf16.rs
+++ b/crates/core_arch/src/x86/avx512bf16.rs
@@ -1833,7 +1833,7 @@ mod tests {
     const BF16_EIGHT: u16 = 0b0_10000010_0000000;
 
     #[simd_test(enable = "avx512bf16")]
-    unsafe fn test_mm512_cvtpbh_ps() {
+    fn test_mm512_cvtpbh_ps() {
         let a = __m256bh([
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
@@ -1846,7 +1846,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16")]
-    unsafe fn test_mm512_mask_cvtpbh_ps() {
+    fn test_mm512_mask_cvtpbh_ps() {
         let a = __m256bh([
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
@@ -1863,7 +1863,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16")]
-    unsafe fn test_mm512_maskz_cvtpbh_ps() {
+    fn test_mm512_maskz_cvtpbh_ps() {
         let a = __m256bh([
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
@@ -1877,7 +1877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm256_cvtpbh_ps() {
+    fn test_mm256_cvtpbh_ps() {
         let a = __m128bh([
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
         ]);
@@ -1887,7 +1887,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpbh_ps() {
+    fn test_mm256_mask_cvtpbh_ps() {
         let a = __m128bh([
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
         ]);
@@ -1899,7 +1899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpbh_ps() {
+    fn test_mm256_maskz_cvtpbh_ps() {
         let a = __m128bh([
             BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, BF16_FIVE, BF16_SIX, BF16_SEVEN, BF16_EIGHT,
         ]);
@@ -1910,7 +1910,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm_cvtpbh_ps() {
+    fn test_mm_cvtpbh_ps() {
         let a = __m128bh([BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, 0, 0, 0, 0]);
         let r = _mm_cvtpbh_ps(a);
         let e = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
@@ -1918,7 +1918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm_mask_cvtpbh_ps() {
+    fn test_mm_mask_cvtpbh_ps() {
         let a = __m128bh([BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, 0, 0, 0, 0]);
         let src = _mm_setr_ps(9., 10., 11., 12.);
         let k = 0b1010;
@@ -1928,7 +1928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpbh_ps() {
+    fn test_mm_maskz_cvtpbh_ps() {
         let a = __m128bh([BF16_ONE, BF16_TWO, BF16_THREE, BF16_FOUR, 0, 0, 0, 0]);
         let k = 0b1010;
         let r = _mm_maskz_cvtpbh_ps(k, a);
@@ -1937,7 +1937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16")]
-    unsafe fn test_mm_cvtsbh_ss() {
+    fn test_mm_cvtsbh_ss() {
         let r = _mm_cvtsbh_ss(bf16::from_bits(BF16_ONE));
         assert_eq!(r, 1.);
     }
@@ -1970,7 +1970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bf16,avx512vl")]
-    unsafe fn test_mm_cvtness_sbh() {
+    fn test_mm_cvtness_sbh() {
         let r = _mm_cvtness_sbh(1.);
         assert_eq!(r.to_bits(), BF16_ONE);
     }

--- a/crates/core_arch/src/x86/avx512bitalg.rs
+++ b/crates/core_arch/src/x86/avx512bitalg.rs
@@ -460,7 +460,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    const unsafe fn test_mm512_popcnt_epi16() {
+    const fn test_mm512_popcnt_epi16() {
         let test_data = _mm512_set_epi16(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1_FF, 0x3_FF, 0x7_FF, 0xF_FF, 0x1F_FF,
             0x3F_FF, 0x7F_FF, 0xFF_FF, -1, -100, 255, 256, 2, 4, 8, 16, 32, 64, 128, 256, 512,
@@ -475,7 +475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    const unsafe fn test_mm512_maskz_popcnt_epi16() {
+    const fn test_mm512_maskz_popcnt_epi16() {
         let test_data = _mm512_set_epi16(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1_FF, 0x3_FF, 0x7_FF, 0xF_FF, 0x1F_FF,
             0x3F_FF, 0x7F_FF, 0xFF_FF, -1, -100, 255, 256, 2, 4, 8, 16, 32, 64, 128, 256, 512,
@@ -491,7 +491,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    const unsafe fn test_mm512_mask_popcnt_epi16() {
+    const fn test_mm512_mask_popcnt_epi16() {
         let test_data = _mm512_set_epi16(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1_FF, 0x3_FF, 0x7_FF, 0xF_FF, 0x1F_FF,
             0x3F_FF, 0x7F_FF, 0xFF_FF, -1, -100, 255, 256, 2, 4, 8, 16, 32, 64, 128, 256, 512,
@@ -507,7 +507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm256_popcnt_epi16() {
+    const fn test_mm256_popcnt_epi16() {
         let test_data = _mm256_set_epi16(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1_FF, 0x3_FF, 0x7_FF, 0xF_FF, 0x1F_FF,
             0x3F_FF, 0x7F_FF,
@@ -519,7 +519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_popcnt_epi16() {
+    const fn test_mm256_maskz_popcnt_epi16() {
         let test_data = _mm256_set_epi16(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1_FF, 0x3_FF, 0x7_FF, 0xF_FF, 0x1F_FF,
             0x3F_FF, 0x7F_FF,
@@ -531,7 +531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_popcnt_epi16() {
+    const fn test_mm256_mask_popcnt_epi16() {
         let test_data = _mm256_set_epi16(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, 0x1_FF, 0x3_FF, 0x7_FF, 0xF_FF, 0x1F_FF,
             0x3F_FF, 0x7F_FF,
@@ -545,7 +545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm_popcnt_epi16() {
+    const fn test_mm_popcnt_epi16() {
         let test_data = _mm_set_epi16(0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F);
         let actual_result = _mm_popcnt_epi16(test_data);
         let reference_result = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
@@ -553,7 +553,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_popcnt_epi16() {
+    const fn test_mm_maskz_popcnt_epi16() {
         let test_data = _mm_set_epi16(0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F);
         let mask = 0xF0;
         let actual_result = _mm_maskz_popcnt_epi16(mask, test_data);
@@ -562,7 +562,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_popcnt_epi16() {
+    const fn test_mm_mask_popcnt_epi16() {
         let test_data = _mm_set_epi16(0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F);
         let mask = 0xF0;
         let actual_result = _mm_mask_popcnt_epi16(test_data, mask, test_data);
@@ -571,7 +571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    const unsafe fn test_mm512_popcnt_epi8() {
+    const fn test_mm512_popcnt_epi8() {
         let test_data = _mm512_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64, 128, 171, 206, 100,
             217, 109, 253, 190, 177, 254, 179, 215, 230, 68, 201, 172, 183, 154, 84, 56, 227, 189,
@@ -588,7 +588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    const unsafe fn test_mm512_maskz_popcnt_epi8() {
+    const fn test_mm512_maskz_popcnt_epi8() {
         let test_data = _mm512_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64, 128, 171, 206, 100,
             217, 109, 253, 190, 177, 254, 179, 215, 230, 68, 201, 172, 183, 154, 84, 56, 227, 189,
@@ -606,7 +606,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    const unsafe fn test_mm512_mask_popcnt_epi8() {
+    const fn test_mm512_mask_popcnt_epi8() {
         let test_data = _mm512_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64, 128, 171, 206, 100,
             217, 109, 253, 190, 177, 254, 179, 215, 230, 68, 201, 172, 183, 154, 84, 56, 227, 189,
@@ -624,7 +624,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm256_popcnt_epi8() {
+    const fn test_mm256_popcnt_epi8() {
         let test_data = _mm256_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64, 128, 171, 206, 100,
             217, 109, 253, 190, 177, 254, 179, 215, 230, 68, 201, 172,
@@ -638,7 +638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_popcnt_epi8() {
+    const fn test_mm256_maskz_popcnt_epi8() {
         let test_data = _mm256_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64, 251, 73, 121, 143,
             145, 85, 91, 137, 90, 225, 21, 249, 211, 155, 228, 70,
@@ -653,7 +653,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_popcnt_epi8() {
+    const fn test_mm256_mask_popcnt_epi8() {
         let test_data = _mm256_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64, 251, 73, 121, 143,
             145, 85, 91, 137, 90, 225, 21, 249, 211, 155, 228, 70,
@@ -668,7 +668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm_popcnt_epi8() {
+    const fn test_mm_popcnt_epi8() {
         let test_data = _mm_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 0xFF, -1, 2, 4, 8, 16, 32, 64,
         );
@@ -678,7 +678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_popcnt_epi8() {
+    const fn test_mm_maskz_popcnt_epi8() {
         let test_data = _mm_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 90, 225, 21, 249, 211, 155, 228, 70,
         );
@@ -689,7 +689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_popcnt_epi8() {
+    const fn test_mm_mask_popcnt_epi8() {
         let test_data = _mm_set_epi8(
             0, 1, 3, 7, 0xF, 0x1F, 0x3F, 0x7F, 90, 225, 21, 249, 211, 155, 228, 70,
         );
@@ -701,7 +701,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    unsafe fn test_mm512_bitshuffle_epi64_mask() {
+    fn test_mm512_bitshuffle_epi64_mask() {
         let test_indices = _mm512_set_epi8(
             63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59, 58, 57, 56, 32, 32, 16, 16, 0, 0,
             8, 8, 56, 48, 40, 32, 24, 16, 8, 0, 63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59,
@@ -731,7 +731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f")]
-    unsafe fn test_mm512_mask_bitshuffle_epi64_mask() {
+    fn test_mm512_mask_bitshuffle_epi64_mask() {
         let test_indices = _mm512_set_epi8(
             63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59, 58, 57, 56, 32, 32, 16, 16, 0, 0,
             8, 8, 56, 48, 40, 32, 24, 16, 8, 0, 63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59,
@@ -762,7 +762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    unsafe fn test_mm256_bitshuffle_epi64_mask() {
+    fn test_mm256_bitshuffle_epi64_mask() {
         let test_indices = _mm256_set_epi8(
             63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59, 58, 57, 56, 32, 32, 16, 16, 0, 0,
             8, 8, 56, 48, 40, 32, 24, 16, 8, 0,
@@ -780,7 +780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_bitshuffle_epi64_mask() {
+    fn test_mm256_mask_bitshuffle_epi64_mask() {
         let test_indices = _mm256_set_epi8(
             63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59, 58, 57, 56, 32, 32, 16, 16, 0, 0,
             8, 8, 56, 48, 40, 32, 24, 16, 8, 0,
@@ -799,7 +799,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    unsafe fn test_mm_bitshuffle_epi64_mask() {
+    fn test_mm_bitshuffle_epi64_mask() {
         let test_indices = _mm_set_epi8(
             63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59, 58, 57, 56,
         );
@@ -811,7 +811,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bitalg,avx512f,avx512vl")]
-    unsafe fn test_mm_mask_bitshuffle_epi64_mask() {
+    fn test_mm_mask_bitshuffle_epi64_mask() {
         let test_indices = _mm_set_epi8(
             63, 62, 61, 60, 59, 58, 57, 56, 63, 62, 61, 60, 59, 58, 57, 56,
         );

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -12662,7 +12662,7 @@ mod tests {
     use crate::mem::{self};
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_abs_epi16() {
+    const fn test_mm512_abs_epi16() {
         let a = _mm512_set1_epi16(-1);
         let r = _mm512_abs_epi16(a);
         let e = _mm512_set1_epi16(1);
@@ -12670,7 +12670,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_abs_epi16() {
+    const fn test_mm512_mask_abs_epi16() {
         let a = _mm512_set1_epi16(-1);
         let r = _mm512_mask_abs_epi16(a, 0, a);
         assert_eq_m512i(r, a);
@@ -12682,7 +12682,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_abs_epi16() {
+    const fn test_mm512_maskz_abs_epi16() {
         let a = _mm512_set1_epi16(-1);
         let r = _mm512_maskz_abs_epi16(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -12694,7 +12694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_abs_epi16() {
+    const fn test_mm256_mask_abs_epi16() {
         let a = _mm256_set1_epi16(-1);
         let r = _mm256_mask_abs_epi16(a, 0, a);
         assert_eq_m256i(r, a);
@@ -12704,7 +12704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_abs_epi16() {
+    const fn test_mm256_maskz_abs_epi16() {
         let a = _mm256_set1_epi16(-1);
         let r = _mm256_maskz_abs_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -12714,7 +12714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_abs_epi16() {
+    const fn test_mm_mask_abs_epi16() {
         let a = _mm_set1_epi16(-1);
         let r = _mm_mask_abs_epi16(a, 0, a);
         assert_eq_m128i(r, a);
@@ -12724,7 +12724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_abs_epi16() {
+    const fn test_mm_maskz_abs_epi16() {
         let a = _mm_set1_epi16(-1);
         let r = _mm_maskz_abs_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -12734,7 +12734,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_abs_epi8() {
+    const fn test_mm512_abs_epi8() {
         let a = _mm512_set1_epi8(-1);
         let r = _mm512_abs_epi8(a);
         let e = _mm512_set1_epi8(1);
@@ -12742,7 +12742,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_abs_epi8() {
+    const fn test_mm512_mask_abs_epi8() {
         let a = _mm512_set1_epi8(-1);
         let r = _mm512_mask_abs_epi8(a, 0, a);
         assert_eq_m512i(r, a);
@@ -12760,7 +12760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_abs_epi8() {
+    const fn test_mm512_maskz_abs_epi8() {
         let a = _mm512_set1_epi8(-1);
         let r = _mm512_maskz_abs_epi8(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -12777,7 +12777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_abs_epi8() {
+    const fn test_mm256_mask_abs_epi8() {
         let a = _mm256_set1_epi8(-1);
         let r = _mm256_mask_abs_epi8(a, 0, a);
         assert_eq_m256i(r, a);
@@ -12789,7 +12789,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_abs_epi8() {
+    const fn test_mm256_maskz_abs_epi8() {
         let a = _mm256_set1_epi8(-1);
         let r = _mm256_maskz_abs_epi8(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -12801,7 +12801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_abs_epi8() {
+    const fn test_mm_mask_abs_epi8() {
         let a = _mm_set1_epi8(-1);
         let r = _mm_mask_abs_epi8(a, 0, a);
         assert_eq_m128i(r, a);
@@ -12811,7 +12811,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_abs_epi8() {
+    const fn test_mm_maskz_abs_epi8() {
         let a = _mm_set1_epi8(-1);
         let r = _mm_maskz_abs_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -12822,7 +12822,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_add_epi16() {
+    const fn test_mm512_add_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_add_epi16(a, b);
@@ -12831,7 +12831,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_add_epi16() {
+    const fn test_mm512_mask_add_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_mask_add_epi16(a, 0, a, b);
@@ -12844,7 +12844,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_add_epi16() {
+    const fn test_mm512_maskz_add_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_maskz_add_epi16(0, a, b);
@@ -12857,7 +12857,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_add_epi16() {
+    const fn test_mm256_mask_add_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_mask_add_epi16(a, 0, a, b);
@@ -12868,7 +12868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_epi16() {
+    const fn test_mm256_maskz_add_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_maskz_add_epi16(0, a, b);
@@ -12879,7 +12879,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_add_epi16() {
+    const fn test_mm_mask_add_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(2);
         let r = _mm_mask_add_epi16(a, 0, a, b);
@@ -12890,7 +12890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_add_epi16() {
+    const fn test_mm_maskz_add_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(2);
         let r = _mm_maskz_add_epi16(0, a, b);
@@ -12901,7 +12901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_add_epi8() {
+    const fn test_mm512_add_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_add_epi8(a, b);
@@ -12910,7 +12910,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_add_epi8() {
+    const fn test_mm512_mask_add_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_mask_add_epi8(a, 0, a, b);
@@ -12930,7 +12930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_add_epi8() {
+    const fn test_mm512_maskz_add_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_maskz_add_epi8(0, a, b);
@@ -12949,7 +12949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_add_epi8() {
+    const fn test_mm256_mask_add_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_mask_add_epi8(a, 0, a, b);
@@ -12962,7 +12962,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_epi8() {
+    const fn test_mm256_maskz_add_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_maskz_add_epi8(0, a, b);
@@ -12975,7 +12975,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_add_epi8() {
+    const fn test_mm_mask_add_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(2);
         let r = _mm_mask_add_epi8(a, 0, a, b);
@@ -12986,7 +12986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_add_epi8() {
+    const fn test_mm_maskz_add_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(2);
         let r = _mm_maskz_add_epi8(0, a, b);
@@ -12997,7 +12997,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_adds_epu16() {
+    const fn test_mm512_adds_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(u16::MAX as i16);
         let r = _mm512_adds_epu16(a, b);
@@ -13006,7 +13006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_adds_epu16() {
+    const fn test_mm512_mask_adds_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(u16::MAX as i16);
         let r = _mm512_mask_adds_epu16(a, 0, a, b);
@@ -13019,7 +13019,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_adds_epu16() {
+    const fn test_mm512_maskz_adds_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(u16::MAX as i16);
         let r = _mm512_maskz_adds_epu16(0, a, b);
@@ -13032,7 +13032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_adds_epu16() {
+    const fn test_mm256_mask_adds_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(u16::MAX as i16);
         let r = _mm256_mask_adds_epu16(a, 0, a, b);
@@ -13044,7 +13044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_adds_epu16() {
+    const fn test_mm256_maskz_adds_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(u16::MAX as i16);
         let r = _mm256_maskz_adds_epu16(0, a, b);
@@ -13056,7 +13056,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_adds_epu16() {
+    const fn test_mm_mask_adds_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(u16::MAX as i16);
         let r = _mm_mask_adds_epu16(a, 0, a, b);
@@ -13068,7 +13068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_adds_epu16() {
+    const fn test_mm_maskz_adds_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(u16::MAX as i16);
         let r = _mm_maskz_adds_epu16(0, a, b);
@@ -13080,7 +13080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_adds_epu8() {
+    const fn test_mm512_adds_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(u8::MAX as i8);
         let r = _mm512_adds_epu8(a, b);
@@ -13089,7 +13089,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_adds_epu8() {
+    const fn test_mm512_mask_adds_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(u8::MAX as i8);
         let r = _mm512_mask_adds_epu8(a, 0, a, b);
@@ -13109,7 +13109,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_adds_epu8() {
+    const fn test_mm512_maskz_adds_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(u8::MAX as i8);
         let r = _mm512_maskz_adds_epu8(0, a, b);
@@ -13128,7 +13128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_adds_epu8() {
+    const fn test_mm256_mask_adds_epu8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(u8::MAX as i8);
         let r = _mm256_mask_adds_epu8(a, 0, a, b);
@@ -13141,7 +13141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_adds_epu8() {
+    const fn test_mm256_maskz_adds_epu8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(u8::MAX as i8);
         let r = _mm256_maskz_adds_epu8(0, a, b);
@@ -13154,7 +13154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_adds_epu8() {
+    const fn test_mm_mask_adds_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(u8::MAX as i8);
         let r = _mm_mask_adds_epu8(a, 0, a, b);
@@ -13166,7 +13166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_adds_epu8() {
+    const fn test_mm_maskz_adds_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(u8::MAX as i8);
         let r = _mm_maskz_adds_epu8(0, a, b);
@@ -13178,7 +13178,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_adds_epi16() {
+    const fn test_mm512_adds_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_adds_epi16(a, b);
@@ -13187,7 +13187,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_adds_epi16() {
+    const fn test_mm512_mask_adds_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_mask_adds_epi16(a, 0, a, b);
@@ -13200,7 +13200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_adds_epi16() {
+    const fn test_mm512_maskz_adds_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_maskz_adds_epi16(0, a, b);
@@ -13213,7 +13213,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_adds_epi16() {
+    const fn test_mm256_mask_adds_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_mask_adds_epi16(a, 0, a, b);
@@ -13225,7 +13225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_adds_epi16() {
+    const fn test_mm256_maskz_adds_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_maskz_adds_epi16(0, a, b);
@@ -13237,7 +13237,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_adds_epi16() {
+    const fn test_mm_mask_adds_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(i16::MAX);
         let r = _mm_mask_adds_epi16(a, 0, a, b);
@@ -13248,7 +13248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_adds_epi16() {
+    const fn test_mm_maskz_adds_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(i16::MAX);
         let r = _mm_maskz_adds_epi16(0, a, b);
@@ -13259,7 +13259,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_adds_epi8() {
+    const fn test_mm512_adds_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(i8::MAX);
         let r = _mm512_adds_epi8(a, b);
@@ -13268,7 +13268,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_adds_epi8() {
+    const fn test_mm512_mask_adds_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(i8::MAX);
         let r = _mm512_mask_adds_epi8(a, 0, a, b);
@@ -13288,7 +13288,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_adds_epi8() {
+    const fn test_mm512_maskz_adds_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(i8::MAX);
         let r = _mm512_maskz_adds_epi8(0, a, b);
@@ -13307,7 +13307,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_adds_epi8() {
+    const fn test_mm256_mask_adds_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(i8::MAX);
         let r = _mm256_mask_adds_epi8(a, 0, a, b);
@@ -13320,7 +13320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_adds_epi8() {
+    const fn test_mm256_maskz_adds_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(i8::MAX);
         let r = _mm256_maskz_adds_epi8(0, a, b);
@@ -13333,7 +13333,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_adds_epi8() {
+    const fn test_mm_mask_adds_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(i8::MAX);
         let r = _mm_mask_adds_epi8(a, 0, a, b);
@@ -13345,7 +13345,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_adds_epi8() {
+    const fn test_mm_maskz_adds_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(i8::MAX);
         let r = _mm_maskz_adds_epi8(0, a, b);
@@ -13357,7 +13357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_sub_epi16() {
+    const fn test_mm512_sub_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_sub_epi16(a, b);
@@ -13366,7 +13366,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_sub_epi16() {
+    const fn test_mm512_mask_sub_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_mask_sub_epi16(a, 0, a, b);
@@ -13379,7 +13379,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_sub_epi16() {
+    const fn test_mm512_maskz_sub_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_maskz_sub_epi16(0, a, b);
@@ -13392,7 +13392,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_epi16() {
+    const fn test_mm256_mask_sub_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_mask_sub_epi16(a, 0, a, b);
@@ -13403,7 +13403,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_epi16() {
+    const fn test_mm256_maskz_sub_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_maskz_sub_epi16(0, a, b);
@@ -13414,7 +13414,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_sub_epi16() {
+    const fn test_mm_mask_sub_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(2);
         let r = _mm_mask_sub_epi16(a, 0, a, b);
@@ -13425,7 +13425,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_epi16() {
+    const fn test_mm_maskz_sub_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(2);
         let r = _mm_maskz_sub_epi16(0, a, b);
@@ -13436,7 +13436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_sub_epi8() {
+    const fn test_mm512_sub_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_sub_epi8(a, b);
@@ -13445,7 +13445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_sub_epi8() {
+    const fn test_mm512_mask_sub_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_mask_sub_epi8(a, 0, a, b);
@@ -13465,7 +13465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_sub_epi8() {
+    const fn test_mm512_maskz_sub_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_maskz_sub_epi8(0, a, b);
@@ -13484,7 +13484,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_epi8() {
+    const fn test_mm256_mask_sub_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_mask_sub_epi8(a, 0, a, b);
@@ -13497,7 +13497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_epi8() {
+    const fn test_mm256_maskz_sub_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_maskz_sub_epi8(0, a, b);
@@ -13510,7 +13510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_sub_epi8() {
+    const fn test_mm_mask_sub_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(2);
         let r = _mm_mask_sub_epi8(a, 0, a, b);
@@ -13521,7 +13521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_epi8() {
+    const fn test_mm_maskz_sub_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(2);
         let r = _mm_maskz_sub_epi8(0, a, b);
@@ -13532,7 +13532,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_subs_epu16() {
+    const fn test_mm512_subs_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(u16::MAX as i16);
         let r = _mm512_subs_epu16(a, b);
@@ -13541,7 +13541,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_subs_epu16() {
+    const fn test_mm512_mask_subs_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(u16::MAX as i16);
         let r = _mm512_mask_subs_epu16(a, 0, a, b);
@@ -13554,7 +13554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_subs_epu16() {
+    const fn test_mm512_maskz_subs_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(u16::MAX as i16);
         let r = _mm512_maskz_subs_epu16(0, a, b);
@@ -13567,7 +13567,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_subs_epu16() {
+    const fn test_mm256_mask_subs_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(u16::MAX as i16);
         let r = _mm256_mask_subs_epu16(a, 0, a, b);
@@ -13578,7 +13578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_subs_epu16() {
+    const fn test_mm256_maskz_subs_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(u16::MAX as i16);
         let r = _mm256_maskz_subs_epu16(0, a, b);
@@ -13589,7 +13589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_subs_epu16() {
+    const fn test_mm_mask_subs_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(u16::MAX as i16);
         let r = _mm_mask_subs_epu16(a, 0, a, b);
@@ -13600,7 +13600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_subs_epu16() {
+    const fn test_mm_maskz_subs_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(u16::MAX as i16);
         let r = _mm_maskz_subs_epu16(0, a, b);
@@ -13611,7 +13611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_subs_epu8() {
+    const fn test_mm512_subs_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(u8::MAX as i8);
         let r = _mm512_subs_epu8(a, b);
@@ -13620,7 +13620,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_subs_epu8() {
+    const fn test_mm512_mask_subs_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(u8::MAX as i8);
         let r = _mm512_mask_subs_epu8(a, 0, a, b);
@@ -13640,7 +13640,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_subs_epu8() {
+    const fn test_mm512_maskz_subs_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(u8::MAX as i8);
         let r = _mm512_maskz_subs_epu8(0, a, b);
@@ -13659,7 +13659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_subs_epu8() {
+    const fn test_mm256_mask_subs_epu8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(u8::MAX as i8);
         let r = _mm256_mask_subs_epu8(a, 0, a, b);
@@ -13672,7 +13672,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_subs_epu8() {
+    const fn test_mm256_maskz_subs_epu8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(u8::MAX as i8);
         let r = _mm256_maskz_subs_epu8(0, a, b);
@@ -13685,7 +13685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_subs_epu8() {
+    const fn test_mm_mask_subs_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(u8::MAX as i8);
         let r = _mm_mask_subs_epu8(a, 0, a, b);
@@ -13696,7 +13696,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_subs_epu8() {
+    const fn test_mm_maskz_subs_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(u8::MAX as i8);
         let r = _mm_maskz_subs_epu8(0, a, b);
@@ -13707,7 +13707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_subs_epi16() {
+    const fn test_mm512_subs_epi16() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_subs_epi16(a, b);
@@ -13716,7 +13716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_subs_epi16() {
+    const fn test_mm512_mask_subs_epi16() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_mask_subs_epi16(a, 0, a, b);
@@ -13729,7 +13729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_subs_epi16() {
+    const fn test_mm512_maskz_subs_epi16() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_maskz_subs_epi16(0, a, b);
@@ -13742,7 +13742,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_subs_epi16() {
+    const fn test_mm256_mask_subs_epi16() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_mask_subs_epi16(a, 0, a, b);
@@ -13754,7 +13754,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_subs_epi16() {
+    const fn test_mm256_maskz_subs_epi16() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_maskz_subs_epi16(0, a, b);
@@ -13766,7 +13766,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_subs_epi16() {
+    const fn test_mm_mask_subs_epi16() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(i16::MAX);
         let r = _mm_mask_subs_epi16(a, 0, a, b);
@@ -13777,7 +13777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_subs_epi16() {
+    const fn test_mm_maskz_subs_epi16() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(i16::MAX);
         let r = _mm_maskz_subs_epi16(0, a, b);
@@ -13788,7 +13788,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_subs_epi8() {
+    const fn test_mm512_subs_epi8() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(i8::MAX);
         let r = _mm512_subs_epi8(a, b);
@@ -13797,7 +13797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_subs_epi8() {
+    const fn test_mm512_mask_subs_epi8() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(i8::MAX);
         let r = _mm512_mask_subs_epi8(a, 0, a, b);
@@ -13817,7 +13817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_subs_epi8() {
+    const fn test_mm512_maskz_subs_epi8() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(i8::MAX);
         let r = _mm512_maskz_subs_epi8(0, a, b);
@@ -13836,7 +13836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_subs_epi8() {
+    const fn test_mm256_mask_subs_epi8() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(i8::MAX);
         let r = _mm256_mask_subs_epi8(a, 0, a, b);
@@ -13849,7 +13849,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_subs_epi8() {
+    const fn test_mm256_maskz_subs_epi8() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(i8::MAX);
         let r = _mm256_maskz_subs_epi8(0, a, b);
@@ -13862,7 +13862,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_subs_epi8() {
+    const fn test_mm_mask_subs_epi8() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(i8::MAX);
         let r = _mm_mask_subs_epi8(a, 0, a, b);
@@ -13874,7 +13874,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_subs_epi8() {
+    const fn test_mm_maskz_subs_epi8() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(i8::MAX);
         let r = _mm_maskz_subs_epi8(0, a, b);
@@ -13886,7 +13886,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mulhi_epu16() {
+    const fn test_mm512_mulhi_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mulhi_epu16(a, b);
@@ -13895,7 +13895,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_mulhi_epu16() {
+    const fn test_mm512_mask_mulhi_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mask_mulhi_epu16(a, 0, a, b);
@@ -13908,7 +13908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_mulhi_epu16() {
+    const fn test_mm512_maskz_mulhi_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_mulhi_epu16(0, a, b);
@@ -13921,7 +13921,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_mulhi_epu16() {
+    const fn test_mm256_mask_mulhi_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_mask_mulhi_epu16(a, 0, a, b);
@@ -13932,7 +13932,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_mulhi_epu16() {
+    const fn test_mm256_maskz_mulhi_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_mulhi_epu16(0, a, b);
@@ -13943,7 +13943,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_mulhi_epu16() {
+    const fn test_mm_mask_mulhi_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_mask_mulhi_epu16(a, 0, a, b);
@@ -13954,7 +13954,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_mulhi_epu16() {
+    const fn test_mm_maskz_mulhi_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_mulhi_epu16(0, a, b);
@@ -13965,7 +13965,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mulhi_epi16() {
+    const fn test_mm512_mulhi_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mulhi_epi16(a, b);
@@ -13974,7 +13974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_mulhi_epi16() {
+    const fn test_mm512_mask_mulhi_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mask_mulhi_epi16(a, 0, a, b);
@@ -13987,7 +13987,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_mulhi_epi16() {
+    const fn test_mm512_maskz_mulhi_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_mulhi_epi16(0, a, b);
@@ -14000,7 +14000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_mulhi_epi16() {
+    const fn test_mm256_mask_mulhi_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_mask_mulhi_epi16(a, 0, a, b);
@@ -14011,7 +14011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_mulhi_epi16() {
+    const fn test_mm256_maskz_mulhi_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_mulhi_epi16(0, a, b);
@@ -14022,7 +14022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_mulhi_epi16() {
+    const fn test_mm_mask_mulhi_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_mask_mulhi_epi16(a, 0, a, b);
@@ -14033,7 +14033,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_mulhi_epi16() {
+    const fn test_mm_maskz_mulhi_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_mulhi_epi16(0, a, b);
@@ -14044,7 +14044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mulhrs_epi16() {
+    fn test_mm512_mulhrs_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mulhrs_epi16(a, b);
@@ -14053,7 +14053,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_mulhrs_epi16() {
+    fn test_mm512_mask_mulhrs_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mask_mulhrs_epi16(a, 0, a, b);
@@ -14066,7 +14066,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_mulhrs_epi16() {
+    fn test_mm512_maskz_mulhrs_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_mulhrs_epi16(0, a, b);
@@ -14079,7 +14079,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_mulhrs_epi16() {
+    fn test_mm256_mask_mulhrs_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_mask_mulhrs_epi16(a, 0, a, b);
@@ -14090,7 +14090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_mulhrs_epi16() {
+    fn test_mm256_maskz_mulhrs_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_mulhrs_epi16(0, a, b);
@@ -14101,7 +14101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_mulhrs_epi16() {
+    fn test_mm_mask_mulhrs_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_mask_mulhrs_epi16(a, 0, a, b);
@@ -14112,7 +14112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_mulhrs_epi16() {
+    fn test_mm_maskz_mulhrs_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_mulhrs_epi16(0, a, b);
@@ -14123,7 +14123,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mullo_epi16() {
+    const fn test_mm512_mullo_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mullo_epi16(a, b);
@@ -14132,7 +14132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_mullo_epi16() {
+    const fn test_mm512_mask_mullo_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mask_mullo_epi16(a, 0, a, b);
@@ -14145,7 +14145,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_mullo_epi16() {
+    const fn test_mm512_maskz_mullo_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_mullo_epi16(0, a, b);
@@ -14158,7 +14158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_mullo_epi16() {
+    const fn test_mm256_mask_mullo_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_mask_mullo_epi16(a, 0, a, b);
@@ -14169,7 +14169,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_mullo_epi16() {
+    const fn test_mm256_maskz_mullo_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_mullo_epi16(0, a, b);
@@ -14180,7 +14180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_mullo_epi16() {
+    const fn test_mm_mask_mullo_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_mask_mullo_epi16(a, 0, a, b);
@@ -14191,7 +14191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_mullo_epi16() {
+    const fn test_mm_maskz_mullo_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_mullo_epi16(0, a, b);
@@ -14202,7 +14202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_max_epu16() {
+    const fn test_mm512_max_epu16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14217,7 +14217,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_max_epu16() {
+    const fn test_mm512_mask_max_epu16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14234,7 +14234,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_max_epu16() {
+    const fn test_mm512_maskz_max_epu16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14251,7 +14251,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epu16() {
+    const fn test_mm256_mask_max_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_max_epu16(a, 0, a, b);
@@ -14262,7 +14262,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epu16() {
+    const fn test_mm256_maskz_max_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_max_epu16(0, a, b);
@@ -14273,7 +14273,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_max_epu16() {
+    const fn test_mm_mask_max_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_max_epu16(a, 0, a, b);
@@ -14284,7 +14284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epu16() {
+    const fn test_mm_maskz_max_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_max_epu16(0, a, b);
@@ -14295,7 +14295,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_max_epu8() {
+    const fn test_mm512_max_epu8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14316,7 +14316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_max_epu8() {
+    const fn test_mm512_mask_max_epu8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14344,7 +14344,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_max_epu8() {
+    const fn test_mm512_maskz_max_epu8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14371,7 +14371,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epu8() {
+    const fn test_mm256_mask_max_epu8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14388,7 +14388,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epu8() {
+    const fn test_mm256_maskz_max_epu8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14405,7 +14405,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_max_epu8() {
+    const fn test_mm_mask_max_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_max_epu8(a, 0, a, b);
@@ -14416,7 +14416,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epu8() {
+    const fn test_mm_maskz_max_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_max_epu8(0, a, b);
@@ -14427,7 +14427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_max_epi16() {
+    const fn test_mm512_max_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14442,7 +14442,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_max_epi16() {
+    const fn test_mm512_mask_max_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14459,7 +14459,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_max_epi16() {
+    const fn test_mm512_maskz_max_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14476,7 +14476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epi16() {
+    const fn test_mm256_mask_max_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_max_epi16(a, 0, a, b);
@@ -14487,7 +14487,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epi16() {
+    const fn test_mm256_maskz_max_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_max_epi16(0, a, b);
@@ -14498,7 +14498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_max_epi16() {
+    const fn test_mm_mask_max_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_max_epi16(a, 0, a, b);
@@ -14509,7 +14509,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epi16() {
+    const fn test_mm_maskz_max_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_max_epi16(0, a, b);
@@ -14520,7 +14520,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_max_epi8() {
+    const fn test_mm512_max_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14541,7 +14541,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_max_epi8() {
+    const fn test_mm512_mask_max_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14569,7 +14569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_max_epi8() {
+    const fn test_mm512_maskz_max_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14596,7 +14596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epi8() {
+    const fn test_mm256_mask_max_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14613,7 +14613,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epi8() {
+    const fn test_mm256_maskz_max_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14630,7 +14630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_max_epi8() {
+    const fn test_mm_mask_max_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_max_epi8(a, 0, a, b);
@@ -14641,7 +14641,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epi8() {
+    const fn test_mm_maskz_max_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_max_epi8(0, a, b);
@@ -14652,7 +14652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_min_epu16() {
+    const fn test_mm512_min_epu16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14667,7 +14667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_min_epu16() {
+    const fn test_mm512_mask_min_epu16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14684,7 +14684,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_min_epu16() {
+    const fn test_mm512_maskz_min_epu16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14701,7 +14701,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epu16() {
+    const fn test_mm256_mask_min_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_min_epu16(a, 0, a, b);
@@ -14712,7 +14712,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epu16() {
+    const fn test_mm256_maskz_min_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_min_epu16(0, a, b);
@@ -14723,7 +14723,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_min_epu16() {
+    const fn test_mm_mask_min_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_min_epu16(a, 0, a, b);
@@ -14734,7 +14734,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epu16() {
+    const fn test_mm_maskz_min_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_min_epu16(0, a, b);
@@ -14745,7 +14745,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_min_epu8() {
+    const fn test_mm512_min_epu8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14766,7 +14766,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_min_epu8() {
+    const fn test_mm512_mask_min_epu8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14794,7 +14794,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_min_epu8() {
+    const fn test_mm512_maskz_min_epu8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14821,7 +14821,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epu8() {
+    const fn test_mm256_mask_min_epu8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14838,7 +14838,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epu8() {
+    const fn test_mm256_maskz_min_epu8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14855,7 +14855,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_min_epu8() {
+    const fn test_mm_mask_min_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_min_epu8(a, 0, a, b);
@@ -14866,7 +14866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epu8() {
+    const fn test_mm_maskz_min_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_min_epu8(0, a, b);
@@ -14877,7 +14877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_min_epi16() {
+    const fn test_mm512_min_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14892,7 +14892,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_min_epi16() {
+    const fn test_mm512_mask_min_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14909,7 +14909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_min_epi16() {
+    const fn test_mm512_maskz_min_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -14926,7 +14926,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epi16() {
+    const fn test_mm256_mask_min_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_min_epi16(a, 0, a, b);
@@ -14937,7 +14937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epi16() {
+    const fn test_mm256_maskz_min_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm256_set_epi16(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_min_epi16(0, a, b);
@@ -14948,7 +14948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_min_epi16() {
+    const fn test_mm_mask_min_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_min_epi16(a, 0, a, b);
@@ -14959,7 +14959,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epi16() {
+    const fn test_mm_maskz_min_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_set_epi16(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_min_epi16(0, a, b);
@@ -14970,7 +14970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_min_epi8() {
+    const fn test_mm512_min_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -14991,7 +14991,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_min_epi8() {
+    const fn test_mm512_mask_min_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -15019,7 +15019,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_min_epi8() {
+    const fn test_mm512_maskz_min_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -15046,7 +15046,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epi8() {
+    const fn test_mm256_mask_min_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -15063,7 +15063,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epi8() {
+    const fn test_mm256_maskz_min_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -15080,7 +15080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_min_epi8() {
+    const fn test_mm_mask_min_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_mask_min_epi8(a, 0, a, b);
@@ -15091,7 +15091,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epi8() {
+    const fn test_mm_maskz_min_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_maskz_min_epi8(0, a, b);
@@ -15102,7 +15102,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmplt_epu16_mask() {
+    const fn test_mm512_cmplt_epu16_mask() {
         let a = _mm512_set1_epi16(-2);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmplt_epu16_mask(a, b);
@@ -15110,7 +15110,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmplt_epu16_mask() {
+    const fn test_mm512_mask_cmplt_epu16_mask() {
         let a = _mm512_set1_epi16(-2);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15119,7 +15119,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epu16_mask() {
+    const fn test_mm256_cmplt_epu16_mask() {
         let a = _mm256_set1_epi16(-2);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmplt_epu16_mask(a, b);
@@ -15127,7 +15127,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epu16_mask() {
+    const fn test_mm256_mask_cmplt_epu16_mask() {
         let a = _mm256_set1_epi16(-2);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -15136,7 +15136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmplt_epu16_mask() {
+    const fn test_mm_cmplt_epu16_mask() {
         let a = _mm_set1_epi16(-2);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmplt_epu16_mask(a, b);
@@ -15144,7 +15144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epu16_mask() {
+    const fn test_mm_mask_cmplt_epu16_mask() {
         let a = _mm_set1_epi16(-2);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -15153,7 +15153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmplt_epu8_mask() {
+    const fn test_mm512_cmplt_epu8_mask() {
         let a = _mm512_set1_epi8(-2);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmplt_epu8_mask(a, b);
@@ -15164,7 +15164,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmplt_epu8_mask() {
+    const fn test_mm512_mask_cmplt_epu8_mask() {
         let a = _mm512_set1_epi8(-2);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15176,7 +15176,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epu8_mask() {
+    const fn test_mm256_cmplt_epu8_mask() {
         let a = _mm256_set1_epi8(-2);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmplt_epu8_mask(a, b);
@@ -15184,7 +15184,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epu8_mask() {
+    const fn test_mm256_mask_cmplt_epu8_mask() {
         let a = _mm256_set1_epi8(-2);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15193,7 +15193,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmplt_epu8_mask() {
+    const fn test_mm_cmplt_epu8_mask() {
         let a = _mm_set1_epi8(-2);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmplt_epu8_mask(a, b);
@@ -15201,7 +15201,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epu8_mask() {
+    const fn test_mm_mask_cmplt_epu8_mask() {
         let a = _mm_set1_epi8(-2);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -15210,7 +15210,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmplt_epi16_mask() {
+    const fn test_mm512_cmplt_epi16_mask() {
         let a = _mm512_set1_epi16(-2);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmplt_epi16_mask(a, b);
@@ -15218,7 +15218,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmplt_epi16_mask() {
+    const fn test_mm512_mask_cmplt_epi16_mask() {
         let a = _mm512_set1_epi16(-2);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15227,7 +15227,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epi16_mask() {
+    const fn test_mm256_cmplt_epi16_mask() {
         let a = _mm256_set1_epi16(-2);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmplt_epi16_mask(a, b);
@@ -15235,7 +15235,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epi16_mask() {
+    const fn test_mm256_mask_cmplt_epi16_mask() {
         let a = _mm256_set1_epi16(-2);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -15244,7 +15244,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmplt_epi16_mask() {
+    const fn test_mm_cmplt_epi16_mask() {
         let a = _mm_set1_epi16(-2);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmplt_epi16_mask(a, b);
@@ -15252,7 +15252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epi16_mask() {
+    const fn test_mm_mask_cmplt_epi16_mask() {
         let a = _mm_set1_epi16(-2);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -15261,7 +15261,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmplt_epi8_mask() {
+    const fn test_mm512_cmplt_epi8_mask() {
         let a = _mm512_set1_epi8(-2);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmplt_epi8_mask(a, b);
@@ -15272,7 +15272,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmplt_epi8_mask() {
+    const fn test_mm512_mask_cmplt_epi8_mask() {
         let a = _mm512_set1_epi8(-2);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15284,7 +15284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epi8_mask() {
+    const fn test_mm256_cmplt_epi8_mask() {
         let a = _mm256_set1_epi8(-2);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmplt_epi8_mask(a, b);
@@ -15292,7 +15292,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epi8_mask() {
+    const fn test_mm256_mask_cmplt_epi8_mask() {
         let a = _mm256_set1_epi8(-2);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15301,7 +15301,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmplt_epi8_mask() {
+    const fn test_mm_cmplt_epi8_mask() {
         let a = _mm_set1_epi8(-2);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmplt_epi8_mask(a, b);
@@ -15309,7 +15309,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epi8_mask() {
+    const fn test_mm_mask_cmplt_epi8_mask() {
         let a = _mm_set1_epi8(-2);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -15318,7 +15318,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpgt_epu16_mask() {
+    const fn test_mm512_cmpgt_epu16_mask() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(1);
         let m = _mm512_cmpgt_epu16_mask(a, b);
@@ -15326,7 +15326,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpgt_epu16_mask() {
+    const fn test_mm512_mask_cmpgt_epu16_mask() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15335,7 +15335,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epu16_mask() {
+    const fn test_mm256_cmpgt_epu16_mask() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(1);
         let m = _mm256_cmpgt_epu16_mask(a, b);
@@ -15343,7 +15343,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epu16_mask() {
+    const fn test_mm256_mask_cmpgt_epu16_mask() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(1);
         let mask = 0b01010101_01010101;
@@ -15352,7 +15352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epu16_mask() {
+    const fn test_mm_cmpgt_epu16_mask() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(1);
         let m = _mm_cmpgt_epu16_mask(a, b);
@@ -15360,7 +15360,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epu16_mask() {
+    const fn test_mm_mask_cmpgt_epu16_mask() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(1);
         let mask = 0b01010101;
@@ -15369,7 +15369,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpgt_epu8_mask() {
+    const fn test_mm512_cmpgt_epu8_mask() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(1);
         let m = _mm512_cmpgt_epu8_mask(a, b);
@@ -15380,7 +15380,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpgt_epu8_mask() {
+    const fn test_mm512_mask_cmpgt_epu8_mask() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15392,7 +15392,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epu8_mask() {
+    const fn test_mm256_cmpgt_epu8_mask() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(1);
         let m = _mm256_cmpgt_epu8_mask(a, b);
@@ -15400,7 +15400,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epu8_mask() {
+    const fn test_mm256_mask_cmpgt_epu8_mask() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15409,7 +15409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epu8_mask() {
+    const fn test_mm_cmpgt_epu8_mask() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(1);
         let m = _mm_cmpgt_epu8_mask(a, b);
@@ -15417,7 +15417,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epu8_mask() {
+    const fn test_mm_mask_cmpgt_epu8_mask() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(1);
         let mask = 0b01010101_01010101;
@@ -15426,7 +15426,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpgt_epi16_mask() {
+    const fn test_mm512_cmpgt_epi16_mask() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmpgt_epi16_mask(a, b);
@@ -15434,7 +15434,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpgt_epi16_mask() {
+    const fn test_mm512_mask_cmpgt_epi16_mask() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15443,7 +15443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epi16_mask() {
+    const fn test_mm256_cmpgt_epi16_mask() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmpgt_epi16_mask(a, b);
@@ -15451,7 +15451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epi16_mask() {
+    const fn test_mm256_mask_cmpgt_epi16_mask() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b001010101_01010101;
@@ -15460,7 +15460,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epi16_mask() {
+    const fn test_mm_cmpgt_epi16_mask() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmpgt_epi16_mask(a, b);
@@ -15468,7 +15468,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epi16_mask() {
+    const fn test_mm_mask_cmpgt_epi16_mask() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -15477,7 +15477,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpgt_epi8_mask() {
+    const fn test_mm512_cmpgt_epi8_mask() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmpgt_epi8_mask(a, b);
@@ -15488,7 +15488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpgt_epi8_mask() {
+    const fn test_mm512_mask_cmpgt_epi8_mask() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15500,7 +15500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epi8_mask() {
+    const fn test_mm256_cmpgt_epi8_mask() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmpgt_epi8_mask(a, b);
@@ -15508,7 +15508,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epi8_mask() {
+    const fn test_mm256_mask_cmpgt_epi8_mask() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15517,7 +15517,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epi8_mask() {
+    const fn test_mm_cmpgt_epi8_mask() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmpgt_epi8_mask(a, b);
@@ -15525,7 +15525,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epi8_mask() {
+    const fn test_mm_mask_cmpgt_epi8_mask() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -15534,7 +15534,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmple_epu16_mask() {
+    const fn test_mm512_cmple_epu16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmple_epu16_mask(a, b);
@@ -15542,7 +15542,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmple_epu16_mask() {
+    const fn test_mm512_mask_cmple_epu16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15551,7 +15551,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmple_epu16_mask() {
+    const fn test_mm256_cmple_epu16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmple_epu16_mask(a, b);
@@ -15559,7 +15559,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epu16_mask() {
+    const fn test_mm256_mask_cmple_epu16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -15568,7 +15568,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmple_epu16_mask() {
+    const fn test_mm_cmple_epu16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmple_epu16_mask(a, b);
@@ -15576,7 +15576,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epu16_mask() {
+    const fn test_mm_mask_cmple_epu16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -15585,7 +15585,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmple_epu8_mask() {
+    const fn test_mm512_cmple_epu8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmple_epu8_mask(a, b);
@@ -15596,7 +15596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmple_epu8_mask() {
+    const fn test_mm512_mask_cmple_epu8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15608,7 +15608,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmple_epu8_mask() {
+    const fn test_mm256_cmple_epu8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmple_epu8_mask(a, b);
@@ -15616,7 +15616,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epu8_mask() {
+    const fn test_mm256_mask_cmple_epu8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15625,7 +15625,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmple_epu8_mask() {
+    const fn test_mm_cmple_epu8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmple_epu8_mask(a, b);
@@ -15633,7 +15633,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epu8_mask() {
+    const fn test_mm_mask_cmple_epu8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -15642,7 +15642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmple_epi16_mask() {
+    const fn test_mm512_cmple_epi16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmple_epi16_mask(a, b);
@@ -15650,7 +15650,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmple_epi16_mask() {
+    const fn test_mm512_mask_cmple_epi16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15659,7 +15659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmple_epi16_mask() {
+    const fn test_mm256_cmple_epi16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmple_epi16_mask(a, b);
@@ -15667,7 +15667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epi16_mask() {
+    const fn test_mm256_mask_cmple_epi16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -15676,7 +15676,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmple_epi16_mask() {
+    const fn test_mm_cmple_epi16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmple_epi16_mask(a, b);
@@ -15684,7 +15684,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epi16_mask() {
+    const fn test_mm_mask_cmple_epi16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -15693,7 +15693,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmple_epi8_mask() {
+    const fn test_mm512_cmple_epi8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmple_epi8_mask(a, b);
@@ -15704,7 +15704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmple_epi8_mask() {
+    const fn test_mm512_mask_cmple_epi8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15716,7 +15716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmple_epi8_mask() {
+    const fn test_mm256_cmple_epi8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmple_epi8_mask(a, b);
@@ -15724,7 +15724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epi8_mask() {
+    const fn test_mm256_mask_cmple_epi8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15733,7 +15733,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmple_epi8_mask() {
+    const fn test_mm_cmple_epi8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmple_epi8_mask(a, b);
@@ -15741,7 +15741,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epi8_mask() {
+    const fn test_mm_mask_cmple_epi8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -15750,7 +15750,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpge_epu16_mask() {
+    const fn test_mm512_cmpge_epu16_mask() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let m = _mm512_cmpge_epu16_mask(a, b);
@@ -15758,7 +15758,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpge_epu16_mask() {
+    const fn test_mm512_mask_cmpge_epu16_mask() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15767,7 +15767,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epu16_mask() {
+    const fn test_mm256_cmpge_epu16_mask() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let m = _mm256_cmpge_epu16_mask(a, b);
@@ -15775,7 +15775,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epu16_mask() {
+    const fn test_mm256_mask_cmpge_epu16_mask() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let mask = 0b01010101_01010101;
@@ -15784,7 +15784,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpge_epu16_mask() {
+    const fn test_mm_cmpge_epu16_mask() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let m = _mm_cmpge_epu16_mask(a, b);
@@ -15792,7 +15792,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epu16_mask() {
+    const fn test_mm_mask_cmpge_epu16_mask() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let mask = 0b01010101;
@@ -15801,7 +15801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpge_epu8_mask() {
+    const fn test_mm512_cmpge_epu8_mask() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let m = _mm512_cmpge_epu8_mask(a, b);
@@ -15812,7 +15812,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpge_epu8_mask() {
+    const fn test_mm512_mask_cmpge_epu8_mask() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15824,7 +15824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epu8_mask() {
+    const fn test_mm256_cmpge_epu8_mask() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let m = _mm256_cmpge_epu8_mask(a, b);
@@ -15832,7 +15832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epu8_mask() {
+    const fn test_mm256_mask_cmpge_epu8_mask() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15841,7 +15841,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpge_epu8_mask() {
+    const fn test_mm_cmpge_epu8_mask() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let m = _mm_cmpge_epu8_mask(a, b);
@@ -15849,7 +15849,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epu8_mask() {
+    const fn test_mm_mask_cmpge_epu8_mask() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let mask = 0b01010101_01010101;
@@ -15858,7 +15858,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpge_epi16_mask() {
+    const fn test_mm512_cmpge_epi16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmpge_epi16_mask(a, b);
@@ -15866,7 +15866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpge_epi16_mask() {
+    const fn test_mm512_mask_cmpge_epi16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15875,7 +15875,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epi16_mask() {
+    const fn test_mm256_cmpge_epi16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmpge_epi16_mask(a, b);
@@ -15883,7 +15883,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epi16_mask() {
+    const fn test_mm256_mask_cmpge_epi16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -15892,7 +15892,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpge_epi16_mask() {
+    const fn test_mm_cmpge_epi16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmpge_epi16_mask(a, b);
@@ -15900,7 +15900,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epi16_mask() {
+    const fn test_mm_mask_cmpge_epi16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -15909,7 +15909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpge_epi8_mask() {
+    const fn test_mm512_cmpge_epi8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmpge_epi8_mask(a, b);
@@ -15920,7 +15920,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpge_epi8_mask() {
+    const fn test_mm512_mask_cmpge_epi8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -15932,7 +15932,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epi8_mask() {
+    const fn test_mm256_cmpge_epi8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmpge_epi8_mask(a, b);
@@ -15940,7 +15940,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epi8_mask() {
+    const fn test_mm256_mask_cmpge_epi8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15949,7 +15949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpge_epi8_mask() {
+    const fn test_mm_cmpge_epi8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmpge_epi8_mask(a, b);
@@ -15957,7 +15957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epi8_mask() {
+    const fn test_mm_mask_cmpge_epi8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -15966,7 +15966,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpeq_epu16_mask() {
+    const fn test_mm512_cmpeq_epu16_mask() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let m = _mm512_cmpeq_epu16_mask(a, b);
@@ -15974,7 +15974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpeq_epu16_mask() {
+    const fn test_mm512_mask_cmpeq_epu16_mask() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -15983,7 +15983,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epu16_mask() {
+    const fn test_mm256_cmpeq_epu16_mask() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let m = _mm256_cmpeq_epu16_mask(a, b);
@@ -15991,7 +15991,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epu16_mask() {
+    const fn test_mm256_mask_cmpeq_epu16_mask() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let mask = 0b01010101_01010101;
@@ -16000,7 +16000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epu16_mask() {
+    const fn test_mm_cmpeq_epu16_mask() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let m = _mm_cmpeq_epu16_mask(a, b);
@@ -16008,7 +16008,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epu16_mask() {
+    const fn test_mm_mask_cmpeq_epu16_mask() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let mask = 0b01010101;
@@ -16017,7 +16017,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpeq_epu8_mask() {
+    const fn test_mm512_cmpeq_epu8_mask() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let m = _mm512_cmpeq_epu8_mask(a, b);
@@ -16028,7 +16028,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpeq_epu8_mask() {
+    const fn test_mm512_mask_cmpeq_epu8_mask() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -16040,7 +16040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epu8_mask() {
+    const fn test_mm256_cmpeq_epu8_mask() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let m = _mm256_cmpeq_epu8_mask(a, b);
@@ -16048,7 +16048,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epu8_mask() {
+    const fn test_mm256_mask_cmpeq_epu8_mask() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16057,7 +16057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epu8_mask() {
+    const fn test_mm_cmpeq_epu8_mask() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let m = _mm_cmpeq_epu8_mask(a, b);
@@ -16065,7 +16065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epu8_mask() {
+    const fn test_mm_mask_cmpeq_epu8_mask() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let mask = 0b01010101_01010101;
@@ -16074,7 +16074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpeq_epi16_mask() {
+    const fn test_mm512_cmpeq_epi16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmpeq_epi16_mask(a, b);
@@ -16082,7 +16082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpeq_epi16_mask() {
+    const fn test_mm512_mask_cmpeq_epi16_mask() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16091,7 +16091,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epi16_mask() {
+    const fn test_mm256_cmpeq_epi16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmpeq_epi16_mask(a, b);
@@ -16099,7 +16099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epi16_mask() {
+    const fn test_mm256_mask_cmpeq_epi16_mask() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -16108,7 +16108,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epi16_mask() {
+    const fn test_mm_cmpeq_epi16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmpeq_epi16_mask(a, b);
@@ -16116,7 +16116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epi16_mask() {
+    const fn test_mm_mask_cmpeq_epi16_mask() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -16125,7 +16125,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpeq_epi8_mask() {
+    const fn test_mm512_cmpeq_epi8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmpeq_epi8_mask(a, b);
@@ -16136,7 +16136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpeq_epi8_mask() {
+    const fn test_mm512_mask_cmpeq_epi8_mask() {
         let a = _mm512_set1_epi8(-1);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -16148,7 +16148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epi8_mask() {
+    const fn test_mm256_cmpeq_epi8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmpeq_epi8_mask(a, b);
@@ -16156,7 +16156,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epi8_mask() {
+    const fn test_mm256_mask_cmpeq_epi8_mask() {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16165,7 +16165,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epi8_mask() {
+    const fn test_mm_cmpeq_epi8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmpeq_epi8_mask(a, b);
@@ -16173,7 +16173,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epi8_mask() {
+    const fn test_mm_mask_cmpeq_epi8_mask() {
         let a = _mm_set1_epi8(-1);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -16182,7 +16182,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpneq_epu16_mask() {
+    const fn test_mm512_cmpneq_epu16_mask() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(1);
         let m = _mm512_cmpneq_epu16_mask(a, b);
@@ -16190,7 +16190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpneq_epu16_mask() {
+    const fn test_mm512_mask_cmpneq_epu16_mask() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16199,7 +16199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epu16_mask() {
+    const fn test_mm256_cmpneq_epu16_mask() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(1);
         let m = _mm256_cmpneq_epu16_mask(a, b);
@@ -16207,7 +16207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epu16_mask() {
+    const fn test_mm256_mask_cmpneq_epu16_mask() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(1);
         let mask = 0b01010101_01010101;
@@ -16216,7 +16216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epu16_mask() {
+    const fn test_mm_cmpneq_epu16_mask() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(1);
         let m = _mm_cmpneq_epu16_mask(a, b);
@@ -16224,7 +16224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epu16_mask() {
+    const fn test_mm_mask_cmpneq_epu16_mask() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(1);
         let mask = 0b01010101;
@@ -16233,7 +16233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpneq_epu8_mask() {
+    const fn test_mm512_cmpneq_epu8_mask() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(1);
         let m = _mm512_cmpneq_epu8_mask(a, b);
@@ -16244,7 +16244,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpneq_epu8_mask() {
+    const fn test_mm512_mask_cmpneq_epu8_mask() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -16256,7 +16256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epu8_mask() {
+    const fn test_mm256_cmpneq_epu8_mask() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(1);
         let m = _mm256_cmpneq_epu8_mask(a, b);
@@ -16264,7 +16264,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epu8_mask() {
+    const fn test_mm256_mask_cmpneq_epu8_mask() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16273,7 +16273,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epu8_mask() {
+    const fn test_mm_cmpneq_epu8_mask() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(1);
         let m = _mm_cmpneq_epu8_mask(a, b);
@@ -16281,7 +16281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epu8_mask() {
+    const fn test_mm_mask_cmpneq_epu8_mask() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(1);
         let mask = 0b01010101_01010101;
@@ -16290,7 +16290,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpneq_epi16_mask() {
+    const fn test_mm512_cmpneq_epi16_mask() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(-1);
         let m = _mm512_cmpneq_epi16_mask(a, b);
@@ -16298,7 +16298,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpneq_epi16_mask() {
+    const fn test_mm512_mask_cmpneq_epi16_mask() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16307,7 +16307,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epi16_mask() {
+    const fn test_mm256_cmpneq_epi16_mask() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(-1);
         let m = _mm256_cmpneq_epi16_mask(a, b);
@@ -16315,7 +16315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epi16_mask() {
+    const fn test_mm256_mask_cmpneq_epi16_mask() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(-1);
         let mask = 0b01010101_01010101;
@@ -16324,7 +16324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epi16_mask() {
+    const fn test_mm_cmpneq_epi16_mask() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(-1);
         let m = _mm_cmpneq_epi16_mask(a, b);
@@ -16332,7 +16332,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epi16_mask() {
+    const fn test_mm_mask_cmpneq_epi16_mask() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(-1);
         let mask = 0b01010101;
@@ -16341,7 +16341,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmpneq_epi8_mask() {
+    const fn test_mm512_cmpneq_epi8_mask() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(-1);
         let m = _mm512_cmpneq_epi8_mask(a, b);
@@ -16352,7 +16352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmpneq_epi8_mask() {
+    const fn test_mm512_mask_cmpneq_epi8_mask() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -16364,7 +16364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epi8_mask() {
+    const fn test_mm256_cmpneq_epi8_mask() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(-1);
         let m = _mm256_cmpneq_epi8_mask(a, b);
@@ -16372,7 +16372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epi8_mask() {
+    const fn test_mm256_mask_cmpneq_epi8_mask() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(-1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16381,7 +16381,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epi8_mask() {
+    const fn test_mm_cmpneq_epi8_mask() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(-1);
         let m = _mm_cmpneq_epi8_mask(a, b);
@@ -16389,7 +16389,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epi8_mask() {
+    const fn test_mm_mask_cmpneq_epi8_mask() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(-1);
         let mask = 0b01010101_01010101;
@@ -16398,7 +16398,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmp_epu16_mask() {
+    const fn test_mm512_cmp_epu16_mask() {
         let a = _mm512_set1_epi16(0);
         let b = _mm512_set1_epi16(1);
         let m = _mm512_cmp_epu16_mask::<_MM_CMPINT_LT>(a, b);
@@ -16406,7 +16406,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmp_epu16_mask() {
+    const fn test_mm512_mask_cmp_epu16_mask() {
         let a = _mm512_set1_epi16(0);
         let b = _mm512_set1_epi16(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16415,7 +16415,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmp_epu16_mask() {
+    const fn test_mm256_cmp_epu16_mask() {
         let a = _mm256_set1_epi16(0);
         let b = _mm256_set1_epi16(1);
         let m = _mm256_cmp_epu16_mask::<_MM_CMPINT_LT>(a, b);
@@ -16423,7 +16423,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epu16_mask() {
+    const fn test_mm256_mask_cmp_epu16_mask() {
         let a = _mm256_set1_epi16(0);
         let b = _mm256_set1_epi16(1);
         let mask = 0b01010101_01010101;
@@ -16432,7 +16432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmp_epu16_mask() {
+    const fn test_mm_cmp_epu16_mask() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let m = _mm_cmp_epu16_mask::<_MM_CMPINT_LT>(a, b);
@@ -16440,7 +16440,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epu16_mask() {
+    const fn test_mm_mask_cmp_epu16_mask() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let mask = 0b01010101;
@@ -16449,7 +16449,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmp_epu8_mask() {
+    const fn test_mm512_cmp_epu8_mask() {
         let a = _mm512_set1_epi8(0);
         let b = _mm512_set1_epi8(1);
         let m = _mm512_cmp_epu8_mask::<_MM_CMPINT_LT>(a, b);
@@ -16460,7 +16460,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmp_epu8_mask() {
+    const fn test_mm512_mask_cmp_epu8_mask() {
         let a = _mm512_set1_epi8(0);
         let b = _mm512_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -16472,7 +16472,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmp_epu8_mask() {
+    const fn test_mm256_cmp_epu8_mask() {
         let a = _mm256_set1_epi8(0);
         let b = _mm256_set1_epi8(1);
         let m = _mm256_cmp_epu8_mask::<_MM_CMPINT_LT>(a, b);
@@ -16480,7 +16480,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epu8_mask() {
+    const fn test_mm256_mask_cmp_epu8_mask() {
         let a = _mm256_set1_epi8(0);
         let b = _mm256_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16489,7 +16489,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmp_epu8_mask() {
+    const fn test_mm_cmp_epu8_mask() {
         let a = _mm_set1_epi8(0);
         let b = _mm_set1_epi8(1);
         let m = _mm_cmp_epu8_mask::<_MM_CMPINT_LT>(a, b);
@@ -16497,7 +16497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epu8_mask() {
+    const fn test_mm_mask_cmp_epu8_mask() {
         let a = _mm_set1_epi8(0);
         let b = _mm_set1_epi8(1);
         let mask = 0b01010101_01010101;
@@ -16506,7 +16506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmp_epi16_mask() {
+    const fn test_mm512_cmp_epi16_mask() {
         let a = _mm512_set1_epi16(0);
         let b = _mm512_set1_epi16(1);
         let m = _mm512_cmp_epi16_mask::<_MM_CMPINT_LT>(a, b);
@@ -16514,7 +16514,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmp_epi16_mask() {
+    const fn test_mm512_mask_cmp_epi16_mask() {
         let a = _mm512_set1_epi16(0);
         let b = _mm512_set1_epi16(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16523,7 +16523,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmp_epi16_mask() {
+    const fn test_mm256_cmp_epi16_mask() {
         let a = _mm256_set1_epi16(0);
         let b = _mm256_set1_epi16(1);
         let m = _mm256_cmp_epi16_mask::<_MM_CMPINT_LT>(a, b);
@@ -16531,7 +16531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epi16_mask() {
+    const fn test_mm256_mask_cmp_epi16_mask() {
         let a = _mm256_set1_epi16(0);
         let b = _mm256_set1_epi16(1);
         let mask = 0b01010101_01010101;
@@ -16540,7 +16540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmp_epi16_mask() {
+    const fn test_mm_cmp_epi16_mask() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let m = _mm_cmp_epi16_mask::<_MM_CMPINT_LT>(a, b);
@@ -16548,7 +16548,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epi16_mask() {
+    const fn test_mm_mask_cmp_epi16_mask() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let mask = 0b01010101;
@@ -16557,7 +16557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cmp_epi8_mask() {
+    const fn test_mm512_cmp_epi8_mask() {
         let a = _mm512_set1_epi8(0);
         let b = _mm512_set1_epi8(1);
         let m = _mm512_cmp_epi8_mask::<_MM_CMPINT_LT>(a, b);
@@ -16568,7 +16568,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cmp_epi8_mask() {
+    const fn test_mm512_mask_cmp_epi8_mask() {
         let a = _mm512_set1_epi8(0);
         let b = _mm512_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
@@ -16580,7 +16580,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cmp_epi8_mask() {
+    const fn test_mm256_cmp_epi8_mask() {
         let a = _mm256_set1_epi8(0);
         let b = _mm256_set1_epi8(1);
         let m = _mm256_cmp_epi8_mask::<_MM_CMPINT_LT>(a, b);
@@ -16588,7 +16588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epi8_mask() {
+    const fn test_mm256_mask_cmp_epi8_mask() {
         let a = _mm256_set1_epi8(0);
         let b = _mm256_set1_epi8(1);
         let mask = 0b01010101_01010101_01010101_01010101;
@@ -16597,7 +16597,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cmp_epi8_mask() {
+    const fn test_mm_cmp_epi8_mask() {
         let a = _mm_set1_epi8(0);
         let b = _mm_set1_epi8(1);
         let m = _mm_cmp_epi8_mask::<_MM_CMPINT_LT>(a, b);
@@ -16605,7 +16605,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epi8_mask() {
+    const fn test_mm_mask_cmp_epi8_mask() {
         let a = _mm_set1_epi8(0);
         let b = _mm_set1_epi8(1);
         let mask = 0b01010101_01010101;
@@ -16614,91 +16614,91 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_add_epi16() {
+    const fn test_mm256_reduce_add_epi16() {
         let a = _mm256_set1_epi16(1);
         let e = _mm256_reduce_add_epi16(a);
         assert_eq!(16, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_add_epi16() {
+    const fn test_mm256_mask_reduce_add_epi16() {
         let a = _mm256_set1_epi16(1);
         let e = _mm256_mask_reduce_add_epi16(0b11111111_00000000, a);
         assert_eq!(8, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_add_epi16() {
+    const fn test_mm_reduce_add_epi16() {
         let a = _mm_set1_epi16(1);
         let e = _mm_reduce_add_epi16(a);
         assert_eq!(8, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_add_epi16() {
+    const fn test_mm_mask_reduce_add_epi16() {
         let a = _mm_set1_epi16(1);
         let e = _mm_mask_reduce_add_epi16(0b11110000, a);
         assert_eq!(4, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_add_epi8() {
+    const fn test_mm256_reduce_add_epi8() {
         let a = _mm256_set1_epi8(1);
         let e = _mm256_reduce_add_epi8(a);
         assert_eq!(32, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_add_epi8() {
+    const fn test_mm256_mask_reduce_add_epi8() {
         let a = _mm256_set1_epi8(1);
         let e = _mm256_mask_reduce_add_epi8(0b11111111_00000000_11111111_00000000, a);
         assert_eq!(16, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_add_epi8() {
+    const fn test_mm_reduce_add_epi8() {
         let a = _mm_set1_epi8(1);
         let e = _mm_reduce_add_epi8(a);
         assert_eq!(16, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_add_epi8() {
+    const fn test_mm_mask_reduce_add_epi8() {
         let a = _mm_set1_epi8(1);
         let e = _mm_mask_reduce_add_epi8(0b11111111_00000000, a);
         assert_eq!(8, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_and_epi16() {
+    const fn test_mm256_reduce_and_epi16() {
         let a = _mm256_set_epi16(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm256_reduce_and_epi16(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_and_epi16() {
+    const fn test_mm256_mask_reduce_and_epi16() {
         let a = _mm256_set_epi16(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm256_mask_reduce_and_epi16(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_and_epi16() {
+    const fn test_mm_reduce_and_epi16() {
         let a = _mm_set_epi16(1, 1, 1, 1, 2, 2, 2, 2);
         let e = _mm_reduce_and_epi16(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_and_epi16() {
+    const fn test_mm_mask_reduce_and_epi16() {
         let a = _mm_set_epi16(1, 1, 1, 1, 2, 2, 2, 2);
         let e = _mm_mask_reduce_and_epi16(0b11110000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_and_epi8() {
+    const fn test_mm256_reduce_and_epi8() {
         let a = _mm256_set_epi8(
             1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
             2, 2, 2,
@@ -16708,7 +16708,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_and_epi8() {
+    const fn test_mm256_mask_reduce_and_epi8() {
         let a = _mm256_set_epi8(
             1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
             2, 2, 2,
@@ -16718,49 +16718,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_and_epi8() {
+    const fn test_mm_reduce_and_epi8() {
         let a = _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm_reduce_and_epi8(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_and_epi8() {
+    const fn test_mm_mask_reduce_and_epi8() {
         let a = _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm_mask_reduce_and_epi8(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_mul_epi16() {
+    const fn test_mm256_reduce_mul_epi16() {
         let a = _mm256_set_epi16(2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1);
         let e = _mm256_reduce_mul_epi16(a);
         assert_eq!(256, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_mul_epi16() {
+    const fn test_mm256_mask_reduce_mul_epi16() {
         let a = _mm256_set_epi16(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm256_mask_reduce_mul_epi16(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_mul_epi16() {
+    const fn test_mm_reduce_mul_epi16() {
         let a = _mm_set_epi16(2, 2, 2, 2, 1, 1, 1, 1);
         let e = _mm_reduce_mul_epi16(a);
         assert_eq!(16, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_mul_epi16() {
+    const fn test_mm_mask_reduce_mul_epi16() {
         let a = _mm_set_epi16(1, 1, 1, 1, 2, 2, 2, 2);
         let e = _mm_mask_reduce_mul_epi16(0b11110000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_mul_epi8() {
+    const fn test_mm256_reduce_mul_epi8() {
         let a = _mm256_set_epi8(
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             2, 2, 2,
@@ -16770,7 +16770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_mul_epi8() {
+    const fn test_mm256_mask_reduce_mul_epi8() {
         let a = _mm256_set_epi8(
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             2, 2, 2,
@@ -16780,49 +16780,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_mul_epi8() {
+    const fn test_mm_reduce_mul_epi8() {
         let a = _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2);
         let e = _mm_reduce_mul_epi8(a);
         assert_eq!(8, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_mul_epi8() {
+    const fn test_mm_mask_reduce_mul_epi8() {
         let a = _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2);
         let e = _mm_mask_reduce_mul_epi8(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_max_epi16() {
+    const fn test_mm256_reduce_max_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i16 = _mm256_reduce_max_epi16(a);
         assert_eq!(15, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_max_epi16() {
+    const fn test_mm256_mask_reduce_max_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i16 = _mm256_mask_reduce_max_epi16(0b11111111_00000000, a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_max_epi16() {
+    const fn test_mm_reduce_max_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i16 = _mm_reduce_max_epi16(a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_max_epi16() {
+    const fn test_mm_mask_reduce_max_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i16 = _mm_mask_reduce_max_epi16(0b11110000, a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_max_epi8() {
+    const fn test_mm256_reduce_max_epi8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -16832,7 +16832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_max_epi8() {
+    const fn test_mm256_mask_reduce_max_epi8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -16842,49 +16842,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_max_epi8() {
+    const fn test_mm_reduce_max_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i8 = _mm_reduce_max_epi8(a);
         assert_eq!(15, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_max_epi8() {
+    const fn test_mm_mask_reduce_max_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i8 = _mm_mask_reduce_max_epi8(0b11111111_00000000, a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_max_epu16() {
+    const fn test_mm256_reduce_max_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u16 = _mm256_reduce_max_epu16(a);
         assert_eq!(15, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_max_epu16() {
+    const fn test_mm256_mask_reduce_max_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u16 = _mm256_mask_reduce_max_epu16(0b11111111_00000000, a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_max_epu16() {
+    const fn test_mm_reduce_max_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u16 = _mm_reduce_max_epu16(a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_max_epu16() {
+    const fn test_mm_mask_reduce_max_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u16 = _mm_mask_reduce_max_epu16(0b11110000, a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_max_epu8() {
+    const fn test_mm256_reduce_max_epu8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -16894,7 +16894,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_max_epu8() {
+    const fn test_mm256_mask_reduce_max_epu8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -16904,49 +16904,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_max_epu8() {
+    const fn test_mm_reduce_max_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u8 = _mm_reduce_max_epu8(a);
         assert_eq!(15, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_max_epu8() {
+    const fn test_mm_mask_reduce_max_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u8 = _mm_mask_reduce_max_epu8(0b11111111_00000000, a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_min_epi16() {
+    const fn test_mm256_reduce_min_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i16 = _mm256_reduce_min_epi16(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_min_epi16() {
+    const fn test_mm256_mask_reduce_min_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i16 = _mm256_mask_reduce_min_epi16(0b11111111_00000000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_min_epi16() {
+    const fn test_mm_reduce_min_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i16 = _mm_reduce_min_epi16(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_min_epi16() {
+    const fn test_mm_mask_reduce_min_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i16 = _mm_mask_reduce_min_epi16(0b11110000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_min_epi8() {
+    const fn test_mm256_reduce_min_epi8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -16956,7 +16956,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_min_epi8() {
+    const fn test_mm256_mask_reduce_min_epi8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -16966,49 +16966,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_min_epi8() {
+    const fn test_mm_reduce_min_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i8 = _mm_reduce_min_epi8(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_min_epi8() {
+    const fn test_mm_mask_reduce_min_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i8 = _mm_mask_reduce_min_epi8(0b11111111_00000000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_min_epu16() {
+    const fn test_mm256_reduce_min_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u16 = _mm256_reduce_min_epu16(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_min_epu16() {
+    const fn test_mm256_mask_reduce_min_epu16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u16 = _mm256_mask_reduce_min_epu16(0b11111111_00000000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_min_epu16() {
+    const fn test_mm_reduce_min_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u16 = _mm_reduce_min_epu16(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_min_epu16() {
+    const fn test_mm_mask_reduce_min_epu16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u16 = _mm_mask_reduce_min_epu16(0b11110000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_min_epu8() {
+    const fn test_mm256_reduce_min_epu8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -17018,7 +17018,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_min_epu8() {
+    const fn test_mm256_mask_reduce_min_epu8() {
         let a = _mm256_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
@@ -17028,49 +17028,49 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_min_epu8() {
+    const fn test_mm_reduce_min_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u8 = _mm_reduce_min_epu8(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_min_epu8() {
+    const fn test_mm_mask_reduce_min_epu8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u8 = _mm_mask_reduce_min_epu8(0b11111111_00000000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_or_epi16() {
+    const fn test_mm256_reduce_or_epi16() {
         let a = _mm256_set_epi16(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm256_reduce_or_epi16(a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_or_epi16() {
+    const fn test_mm256_mask_reduce_or_epi16() {
         let a = _mm256_set_epi16(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm256_mask_reduce_or_epi16(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_or_epi16() {
+    const fn test_mm_reduce_or_epi16() {
         let a = _mm_set_epi16(1, 1, 1, 1, 2, 2, 2, 2);
         let e = _mm_reduce_or_epi16(a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_or_epi16() {
+    const fn test_mm_mask_reduce_or_epi16() {
         let a = _mm_set_epi16(1, 1, 1, 1, 2, 2, 2, 2);
         let e = _mm_mask_reduce_or_epi16(0b11110000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_reduce_or_epi8() {
+    const fn test_mm256_reduce_or_epi8() {
         let a = _mm256_set_epi8(
             1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
             2, 2, 2,
@@ -17080,7 +17080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_reduce_or_epi8() {
+    const fn test_mm256_mask_reduce_or_epi8() {
         let a = _mm256_set_epi8(
             1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
             2, 2, 2,
@@ -17090,14 +17090,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_reduce_or_epi8() {
+    const fn test_mm_reduce_or_epi8() {
         let a = _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm_reduce_or_epi8(a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_reduce_or_epi8() {
+    const fn test_mm_mask_reduce_or_epi8() {
         let a = _mm_set_epi8(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e = _mm_mask_reduce_or_epi8(0b11111111_00000000, a);
         assert_eq!(1, e);
@@ -17486,7 +17486,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_madd_epi16() {
+    const fn test_mm512_madd_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_madd_epi16(a, b);
@@ -17495,7 +17495,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_madd_epi16() {
+    const fn test_mm512_mask_madd_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mask_madd_epi16(a, 0, a, b);
@@ -17523,7 +17523,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_madd_epi16() {
+    const fn test_mm512_maskz_madd_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_madd_epi16(0, a, b);
@@ -17534,7 +17534,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_madd_epi16() {
+    const fn test_mm256_mask_madd_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_mask_madd_epi16(a, 0, a, b);
@@ -17554,7 +17554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_madd_epi16() {
+    const fn test_mm256_maskz_madd_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_madd_epi16(0, a, b);
@@ -17565,7 +17565,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_madd_epi16() {
+    const fn test_mm_mask_madd_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_mask_madd_epi16(a, 0, a, b);
@@ -17576,7 +17576,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_madd_epi16() {
+    const fn test_mm_maskz_madd_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_madd_epi16(0, a, b);
@@ -17587,7 +17587,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maddubs_epi16() {
+    fn test_mm512_maddubs_epi16() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_maddubs_epi16(a, b);
@@ -17596,7 +17596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_maddubs_epi16() {
+    fn test_mm512_mask_maddubs_epi16() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let src = _mm512_set1_epi16(1);
@@ -17610,7 +17610,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_maddubs_epi16() {
+    fn test_mm512_maskz_maddubs_epi16() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_maskz_maddubs_epi16(0, a, b);
@@ -17623,7 +17623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_maddubs_epi16() {
+    fn test_mm256_mask_maddubs_epi16() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let src = _mm256_set1_epi16(1);
@@ -17635,7 +17635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_maddubs_epi16() {
+    fn test_mm256_maskz_maddubs_epi16() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_maskz_maddubs_epi16(0, a, b);
@@ -17646,7 +17646,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_maddubs_epi16() {
+    fn test_mm_mask_maddubs_epi16() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let src = _mm_set1_epi16(1);
@@ -17658,7 +17658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_maddubs_epi16() {
+    fn test_mm_maskz_maddubs_epi16() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let r = _mm_maskz_maddubs_epi16(0, a, b);
@@ -17669,7 +17669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_packs_epi32() {
+    fn test_mm512_packs_epi32() {
         let a = _mm512_set1_epi32(i32::MAX);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_packs_epi32(a, b);
@@ -17680,7 +17680,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_packs_epi32() {
+    fn test_mm512_mask_packs_epi32() {
         let a = _mm512_set1_epi32(i32::MAX);
         let b = _mm512_set1_epi32(1 << 16 | 1);
         let r = _mm512_mask_packs_epi32(a, 0, a, b);
@@ -17693,7 +17693,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_packs_epi32() {
+    fn test_mm512_maskz_packs_epi32() {
         let a = _mm512_set1_epi32(i32::MAX);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_maskz_packs_epi32(0, a, b);
@@ -17706,7 +17706,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_packs_epi32() {
+    fn test_mm256_mask_packs_epi32() {
         let a = _mm256_set1_epi32(i32::MAX);
         let b = _mm256_set1_epi32(1 << 16 | 1);
         let r = _mm256_mask_packs_epi32(a, 0, a, b);
@@ -17718,7 +17718,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_packs_epi32() {
+    fn test_mm256_maskz_packs_epi32() {
         let a = _mm256_set1_epi32(i32::MAX);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_maskz_packs_epi32(0, a, b);
@@ -17730,7 +17730,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_packs_epi32() {
+    fn test_mm_mask_packs_epi32() {
         let a = _mm_set1_epi32(i32::MAX);
         let b = _mm_set1_epi32(1 << 16 | 1);
         let r = _mm_mask_packs_epi32(a, 0, a, b);
@@ -17741,7 +17741,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_packs_epi32() {
+    fn test_mm_maskz_packs_epi32() {
         let a = _mm_set1_epi32(i32::MAX);
         let b = _mm_set1_epi32(1);
         let r = _mm_maskz_packs_epi32(0, a, b);
@@ -17752,7 +17752,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_packs_epi16() {
+    fn test_mm512_packs_epi16() {
         let a = _mm512_set1_epi16(i16::MAX);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_packs_epi16(a, b);
@@ -17765,7 +17765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_packs_epi16() {
+    fn test_mm512_mask_packs_epi16() {
         let a = _mm512_set1_epi16(i16::MAX);
         let b = _mm512_set1_epi16(1 << 8 | 1);
         let r = _mm512_mask_packs_epi16(a, 0, a, b);
@@ -17785,7 +17785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_packs_epi16() {
+    fn test_mm512_maskz_packs_epi16() {
         let a = _mm512_set1_epi16(i16::MAX);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_packs_epi16(0, a, b);
@@ -17804,7 +17804,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_packs_epi16() {
+    fn test_mm256_mask_packs_epi16() {
         let a = _mm256_set1_epi16(i16::MAX);
         let b = _mm256_set1_epi16(1 << 8 | 1);
         let r = _mm256_mask_packs_epi16(a, 0, a, b);
@@ -17817,7 +17817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_packs_epi16() {
+    fn test_mm256_maskz_packs_epi16() {
         let a = _mm256_set1_epi16(i16::MAX);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_packs_epi16(0, a, b);
@@ -17830,7 +17830,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_packs_epi16() {
+    fn test_mm_mask_packs_epi16() {
         let a = _mm_set1_epi16(i16::MAX);
         let b = _mm_set1_epi16(1 << 8 | 1);
         let r = _mm_mask_packs_epi16(a, 0, a, b);
@@ -17842,7 +17842,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_packs_epi16() {
+    fn test_mm_maskz_packs_epi16() {
         let a = _mm_set1_epi16(i16::MAX);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_packs_epi16(0, a, b);
@@ -17854,7 +17854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_packus_epi32() {
+    fn test_mm512_packus_epi32() {
         let a = _mm512_set1_epi32(-1);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_packus_epi32(a, b);
@@ -17865,7 +17865,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_packus_epi32() {
+    fn test_mm512_mask_packus_epi32() {
         let a = _mm512_set1_epi32(-1);
         let b = _mm512_set1_epi32(1 << 16 | 1);
         let r = _mm512_mask_packus_epi32(a, 0, a, b);
@@ -17878,7 +17878,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_packus_epi32() {
+    fn test_mm512_maskz_packus_epi32() {
         let a = _mm512_set1_epi32(-1);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_maskz_packus_epi32(0, a, b);
@@ -17891,7 +17891,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_packus_epi32() {
+    fn test_mm256_mask_packus_epi32() {
         let a = _mm256_set1_epi32(-1);
         let b = _mm256_set1_epi32(1 << 16 | 1);
         let r = _mm256_mask_packus_epi32(a, 0, a, b);
@@ -17902,7 +17902,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_packus_epi32() {
+    fn test_mm256_maskz_packus_epi32() {
         let a = _mm256_set1_epi32(-1);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_maskz_packus_epi32(0, a, b);
@@ -17913,7 +17913,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_packus_epi32() {
+    fn test_mm_mask_packus_epi32() {
         let a = _mm_set1_epi32(-1);
         let b = _mm_set1_epi32(1 << 16 | 1);
         let r = _mm_mask_packus_epi32(a, 0, a, b);
@@ -17924,7 +17924,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_packus_epi32() {
+    fn test_mm_maskz_packus_epi32() {
         let a = _mm_set1_epi32(-1);
         let b = _mm_set1_epi32(1);
         let r = _mm_maskz_packus_epi32(0, a, b);
@@ -17935,7 +17935,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_packus_epi16() {
+    fn test_mm512_packus_epi16() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_packus_epi16(a, b);
@@ -17948,7 +17948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_packus_epi16() {
+    fn test_mm512_mask_packus_epi16() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(1 << 8 | 1);
         let r = _mm512_mask_packus_epi16(a, 0, a, b);
@@ -17968,7 +17968,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_packus_epi16() {
+    fn test_mm512_maskz_packus_epi16() {
         let a = _mm512_set1_epi16(-1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_packus_epi16(0, a, b);
@@ -17987,7 +17987,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_packus_epi16() {
+    fn test_mm256_mask_packus_epi16() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(1 << 8 | 1);
         let r = _mm256_mask_packus_epi16(a, 0, a, b);
@@ -18000,7 +18000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_packus_epi16() {
+    fn test_mm256_maskz_packus_epi16() {
         let a = _mm256_set1_epi16(-1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_packus_epi16(0, a, b);
@@ -18013,7 +18013,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_packus_epi16() {
+    fn test_mm_mask_packus_epi16() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(1 << 8 | 1);
         let r = _mm_mask_packus_epi16(a, 0, a, b);
@@ -18024,7 +18024,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_packus_epi16() {
+    fn test_mm_maskz_packus_epi16() {
         let a = _mm_set1_epi16(-1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_packus_epi16(0, a, b);
@@ -18035,7 +18035,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_avg_epu16() {
+    const fn test_mm512_avg_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_avg_epu16(a, b);
@@ -18044,7 +18044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_avg_epu16() {
+    const fn test_mm512_mask_avg_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_mask_avg_epu16(a, 0, a, b);
@@ -18057,7 +18057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_avg_epu16() {
+    const fn test_mm512_maskz_avg_epu16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1);
         let r = _mm512_maskz_avg_epu16(0, a, b);
@@ -18070,7 +18070,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_avg_epu16() {
+    const fn test_mm256_mask_avg_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_mask_avg_epu16(a, 0, a, b);
@@ -18081,7 +18081,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_avg_epu16() {
+    const fn test_mm256_maskz_avg_epu16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_maskz_avg_epu16(0, a, b);
@@ -18092,7 +18092,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_avg_epu16() {
+    const fn test_mm_mask_avg_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_mask_avg_epu16(a, 0, a, b);
@@ -18103,7 +18103,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_avg_epu16() {
+    const fn test_mm_maskz_avg_epu16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1);
         let r = _mm_maskz_avg_epu16(0, a, b);
@@ -18114,7 +18114,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_avg_epu8() {
+    const fn test_mm512_avg_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_avg_epu8(a, b);
@@ -18123,7 +18123,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_avg_epu8() {
+    const fn test_mm512_mask_avg_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_mask_avg_epu8(a, 0, a, b);
@@ -18143,7 +18143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_avg_epu8() {
+    const fn test_mm512_maskz_avg_epu8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_maskz_avg_epu8(0, a, b);
@@ -18162,7 +18162,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_avg_epu8() {
+    const fn test_mm256_mask_avg_epu8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_mask_avg_epu8(a, 0, a, b);
@@ -18175,7 +18175,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_avg_epu8() {
+    const fn test_mm256_maskz_avg_epu8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_maskz_avg_epu8(0, a, b);
@@ -18188,7 +18188,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_avg_epu8() {
+    const fn test_mm_mask_avg_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let r = _mm_mask_avg_epu8(a, 0, a, b);
@@ -18199,7 +18199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_avg_epu8() {
+    const fn test_mm_maskz_avg_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let r = _mm_maskz_avg_epu8(0, a, b);
@@ -18210,7 +18210,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_sll_epi16() {
+    fn test_mm512_sll_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm512_sll_epi16(a, count);
@@ -18219,7 +18219,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_sll_epi16() {
+    fn test_mm512_mask_sll_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm512_mask_sll_epi16(a, 0, a, count);
@@ -18230,7 +18230,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_sll_epi16() {
+    fn test_mm512_maskz_sll_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm512_maskz_sll_epi16(0, a, count);
@@ -18241,7 +18241,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_sll_epi16() {
+    fn test_mm256_mask_sll_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm256_mask_sll_epi16(a, 0, a, count);
@@ -18252,7 +18252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_sll_epi16() {
+    fn test_mm256_maskz_sll_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm256_maskz_sll_epi16(0, a, count);
@@ -18263,7 +18263,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_sll_epi16() {
+    fn test_mm_mask_sll_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm_mask_sll_epi16(a, 0, a, count);
@@ -18274,7 +18274,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_sll_epi16() {
+    fn test_mm_maskz_sll_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm_maskz_sll_epi16(0, a, count);
@@ -18285,7 +18285,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_slli_epi16() {
+    const fn test_mm512_slli_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let r = _mm512_slli_epi16::<1>(a);
         let e = _mm512_set1_epi16(0);
@@ -18293,7 +18293,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_slli_epi16() {
+    const fn test_mm512_mask_slli_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let r = _mm512_mask_slli_epi16::<1>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -18303,7 +18303,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_slli_epi16() {
+    const fn test_mm512_maskz_slli_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let r = _mm512_maskz_slli_epi16::<1>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -18313,7 +18313,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_slli_epi16() {
+    const fn test_mm256_mask_slli_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let r = _mm256_mask_slli_epi16::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -18323,7 +18323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_slli_epi16() {
+    const fn test_mm256_maskz_slli_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let r = _mm256_maskz_slli_epi16::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -18333,7 +18333,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_slli_epi16() {
+    const fn test_mm_mask_slli_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let r = _mm_mask_slli_epi16::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -18343,7 +18343,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_slli_epi16() {
+    const fn test_mm_maskz_slli_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let r = _mm_maskz_slli_epi16::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -18353,7 +18353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_sllv_epi16() {
+    const fn test_mm512_sllv_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_sllv_epi16(a, count);
@@ -18362,7 +18362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_sllv_epi16() {
+    const fn test_mm512_mask_sllv_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_mask_sllv_epi16(a, 0, a, count);
@@ -18373,7 +18373,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_sllv_epi16() {
+    const fn test_mm512_maskz_sllv_epi16() {
         let a = _mm512_set1_epi16(1 << 15);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_maskz_sllv_epi16(0, a, count);
@@ -18384,7 +18384,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_sllv_epi16() {
+    const fn test_mm256_sllv_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_sllv_epi16(a, count);
@@ -18393,7 +18393,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_sllv_epi16() {
+    const fn test_mm256_mask_sllv_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_mask_sllv_epi16(a, 0, a, count);
@@ -18404,7 +18404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_sllv_epi16() {
+    const fn test_mm256_maskz_sllv_epi16() {
         let a = _mm256_set1_epi16(1 << 15);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_maskz_sllv_epi16(0, a, count);
@@ -18415,7 +18415,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_sllv_epi16() {
+    const fn test_mm_sllv_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm_sllv_epi16(a, count);
@@ -18424,7 +18424,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_sllv_epi16() {
+    const fn test_mm_mask_sllv_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm_mask_sllv_epi16(a, 0, a, count);
@@ -18435,7 +18435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_sllv_epi16() {
+    const fn test_mm_maskz_sllv_epi16() {
         let a = _mm_set1_epi16(1 << 15);
         let count = _mm_set1_epi16(2);
         let r = _mm_maskz_sllv_epi16(0, a, count);
@@ -18446,7 +18446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_srl_epi16() {
+    fn test_mm512_srl_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm512_srl_epi16(a, count);
@@ -18455,7 +18455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_srl_epi16() {
+    fn test_mm512_mask_srl_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm512_mask_srl_epi16(a, 0, a, count);
@@ -18466,7 +18466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_srl_epi16() {
+    fn test_mm512_maskz_srl_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm512_maskz_srl_epi16(0, a, count);
@@ -18477,7 +18477,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_srl_epi16() {
+    fn test_mm256_mask_srl_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm256_mask_srl_epi16(a, 0, a, count);
@@ -18488,7 +18488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_srl_epi16() {
+    fn test_mm256_maskz_srl_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm256_maskz_srl_epi16(0, a, count);
@@ -18499,7 +18499,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_srl_epi16() {
+    fn test_mm_mask_srl_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm_mask_srl_epi16(a, 0, a, count);
@@ -18510,7 +18510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_srl_epi16() {
+    fn test_mm_maskz_srl_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm_maskz_srl_epi16(0, a, count);
@@ -18521,7 +18521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_srli_epi16() {
+    const fn test_mm512_srli_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let r = _mm512_srli_epi16::<2>(a);
         let e = _mm512_set1_epi16(0);
@@ -18529,7 +18529,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_srli_epi16() {
+    const fn test_mm512_mask_srli_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let r = _mm512_mask_srli_epi16::<2>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -18539,7 +18539,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_srli_epi16() {
+    const fn test_mm512_maskz_srli_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let r = _mm512_maskz_srli_epi16::<2>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -18549,7 +18549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_srli_epi16() {
+    const fn test_mm256_mask_srli_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let r = _mm256_mask_srli_epi16::<2>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -18559,7 +18559,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_srli_epi16() {
+    const fn test_mm256_maskz_srli_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let r = _mm256_maskz_srli_epi16::<2>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -18569,7 +18569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_srli_epi16() {
+    const fn test_mm_mask_srli_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let r = _mm_mask_srli_epi16::<2>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -18579,7 +18579,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_srli_epi16() {
+    const fn test_mm_maskz_srli_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let r = _mm_maskz_srli_epi16::<2>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -18589,7 +18589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_srlv_epi16() {
+    const fn test_mm512_srlv_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_srlv_epi16(a, count);
@@ -18598,7 +18598,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_srlv_epi16() {
+    const fn test_mm512_mask_srlv_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_mask_srlv_epi16(a, 0, a, count);
@@ -18609,7 +18609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_srlv_epi16() {
+    const fn test_mm512_maskz_srlv_epi16() {
         let a = _mm512_set1_epi16(1 << 1);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_maskz_srlv_epi16(0, a, count);
@@ -18620,7 +18620,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_srlv_epi16() {
+    const fn test_mm256_srlv_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_srlv_epi16(a, count);
@@ -18629,7 +18629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_srlv_epi16() {
+    const fn test_mm256_mask_srlv_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_mask_srlv_epi16(a, 0, a, count);
@@ -18640,7 +18640,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_srlv_epi16() {
+    const fn test_mm256_maskz_srlv_epi16() {
         let a = _mm256_set1_epi16(1 << 1);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_maskz_srlv_epi16(0, a, count);
@@ -18651,7 +18651,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_srlv_epi16() {
+    const fn test_mm_srlv_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm_srlv_epi16(a, count);
@@ -18660,7 +18660,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_srlv_epi16() {
+    const fn test_mm_mask_srlv_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm_mask_srlv_epi16(a, 0, a, count);
@@ -18671,7 +18671,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_srlv_epi16() {
+    const fn test_mm_maskz_srlv_epi16() {
         let a = _mm_set1_epi16(1 << 1);
         let count = _mm_set1_epi16(2);
         let r = _mm_maskz_srlv_epi16(0, a, count);
@@ -18682,7 +18682,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_sra_epi16() {
+    fn test_mm512_sra_epi16() {
         let a = _mm512_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm512_sra_epi16(a, count);
@@ -18691,7 +18691,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_sra_epi16() {
+    fn test_mm512_mask_sra_epi16() {
         let a = _mm512_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm512_mask_sra_epi16(a, 0, a, count);
@@ -18702,7 +18702,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_sra_epi16() {
+    fn test_mm512_maskz_sra_epi16() {
         let a = _mm512_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm512_maskz_sra_epi16(0, a, count);
@@ -18713,7 +18713,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_sra_epi16() {
+    fn test_mm256_mask_sra_epi16() {
         let a = _mm256_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm256_mask_sra_epi16(a, 0, a, count);
@@ -18724,7 +18724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_sra_epi16() {
+    fn test_mm256_maskz_sra_epi16() {
         let a = _mm256_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm256_maskz_sra_epi16(0, a, count);
@@ -18735,7 +18735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_sra_epi16() {
+    fn test_mm_mask_sra_epi16() {
         let a = _mm_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm_mask_sra_epi16(a, 0, a, count);
@@ -18746,7 +18746,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_sra_epi16() {
+    fn test_mm_maskz_sra_epi16() {
         let a = _mm_set1_epi16(8);
         let count = _mm_set1_epi16(1);
         let r = _mm_maskz_sra_epi16(0, a, count);
@@ -18757,7 +18757,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_srai_epi16() {
+    const fn test_mm512_srai_epi16() {
         let a = _mm512_set1_epi16(8);
         let r = _mm512_srai_epi16::<2>(a);
         let e = _mm512_set1_epi16(2);
@@ -18765,7 +18765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_srai_epi16() {
+    const fn test_mm512_mask_srai_epi16() {
         let a = _mm512_set1_epi16(8);
         let r = _mm512_mask_srai_epi16::<2>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -18775,7 +18775,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_srai_epi16() {
+    const fn test_mm512_maskz_srai_epi16() {
         let a = _mm512_set1_epi16(8);
         let r = _mm512_maskz_srai_epi16::<2>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -18785,7 +18785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_srai_epi16() {
+    const fn test_mm256_mask_srai_epi16() {
         let a = _mm256_set1_epi16(8);
         let r = _mm256_mask_srai_epi16::<2>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -18795,7 +18795,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_srai_epi16() {
+    const fn test_mm256_maskz_srai_epi16() {
         let a = _mm256_set1_epi16(8);
         let r = _mm256_maskz_srai_epi16::<2>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -18805,7 +18805,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_srai_epi16() {
+    const fn test_mm_mask_srai_epi16() {
         let a = _mm_set1_epi16(8);
         let r = _mm_mask_srai_epi16::<2>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -18815,7 +18815,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_srai_epi16() {
+    const fn test_mm_maskz_srai_epi16() {
         let a = _mm_set1_epi16(8);
         let r = _mm_maskz_srai_epi16::<2>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -18825,7 +18825,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_srav_epi16() {
+    const fn test_mm512_srav_epi16() {
         let a = _mm512_set1_epi16(8);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_srav_epi16(a, count);
@@ -18834,7 +18834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_srav_epi16() {
+    const fn test_mm512_mask_srav_epi16() {
         let a = _mm512_set1_epi16(8);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_mask_srav_epi16(a, 0, a, count);
@@ -18845,7 +18845,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_srav_epi16() {
+    const fn test_mm512_maskz_srav_epi16() {
         let a = _mm512_set1_epi16(8);
         let count = _mm512_set1_epi16(2);
         let r = _mm512_maskz_srav_epi16(0, a, count);
@@ -18856,7 +18856,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_srav_epi16() {
+    const fn test_mm256_srav_epi16() {
         let a = _mm256_set1_epi16(8);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_srav_epi16(a, count);
@@ -18865,7 +18865,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_srav_epi16() {
+    const fn test_mm256_mask_srav_epi16() {
         let a = _mm256_set1_epi16(8);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_mask_srav_epi16(a, 0, a, count);
@@ -18876,7 +18876,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_srav_epi16() {
+    const fn test_mm256_maskz_srav_epi16() {
         let a = _mm256_set1_epi16(8);
         let count = _mm256_set1_epi16(2);
         let r = _mm256_maskz_srav_epi16(0, a, count);
@@ -18887,7 +18887,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_srav_epi16() {
+    const fn test_mm_srav_epi16() {
         let a = _mm_set1_epi16(8);
         let count = _mm_set1_epi16(2);
         let r = _mm_srav_epi16(a, count);
@@ -18896,7 +18896,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_srav_epi16() {
+    const fn test_mm_mask_srav_epi16() {
         let a = _mm_set1_epi16(8);
         let count = _mm_set1_epi16(2);
         let r = _mm_mask_srav_epi16(a, 0, a, count);
@@ -18907,7 +18907,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_srav_epi16() {
+    const fn test_mm_maskz_srav_epi16() {
         let a = _mm_set1_epi16(8);
         let count = _mm_set1_epi16(2);
         let r = _mm_maskz_srav_epi16(0, a, count);
@@ -18918,7 +18918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_permutex2var_epi16() {
+    fn test_mm512_permutex2var_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -18936,7 +18936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_permutex2var_epi16() {
+    fn test_mm512_mask_permutex2var_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -18956,7 +18956,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_permutex2var_epi16() {
+    fn test_mm512_maskz_permutex2var_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -18976,7 +18976,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask2_permutex2var_epi16() {
+    fn test_mm512_mask2_permutex2var_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -18996,7 +18996,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_permutex2var_epi16() {
+    fn test_mm256_permutex2var_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm256_set_epi16(1, 1<<4, 2, 1<<4, 3, 1<<4, 4, 1<<4, 5, 1<<4, 6, 1<<4, 7, 1<<4, 8, 1<<4);
@@ -19009,7 +19009,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_permutex2var_epi16() {
+    fn test_mm256_mask_permutex2var_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm256_set_epi16(1, 1<<4, 2, 1<<4, 3, 1<<4, 4, 1<<4, 5, 1<<4, 6, 1<<4, 7, 1<<4, 8, 1<<4);
@@ -19024,7 +19024,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_permutex2var_epi16() {
+    fn test_mm256_maskz_permutex2var_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm256_set_epi16(1, 1<<4, 2, 1<<4, 3, 1<<4, 4, 1<<4, 5, 1<<4, 6, 1<<4, 7, 1<<4, 8, 1<<4);
@@ -19039,7 +19039,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask2_permutex2var_epi16() {
+    fn test_mm256_mask2_permutex2var_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm256_set_epi16(1, 1<<4, 2, 1<<4, 3, 1<<4, 4, 1<<4, 5, 1<<4, 6, 1<<4, 7, 1<<4, 8, 1<<4);
@@ -19055,7 +19055,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_permutex2var_epi16() {
+    fn test_mm_permutex2var_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm_set_epi16(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm_set1_epi16(100);
@@ -19065,7 +19065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_permutex2var_epi16() {
+    fn test_mm_mask_permutex2var_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm_set_epi16(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm_set1_epi16(100);
@@ -19077,7 +19077,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_permutex2var_epi16() {
+    fn test_mm_maskz_permutex2var_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm_set_epi16(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm_set1_epi16(100);
@@ -19089,7 +19089,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask2_permutex2var_epi16() {
+    fn test_mm_mask2_permutex2var_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm_set_epi16(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm_set1_epi16(100);
@@ -19101,7 +19101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_permutexvar_epi16() {
+    fn test_mm512_permutexvar_epi16() {
         let idx = _mm512_set1_epi16(1);
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -19112,7 +19112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_permutexvar_epi16() {
+    fn test_mm512_mask_permutexvar_epi16() {
         let idx = _mm512_set1_epi16(1);
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -19125,7 +19125,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_permutexvar_epi16() {
+    fn test_mm512_maskz_permutexvar_epi16() {
         let idx = _mm512_set1_epi16(1);
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -19138,7 +19138,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_permutexvar_epi16() {
+    fn test_mm256_permutexvar_epi16() {
         let idx = _mm256_set1_epi16(1);
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_permutexvar_epi16(idx, a);
@@ -19147,7 +19147,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_permutexvar_epi16() {
+    fn test_mm256_mask_permutexvar_epi16() {
         let idx = _mm256_set1_epi16(1);
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_mask_permutexvar_epi16(a, 0, idx, a);
@@ -19158,7 +19158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_permutexvar_epi16() {
+    fn test_mm256_maskz_permutexvar_epi16() {
         let idx = _mm256_set1_epi16(1);
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_permutexvar_epi16(0, idx, a);
@@ -19169,7 +19169,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_permutexvar_epi16() {
+    fn test_mm_permutexvar_epi16() {
         let idx = _mm_set1_epi16(1);
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_permutexvar_epi16(idx, a);
@@ -19178,7 +19178,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_permutexvar_epi16() {
+    fn test_mm_mask_permutexvar_epi16() {
         let idx = _mm_set1_epi16(1);
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_mask_permutexvar_epi16(a, 0, idx, a);
@@ -19189,7 +19189,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_permutexvar_epi16() {
+    fn test_mm_maskz_permutexvar_epi16() {
         let idx = _mm_set1_epi16(1);
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_maskz_permutexvar_epi16(0, idx, a);
@@ -19200,7 +19200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_blend_epi16() {
+    const fn test_mm512_mask_blend_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(2);
         let r = _mm512_mask_blend_epi16(0b11111111_00000000_11111111_00000000, a, b);
@@ -19211,7 +19211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_epi16() {
+    const fn test_mm256_mask_blend_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_mask_blend_epi16(0b11111111_00000000, a, b);
@@ -19220,7 +19220,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_blend_epi16() {
+    const fn test_mm_mask_blend_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(2);
         let r = _mm_mask_blend_epi16(0b11110000, a, b);
@@ -19229,7 +19229,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_blend_epi8() {
+    const fn test_mm512_mask_blend_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(2);
         let r = _mm512_mask_blend_epi8(
@@ -19246,7 +19246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_epi8() {
+    const fn test_mm256_mask_blend_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_mask_blend_epi8(0b11111111_00000000_11111111_00000000, a, b);
@@ -19257,7 +19257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_blend_epi8() {
+    const fn test_mm_mask_blend_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(2);
         let r = _mm_mask_blend_epi8(0b11111111_00000000, a, b);
@@ -19266,7 +19266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_broadcastw_epi16() {
+    const fn test_mm512_broadcastw_epi16() {
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_broadcastw_epi16(a);
         let e = _mm512_set1_epi16(24);
@@ -19274,7 +19274,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_broadcastw_epi16() {
+    const fn test_mm512_mask_broadcastw_epi16() {
         let src = _mm512_set1_epi16(1);
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_mask_broadcastw_epi16(src, 0, a);
@@ -19285,7 +19285,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_broadcastw_epi16() {
+    const fn test_mm512_maskz_broadcastw_epi16() {
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_maskz_broadcastw_epi16(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -19295,7 +19295,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcastw_epi16() {
+    const fn test_mm256_mask_broadcastw_epi16() {
         let src = _mm256_set1_epi16(1);
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm256_mask_broadcastw_epi16(src, 0, a);
@@ -19306,7 +19306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcastw_epi16() {
+    const fn test_mm256_maskz_broadcastw_epi16() {
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm256_maskz_broadcastw_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -19316,7 +19316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_broadcastw_epi16() {
+    const fn test_mm_mask_broadcastw_epi16() {
         let src = _mm_set1_epi16(1);
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm_mask_broadcastw_epi16(src, 0, a);
@@ -19327,7 +19327,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_broadcastw_epi16() {
+    const fn test_mm_maskz_broadcastw_epi16() {
         let a = _mm_set_epi16(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm_maskz_broadcastw_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -19337,7 +19337,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_broadcastb_epi8() {
+    const fn test_mm512_broadcastb_epi8() {
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
         );
@@ -19347,7 +19347,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_broadcastb_epi8() {
+    const fn test_mm512_mask_broadcastb_epi8() {
         let src = _mm512_set1_epi8(1);
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19364,7 +19364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_broadcastb_epi8() {
+    const fn test_mm512_maskz_broadcastb_epi8() {
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
         );
@@ -19379,7 +19379,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcastb_epi8() {
+    const fn test_mm256_mask_broadcastb_epi8() {
         let src = _mm256_set1_epi8(1);
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19392,7 +19392,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcastb_epi8() {
+    const fn test_mm256_maskz_broadcastb_epi8() {
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
         );
@@ -19404,7 +19404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_broadcastb_epi8() {
+    const fn test_mm_mask_broadcastb_epi8() {
         let src = _mm_set1_epi8(1);
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19417,7 +19417,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_broadcastb_epi8() {
+    const fn test_mm_maskz_broadcastb_epi8() {
         let a = _mm_set_epi8(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
         );
@@ -19429,7 +19429,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_unpackhi_epi16() {
+    const fn test_mm512_unpackhi_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19444,7 +19444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_unpackhi_epi16() {
+    const fn test_mm512_mask_unpackhi_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19461,7 +19461,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_unpackhi_epi16() {
+    const fn test_mm512_maskz_unpackhi_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19478,7 +19478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_unpackhi_epi16() {
+    const fn test_mm256_mask_unpackhi_epi16() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi16(
             33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
@@ -19491,7 +19491,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpackhi_epi16() {
+    const fn test_mm256_maskz_unpackhi_epi16() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi16(
             33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
@@ -19504,7 +19504,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_unpackhi_epi16() {
+    const fn test_mm_mask_unpackhi_epi16() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi16(33, 34, 35, 36, 37, 38, 39, 40);
         let r = _mm_mask_unpackhi_epi16(a, 0, a, b);
@@ -19515,7 +19515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_unpackhi_epi16() {
+    const fn test_mm_maskz_unpackhi_epi16() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi16(33, 34, 35, 36, 37, 38, 39, 40);
         let r = _mm_maskz_unpackhi_epi16(0, a, b);
@@ -19526,7 +19526,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_unpackhi_epi8() {
+    const fn test_mm512_unpackhi_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19547,7 +19547,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_unpackhi_epi8() {
+    const fn test_mm512_mask_unpackhi_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19575,7 +19575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_unpackhi_epi8() {
+    const fn test_mm512_maskz_unpackhi_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19602,7 +19602,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_unpackhi_epi8() {
+    const fn test_mm256_mask_unpackhi_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19619,7 +19619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpackhi_epi8() {
+    const fn test_mm256_maskz_unpackhi_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19636,7 +19636,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_unpackhi_epi8() {
+    const fn test_mm_mask_unpackhi_epi8() {
         let a = _mm_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_set_epi8(
             65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
@@ -19649,7 +19649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_unpackhi_epi8() {
+    const fn test_mm_maskz_unpackhi_epi8() {
         let a = _mm_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_set_epi8(
             65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
@@ -19662,7 +19662,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_unpacklo_epi16() {
+    const fn test_mm512_unpacklo_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19677,7 +19677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_unpacklo_epi16() {
+    const fn test_mm512_mask_unpacklo_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19694,7 +19694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_unpacklo_epi16() {
+    const fn test_mm512_maskz_unpacklo_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19711,7 +19711,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_unpacklo_epi16() {
+    const fn test_mm256_mask_unpacklo_epi16() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi16(
             33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
@@ -19724,7 +19724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpacklo_epi16() {
+    const fn test_mm256_maskz_unpacklo_epi16() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi16(
             33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
@@ -19737,7 +19737,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_unpacklo_epi16() {
+    const fn test_mm_mask_unpacklo_epi16() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi16(33, 34, 35, 36, 37, 38, 39, 40);
         let r = _mm_mask_unpacklo_epi16(a, 0, a, b);
@@ -19748,7 +19748,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_unpacklo_epi16() {
+    const fn test_mm_maskz_unpacklo_epi16() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi16(33, 34, 35, 36, 37, 38, 39, 40);
         let r = _mm_maskz_unpacklo_epi16(0, a, b);
@@ -19759,7 +19759,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_unpacklo_epi8() {
+    const fn test_mm512_unpacklo_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19780,7 +19780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_unpacklo_epi8() {
+    const fn test_mm512_mask_unpacklo_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19808,7 +19808,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_unpacklo_epi8() {
+    const fn test_mm512_maskz_unpacklo_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -19835,7 +19835,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_unpacklo_epi8() {
+    const fn test_mm256_mask_unpacklo_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19852,7 +19852,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpacklo_epi8() {
+    const fn test_mm256_maskz_unpacklo_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                                 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
@@ -19869,7 +19869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_unpacklo_epi8() {
+    const fn test_mm_mask_unpacklo_epi8() {
         let a = _mm_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_set_epi8(
             65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
@@ -19884,7 +19884,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_unpacklo_epi8() {
+    const fn test_mm_maskz_unpacklo_epi8() {
         let a = _mm_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_set_epi8(
             65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
@@ -19899,7 +19899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_mov_epi16() {
+    const fn test_mm512_mask_mov_epi16() {
         let src = _mm512_set1_epi16(1);
         let a = _mm512_set1_epi16(2);
         let r = _mm512_mask_mov_epi16(src, 0, a);
@@ -19909,7 +19909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_mov_epi16() {
+    const fn test_mm512_maskz_mov_epi16() {
         let a = _mm512_set1_epi16(2);
         let r = _mm512_maskz_mov_epi16(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -19918,7 +19918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_mov_epi16() {
+    const fn test_mm256_mask_mov_epi16() {
         let src = _mm256_set1_epi16(1);
         let a = _mm256_set1_epi16(2);
         let r = _mm256_mask_mov_epi16(src, 0, a);
@@ -19928,7 +19928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_mov_epi16() {
+    const fn test_mm256_maskz_mov_epi16() {
         let a = _mm256_set1_epi16(2);
         let r = _mm256_maskz_mov_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -19937,7 +19937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_mov_epi16() {
+    const fn test_mm_mask_mov_epi16() {
         let src = _mm_set1_epi16(1);
         let a = _mm_set1_epi16(2);
         let r = _mm_mask_mov_epi16(src, 0, a);
@@ -19947,7 +19947,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_mov_epi16() {
+    const fn test_mm_maskz_mov_epi16() {
         let a = _mm_set1_epi16(2);
         let r = _mm_maskz_mov_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -19956,7 +19956,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_mov_epi8() {
+    const fn test_mm512_mask_mov_epi8() {
         let src = _mm512_set1_epi8(1);
         let a = _mm512_set1_epi8(2);
         let r = _mm512_mask_mov_epi8(src, 0, a);
@@ -19970,7 +19970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_mov_epi8() {
+    const fn test_mm512_maskz_mov_epi8() {
         let a = _mm512_set1_epi8(2);
         let r = _mm512_maskz_mov_epi8(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -19982,7 +19982,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_mov_epi8() {
+    const fn test_mm256_mask_mov_epi8() {
         let src = _mm256_set1_epi8(1);
         let a = _mm256_set1_epi8(2);
         let r = _mm256_mask_mov_epi8(src, 0, a);
@@ -19992,7 +19992,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_mov_epi8() {
+    const fn test_mm256_maskz_mov_epi8() {
         let a = _mm256_set1_epi8(2);
         let r = _mm256_maskz_mov_epi8(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -20001,7 +20001,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_mov_epi8() {
+    const fn test_mm_mask_mov_epi8() {
         let src = _mm_set1_epi8(1);
         let a = _mm_set1_epi8(2);
         let r = _mm_mask_mov_epi8(src, 0, a);
@@ -20011,7 +20011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_mov_epi8() {
+    const fn test_mm_maskz_mov_epi8() {
         let a = _mm_set1_epi8(2);
         let r = _mm_maskz_mov_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -20020,7 +20020,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_set1_epi16() {
+    const fn test_mm512_mask_set1_epi16() {
         let src = _mm512_set1_epi16(2);
         let a: i16 = 11;
         let r = _mm512_mask_set1_epi16(src, 0, a);
@@ -20031,7 +20031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_set1_epi16() {
+    const fn test_mm512_maskz_set1_epi16() {
         let a: i16 = 11;
         let r = _mm512_maskz_set1_epi16(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -20041,7 +20041,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_set1_epi16() {
+    const fn test_mm256_mask_set1_epi16() {
         let src = _mm256_set1_epi16(2);
         let a: i16 = 11;
         let r = _mm256_mask_set1_epi16(src, 0, a);
@@ -20052,7 +20052,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_set1_epi16() {
+    const fn test_mm256_maskz_set1_epi16() {
         let a: i16 = 11;
         let r = _mm256_maskz_set1_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -20062,7 +20062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_set1_epi16() {
+    const fn test_mm_mask_set1_epi16() {
         let src = _mm_set1_epi16(2);
         let a: i16 = 11;
         let r = _mm_mask_set1_epi16(src, 0, a);
@@ -20073,7 +20073,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_set1_epi16() {
+    const fn test_mm_maskz_set1_epi16() {
         let a: i16 = 11;
         let r = _mm_maskz_set1_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -20083,7 +20083,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_set1_epi8() {
+    const fn test_mm512_mask_set1_epi8() {
         let src = _mm512_set1_epi8(2);
         let a: i8 = 11;
         let r = _mm512_mask_set1_epi8(src, 0, a);
@@ -20098,7 +20098,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_set1_epi8() {
+    const fn test_mm512_maskz_set1_epi8() {
         let a: i8 = 11;
         let r = _mm512_maskz_set1_epi8(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -20111,7 +20111,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_set1_epi8() {
+    const fn test_mm256_mask_set1_epi8() {
         let src = _mm256_set1_epi8(2);
         let a: i8 = 11;
         let r = _mm256_mask_set1_epi8(src, 0, a);
@@ -20122,7 +20122,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_set1_epi8() {
+    const fn test_mm256_maskz_set1_epi8() {
         let a: i8 = 11;
         let r = _mm256_maskz_set1_epi8(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -20132,7 +20132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_set1_epi8() {
+    const fn test_mm_mask_set1_epi8() {
         let src = _mm_set1_epi8(2);
         let a: i8 = 11;
         let r = _mm_mask_set1_epi8(src, 0, a);
@@ -20143,7 +20143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_set1_epi8() {
+    const fn test_mm_maskz_set1_epi8() {
         let a: i8 = 11;
         let r = _mm_maskz_set1_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -20153,7 +20153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_shufflelo_epi16() {
+    const fn test_mm512_shufflelo_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -20169,7 +20169,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_shufflelo_epi16() {
+    const fn test_mm512_mask_shufflelo_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -20191,7 +20191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_shufflelo_epi16() {
+    const fn test_mm512_maskz_shufflelo_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -20210,7 +20210,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_shufflelo_epi16() {
+    const fn test_mm256_mask_shufflelo_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_mask_shufflelo_epi16::<0b00_01_01_11>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -20220,7 +20220,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_shufflelo_epi16() {
+    const fn test_mm256_maskz_shufflelo_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_shufflelo_epi16::<0b00_01_01_11>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -20230,7 +20230,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_shufflelo_epi16() {
+    const fn test_mm_mask_shufflelo_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_mask_shufflelo_epi16::<0b00_01_01_11>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -20240,7 +20240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_shufflelo_epi16() {
+    const fn test_mm_maskz_shufflelo_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_maskz_shufflelo_epi16::<0b00_01_01_11>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -20250,7 +20250,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_shufflehi_epi16() {
+    const fn test_mm512_shufflehi_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -20266,7 +20266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_shufflehi_epi16() {
+    const fn test_mm512_mask_shufflehi_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -20288,7 +20288,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_shufflehi_epi16() {
+    const fn test_mm512_maskz_shufflehi_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -20307,7 +20307,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_shufflehi_epi16() {
+    const fn test_mm256_mask_shufflehi_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_mask_shufflehi_epi16::<0b00_01_01_11>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -20317,7 +20317,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_shufflehi_epi16() {
+    const fn test_mm256_maskz_shufflehi_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_shufflehi_epi16::<0b00_01_01_11>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -20327,7 +20327,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_shufflehi_epi16() {
+    const fn test_mm_mask_shufflehi_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_mask_shufflehi_epi16::<0b00_01_01_11>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -20337,7 +20337,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_shufflehi_epi16() {
+    const fn test_mm_maskz_shufflehi_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_maskz_shufflehi_epi16::<0b00_01_01_11>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -20347,7 +20347,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_shuffle_epi8() {
+    fn test_mm512_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -20364,7 +20364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_shuffle_epi8() {
+    fn test_mm512_mask_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -20388,7 +20388,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_shuffle_epi8() {
+    fn test_mm512_maskz_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -20411,7 +20411,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_shuffle_epi8() {
+    fn test_mm256_mask_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -20426,7 +20426,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_shuffle_epi8() {
+    fn test_mm256_maskz_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -20441,7 +20441,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_shuffle_epi8() {
+    fn test_mm_mask_shuffle_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_set1_epi8(1);
         let r = _mm_mask_shuffle_epi8(a, 0, a, b);
@@ -20454,7 +20454,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_shuffle_epi8() {
+    fn test_mm_maskz_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15);
         let b = _mm_set1_epi8(1);
@@ -20468,7 +20468,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_test_epi16_mask() {
+    const fn test_mm512_test_epi16_mask() {
         let a = _mm512_set1_epi16(1 << 0);
         let b = _mm512_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm512_test_epi16_mask(a, b);
@@ -20477,7 +20477,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_test_epi16_mask() {
+    const fn test_mm512_mask_test_epi16_mask() {
         let a = _mm512_set1_epi16(1 << 0);
         let b = _mm512_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm512_mask_test_epi16_mask(0, a, b);
@@ -20488,7 +20488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_test_epi16_mask() {
+    const fn test_mm256_test_epi16_mask() {
         let a = _mm256_set1_epi16(1 << 0);
         let b = _mm256_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm256_test_epi16_mask(a, b);
@@ -20497,7 +20497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_test_epi16_mask() {
+    const fn test_mm256_mask_test_epi16_mask() {
         let a = _mm256_set1_epi16(1 << 0);
         let b = _mm256_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm256_mask_test_epi16_mask(0, a, b);
@@ -20508,7 +20508,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_test_epi16_mask() {
+    const fn test_mm_test_epi16_mask() {
         let a = _mm_set1_epi16(1 << 0);
         let b = _mm_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm_test_epi16_mask(a, b);
@@ -20517,7 +20517,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_test_epi16_mask() {
+    const fn test_mm_mask_test_epi16_mask() {
         let a = _mm_set1_epi16(1 << 0);
         let b = _mm_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm_mask_test_epi16_mask(0, a, b);
@@ -20528,7 +20528,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_test_epi8_mask() {
+    const fn test_mm512_test_epi8_mask() {
         let a = _mm512_set1_epi8(1 << 0);
         let b = _mm512_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm512_test_epi8_mask(a, b);
@@ -20538,7 +20538,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_test_epi8_mask() {
+    const fn test_mm512_mask_test_epi8_mask() {
         let a = _mm512_set1_epi8(1 << 0);
         let b = _mm512_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm512_mask_test_epi8_mask(0, a, b);
@@ -20554,7 +20554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_test_epi8_mask() {
+    const fn test_mm256_test_epi8_mask() {
         let a = _mm256_set1_epi8(1 << 0);
         let b = _mm256_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm256_test_epi8_mask(a, b);
@@ -20563,7 +20563,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_test_epi8_mask() {
+    const fn test_mm256_mask_test_epi8_mask() {
         let a = _mm256_set1_epi8(1 << 0);
         let b = _mm256_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm256_mask_test_epi8_mask(0, a, b);
@@ -20574,7 +20574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_test_epi8_mask() {
+    const fn test_mm_test_epi8_mask() {
         let a = _mm_set1_epi8(1 << 0);
         let b = _mm_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm_test_epi8_mask(a, b);
@@ -20583,7 +20583,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_test_epi8_mask() {
+    const fn test_mm_mask_test_epi8_mask() {
         let a = _mm_set1_epi8(1 << 0);
         let b = _mm_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm_mask_test_epi8_mask(0, a, b);
@@ -20594,7 +20594,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_testn_epi16_mask() {
+    const fn test_mm512_testn_epi16_mask() {
         let a = _mm512_set1_epi16(1 << 0);
         let b = _mm512_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm512_testn_epi16_mask(a, b);
@@ -20603,7 +20603,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_testn_epi16_mask() {
+    const fn test_mm512_mask_testn_epi16_mask() {
         let a = _mm512_set1_epi16(1 << 0);
         let b = _mm512_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm512_mask_testn_epi16_mask(0, a, b);
@@ -20614,7 +20614,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_testn_epi16_mask() {
+    const fn test_mm256_testn_epi16_mask() {
         let a = _mm256_set1_epi16(1 << 0);
         let b = _mm256_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm256_testn_epi16_mask(a, b);
@@ -20623,7 +20623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_testn_epi16_mask() {
+    const fn test_mm256_mask_testn_epi16_mask() {
         let a = _mm256_set1_epi16(1 << 0);
         let b = _mm256_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm256_mask_testn_epi16_mask(0, a, b);
@@ -20634,7 +20634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_testn_epi16_mask() {
+    const fn test_mm_testn_epi16_mask() {
         let a = _mm_set1_epi16(1 << 0);
         let b = _mm_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm_testn_epi16_mask(a, b);
@@ -20643,7 +20643,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_testn_epi16_mask() {
+    const fn test_mm_mask_testn_epi16_mask() {
         let a = _mm_set1_epi16(1 << 0);
         let b = _mm_set1_epi16(1 << 0 | 1 << 1);
         let r = _mm_mask_testn_epi16_mask(0, a, b);
@@ -20654,7 +20654,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_testn_epi8_mask() {
+    const fn test_mm512_testn_epi8_mask() {
         let a = _mm512_set1_epi8(1 << 0);
         let b = _mm512_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm512_testn_epi8_mask(a, b);
@@ -20664,7 +20664,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_testn_epi8_mask() {
+    const fn test_mm512_mask_testn_epi8_mask() {
         let a = _mm512_set1_epi8(1 << 0);
         let b = _mm512_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm512_mask_testn_epi8_mask(0, a, b);
@@ -20680,7 +20680,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_testn_epi8_mask() {
+    const fn test_mm256_testn_epi8_mask() {
         let a = _mm256_set1_epi8(1 << 0);
         let b = _mm256_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm256_testn_epi8_mask(a, b);
@@ -20689,7 +20689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_testn_epi8_mask() {
+    const fn test_mm256_mask_testn_epi8_mask() {
         let a = _mm256_set1_epi8(1 << 0);
         let b = _mm256_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm256_mask_testn_epi8_mask(0, a, b);
@@ -20700,7 +20700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_testn_epi8_mask() {
+    const fn test_mm_testn_epi8_mask() {
         let a = _mm_set1_epi8(1 << 0);
         let b = _mm_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm_testn_epi8_mask(a, b);
@@ -20709,7 +20709,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_testn_epi8_mask() {
+    const fn test_mm_mask_testn_epi8_mask() {
         let a = _mm_set1_epi8(1 << 0);
         let b = _mm_set1_epi8(1 << 0 | 1 << 1);
         let r = _mm_mask_testn_epi8_mask(0, a, b);
@@ -20755,7 +20755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_sad_epu8() {
+    fn test_mm512_sad_epu8() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(4);
         let r = _mm512_sad_epu8(a, b);
@@ -20764,7 +20764,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_dbsad_epu8() {
+    fn test_mm512_dbsad_epu8() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(4);
         let r = _mm512_dbsad_epu8::<0>(a, b);
@@ -20773,7 +20773,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_dbsad_epu8() {
+    fn test_mm512_mask_dbsad_epu8() {
         let src = _mm512_set1_epi16(1);
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(4);
@@ -20785,7 +20785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_dbsad_epu8() {
+    fn test_mm512_maskz_dbsad_epu8() {
         let a = _mm512_set1_epi8(2);
         let b = _mm512_set1_epi8(4);
         let r = _mm512_maskz_dbsad_epu8::<0>(0, a, b);
@@ -20796,7 +20796,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_dbsad_epu8() {
+    fn test_mm256_dbsad_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_dbsad_epu8::<0>(a, b);
@@ -20805,7 +20805,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_dbsad_epu8() {
+    fn test_mm256_mask_dbsad_epu8() {
         let src = _mm256_set1_epi16(1);
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
@@ -20817,7 +20817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_dbsad_epu8() {
+    fn test_mm256_maskz_dbsad_epu8() {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_maskz_dbsad_epu8::<0>(0, a, b);
@@ -20828,7 +20828,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_dbsad_epu8() {
+    fn test_mm_dbsad_epu8() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(4);
         let r = _mm_dbsad_epu8::<0>(a, b);
@@ -20837,7 +20837,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_dbsad_epu8() {
+    fn test_mm_mask_dbsad_epu8() {
         let src = _mm_set1_epi16(1);
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(4);
@@ -20849,7 +20849,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_dbsad_epu8() {
+    fn test_mm_maskz_dbsad_epu8() {
         let a = _mm_set1_epi8(2);
         let b = _mm_set1_epi8(4);
         let r = _mm_maskz_dbsad_epu8::<0>(0, a, b);
@@ -20860,7 +20860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_movepi16_mask() {
+    const fn test_mm512_movepi16_mask() {
         let a = _mm512_set1_epi16(1 << 15);
         let r = _mm512_movepi16_mask(a);
         let e: __mmask32 = 0b11111111_11111111_11111111_11111111;
@@ -20868,7 +20868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_movepi16_mask() {
+    const fn test_mm256_movepi16_mask() {
         let a = _mm256_set1_epi16(1 << 15);
         let r = _mm256_movepi16_mask(a);
         let e: __mmask16 = 0b11111111_11111111;
@@ -20876,7 +20876,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_movepi16_mask() {
+    const fn test_mm_movepi16_mask() {
         let a = _mm_set1_epi16(1 << 15);
         let r = _mm_movepi16_mask(a);
         let e: __mmask8 = 0b11111111;
@@ -20884,7 +20884,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_movepi8_mask() {
+    const fn test_mm512_movepi8_mask() {
         let a = _mm512_set1_epi8(1 << 7);
         let r = _mm512_movepi8_mask(a);
         let e: __mmask64 =
@@ -20893,7 +20893,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_movepi8_mask() {
+    const fn test_mm256_movepi8_mask() {
         let a = _mm256_set1_epi8(1 << 7);
         let r = _mm256_movepi8_mask(a);
         let e: __mmask32 = 0b11111111_11111111_11111111_11111111;
@@ -20901,7 +20901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_movepi8_mask() {
+    const fn test_mm_movepi8_mask() {
         let a = _mm_set1_epi8(1 << 7);
         let r = _mm_movepi8_mask(a);
         let e: __mmask16 = 0b11111111_11111111;
@@ -20909,7 +20909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_movm_epi16() {
+    const fn test_mm512_movm_epi16() {
         let a: __mmask32 = 0b11111111_11111111_11111111_11111111;
         let r = _mm512_movm_epi16(a);
         let e = _mm512_set1_epi16(
@@ -20934,7 +20934,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_movm_epi16() {
+    const fn test_mm256_movm_epi16() {
         let a: __mmask16 = 0b11111111_11111111;
         let r = _mm256_movm_epi16(a);
         let e = _mm256_set1_epi16(
@@ -20959,7 +20959,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_movm_epi16() {
+    const fn test_mm_movm_epi16() {
         let a: __mmask8 = 0b11111111;
         let r = _mm_movm_epi16(a);
         let e = _mm_set1_epi16(
@@ -20984,7 +20984,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_movm_epi8() {
+    const fn test_mm512_movm_epi8() {
         let a: __mmask64 =
             0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111;
         let r = _mm512_movm_epi8(a);
@@ -20994,7 +20994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_movm_epi8() {
+    const fn test_mm256_movm_epi8() {
         let a: __mmask32 = 0b11111111_11111111_11111111_11111111;
         let r = _mm256_movm_epi8(a);
         let e =
@@ -21003,7 +21003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_movm_epi8() {
+    const fn test_mm_movm_epi8() {
         let a: __mmask16 = 0b11111111_11111111;
         let r = _mm_movm_epi8(a);
         let e =
@@ -21012,7 +21012,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_cvtmask32_u32() {
+    const fn test_cvtmask32_u32() {
         let a: __mmask32 = 0b11001100_00110011_01100110_10011001;
         let r = _cvtmask32_u32(a);
         let e: u32 = 0b11001100_00110011_01100110_10011001;
@@ -21020,7 +21020,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_cvtu32_mask32() {
+    const fn test_cvtu32_mask32() {
         let a: u32 = 0b11001100_00110011_01100110_10011001;
         let r = _cvtu32_mask32(a);
         let e: __mmask32 = 0b11001100_00110011_01100110_10011001;
@@ -21028,7 +21028,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kadd_mask32() {
+    const fn test_kadd_mask32() {
         let a: __mmask32 = 11;
         let b: __mmask32 = 22;
         let r = _kadd_mask32(a, b);
@@ -21037,7 +21037,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kadd_mask64() {
+    const fn test_kadd_mask64() {
         let a: __mmask64 = 11;
         let b: __mmask64 = 22;
         let r = _kadd_mask64(a, b);
@@ -21046,7 +21046,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kand_mask32() {
+    const fn test_kand_mask32() {
         let a: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let b: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let r = _kand_mask32(a, b);
@@ -21055,7 +21055,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kand_mask64() {
+    const fn test_kand_mask64() {
         let a: __mmask64 =
             0b11001100_00110011_11001100_00110011_11001100_00110011_11001100_00110011;
         let b: __mmask64 =
@@ -21067,7 +21067,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_knot_mask32() {
+    const fn test_knot_mask32() {
         let a: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let r = _knot_mask32(a);
         let e: __mmask32 = 0b00110011_11001100_00110011_11001100;
@@ -21075,7 +21075,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_knot_mask64() {
+    const fn test_knot_mask64() {
         let a: __mmask64 =
             0b11001100_00110011_11001100_00110011_11001100_00110011_11001100_00110011;
         let r = _knot_mask64(a);
@@ -21085,7 +21085,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kandn_mask32() {
+    const fn test_kandn_mask32() {
         let a: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let b: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let r = _kandn_mask32(a, b);
@@ -21094,7 +21094,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kandn_mask64() {
+    const fn test_kandn_mask64() {
         let a: __mmask64 =
             0b11001100_00110011_11001100_00110011_11001100_00110011_11001100_00110011;
         let b: __mmask64 =
@@ -21106,7 +21106,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kor_mask32() {
+    const fn test_kor_mask32() {
         let a: __mmask32 = 0b00110011_11001100_00110011_11001100;
         let b: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let r = _kor_mask32(a, b);
@@ -21115,7 +21115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kor_mask64() {
+    const fn test_kor_mask64() {
         let a: __mmask64 =
             0b00110011_11001100_00110011_11001100_00110011_11001100_00110011_11001100;
         let b: __mmask64 =
@@ -21127,7 +21127,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kxor_mask32() {
+    const fn test_kxor_mask32() {
         let a: __mmask32 = 0b00110011_11001100_00110011_11001100;
         let b: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let r = _kxor_mask32(a, b);
@@ -21136,7 +21136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kxor_mask64() {
+    const fn test_kxor_mask64() {
         let a: __mmask64 =
             0b00110011_11001100_00110011_11001100_00110011_11001100_00110011_11001100;
         let b: __mmask64 =
@@ -21148,7 +21148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kxnor_mask32() {
+    const fn test_kxnor_mask32() {
         let a: __mmask32 = 0b00110011_11001100_00110011_11001100;
         let b: __mmask32 = 0b11001100_00110011_11001100_00110011;
         let r = _kxnor_mask32(a, b);
@@ -21157,7 +21157,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kxnor_mask64() {
+    const fn test_kxnor_mask64() {
         let a: __mmask64 =
             0b00110011_11001100_00110011_11001100_00110011_11001100_00110011_11001100;
         let b: __mmask64 =
@@ -21189,7 +21189,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kortestc_mask32_u8() {
+    const fn test_kortestc_mask32_u8() {
         let a: __mmask32 = 0b0110100101101001_0110100101101001;
         let b: __mmask32 = 0b1011011010110110_1011011010110110;
         let r = _kortestc_mask32_u8(a, b);
@@ -21197,7 +21197,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kortestc_mask64_u8() {
+    const fn test_kortestc_mask64_u8() {
         let a: __mmask64 = 0b0110100101101001_0110100101101001;
         let b: __mmask64 = 0b1011011010110110_1011011010110110;
         let r = _kortestc_mask64_u8(a, b);
@@ -21205,7 +21205,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kortestz_mask32_u8() {
+    const fn test_kortestz_mask32_u8() {
         let a: __mmask32 = 0b0110100101101001_0110100101101001;
         let b: __mmask32 = 0b1011011010110110_1011011010110110;
         let r = _kortestz_mask32_u8(a, b);
@@ -21213,7 +21213,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kortestz_mask64_u8() {
+    const fn test_kortestz_mask64_u8() {
         let a: __mmask64 = 0b0110100101101001_0110100101101001;
         let b: __mmask64 = 0b1011011010110110_1011011010110110;
         let r = _kortestz_mask64_u8(a, b);
@@ -21221,7 +21221,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kshiftli_mask32() {
+    const fn test_kshiftli_mask32() {
         let a: __mmask32 = 0b0110100101101001_0110100101101001;
         let r = _kshiftli_mask32::<3>(a);
         let e: __mmask32 = 0b0100101101001011_0100101101001000;
@@ -21241,7 +21241,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kshiftli_mask64() {
+    const fn test_kshiftli_mask64() {
         let a: __mmask64 = 0b0110100101101001_0110100101101001;
         let r = _kshiftli_mask64::<3>(a);
         let e: __mmask64 = 0b0110100101101001011_0100101101001000;
@@ -21261,7 +21261,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kshiftri_mask32() {
+    const fn test_kshiftri_mask32() {
         let a: __mmask32 = 0b1010100101101001_0110100101101001;
         let r = _kshiftri_mask32::<3>(a);
         let e: __mmask32 = 0b0001010100101101_0010110100101101;
@@ -21281,7 +21281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_kshiftri_mask64() {
+    const fn test_kshiftri_mask64() {
         let a: __mmask64 = 0b1010100101101001011_0100101101001000;
         let r = _kshiftri_mask64::<3>(a);
         let e: __mmask64 = 0b1010100101101001_0110100101101001;
@@ -21315,7 +21315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_ktestc_mask32_u8() {
+    const fn test_ktestc_mask32_u8() {
         let a: __mmask32 = 0b0110100100111100_0110100100111100;
         let b: __mmask32 = 0b1001011011000011_1001011011000011;
         let r = _ktestc_mask32_u8(a, b);
@@ -21323,7 +21323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_ktestz_mask32_u8() {
+    const fn test_ktestz_mask32_u8() {
         let a: __mmask32 = 0b0110100100111100_0110100100111100;
         let b: __mmask32 = 0b1001011011000011_1001011011000011;
         let r = _ktestz_mask32_u8(a, b);
@@ -21341,7 +21341,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_ktestc_mask64_u8() {
+    const fn test_ktestc_mask64_u8() {
         let a: __mmask64 = 0b0110100100111100_0110100100111100;
         let b: __mmask64 = 0b1001011011000011_1001011011000011;
         let r = _ktestc_mask64_u8(a, b);
@@ -21349,7 +21349,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_ktestz_mask64_u8() {
+    const fn test_ktestz_mask64_u8() {
         let a: __mmask64 = 0b0110100100111100_0110100100111100;
         let b: __mmask64 = 0b1001011011000011_1001011011000011;
         let r = _ktestz_mask64_u8(a, b);
@@ -21357,7 +21357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_kunpackw() {
+    const fn test_mm512_kunpackw() {
         let a: u32 = 0x00110011;
         let b: u32 = 0x00001011;
         let r = _mm512_kunpackw(a, b);
@@ -21366,7 +21366,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_kunpackd() {
+    const fn test_mm512_kunpackd() {
         let a: u64 = 0x11001100_00110011;
         let b: u64 = 0x00101110_00001011;
         let r = _mm512_kunpackd(a, b);
@@ -21375,7 +21375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cvtepi16_epi8() {
+    const fn test_mm512_cvtepi16_epi8() {
         let a = _mm512_set1_epi16(2);
         let r = _mm512_cvtepi16_epi8(a);
         let e = _mm256_set1_epi8(2);
@@ -21383,7 +21383,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cvtepi16_epi8() {
+    const fn test_mm512_mask_cvtepi16_epi8() {
         let src = _mm256_set1_epi8(1);
         let a = _mm512_set1_epi16(2);
         let r = _mm512_mask_cvtepi16_epi8(src, 0, a);
@@ -21394,7 +21394,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_cvtepi16_epi8() {
+    const fn test_mm512_maskz_cvtepi16_epi8() {
         let a = _mm512_set1_epi16(2);
         let r = _mm512_maskz_cvtepi16_epi8(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -21404,7 +21404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_cvtepi16_epi8() {
+    const fn test_mm256_cvtepi16_epi8() {
         let a = _mm256_set1_epi16(2);
         let r = _mm256_cvtepi16_epi8(a);
         let e = _mm_set1_epi8(2);
@@ -21412,7 +21412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi16_epi8() {
+    const fn test_mm256_mask_cvtepi16_epi8() {
         let src = _mm_set1_epi8(1);
         let a = _mm256_set1_epi16(2);
         let r = _mm256_mask_cvtepi16_epi8(src, 0, a);
@@ -21423,7 +21423,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi16_epi8() {
+    const fn test_mm256_maskz_cvtepi16_epi8() {
         let a = _mm256_set1_epi16(2);
         let r = _mm256_maskz_cvtepi16_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21433,7 +21433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_cvtepi16_epi8() {
+    const fn test_mm_cvtepi16_epi8() {
         let a = _mm_set1_epi16(2);
         let r = _mm_cvtepi16_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2);
@@ -21441,7 +21441,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi16_epi8() {
+    const fn test_mm_mask_cvtepi16_epi8() {
         let src = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
         let a = _mm_set1_epi16(2);
         let r = _mm_mask_cvtepi16_epi8(src, 0, a);
@@ -21452,7 +21452,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi16_epi8() {
+    const fn test_mm_maskz_cvtepi16_epi8() {
         let a = _mm_set1_epi16(2);
         let r = _mm_maskz_cvtepi16_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21462,7 +21462,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_cvtsepi16_epi8() {
+    fn test_mm512_cvtsepi16_epi8() {
         let a = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_cvtsepi16_epi8(a);
         let e = _mm256_set1_epi8(i8::MAX);
@@ -21470,7 +21470,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_cvtsepi16_epi8() {
+    fn test_mm512_mask_cvtsepi16_epi8() {
         let src = _mm256_set1_epi8(1);
         let a = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_mask_cvtsepi16_epi8(src, 0, a);
@@ -21481,7 +21481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_cvtsepi16_epi8() {
+    fn test_mm256_cvtsepi16_epi8() {
         let a = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_cvtsepi16_epi8(a);
         let e = _mm_set1_epi8(i8::MAX);
@@ -21489,7 +21489,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_cvtsepi16_epi8() {
+    fn test_mm256_mask_cvtsepi16_epi8() {
         let src = _mm_set1_epi8(1);
         let a = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_mask_cvtsepi16_epi8(src, 0, a);
@@ -21500,7 +21500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtsepi16_epi8() {
+    fn test_mm256_maskz_cvtsepi16_epi8() {
         let a = _mm256_set1_epi16(i16::MAX);
         let r = _mm256_maskz_cvtsepi16_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21510,7 +21510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_cvtsepi16_epi8() {
+    fn test_mm_cvtsepi16_epi8() {
         let a = _mm_set1_epi16(i16::MAX);
         let r = _mm_cvtsepi16_epi8(a);
         #[rustfmt::skip]
@@ -21519,7 +21519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_cvtsepi16_epi8() {
+    fn test_mm_mask_cvtsepi16_epi8() {
         let src = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
         let a = _mm_set1_epi16(i16::MAX);
         let r = _mm_mask_cvtsepi16_epi8(src, 0, a);
@@ -21531,7 +21531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsepi16_epi8() {
+    fn test_mm_maskz_cvtsepi16_epi8() {
         let a = _mm_set1_epi16(i16::MAX);
         let r = _mm_maskz_cvtsepi16_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21542,7 +21542,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_cvtsepi16_epi8() {
+    fn test_mm512_maskz_cvtsepi16_epi8() {
         let a = _mm512_set1_epi16(i16::MAX);
         let r = _mm512_maskz_cvtsepi16_epi8(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -21552,7 +21552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_cvtusepi16_epi8() {
+    fn test_mm512_cvtusepi16_epi8() {
         let a = _mm512_set1_epi16(i16::MIN);
         let r = _mm512_cvtusepi16_epi8(a);
         let e = _mm256_set1_epi8(-1);
@@ -21560,7 +21560,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_mask_cvtusepi16_epi8() {
+    fn test_mm512_mask_cvtusepi16_epi8() {
         let src = _mm256_set1_epi8(1);
         let a = _mm512_set1_epi16(i16::MIN);
         let r = _mm512_mask_cvtusepi16_epi8(src, 0, a);
@@ -21571,7 +21571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    unsafe fn test_mm512_maskz_cvtusepi16_epi8() {
+    fn test_mm512_maskz_cvtusepi16_epi8() {
         let a = _mm512_set1_epi16(i16::MIN);
         let r = _mm512_maskz_cvtusepi16_epi8(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -21581,7 +21581,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_cvtusepi16_epi8() {
+    fn test_mm256_cvtusepi16_epi8() {
         let a = _mm256_set1_epi16(i16::MIN);
         let r = _mm256_cvtusepi16_epi8(a);
         let e = _mm_set1_epi8(-1);
@@ -21589,7 +21589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_mask_cvtusepi16_epi8() {
+    fn test_mm256_mask_cvtusepi16_epi8() {
         let src = _mm_set1_epi8(1);
         let a = _mm256_set1_epi16(i16::MIN);
         let r = _mm256_mask_cvtusepi16_epi8(src, 0, a);
@@ -21600,7 +21600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtusepi16_epi8() {
+    fn test_mm256_maskz_cvtusepi16_epi8() {
         let a = _mm256_set1_epi16(i16::MIN);
         let r = _mm256_maskz_cvtusepi16_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21610,7 +21610,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_cvtusepi16_epi8() {
+    fn test_mm_cvtusepi16_epi8() {
         let a = _mm_set1_epi16(i16::MIN);
         let r = _mm_cvtusepi16_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1);
@@ -21618,7 +21618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_mask_cvtusepi16_epi8() {
+    fn test_mm_mask_cvtusepi16_epi8() {
         let src = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
         let a = _mm_set1_epi16(i16::MIN);
         let r = _mm_mask_cvtusepi16_epi8(src, 0, a);
@@ -21629,7 +21629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    unsafe fn test_mm_maskz_cvtusepi16_epi8() {
+    fn test_mm_maskz_cvtusepi16_epi8() {
         let a = _mm_set1_epi16(i16::MIN);
         let r = _mm_maskz_cvtusepi16_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21639,7 +21639,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cvtepi8_epi16() {
+    const fn test_mm512_cvtepi8_epi16() {
         let a = _mm256_set1_epi8(2);
         let r = _mm512_cvtepi8_epi16(a);
         let e = _mm512_set1_epi16(2);
@@ -21647,7 +21647,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cvtepi8_epi16() {
+    const fn test_mm512_mask_cvtepi8_epi16() {
         let src = _mm512_set1_epi16(1);
         let a = _mm256_set1_epi8(2);
         let r = _mm512_mask_cvtepi8_epi16(src, 0, a);
@@ -21658,7 +21658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_cvtepi8_epi16() {
+    const fn test_mm512_maskz_cvtepi8_epi16() {
         let a = _mm256_set1_epi8(2);
         let r = _mm512_maskz_cvtepi8_epi16(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -21668,7 +21668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi8_epi16() {
+    const fn test_mm256_mask_cvtepi8_epi16() {
         let src = _mm256_set1_epi16(1);
         let a = _mm_set1_epi8(2);
         let r = _mm256_mask_cvtepi8_epi16(src, 0, a);
@@ -21679,7 +21679,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi8_epi16() {
+    const fn test_mm256_maskz_cvtepi8_epi16() {
         let a = _mm_set1_epi8(2);
         let r = _mm256_maskz_cvtepi8_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -21689,7 +21689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi8_epi16() {
+    const fn test_mm_mask_cvtepi8_epi16() {
         let src = _mm_set1_epi16(1);
         let a = _mm_set1_epi8(2);
         let r = _mm_mask_cvtepi8_epi16(src, 0, a);
@@ -21700,7 +21700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi8_epi16() {
+    const fn test_mm_maskz_cvtepi8_epi16() {
         let a = _mm_set1_epi8(2);
         let r = _mm_maskz_cvtepi8_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21710,7 +21710,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_cvtepu8_epi16() {
+    const fn test_mm512_cvtepu8_epi16() {
         let a = _mm256_set1_epi8(2);
         let r = _mm512_cvtepu8_epi16(a);
         let e = _mm512_set1_epi16(2);
@@ -21718,7 +21718,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_cvtepu8_epi16() {
+    const fn test_mm512_mask_cvtepu8_epi16() {
         let src = _mm512_set1_epi16(1);
         let a = _mm256_set1_epi8(2);
         let r = _mm512_mask_cvtepu8_epi16(src, 0, a);
@@ -21729,7 +21729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_cvtepu8_epi16() {
+    const fn test_mm512_maskz_cvtepu8_epi16() {
         let a = _mm256_set1_epi8(2);
         let r = _mm512_maskz_cvtepu8_epi16(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -21739,7 +21739,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu8_epi16() {
+    const fn test_mm256_mask_cvtepu8_epi16() {
         let src = _mm256_set1_epi16(1);
         let a = _mm_set1_epi8(2);
         let r = _mm256_mask_cvtepu8_epi16(src, 0, a);
@@ -21750,7 +21750,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu8_epi16() {
+    const fn test_mm256_maskz_cvtepu8_epi16() {
         let a = _mm_set1_epi8(2);
         let r = _mm256_maskz_cvtepu8_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -21760,7 +21760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu8_epi16() {
+    const fn test_mm_mask_cvtepu8_epi16() {
         let src = _mm_set1_epi16(1);
         let a = _mm_set1_epi8(2);
         let r = _mm_mask_cvtepu8_epi16(src, 0, a);
@@ -21771,7 +21771,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu8_epi16() {
+    const fn test_mm_maskz_cvtepu8_epi16() {
         let a = _mm_set1_epi8(2);
         let r = _mm_maskz_cvtepu8_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -21781,7 +21781,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_bslli_epi128() {
+    const fn test_mm512_bslli_epi128() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(
             1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
@@ -21801,7 +21801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_bsrli_epi128() {
+    const fn test_mm512_bsrli_epi128() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -21821,7 +21821,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_alignr_epi8() {
+    const fn test_mm512_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(
             1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
@@ -21842,7 +21842,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_mask_alignr_epi8() {
+    const fn test_mm512_mask_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(
             1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
@@ -21870,7 +21870,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_mm512_maskz_alignr_epi8() {
+    const fn test_mm512_maskz_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(
             1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
@@ -21897,7 +21897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_mask_alignr_epi8() {
+    const fn test_mm256_mask_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(
             1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
@@ -21916,7 +21916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm256_maskz_alignr_epi8() {
+    const fn test_mm256_maskz_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(
             1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
@@ -21935,7 +21935,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_mask_alignr_epi8() {
+    const fn test_mm_mask_alignr_epi8() {
         let a = _mm_set_epi8(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
         let b = _mm_set1_epi8(1);
         let r = _mm_mask_alignr_epi8::<14>(a, 0, a, b);
@@ -21946,7 +21946,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw,avx512vl")]
-    const unsafe fn test_mm_maskz_alignr_epi8() {
+    const fn test_mm_maskz_alignr_epi8() {
         let a = _mm_set_epi8(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
         let b = _mm_set1_epi8(1);
         let r = _mm_maskz_alignr_epi8::<14>(0, a, b);

--- a/crates/core_arch/src/x86/avx512cd.rs
+++ b/crates/core_arch/src/x86/avx512cd.rs
@@ -587,7 +587,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_broadcastmw_epi32() {
+    const fn test_mm512_broadcastmw_epi32() {
         let a: __mmask16 = 2;
         let r = _mm512_broadcastmw_epi32(a);
         let e = _mm512_set1_epi32(2);
@@ -595,7 +595,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_broadcastmw_epi32() {
+    const fn test_mm256_broadcastmw_epi32() {
         let a: __mmask16 = 2;
         let r = _mm256_broadcastmw_epi32(a);
         let e = _mm256_set1_epi32(2);
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_broadcastmw_epi32() {
+    const fn test_mm_broadcastmw_epi32() {
         let a: __mmask16 = 2;
         let r = _mm_broadcastmw_epi32(a);
         let e = _mm_set1_epi32(2);
@@ -611,7 +611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_broadcastmb_epi64() {
+    const fn test_mm512_broadcastmb_epi64() {
         let a: __mmask8 = 2;
         let r = _mm512_broadcastmb_epi64(a);
         let e = _mm512_set1_epi64(2);
@@ -619,7 +619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_broadcastmb_epi64() {
+    const fn test_mm256_broadcastmb_epi64() {
         let a: __mmask8 = 2;
         let r = _mm256_broadcastmb_epi64(a);
         let e = _mm256_set1_epi64x(2);
@@ -627,7 +627,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_broadcastmb_epi64() {
+    const fn test_mm_broadcastmb_epi64() {
         let a: __mmask8 = 2;
         let r = _mm_broadcastmb_epi64(a);
         let e = _mm_set1_epi64x(2);
@@ -635,7 +635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    unsafe fn test_mm512_conflict_epi32() {
+    fn test_mm512_conflict_epi32() {
         let a = _mm512_set1_epi32(1);
         let r = _mm512_conflict_epi32(a);
         let e = _mm512_set_epi32(
@@ -720,7 +720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    unsafe fn test_mm512_mask_conflict_epi32() {
+    fn test_mm512_mask_conflict_epi32() {
         let a = _mm512_set1_epi32(1);
         let r = _mm512_mask_conflict_epi32(a, 0, a);
         assert_eq_m512i(r, a);
@@ -807,7 +807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    unsafe fn test_mm512_maskz_conflict_epi32() {
+    fn test_mm512_maskz_conflict_epi32() {
         let a = _mm512_set1_epi32(1);
         let r = _mm512_maskz_conflict_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -894,7 +894,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm256_conflict_epi32() {
+    fn test_mm256_conflict_epi32() {
         let a = _mm256_set1_epi32(1);
         let r = _mm256_conflict_epi32(a);
         let e = _mm256_set_epi32(
@@ -911,7 +911,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm256_mask_conflict_epi32() {
+    fn test_mm256_mask_conflict_epi32() {
         let a = _mm256_set1_epi32(1);
         let r = _mm256_mask_conflict_epi32(a, 0, a);
         assert_eq_m256i(r, a);
@@ -930,7 +930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm256_maskz_conflict_epi32() {
+    fn test_mm256_maskz_conflict_epi32() {
         let a = _mm256_set1_epi32(1);
         let r = _mm256_maskz_conflict_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -949,7 +949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm_conflict_epi32() {
+    fn test_mm_conflict_epi32() {
         let a = _mm_set1_epi32(1);
         let r = _mm_conflict_epi32(a);
         let e = _mm_set_epi32(1 << 2 | 1 << 1 | 1 << 0, 1 << 1 | 1 << 0, 1 << 0, 0);
@@ -957,7 +957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm_mask_conflict_epi32() {
+    fn test_mm_mask_conflict_epi32() {
         let a = _mm_set1_epi32(1);
         let r = _mm_mask_conflict_epi32(a, 0, a);
         assert_eq_m128i(r, a);
@@ -967,7 +967,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm_maskz_conflict_epi32() {
+    fn test_mm_maskz_conflict_epi32() {
         let a = _mm_set1_epi32(1);
         let r = _mm_maskz_conflict_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -977,7 +977,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    unsafe fn test_mm512_conflict_epi64() {
+    fn test_mm512_conflict_epi64() {
         let a = _mm512_set1_epi64(1);
         let r = _mm512_conflict_epi64(a);
         let e = _mm512_set_epi64(
@@ -994,7 +994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    unsafe fn test_mm512_mask_conflict_epi64() {
+    fn test_mm512_mask_conflict_epi64() {
         let a = _mm512_set1_epi64(1);
         let r = _mm512_mask_conflict_epi64(a, 0, a);
         assert_eq_m512i(r, a);
@@ -1013,7 +1013,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    unsafe fn test_mm512_maskz_conflict_epi64() {
+    fn test_mm512_maskz_conflict_epi64() {
         let a = _mm512_set1_epi64(1);
         let r = _mm512_maskz_conflict_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -1032,7 +1032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm256_conflict_epi64() {
+    fn test_mm256_conflict_epi64() {
         let a = _mm256_set1_epi64x(1);
         let r = _mm256_conflict_epi64(a);
         let e = _mm256_set_epi64x(1 << 2 | 1 << 1 | 1 << 0, 1 << 1 | 1 << 0, 1 << 0, 0);
@@ -1040,7 +1040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm256_mask_conflict_epi64() {
+    fn test_mm256_mask_conflict_epi64() {
         let a = _mm256_set1_epi64x(1);
         let r = _mm256_mask_conflict_epi64(a, 0, a);
         assert_eq_m256i(r, a);
@@ -1050,7 +1050,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm256_maskz_conflict_epi64() {
+    fn test_mm256_maskz_conflict_epi64() {
         let a = _mm256_set1_epi64x(1);
         let r = _mm256_maskz_conflict_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -1060,7 +1060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm_conflict_epi64() {
+    fn test_mm_conflict_epi64() {
         let a = _mm_set1_epi64x(1);
         let r = _mm_conflict_epi64(a);
         let e = _mm_set_epi64x(1 << 0, 0);
@@ -1068,7 +1068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm_mask_conflict_epi64() {
+    fn test_mm_mask_conflict_epi64() {
         let a = _mm_set1_epi64x(1);
         let r = _mm_mask_conflict_epi64(a, 0, a);
         assert_eq_m128i(r, a);
@@ -1078,7 +1078,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    unsafe fn test_mm_maskz_conflict_epi64() {
+    fn test_mm_maskz_conflict_epi64() {
         let a = _mm_set1_epi64x(1);
         let r = _mm_maskz_conflict_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -1088,7 +1088,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_lzcnt_epi32() {
+    const fn test_mm512_lzcnt_epi32() {
         let a = _mm512_set1_epi32(1);
         let r = _mm512_lzcnt_epi32(a);
         let e = _mm512_set1_epi32(31);
@@ -1096,7 +1096,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_mask_lzcnt_epi32() {
+    const fn test_mm512_mask_lzcnt_epi32() {
         let a = _mm512_set1_epi32(1);
         let r = _mm512_mask_lzcnt_epi32(a, 0, a);
         assert_eq_m512i(r, a);
@@ -1106,7 +1106,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_maskz_lzcnt_epi32() {
+    const fn test_mm512_maskz_lzcnt_epi32() {
         let a = _mm512_set1_epi32(2);
         let r = _mm512_maskz_lzcnt_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -1116,7 +1116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_lzcnt_epi32() {
+    const fn test_mm256_lzcnt_epi32() {
         let a = _mm256_set1_epi32(1);
         let r = _mm256_lzcnt_epi32(a);
         let e = _mm256_set1_epi32(31);
@@ -1124,7 +1124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_mask_lzcnt_epi32() {
+    const fn test_mm256_mask_lzcnt_epi32() {
         let a = _mm256_set1_epi32(1);
         let r = _mm256_mask_lzcnt_epi32(a, 0, a);
         assert_eq_m256i(r, a);
@@ -1134,7 +1134,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_maskz_lzcnt_epi32() {
+    const fn test_mm256_maskz_lzcnt_epi32() {
         let a = _mm256_set1_epi32(1);
         let r = _mm256_maskz_lzcnt_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -1144,7 +1144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_lzcnt_epi32() {
+    const fn test_mm_lzcnt_epi32() {
         let a = _mm_set1_epi32(1);
         let r = _mm_lzcnt_epi32(a);
         let e = _mm_set1_epi32(31);
@@ -1152,7 +1152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_mask_lzcnt_epi32() {
+    const fn test_mm_mask_lzcnt_epi32() {
         let a = _mm_set1_epi32(1);
         let r = _mm_mask_lzcnt_epi32(a, 0, a);
         assert_eq_m128i(r, a);
@@ -1162,7 +1162,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_maskz_lzcnt_epi32() {
+    const fn test_mm_maskz_lzcnt_epi32() {
         let a = _mm_set1_epi32(1);
         let r = _mm_maskz_lzcnt_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -1172,7 +1172,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_lzcnt_epi64() {
+    const fn test_mm512_lzcnt_epi64() {
         let a = _mm512_set1_epi64(1);
         let r = _mm512_lzcnt_epi64(a);
         let e = _mm512_set1_epi64(63);
@@ -1180,7 +1180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_mask_lzcnt_epi64() {
+    const fn test_mm512_mask_lzcnt_epi64() {
         let a = _mm512_set1_epi64(1);
         let r = _mm512_mask_lzcnt_epi64(a, 0, a);
         assert_eq_m512i(r, a);
@@ -1190,7 +1190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd")]
-    const unsafe fn test_mm512_maskz_lzcnt_epi64() {
+    const fn test_mm512_maskz_lzcnt_epi64() {
         let a = _mm512_set1_epi64(2);
         let r = _mm512_maskz_lzcnt_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -1200,7 +1200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_lzcnt_epi64() {
+    const fn test_mm256_lzcnt_epi64() {
         let a = _mm256_set1_epi64x(1);
         let r = _mm256_lzcnt_epi64(a);
         let e = _mm256_set1_epi64x(63);
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_mask_lzcnt_epi64() {
+    const fn test_mm256_mask_lzcnt_epi64() {
         let a = _mm256_set1_epi64x(1);
         let r = _mm256_mask_lzcnt_epi64(a, 0, a);
         assert_eq_m256i(r, a);
@@ -1218,7 +1218,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm256_maskz_lzcnt_epi64() {
+    const fn test_mm256_maskz_lzcnt_epi64() {
         let a = _mm256_set1_epi64x(1);
         let r = _mm256_maskz_lzcnt_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -1228,7 +1228,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_lzcnt_epi64() {
+    const fn test_mm_lzcnt_epi64() {
         let a = _mm_set1_epi64x(1);
         let r = _mm_lzcnt_epi64(a);
         let e = _mm_set1_epi64x(63);
@@ -1236,7 +1236,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_mask_lzcnt_epi64() {
+    const fn test_mm_mask_lzcnt_epi64() {
         let a = _mm_set1_epi64x(1);
         let r = _mm_mask_lzcnt_epi64(a, 0, a);
         assert_eq_m128i(r, a);
@@ -1246,7 +1246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512cd,avx512vl")]
-    const unsafe fn test_mm_maskz_lzcnt_epi64() {
+    const fn test_mm_maskz_lzcnt_epi64() {
         let a = _mm_set1_epi64x(1);
         let r = _mm_maskz_lzcnt_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());

--- a/crates/core_arch/src/x86/avx512dq.rs
+++ b/crates/core_arch/src/x86/avx512dq.rs
@@ -7424,7 +7424,7 @@ mod tests {
     const XOR_32: f32 = unsafe { transmute(0x66666666_u32) };
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_and_pd() {
+    const fn test_mm_mask_and_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let src = _mm_set_pd(1., 2.);
@@ -7434,7 +7434,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_and_pd() {
+    const fn test_mm_maskz_and_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let r = _mm_maskz_and_pd(0b01, a, b);
@@ -7443,7 +7443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_and_pd() {
+    const fn test_mm256_mask_and_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let src = _mm256_set_pd(1., 2., 3., 4.);
@@ -7453,7 +7453,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_and_pd() {
+    const fn test_mm256_maskz_and_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let r = _mm256_maskz_and_pd(0b0101, a, b);
@@ -7462,7 +7462,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_and_pd() {
+    const fn test_mm512_and_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_and_pd(a, b);
@@ -7471,7 +7471,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_and_pd() {
+    const fn test_mm512_mask_and_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let src = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7481,7 +7481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_and_pd() {
+    const fn test_mm512_maskz_and_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_maskz_and_pd(0b01010101, a, b);
@@ -7490,7 +7490,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_and_ps() {
+    const fn test_mm_mask_and_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let src = _mm_set_ps(1., 2., 3., 4.);
@@ -7500,7 +7500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_and_ps() {
+    const fn test_mm_maskz_and_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let r = _mm_maskz_and_ps(0b0101, a, b);
@@ -7509,7 +7509,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_and_ps() {
+    const fn test_mm256_mask_and_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let src = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7519,7 +7519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_and_ps() {
+    const fn test_mm256_maskz_and_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let r = _mm256_maskz_and_ps(0b01010101, a, b);
@@ -7528,7 +7528,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_and_ps() {
+    const fn test_mm512_and_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_and_ps(a, b);
@@ -7537,7 +7537,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_and_ps() {
+    const fn test_mm512_mask_and_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let src = _mm512_set_ps(
@@ -7552,7 +7552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_and_ps() {
+    const fn test_mm512_maskz_and_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_maskz_and_ps(0b0101010101010101, a, b);
@@ -7564,7 +7564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_andnot_pd() {
+    const fn test_mm_mask_andnot_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let src = _mm_set_pd(1., 2.);
@@ -7574,7 +7574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_andnot_pd() {
+    const fn test_mm_maskz_andnot_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let r = _mm_maskz_andnot_pd(0b01, a, b);
@@ -7583,7 +7583,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_andnot_pd() {
+    const fn test_mm256_mask_andnot_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let src = _mm256_set_pd(1., 2., 3., 4.);
@@ -7593,7 +7593,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_andnot_pd() {
+    const fn test_mm256_maskz_andnot_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let r = _mm256_maskz_andnot_pd(0b0101, a, b);
@@ -7602,7 +7602,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_andnot_pd() {
+    const fn test_mm512_andnot_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_andnot_pd(a, b);
@@ -7611,7 +7611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_andnot_pd() {
+    const fn test_mm512_mask_andnot_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let src = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7621,7 +7621,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_andnot_pd() {
+    const fn test_mm512_maskz_andnot_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_maskz_andnot_pd(0b01010101, a, b);
@@ -7630,7 +7630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_andnot_ps() {
+    const fn test_mm_mask_andnot_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let src = _mm_set_ps(1., 2., 3., 4.);
@@ -7640,7 +7640,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_andnot_ps() {
+    const fn test_mm_maskz_andnot_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let r = _mm_maskz_andnot_ps(0b0101, a, b);
@@ -7649,7 +7649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_andnot_ps() {
+    const fn test_mm256_mask_andnot_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let src = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7659,7 +7659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_andnot_ps() {
+    const fn test_mm256_maskz_andnot_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let r = _mm256_maskz_andnot_ps(0b01010101, a, b);
@@ -7668,7 +7668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_andnot_ps() {
+    const fn test_mm512_andnot_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_andnot_ps(a, b);
@@ -7677,7 +7677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_andnot_ps() {
+    const fn test_mm512_mask_andnot_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let src = _mm512_set_ps(
@@ -7692,7 +7692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_andnot_ps() {
+    const fn test_mm512_maskz_andnot_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_maskz_andnot_ps(0b0101010101010101, a, b);
@@ -7704,7 +7704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_or_pd() {
+    const fn test_mm_mask_or_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let src = _mm_set_pd(1., 2.);
@@ -7714,7 +7714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_or_pd() {
+    const fn test_mm_maskz_or_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let r = _mm_maskz_or_pd(0b01, a, b);
@@ -7723,7 +7723,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_or_pd() {
+    const fn test_mm256_mask_or_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let src = _mm256_set_pd(1., 2., 3., 4.);
@@ -7733,7 +7733,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_or_pd() {
+    const fn test_mm256_maskz_or_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let r = _mm256_maskz_or_pd(0b0101, a, b);
@@ -7742,7 +7742,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_or_pd() {
+    const fn test_mm512_or_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_or_pd(a, b);
@@ -7751,7 +7751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_or_pd() {
+    const fn test_mm512_mask_or_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let src = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7761,7 +7761,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_or_pd() {
+    const fn test_mm512_maskz_or_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_maskz_or_pd(0b01010101, a, b);
@@ -7770,7 +7770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_or_ps() {
+    const fn test_mm_mask_or_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let src = _mm_set_ps(1., 2., 3., 4.);
@@ -7780,7 +7780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_or_ps() {
+    const fn test_mm_maskz_or_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let r = _mm_maskz_or_ps(0b0101, a, b);
@@ -7789,7 +7789,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_or_ps() {
+    const fn test_mm256_mask_or_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let src = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7799,7 +7799,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_or_ps() {
+    const fn test_mm256_maskz_or_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let r = _mm256_maskz_or_ps(0b01010101, a, b);
@@ -7808,7 +7808,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_or_ps() {
+    const fn test_mm512_or_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_or_ps(a, b);
@@ -7817,7 +7817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_or_ps() {
+    const fn test_mm512_mask_or_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let src = _mm512_set_ps(
@@ -7832,7 +7832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_or_ps() {
+    const fn test_mm512_maskz_or_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_maskz_or_ps(0b0101010101010101, a, b);
@@ -7843,7 +7843,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_xor_pd() {
+    const fn test_mm_mask_xor_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let src = _mm_set_pd(1., 2.);
@@ -7853,7 +7853,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_xor_pd() {
+    const fn test_mm_maskz_xor_pd() {
         let a = _mm_set1_pd(OPRND1_64);
         let b = _mm_set1_pd(OPRND2_64);
         let r = _mm_maskz_xor_pd(0b01, a, b);
@@ -7862,7 +7862,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_xor_pd() {
+    const fn test_mm256_mask_xor_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let src = _mm256_set_pd(1., 2., 3., 4.);
@@ -7872,7 +7872,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_xor_pd() {
+    const fn test_mm256_maskz_xor_pd() {
         let a = _mm256_set1_pd(OPRND1_64);
         let b = _mm256_set1_pd(OPRND2_64);
         let r = _mm256_maskz_xor_pd(0b0101, a, b);
@@ -7881,7 +7881,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_xor_pd() {
+    const fn test_mm512_xor_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_xor_pd(a, b);
@@ -7890,7 +7890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_xor_pd() {
+    const fn test_mm512_mask_xor_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let src = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7900,7 +7900,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_xor_pd() {
+    const fn test_mm512_maskz_xor_pd() {
         let a = _mm512_set1_pd(OPRND1_64);
         let b = _mm512_set1_pd(OPRND2_64);
         let r = _mm512_maskz_xor_pd(0b01010101, a, b);
@@ -7909,7 +7909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_xor_ps() {
+    const fn test_mm_mask_xor_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let src = _mm_set_ps(1., 2., 3., 4.);
@@ -7919,7 +7919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_xor_ps() {
+    const fn test_mm_maskz_xor_ps() {
         let a = _mm_set1_ps(OPRND1_32);
         let b = _mm_set1_ps(OPRND2_32);
         let r = _mm_maskz_xor_ps(0b0101, a, b);
@@ -7928,7 +7928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_xor_ps() {
+    const fn test_mm256_mask_xor_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let src = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -7938,7 +7938,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_xor_ps() {
+    const fn test_mm256_maskz_xor_ps() {
         let a = _mm256_set1_ps(OPRND1_32);
         let b = _mm256_set1_ps(OPRND2_32);
         let r = _mm256_maskz_xor_ps(0b01010101, a, b);
@@ -7947,7 +7947,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_xor_ps() {
+    const fn test_mm512_xor_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_xor_ps(a, b);
@@ -7956,7 +7956,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_xor_ps() {
+    const fn test_mm512_mask_xor_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let src = _mm512_set_ps(
@@ -7971,7 +7971,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_xor_ps() {
+    const fn test_mm512_maskz_xor_ps() {
         let a = _mm512_set1_ps(OPRND1_32);
         let b = _mm512_set1_ps(OPRND2_32);
         let r = _mm512_maskz_xor_ps(0b0101010101010101, a, b);
@@ -7983,7 +7983,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_broadcast_f32x2() {
+    const fn test_mm256_broadcast_f32x2() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_broadcast_f32x2(a);
         let e = _mm256_set_ps(3., 4., 3., 4., 3., 4., 3., 4.);
@@ -7991,7 +7991,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcast_f32x2() {
+    const fn test_mm256_mask_broadcast_f32x2() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm256_set_ps(5., 6., 7., 8., 9., 10., 11., 12.);
         let r = _mm256_mask_broadcast_f32x2(b, 0b01101001, a);
@@ -8000,7 +8000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcast_f32x2() {
+    const fn test_mm256_maskz_broadcast_f32x2() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_maskz_broadcast_f32x2(0b01101001, a);
         let e = _mm256_set_ps(0., 4., 3., 0., 3., 0., 0., 4.);
@@ -8008,7 +8008,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_broadcast_f32x2() {
+    const fn test_mm512_broadcast_f32x2() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm512_broadcast_f32x2(a);
         let e = _mm512_set_ps(
@@ -8018,7 +8018,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_broadcast_f32x2() {
+    const fn test_mm512_mask_broadcast_f32x2() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm512_set_ps(
             5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20.,
@@ -8031,7 +8031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_broadcast_f32x2() {
+    const fn test_mm512_maskz_broadcast_f32x2() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm512_maskz_broadcast_f32x2(0b0110100100111100, a);
         let e = _mm512_set_ps(
@@ -8041,7 +8041,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_broadcast_f32x8() {
+    const fn test_mm512_broadcast_f32x8() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_broadcast_f32x8(a);
         let e = _mm512_set_ps(
@@ -8051,7 +8051,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_broadcast_f32x8() {
+    const fn test_mm512_mask_broadcast_f32x8() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_ps(
             9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24.,
@@ -8064,7 +8064,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_broadcast_f32x8() {
+    const fn test_mm512_maskz_broadcast_f32x8() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_broadcast_f32x8(0b0110100100111100, a);
         let e = _mm512_set_ps(
@@ -8074,7 +8074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_broadcast_f64x2() {
+    const fn test_mm256_broadcast_f64x2() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm256_broadcast_f64x2(a);
         let e = _mm256_set_pd(1., 2., 1., 2.);
@@ -8082,7 +8082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcast_f64x2() {
+    const fn test_mm256_mask_broadcast_f64x2() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm256_set_pd(3., 4., 5., 6.);
         let r = _mm256_mask_broadcast_f64x2(b, 0b0110, a);
@@ -8091,7 +8091,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcast_f64x2() {
+    const fn test_mm256_maskz_broadcast_f64x2() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm256_maskz_broadcast_f64x2(0b0110, a);
         let e = _mm256_set_pd(0., 2., 1., 0.);
@@ -8099,7 +8099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_broadcast_f64x2() {
+    const fn test_mm512_broadcast_f64x2() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm512_broadcast_f64x2(a);
         let e = _mm512_set_pd(1., 2., 1., 2., 1., 2., 1., 2.);
@@ -8107,7 +8107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_broadcast_f64x2() {
+    const fn test_mm512_mask_broadcast_f64x2() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm512_set_pd(3., 4., 5., 6., 7., 8., 9., 10.);
         let r = _mm512_mask_broadcast_f64x2(b, 0b01101001, a);
@@ -8116,7 +8116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_broadcast_f64x2() {
+    const fn test_mm512_maskz_broadcast_f64x2() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm512_maskz_broadcast_f64x2(0b01101001, a);
         let e = _mm512_set_pd(0., 2., 1., 0., 1., 0., 0., 2.);
@@ -8124,7 +8124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_broadcast_i32x2() {
+    const fn test_mm_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_broadcast_i32x2(a);
         let e = _mm_set_epi32(3, 4, 3, 4);
@@ -8132,7 +8132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_broadcast_i32x2() {
+    const fn test_mm_mask_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm_set_epi32(5, 6, 7, 8);
         let r = _mm_mask_broadcast_i32x2(b, 0b0110, a);
@@ -8141,7 +8141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_broadcast_i32x2() {
+    const fn test_mm_maskz_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_maskz_broadcast_i32x2(0b0110, a);
         let e = _mm_set_epi32(0, 4, 3, 0);
@@ -8149,7 +8149,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_broadcast_i32x2() {
+    const fn test_mm256_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm256_broadcast_i32x2(a);
         let e = _mm256_set_epi32(3, 4, 3, 4, 3, 4, 3, 4);
@@ -8157,7 +8157,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcast_i32x2() {
+    const fn test_mm256_mask_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm256_set_epi32(5, 6, 7, 8, 9, 10, 11, 12);
         let r = _mm256_mask_broadcast_i32x2(b, 0b01101001, a);
@@ -8166,7 +8166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcast_i32x2() {
+    const fn test_mm256_maskz_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm256_maskz_broadcast_i32x2(0b01101001, a);
         let e = _mm256_set_epi32(0, 4, 3, 0, 3, 0, 0, 4);
@@ -8174,7 +8174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_broadcast_i32x2() {
+    const fn test_mm512_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm512_broadcast_i32x2(a);
         let e = _mm512_set_epi32(3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4);
@@ -8182,7 +8182,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_broadcast_i32x2() {
+    const fn test_mm512_mask_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm512_set_epi32(5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
         let r = _mm512_mask_broadcast_i32x2(b, 0b0110100100111100, a);
@@ -8191,7 +8191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_broadcast_i32x2() {
+    const fn test_mm512_maskz_broadcast_i32x2() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm512_maskz_broadcast_i32x2(0b0110100100111100, a);
         let e = _mm512_set_epi32(0, 4, 3, 0, 3, 0, 0, 4, 0, 0, 3, 4, 3, 4, 0, 0);
@@ -8199,7 +8199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_broadcast_i32x8() {
+    const fn test_mm512_broadcast_i32x8() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_broadcast_i32x8(a);
         let e = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
@@ -8207,7 +8207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_broadcast_i32x8() {
+    const fn test_mm512_mask_broadcast_i32x8() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi32(
             9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
@@ -8218,7 +8218,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_broadcast_i32x8() {
+    const fn test_mm512_maskz_broadcast_i32x8() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_broadcast_i32x8(0b0110100100111100, a);
         let e = _mm512_set_epi32(0, 2, 3, 0, 5, 0, 0, 8, 0, 0, 3, 4, 5, 6, 0, 0);
@@ -8226,7 +8226,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_broadcast_i64x2() {
+    const fn test_mm256_broadcast_i64x2() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm256_broadcast_i64x2(a);
         let e = _mm256_set_epi64x(1, 2, 1, 2);
@@ -8234,7 +8234,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcast_i64x2() {
+    const fn test_mm256_mask_broadcast_i64x2() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm256_set_epi64x(3, 4, 5, 6);
         let r = _mm256_mask_broadcast_i64x2(b, 0b0110, a);
@@ -8243,7 +8243,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcast_i64x2() {
+    const fn test_mm256_maskz_broadcast_i64x2() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm256_maskz_broadcast_i64x2(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 1, 0);
@@ -8251,7 +8251,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_broadcast_i64x2() {
+    const fn test_mm512_broadcast_i64x2() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm512_broadcast_i64x2(a);
         let e = _mm512_set_epi64(1, 2, 1, 2, 1, 2, 1, 2);
@@ -8259,7 +8259,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_broadcast_i64x2() {
+    const fn test_mm512_mask_broadcast_i64x2() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm512_set_epi64(3, 4, 5, 6, 7, 8, 9, 10);
         let r = _mm512_mask_broadcast_i64x2(b, 0b01101001, a);
@@ -8268,7 +8268,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_broadcast_i64x2() {
+    const fn test_mm512_maskz_broadcast_i64x2() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm512_maskz_broadcast_i64x2(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 1, 0, 1, 0, 0, 2);
@@ -8276,7 +8276,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_extractf32x8_ps() {
+    const fn test_mm512_extractf32x8_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -8286,7 +8286,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_extractf32x8_ps() {
+    const fn test_mm512_mask_extractf32x8_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -8297,7 +8297,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_extractf32x8_ps() {
+    const fn test_mm512_maskz_extractf32x8_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -8307,7 +8307,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_extractf64x2_pd() {
+    const fn test_mm256_extractf64x2_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_extractf64x2_pd::<1>(a);
         let e = _mm_set_pd(1., 2.);
@@ -8315,7 +8315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_extractf64x2_pd() {
+    const fn test_mm256_mask_extractf64x2_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm_set_pd(5., 6.);
         let r = _mm256_mask_extractf64x2_pd::<1>(b, 0b01, a);
@@ -8324,7 +8324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_extractf64x2_pd() {
+    const fn test_mm256_maskz_extractf64x2_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_maskz_extractf64x2_pd::<1>(0b01, a);
         let e = _mm_set_pd(0., 2.);
@@ -8332,7 +8332,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_extractf64x2_pd() {
+    const fn test_mm512_extractf64x2_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_extractf64x2_pd::<2>(a);
         let e = _mm_set_pd(3., 4.);
@@ -8340,7 +8340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_extractf64x2_pd() {
+    const fn test_mm512_mask_extractf64x2_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_pd(9., 10.);
         let r = _mm512_mask_extractf64x2_pd::<2>(b, 0b01, a);
@@ -8349,7 +8349,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_extractf64x2_pd() {
+    const fn test_mm512_maskz_extractf64x2_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_extractf64x2_pd::<2>(0b01, a);
         let e = _mm_set_pd(0., 4.);
@@ -8357,7 +8357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_extracti32x8_epi32() {
+    const fn test_mm512_extracti32x8_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_extracti32x8_epi32::<1>(a);
         let e = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
@@ -8365,7 +8365,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_extracti32x8_epi32() {
+    const fn test_mm512_mask_extracti32x8_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_mask_extracti32x8_epi32::<1>(b, 0b01101001, a);
@@ -8374,7 +8374,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_extracti32x8_epi32() {
+    const fn test_mm512_maskz_extracti32x8_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_extracti32x8_epi32::<1>(0b01101001, a);
         let e = _mm256_set_epi32(0, 2, 3, 0, 5, 0, 0, 8);
@@ -8382,7 +8382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_extracti64x2_epi64() {
+    const fn test_mm256_extracti64x2_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_extracti64x2_epi64::<1>(a);
         let e = _mm_set_epi64x(1, 2);
@@ -8390,7 +8390,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_extracti64x2_epi64() {
+    const fn test_mm256_mask_extracti64x2_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm256_mask_extracti64x2_epi64::<1>(b, 0b01, a);
@@ -8399,7 +8399,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_extracti64x2_epi64() {
+    const fn test_mm256_maskz_extracti64x2_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_extracti64x2_epi64::<1>(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -8407,7 +8407,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_extracti64x2_epi64() {
+    const fn test_mm512_extracti64x2_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_extracti64x2_epi64::<2>(a);
         let e = _mm_set_epi64x(3, 4);
@@ -8415,7 +8415,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_extracti64x2_epi64() {
+    const fn test_mm512_mask_extracti64x2_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi64x(9, 10);
         let r = _mm512_mask_extracti64x2_epi64::<2>(b, 0b01, a);
@@ -8424,7 +8424,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_extracti64x2_epi64() {
+    const fn test_mm512_maskz_extracti64x2_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_extracti64x2_epi64::<2>(0b01, a);
         let e = _mm_set_epi64x(0, 4);
@@ -8432,7 +8432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_insertf32x8() {
+    const fn test_mm512_insertf32x8() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -8445,7 +8445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_insertf32x8() {
+    const fn test_mm512_mask_insertf32x8() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -8461,7 +8461,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_insertf32x8() {
+    const fn test_mm512_maskz_insertf32x8() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -8474,7 +8474,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_insertf64x2() {
+    const fn test_mm256_insertf64x2() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm_set_pd(5., 6.);
         let r = _mm256_insertf64x2::<1>(a, b);
@@ -8483,7 +8483,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_insertf64x2() {
+    const fn test_mm256_mask_insertf64x2() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm_set_pd(5., 6.);
         let src = _mm256_set_pd(7., 8., 9., 10.);
@@ -8493,7 +8493,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_insertf64x2() {
+    const fn test_mm256_maskz_insertf64x2() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm_set_pd(5., 6.);
         let r = _mm256_maskz_insertf64x2::<1>(0b0110, a, b);
@@ -8502,7 +8502,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_insertf64x2() {
+    const fn test_mm512_insertf64x2() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_pd(9., 10.);
         let r = _mm512_insertf64x2::<2>(a, b);
@@ -8511,7 +8511,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_insertf64x2() {
+    const fn test_mm512_mask_insertf64x2() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_pd(9., 10.);
         let src = _mm512_set_pd(11., 12., 13., 14., 15., 16., 17., 18.);
@@ -8521,7 +8521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_insertf64x2() {
+    const fn test_mm512_maskz_insertf64x2() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_pd(9., 10.);
         let r = _mm512_maskz_insertf64x2::<2>(0b01101001, a, b);
@@ -8530,7 +8530,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_inserti32x8() {
+    const fn test_mm512_inserti32x8() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_inserti32x8::<1>(a, b);
@@ -8541,7 +8541,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_inserti32x8() {
+    const fn test_mm512_mask_inserti32x8() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let src = _mm512_set_epi32(
@@ -8555,7 +8555,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_inserti32x8() {
+    const fn test_mm512_maskz_inserti32x8() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_maskz_inserti32x8::<1>(0b0110100100111100, a, b);
@@ -8564,7 +8564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_inserti64x2() {
+    const fn test_mm256_inserti64x2() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm256_inserti64x2::<1>(a, b);
@@ -8573,7 +8573,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_inserti64x2() {
+    const fn test_mm256_mask_inserti64x2() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm_set_epi64x(5, 6);
         let src = _mm256_set_epi64x(7, 8, 9, 10);
@@ -8583,7 +8583,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_inserti64x2() {
+    const fn test_mm256_maskz_inserti64x2() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm256_maskz_inserti64x2::<1>(0b0110, a, b);
@@ -8592,7 +8592,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_inserti64x2() {
+    const fn test_mm512_inserti64x2() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi64x(9, 10);
         let r = _mm512_inserti64x2::<2>(a, b);
@@ -8601,7 +8601,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_inserti64x2() {
+    const fn test_mm512_mask_inserti64x2() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi64x(9, 10);
         let src = _mm512_set_epi64(11, 12, 13, 14, 15, 16, 17, 18);
@@ -8611,7 +8611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_inserti64x2() {
+    const fn test_mm512_maskz_inserti64x2() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi64x(9, 10);
         let r = _mm512_maskz_inserti64x2::<2>(0b01101001, a, b);
@@ -8620,7 +8620,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundepi64_pd() {
+    fn test_mm512_cvt_roundepi64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvt_roundepi64_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8628,7 +8628,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundepi64_pd() {
+    fn test_mm512_mask_cvt_roundepi64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_pd(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvt_roundepi64_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -8639,7 +8639,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundepi64_pd() {
+    fn test_mm512_maskz_cvt_roundepi64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvt_roundepi64_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -8649,7 +8649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtepi64_pd() {
+    fn test_mm_cvtepi64_pd() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_cvtepi64_pd(a);
         let e = _mm_set_pd(1., 2.);
@@ -8657,7 +8657,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi64_pd() {
+    fn test_mm_mask_cvtepi64_pd() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_mask_cvtepi64_pd(b, 0b01, a);
@@ -8666,7 +8666,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi64_pd() {
+    fn test_mm_maskz_cvtepi64_pd() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_maskz_cvtepi64_pd(0b01, a);
         let e = _mm_set_pd(0., 2.);
@@ -8674,7 +8674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtepi64_pd() {
+    fn test_mm256_cvtepi64_pd() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepi64_pd(a);
         let e = _mm256_set_pd(1., 2., 3., 4.);
@@ -8682,7 +8682,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi64_pd() {
+    fn test_mm256_mask_cvtepi64_pd() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_pd(5., 6., 7., 8.);
         let r = _mm256_mask_cvtepi64_pd(b, 0b0110, a);
@@ -8691,7 +8691,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi64_pd() {
+    fn test_mm256_maskz_cvtepi64_pd() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepi64_pd(0b0110, a);
         let e = _mm256_set_pd(0., 2., 3., 0.);
@@ -8699,7 +8699,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtepi64_pd() {
+    fn test_mm512_cvtepi64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvtepi64_pd(a);
         let e = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8707,7 +8707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtepi64_pd() {
+    fn test_mm512_mask_cvtepi64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_pd(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvtepi64_pd(b, 0b01101001, a);
@@ -8716,7 +8716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtepi64_pd() {
+    fn test_mm512_maskz_cvtepi64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvtepi64_pd(0b01101001, a);
         let e = _mm512_set_pd(0., 2., 3., 0., 5., 0., 0., 8.);
@@ -8724,7 +8724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundepi64_ps() {
+    fn test_mm512_cvt_roundepi64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvt_roundepi64_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8732,7 +8732,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundepi64_ps() {
+    fn test_mm512_mask_cvt_roundepi64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvt_roundepi64_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -8743,7 +8743,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundepi64_ps() {
+    fn test_mm512_maskz_cvt_roundepi64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvt_roundepi64_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -8753,7 +8753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtepi64_ps() {
+    fn test_mm_cvtepi64_ps() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_cvtepi64_ps(a);
         let e = _mm_set_ps(0., 0., 1., 2.);
@@ -8761,7 +8761,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi64_ps() {
+    fn test_mm_mask_cvtepi64_ps() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_ps(3., 4., 5., 6.);
         let r = _mm_mask_cvtepi64_ps(b, 0b01, a);
@@ -8770,7 +8770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi64_ps() {
+    fn test_mm_maskz_cvtepi64_ps() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_maskz_cvtepi64_ps(0b01, a);
         let e = _mm_set_ps(0., 0., 0., 2.);
@@ -8778,7 +8778,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtepi64_ps() {
+    fn test_mm256_cvtepi64_ps() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepi64_ps(a);
         let e = _mm_set_ps(1., 2., 3., 4.);
@@ -8786,7 +8786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi64_ps() {
+    fn test_mm256_mask_cvtepi64_ps() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm_set_ps(5., 6., 7., 8.);
         let r = _mm256_mask_cvtepi64_ps(b, 0b0110, a);
@@ -8795,7 +8795,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi64_ps() {
+    fn test_mm256_maskz_cvtepi64_ps() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepi64_ps(0b0110, a);
         let e = _mm_set_ps(0., 2., 3., 0.);
@@ -8803,7 +8803,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtepi64_ps() {
+    fn test_mm512_cvtepi64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvtepi64_ps(a);
         let e = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8811,7 +8811,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtepi64_ps() {
+    fn test_mm512_mask_cvtepi64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvtepi64_ps(b, 0b01101001, a);
@@ -8820,7 +8820,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtepi64_ps() {
+    fn test_mm512_maskz_cvtepi64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvtepi64_ps(0b01101001, a);
         let e = _mm256_set_ps(0., 2., 3., 0., 5., 0., 0., 8.);
@@ -8828,7 +8828,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundepu64_pd() {
+    fn test_mm512_cvt_roundepu64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvt_roundepu64_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8836,7 +8836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundepu64_pd() {
+    fn test_mm512_mask_cvt_roundepu64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_pd(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvt_roundepu64_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -8847,7 +8847,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundepu64_pd() {
+    fn test_mm512_maskz_cvt_roundepu64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvt_roundepu64_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -8857,7 +8857,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtepu64_pd() {
+    fn test_mm_cvtepu64_pd() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_cvtepu64_pd(a);
         let e = _mm_set_pd(1., 2.);
@@ -8865,7 +8865,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtepu64_pd() {
+    fn test_mm_mask_cvtepu64_pd() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_mask_cvtepu64_pd(b, 0b01, a);
@@ -8874,7 +8874,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepu64_pd() {
+    fn test_mm_maskz_cvtepu64_pd() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_maskz_cvtepu64_pd(0b01, a);
         let e = _mm_set_pd(0., 2.);
@@ -8882,7 +8882,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtepu64_pd() {
+    fn test_mm256_cvtepu64_pd() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepu64_pd(a);
         let e = _mm256_set_pd(1., 2., 3., 4.);
@@ -8890,7 +8890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepu64_pd() {
+    fn test_mm256_mask_cvtepu64_pd() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_pd(5., 6., 7., 8.);
         let r = _mm256_mask_cvtepu64_pd(b, 0b0110, a);
@@ -8899,7 +8899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepu64_pd() {
+    fn test_mm256_maskz_cvtepu64_pd() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepu64_pd(0b0110, a);
         let e = _mm256_set_pd(0., 2., 3., 0.);
@@ -8907,7 +8907,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtepu64_pd() {
+    fn test_mm512_cvtepu64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvtepu64_pd(a);
         let e = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8915,7 +8915,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtepu64_pd() {
+    fn test_mm512_mask_cvtepu64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_pd(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvtepu64_pd(b, 0b01101001, a);
@@ -8924,7 +8924,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtepu64_pd() {
+    fn test_mm512_maskz_cvtepu64_pd() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvtepu64_pd(0b01101001, a);
         let e = _mm512_set_pd(0., 2., 3., 0., 5., 0., 0., 8.);
@@ -8932,7 +8932,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundepu64_ps() {
+    fn test_mm512_cvt_roundepu64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvt_roundepu64_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -8940,7 +8940,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundepu64_ps() {
+    fn test_mm512_mask_cvt_roundepu64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvt_roundepu64_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -8951,7 +8951,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundepu64_ps() {
+    fn test_mm512_maskz_cvt_roundepu64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvt_roundepu64_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -8961,7 +8961,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtepu64_ps() {
+    fn test_mm_cvtepu64_ps() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_cvtepu64_ps(a);
         let e = _mm_set_ps(0., 0., 1., 2.);
@@ -8969,7 +8969,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtepu64_ps() {
+    fn test_mm_mask_cvtepu64_ps() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_ps(3., 4., 5., 6.);
         let r = _mm_mask_cvtepu64_ps(b, 0b01, a);
@@ -8978,7 +8978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepu64_ps() {
+    fn test_mm_maskz_cvtepu64_ps() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_maskz_cvtepu64_ps(0b01, a);
         let e = _mm_set_ps(0., 0., 0., 2.);
@@ -8986,7 +8986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtepu64_ps() {
+    fn test_mm256_cvtepu64_ps() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepu64_ps(a);
         let e = _mm_set_ps(1., 2., 3., 4.);
@@ -8994,7 +8994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepu64_ps() {
+    fn test_mm256_mask_cvtepu64_ps() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm_set_ps(5., 6., 7., 8.);
         let r = _mm256_mask_cvtepu64_ps(b, 0b0110, a);
@@ -9003,7 +9003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepu64_ps() {
+    fn test_mm256_maskz_cvtepu64_ps() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepu64_ps(0b0110, a);
         let e = _mm_set_ps(0., 2., 3., 0.);
@@ -9011,7 +9011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtepu64_ps() {
+    fn test_mm512_cvtepu64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvtepu64_ps(a);
         let e = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
@@ -9019,7 +9019,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtepu64_ps() {
+    fn test_mm512_mask_cvtepu64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_ps(9., 10., 11., 12., 13., 14., 15., 16.);
         let r = _mm512_mask_cvtepu64_ps(b, 0b01101001, a);
@@ -9028,7 +9028,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtepu64_ps() {
+    fn test_mm512_maskz_cvtepu64_ps() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvtepu64_ps(0b01101001, a);
         let e = _mm256_set_ps(0., 2., 3., 0., 5., 0., 0., 8.);
@@ -9036,7 +9036,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundpd_epi64() {
+    fn test_mm512_cvt_roundpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvt_roundpd_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9044,7 +9044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundpd_epi64() {
+    fn test_mm512_mask_cvt_roundpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvt_roundpd_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -9055,7 +9055,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundpd_epi64() {
+    fn test_mm512_maskz_cvt_roundpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvt_roundpd_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -9065,7 +9065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtpd_epi64() {
+    fn test_mm_cvtpd_epi64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_cvtpd_epi64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -9073,7 +9073,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtpd_epi64() {
+    fn test_mm_mask_cvtpd_epi64() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_epi64x(3, 4);
         let r = _mm_mask_cvtpd_epi64(b, 0b01, a);
@@ -9082,7 +9082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpd_epi64() {
+    fn test_mm_maskz_cvtpd_epi64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_maskz_cvtpd_epi64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -9090,7 +9090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtpd_epi64() {
+    fn test_mm256_cvtpd_epi64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_cvtpd_epi64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9098,7 +9098,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpd_epi64() {
+    fn test_mm256_mask_cvtpd_epi64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvtpd_epi64(b, 0b0110, a);
@@ -9107,7 +9107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpd_epi64() {
+    fn test_mm256_maskz_cvtpd_epi64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_maskz_cvtpd_epi64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9115,7 +9115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtpd_epi64() {
+    fn test_mm512_cvtpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtpd_epi64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9123,7 +9123,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtpd_epi64() {
+    fn test_mm512_mask_cvtpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtpd_epi64(b, 0b01101001, a);
@@ -9132,7 +9132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtpd_epi64() {
+    fn test_mm512_maskz_cvtpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtpd_epi64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9140,7 +9140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundps_epi64() {
+    fn test_mm512_cvt_roundps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvt_roundps_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9148,7 +9148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundps_epi64() {
+    fn test_mm512_mask_cvt_roundps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvt_roundps_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -9159,7 +9159,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundps_epi64() {
+    fn test_mm512_maskz_cvt_roundps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvt_roundps_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -9169,7 +9169,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtps_epi64() {
+    fn test_mm_cvtps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_cvtps_epi64(a);
         let e = _mm_set_epi64x(3, 4);
@@ -9177,7 +9177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtps_epi64() {
+    fn test_mm_mask_cvtps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm_mask_cvtps_epi64(b, 0b01, a);
@@ -9186,7 +9186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtps_epi64() {
+    fn test_mm_maskz_cvtps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_maskz_cvtps_epi64(0b01, a);
         let e = _mm_set_epi64x(0, 4);
@@ -9194,7 +9194,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtps_epi64() {
+    fn test_mm256_cvtps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_cvtps_epi64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9202,7 +9202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtps_epi64() {
+    fn test_mm256_mask_cvtps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvtps_epi64(b, 0b0110, a);
@@ -9211,7 +9211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtps_epi64() {
+    fn test_mm256_maskz_cvtps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_maskz_cvtps_epi64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9219,7 +9219,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtps_epi64() {
+    fn test_mm512_cvtps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtps_epi64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9227,7 +9227,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtps_epi64() {
+    fn test_mm512_mask_cvtps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtps_epi64(b, 0b01101001, a);
@@ -9236,7 +9236,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtps_epi64() {
+    fn test_mm512_maskz_cvtps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtps_epi64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9244,7 +9244,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundpd_epu64() {
+    fn test_mm512_cvt_roundpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvt_roundpd_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9252,7 +9252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundpd_epu64() {
+    fn test_mm512_mask_cvt_roundpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvt_roundpd_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -9263,7 +9263,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundpd_epu64() {
+    fn test_mm512_maskz_cvt_roundpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvt_roundpd_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -9273,7 +9273,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtpd_epu64() {
+    fn test_mm_cvtpd_epu64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_cvtpd_epu64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -9281,7 +9281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtpd_epu64() {
+    fn test_mm_mask_cvtpd_epu64() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_epi64x(3, 4);
         let r = _mm_mask_cvtpd_epu64(b, 0b01, a);
@@ -9290,7 +9290,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpd_epu64() {
+    fn test_mm_maskz_cvtpd_epu64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_maskz_cvtpd_epu64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -9298,7 +9298,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtpd_epu64() {
+    fn test_mm256_cvtpd_epu64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_cvtpd_epu64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9306,7 +9306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpd_epu64() {
+    fn test_mm256_mask_cvtpd_epu64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvtpd_epu64(b, 0b0110, a);
@@ -9315,7 +9315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpd_epu64() {
+    fn test_mm256_maskz_cvtpd_epu64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_maskz_cvtpd_epu64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9323,7 +9323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtpd_epu64() {
+    fn test_mm512_cvtpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtpd_epu64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9331,7 +9331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtpd_epu64() {
+    fn test_mm512_mask_cvtpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtpd_epu64(b, 0b01101001, a);
@@ -9340,7 +9340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtpd_epu64() {
+    fn test_mm512_maskz_cvtpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtpd_epu64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9348,7 +9348,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvt_roundps_epu64() {
+    fn test_mm512_cvt_roundps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvt_roundps_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9356,7 +9356,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvt_roundps_epu64() {
+    fn test_mm512_mask_cvt_roundps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvt_roundps_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -9367,7 +9367,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvt_roundps_epu64() {
+    fn test_mm512_maskz_cvt_roundps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvt_roundps_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01101001, a,
@@ -9377,7 +9377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvtps_epu64() {
+    fn test_mm_cvtps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_cvtps_epu64(a);
         let e = _mm_set_epi64x(3, 4);
@@ -9385,7 +9385,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvtps_epu64() {
+    fn test_mm_mask_cvtps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm_mask_cvtps_epu64(b, 0b01, a);
@@ -9394,7 +9394,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvtps_epu64() {
+    fn test_mm_maskz_cvtps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_maskz_cvtps_epu64(0b01, a);
         let e = _mm_set_epi64x(0, 4);
@@ -9402,7 +9402,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvtps_epu64() {
+    fn test_mm256_cvtps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_cvtps_epu64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9410,7 +9410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvtps_epu64() {
+    fn test_mm256_mask_cvtps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvtps_epu64(b, 0b0110, a);
@@ -9419,7 +9419,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtps_epu64() {
+    fn test_mm256_maskz_cvtps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_maskz_cvtps_epu64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9427,7 +9427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtps_epu64() {
+    fn test_mm512_cvtps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtps_epu64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9435,7 +9435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtps_epu64() {
+    fn test_mm512_mask_cvtps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtps_epu64(b, 0b01101001, a);
@@ -9444,7 +9444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtps_epu64() {
+    fn test_mm512_maskz_cvtps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtps_epu64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9452,7 +9452,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtt_roundpd_epi64() {
+    fn test_mm512_cvtt_roundpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtt_roundpd_epi64::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9460,7 +9460,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtt_roundpd_epi64() {
+    fn test_mm512_mask_cvtt_roundpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtt_roundpd_epi64::<_MM_FROUND_NO_EXC>(b, 0b01101001, a);
@@ -9469,7 +9469,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtt_roundpd_epi64() {
+    fn test_mm512_maskz_cvtt_roundpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtt_roundpd_epi64::<_MM_FROUND_NO_EXC>(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9477,7 +9477,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvttpd_epi64() {
+    fn test_mm_cvttpd_epi64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_cvttpd_epi64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -9485,7 +9485,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvttpd_epi64() {
+    fn test_mm_mask_cvttpd_epi64() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_epi64x(3, 4);
         let r = _mm_mask_cvttpd_epi64(b, 0b01, a);
@@ -9494,7 +9494,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvttpd_epi64() {
+    fn test_mm_maskz_cvttpd_epi64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_maskz_cvttpd_epi64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -9502,7 +9502,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvttpd_epi64() {
+    fn test_mm256_cvttpd_epi64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_cvttpd_epi64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9510,7 +9510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvttpd_epi64() {
+    fn test_mm256_mask_cvttpd_epi64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvttpd_epi64(b, 0b0110, a);
@@ -9519,7 +9519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttpd_epi64() {
+    fn test_mm256_maskz_cvttpd_epi64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_maskz_cvttpd_epi64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9527,7 +9527,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvttpd_epi64() {
+    fn test_mm512_cvttpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvttpd_epi64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9535,7 +9535,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvttpd_epi64() {
+    fn test_mm512_mask_cvttpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvttpd_epi64(b, 0b01101001, a);
@@ -9544,7 +9544,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvttpd_epi64() {
+    fn test_mm512_maskz_cvttpd_epi64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvttpd_epi64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9552,7 +9552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtt_roundps_epi64() {
+    fn test_mm512_cvtt_roundps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtt_roundps_epi64::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9560,7 +9560,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtt_roundps_epi64() {
+    fn test_mm512_mask_cvtt_roundps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtt_roundps_epi64::<_MM_FROUND_NO_EXC>(b, 0b01101001, a);
@@ -9569,7 +9569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtt_roundps_epi64() {
+    fn test_mm512_maskz_cvtt_roundps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtt_roundps_epi64::<_MM_FROUND_NO_EXC>(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9577,7 +9577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvttps_epi64() {
+    fn test_mm_cvttps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_cvttps_epi64(a);
         let e = _mm_set_epi64x(3, 4);
@@ -9585,7 +9585,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvttps_epi64() {
+    fn test_mm_mask_cvttps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm_mask_cvttps_epi64(b, 0b01, a);
@@ -9594,7 +9594,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvttps_epi64() {
+    fn test_mm_maskz_cvttps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_maskz_cvttps_epi64(0b01, a);
         let e = _mm_set_epi64x(0, 4);
@@ -9602,7 +9602,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvttps_epi64() {
+    fn test_mm256_cvttps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_cvttps_epi64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9610,7 +9610,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvttps_epi64() {
+    fn test_mm256_mask_cvttps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvttps_epi64(b, 0b0110, a);
@@ -9619,7 +9619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttps_epi64() {
+    fn test_mm256_maskz_cvttps_epi64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_maskz_cvttps_epi64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9627,7 +9627,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvttps_epi64() {
+    fn test_mm512_cvttps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvttps_epi64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9635,7 +9635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvttps_epi64() {
+    fn test_mm512_mask_cvttps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvttps_epi64(b, 0b01101001, a);
@@ -9644,7 +9644,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvttps_epi64() {
+    fn test_mm512_maskz_cvttps_epi64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvttps_epi64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9652,7 +9652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtt_roundpd_epu64() {
+    fn test_mm512_cvtt_roundpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtt_roundpd_epu64::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9660,7 +9660,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtt_roundpd_epu64() {
+    fn test_mm512_mask_cvtt_roundpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtt_roundpd_epu64::<_MM_FROUND_NO_EXC>(b, 0b01101001, a);
@@ -9669,7 +9669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtt_roundpd_epu64() {
+    fn test_mm512_maskz_cvtt_roundpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtt_roundpd_epu64::<_MM_FROUND_NO_EXC>(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9677,7 +9677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvttpd_epu64() {
+    fn test_mm_cvttpd_epu64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_cvttpd_epu64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -9685,7 +9685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvttpd_epu64() {
+    fn test_mm_mask_cvttpd_epu64() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_epi64x(3, 4);
         let r = _mm_mask_cvttpd_epu64(b, 0b01, a);
@@ -9694,7 +9694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvttpd_epu64() {
+    fn test_mm_maskz_cvttpd_epu64() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_maskz_cvttpd_epu64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -9702,7 +9702,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvttpd_epu64() {
+    fn test_mm256_cvttpd_epu64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_cvttpd_epu64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9710,7 +9710,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvttpd_epu64() {
+    fn test_mm256_mask_cvttpd_epu64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvttpd_epu64(b, 0b0110, a);
@@ -9719,7 +9719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttpd_epu64() {
+    fn test_mm256_maskz_cvttpd_epu64() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_maskz_cvttpd_epu64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9727,7 +9727,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvttpd_epu64() {
+    fn test_mm512_cvttpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvttpd_epu64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9735,7 +9735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvttpd_epu64() {
+    fn test_mm512_mask_cvttpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvttpd_epu64(b, 0b01101001, a);
@@ -9744,7 +9744,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvttpd_epu64() {
+    fn test_mm512_maskz_cvttpd_epu64() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvttpd_epu64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9752,7 +9752,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvtt_roundps_epu64() {
+    fn test_mm512_cvtt_roundps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvtt_roundps_epu64::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9760,7 +9760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvtt_roundps_epu64() {
+    fn test_mm512_mask_cvtt_roundps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvtt_roundps_epu64::<_MM_FROUND_NO_EXC>(b, 0b01101001, a);
@@ -9769,7 +9769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvtt_roundps_epu64() {
+    fn test_mm512_maskz_cvtt_roundps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvtt_roundps_epu64::<_MM_FROUND_NO_EXC>(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9777,7 +9777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_cvttps_epu64() {
+    fn test_mm_cvttps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_cvttps_epu64(a);
         let e = _mm_set_epi64x(3, 4);
@@ -9785,7 +9785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_cvttps_epu64() {
+    fn test_mm_mask_cvttps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_epi64x(5, 6);
         let r = _mm_mask_cvttps_epu64(b, 0b01, a);
@@ -9794,7 +9794,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_cvttps_epu64() {
+    fn test_mm_maskz_cvttps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_maskz_cvttps_epu64(0b01, a);
         let e = _mm_set_epi64x(0, 4);
@@ -9802,7 +9802,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_cvttps_epu64() {
+    fn test_mm256_cvttps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_cvttps_epu64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -9810,7 +9810,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_cvttps_epu64() {
+    fn test_mm256_mask_cvttps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mask_cvttps_epu64(b, 0b0110, a);
@@ -9819,7 +9819,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttps_epu64() {
+    fn test_mm256_maskz_cvttps_epu64() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm256_maskz_cvttps_epu64(0b0110, a);
         let e = _mm256_set_epi64x(0, 2, 3, 0);
@@ -9827,7 +9827,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_cvttps_epu64() {
+    fn test_mm512_cvttps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_cvttps_epu64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -9835,7 +9835,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_cvttps_epu64() {
+    fn test_mm512_mask_cvttps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_cvttps_epu64(b, 0b01101001, a);
@@ -9844,7 +9844,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_cvttps_epu64() {
+    fn test_mm512_maskz_cvttps_epu64() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_cvttps_epu64(0b01101001, a);
         let e = _mm512_set_epi64(0, 2, 3, 0, 5, 0, 0, 8);
@@ -9852,7 +9852,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mullo_epi64() {
+    const fn test_mm_mullo_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(3, 4);
         let r = _mm_mullo_epi64(a, b);
@@ -9861,7 +9861,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_mask_mullo_epi64() {
+    const fn test_mm_mask_mullo_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(3, 4);
         let c = _mm_set_epi64x(5, 6);
@@ -9871,7 +9871,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_maskz_mullo_epi64() {
+    const fn test_mm_maskz_mullo_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(3, 4);
         let r = _mm_maskz_mullo_epi64(0b01, a, b);
@@ -9880,7 +9880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mullo_epi64() {
+    const fn test_mm256_mullo_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_mullo_epi64(a, b);
@@ -9889,7 +9889,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_mask_mullo_epi64() {
+    const fn test_mm256_mask_mullo_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let c = _mm256_set_epi64x(9, 10, 11, 12);
@@ -9899,7 +9899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_maskz_mullo_epi64() {
+    const fn test_mm256_maskz_mullo_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(5, 6, 7, 8);
         let r = _mm256_maskz_mullo_epi64(0b0110, a, b);
@@ -9908,7 +9908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mullo_epi64() {
+    const fn test_mm512_mullo_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mullo_epi64(a, b);
@@ -9917,7 +9917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_mask_mullo_epi64() {
+    const fn test_mm512_mask_mullo_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let c = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
@@ -9927,7 +9927,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_maskz_mullo_epi64() {
+    const fn test_mm512_maskz_mullo_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_mullo_epi64(0b01101001, a, b);
@@ -9936,7 +9936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_cvtmask8_u32() {
+    const fn test_cvtmask8_u32() {
         let a: __mmask8 = 0b01101001;
         let r = _cvtmask8_u32(a);
         let e: u32 = 0b01101001;
@@ -9944,7 +9944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_cvtu32_mask8() {
+    const fn test_cvtu32_mask8() {
         let a: u32 = 0b01101001;
         let r = _cvtu32_mask8(a);
         let e: __mmask8 = 0b01101001;
@@ -9952,7 +9952,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kadd_mask16() {
+    const fn test_kadd_mask16() {
         let a: __mmask16 = 27549;
         let b: __mmask16 = 23434;
         let r = _kadd_mask16(a, b);
@@ -9961,7 +9961,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kadd_mask8() {
+    const fn test_kadd_mask8() {
         let a: __mmask8 = 98;
         let b: __mmask8 = 117;
         let r = _kadd_mask8(a, b);
@@ -9970,7 +9970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kand_mask8() {
+    const fn test_kand_mask8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110011;
         let r = _kand_mask8(a, b);
@@ -9979,7 +9979,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kandn_mask8() {
+    const fn test_kandn_mask8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110011;
         let r = _kandn_mask8(a, b);
@@ -9988,7 +9988,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_knot_mask8() {
+    const fn test_knot_mask8() {
         let a: __mmask8 = 0b01101001;
         let r = _knot_mask8(a);
         let e: __mmask8 = 0b10010110;
@@ -9996,7 +9996,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kor_mask8() {
+    const fn test_kor_mask8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110011;
         let r = _kor_mask8(a, b);
@@ -10005,7 +10005,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kxnor_mask8() {
+    const fn test_kxnor_mask8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110011;
         let r = _kxnor_mask8(a, b);
@@ -10014,7 +10014,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kxor_mask8() {
+    const fn test_kxor_mask8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110011;
         let r = _kxor_mask8(a, b);
@@ -10033,7 +10033,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kortestc_mask8_u8() {
+    const fn test_kortestc_mask8_u8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110110;
         let r = _kortestc_mask8_u8(a, b);
@@ -10041,7 +10041,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kortestz_mask8_u8() {
+    const fn test_kortestz_mask8_u8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10110110;
         let r = _kortestz_mask8_u8(a, b);
@@ -10069,7 +10069,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_kshiftri_mask8() {
+    const fn test_kshiftri_mask8() {
         let a: __mmask8 = 0b10101001;
         let r = _kshiftri_mask8::<3>(a);
         let e: __mmask8 = 0b00010101;
@@ -10099,7 +10099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_ktestc_mask8_u8() {
+    const fn test_ktestc_mask8_u8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10010110;
         let r = _ktestc_mask8_u8(a, b);
@@ -10107,7 +10107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_ktestz_mask8_u8() {
+    const fn test_ktestz_mask8_u8() {
         let a: __mmask8 = 0b01101001;
         let b: __mmask8 = 0b10010110;
         let r = _ktestz_mask8_u8(a, b);
@@ -10125,7 +10125,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_ktestc_mask16_u8() {
+    const fn test_ktestc_mask16_u8() {
         let a: __mmask16 = 0b0110100100111100;
         let b: __mmask16 = 0b1001011011000011;
         let r = _ktestc_mask16_u8(a, b);
@@ -10133,7 +10133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_ktestz_mask16_u8() {
+    const fn test_ktestz_mask16_u8() {
         let a: __mmask16 = 0b0110100100111100;
         let b: __mmask16 = 0b1001011011000011;
         let r = _ktestz_mask16_u8(a, b);
@@ -10158,7 +10158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_movepi32_mask() {
+    const fn test_mm_movepi32_mask() {
         let a = _mm_set_epi32(0, -2, -3, 4);
         let r = _mm_movepi32_mask(a);
         let e = 0b0110;
@@ -10166,7 +10166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_movepi32_mask() {
+    const fn test_mm256_movepi32_mask() {
         let a = _mm256_set_epi32(0, -2, -3, 4, -5, 6, 7, -8);
         let r = _mm256_movepi32_mask(a);
         let e = 0b01101001;
@@ -10174,7 +10174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_movepi32_mask() {
+    const fn test_mm512_movepi32_mask() {
         let a = _mm512_set_epi32(
             0, -2, -3, 4, -5, 6, 7, -8, 9, 10, -11, -12, -13, -14, 15, 16,
         );
@@ -10184,7 +10184,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_movepi64_mask() {
+    const fn test_mm_movepi64_mask() {
         let a = _mm_set_epi64x(0, -2);
         let r = _mm_movepi64_mask(a);
         let e = 0b01;
@@ -10192,7 +10192,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_movepi64_mask() {
+    const fn test_mm256_movepi64_mask() {
         let a = _mm256_set_epi64x(0, -2, -3, 4);
         let r = _mm256_movepi64_mask(a);
         let e = 0b0110;
@@ -10200,7 +10200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_movepi64_mask() {
+    const fn test_mm512_movepi64_mask() {
         let a = _mm512_set_epi64(0, -2, -3, 4, -5, 6, 7, -8);
         let r = _mm512_movepi64_mask(a);
         let e = 0b01101001;
@@ -10208,7 +10208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_movm_epi32() {
+    const fn test_mm_movm_epi32() {
         let a = 0b0110;
         let r = _mm_movm_epi32(a);
         let e = _mm_set_epi32(0, -1, -1, 0);
@@ -10216,7 +10216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_movm_epi32() {
+    const fn test_mm256_movm_epi32() {
         let a = 0b01101001;
         let r = _mm256_movm_epi32(a);
         let e = _mm256_set_epi32(0, -1, -1, 0, -1, 0, 0, -1);
@@ -10224,7 +10224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_movm_epi32() {
+    const fn test_mm512_movm_epi32() {
         let a = 0b0110100100111100;
         let r = _mm512_movm_epi32(a);
         let e = _mm512_set_epi32(0, -1, -1, 0, -1, 0, 0, -1, 0, 0, -1, -1, -1, -1, 0, 0);
@@ -10232,7 +10232,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm_movm_epi64() {
+    const fn test_mm_movm_epi64() {
         let a = 0b01;
         let r = _mm_movm_epi64(a);
         let e = _mm_set_epi64x(0, -1);
@@ -10240,7 +10240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    const unsafe fn test_mm256_movm_epi64() {
+    const fn test_mm256_movm_epi64() {
         let a = 0b0110;
         let r = _mm256_movm_epi64(a);
         let e = _mm256_set_epi64x(0, -1, -1, 0);
@@ -10248,7 +10248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    const unsafe fn test_mm512_movm_epi64() {
+    const fn test_mm512_movm_epi64() {
         let a = 0b01101001;
         let r = _mm512_movm_epi64(a);
         let e = _mm512_set_epi64(0, -1, -1, 0, -1, 0, 0, -1);
@@ -10256,7 +10256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_range_round_pd() {
+    fn test_mm512_range_round_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(2., 1., 4., 3., 6., 5., 8., 7.);
         let r = _mm512_range_round_pd::<0b0101, _MM_FROUND_NO_EXC>(a, b);
@@ -10265,7 +10265,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_range_round_pd() {
+    fn test_mm512_mask_range_round_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(2., 1., 4., 3., 6., 5., 8., 7.);
         let c = _mm512_set_pd(9., 10., 11., 12., 13., 14., 15., 16.);
@@ -10275,7 +10275,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_range_round_pd() {
+    fn test_mm512_maskz_range_round_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(2., 1., 4., 3., 6., 5., 8., 7.);
         let r = _mm512_maskz_range_round_pd::<0b0101, _MM_FROUND_NO_EXC>(0b01101001, a, b);
@@ -10284,7 +10284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_range_pd() {
+    fn test_mm_range_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(2., 1.);
         let r = _mm_range_pd::<0b0101>(a, b);
@@ -10293,7 +10293,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_range_pd() {
+    fn test_mm_mask_range_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(2., 1.);
         let c = _mm_set_pd(3., 4.);
@@ -10303,7 +10303,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_range_pd() {
+    fn test_mm_maskz_range_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(2., 1.);
         let r = _mm_maskz_range_pd::<0b0101>(0b01, a, b);
@@ -10312,7 +10312,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_range_pd() {
+    fn test_mm256_range_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(2., 1., 4., 3.);
         let r = _mm256_range_pd::<0b0101>(a, b);
@@ -10321,7 +10321,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_range_pd() {
+    fn test_mm256_mask_range_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(2., 1., 4., 3.);
         let c = _mm256_set_pd(5., 6., 7., 8.);
@@ -10331,7 +10331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_range_pd() {
+    fn test_mm256_maskz_range_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(2., 1., 4., 3.);
         let r = _mm256_maskz_range_pd::<0b0101>(0b0110, a, b);
@@ -10340,7 +10340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_range_pd() {
+    fn test_mm512_range_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(2., 1., 4., 3., 6., 5., 8., 7.);
         let r = _mm512_range_pd::<0b0101>(a, b);
@@ -10349,7 +10349,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_range_pd() {
+    fn test_mm512_mask_range_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(2., 1., 4., 3., 6., 5., 8., 7.);
         let c = _mm512_set_pd(9., 10., 11., 12., 13., 14., 15., 16.);
@@ -10359,7 +10359,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_range_pd() {
+    fn test_mm512_maskz_range_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(2., 1., 4., 3., 6., 5., 8., 7.);
         let r = _mm512_maskz_range_pd::<0b0101>(0b01101001, a, b);
@@ -10368,7 +10368,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_range_round_ps() {
+    fn test_mm512_range_round_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -10383,7 +10383,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_range_round_ps() {
+    fn test_mm512_mask_range_round_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -10402,7 +10402,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_range_round_ps() {
+    fn test_mm512_maskz_range_round_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -10417,7 +10417,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_range_ps() {
+    fn test_mm_range_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(2., 1., 4., 3.);
         let r = _mm_range_ps::<0b0101>(a, b);
@@ -10426,7 +10426,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_range_ps() {
+    fn test_mm_mask_range_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(2., 1., 4., 3.);
         let c = _mm_set_ps(5., 6., 7., 8.);
@@ -10436,7 +10436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_range_ps() {
+    fn test_mm_maskz_range_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(2., 1., 4., 3.);
         let r = _mm_maskz_range_ps::<0b0101>(0b0110, a, b);
@@ -10445,7 +10445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_range_ps() {
+    fn test_mm256_range_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(2., 1., 4., 3., 6., 5., 8., 7.);
         let r = _mm256_range_ps::<0b0101>(a, b);
@@ -10454,7 +10454,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_range_ps() {
+    fn test_mm256_mask_range_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(2., 1., 4., 3., 6., 5., 8., 7.);
         let c = _mm256_set_ps(9., 10., 11., 12., 13., 14., 15., 16.);
@@ -10464,7 +10464,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_range_ps() {
+    fn test_mm256_maskz_range_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(2., 1., 4., 3., 6., 5., 8., 7.);
         let r = _mm256_maskz_range_ps::<0b0101>(0b01101001, a, b);
@@ -10473,7 +10473,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_range_ps() {
+    fn test_mm512_range_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -10488,7 +10488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_range_ps() {
+    fn test_mm512_mask_range_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -10506,7 +10506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_range_ps() {
+    fn test_mm512_maskz_range_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -10521,7 +10521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_range_round_sd() {
+    fn test_mm_range_round_sd() {
         let a = _mm_set_sd(1.);
         let b = _mm_set_sd(2.);
         let r = _mm_range_round_sd::<0b0101, _MM_FROUND_NO_EXC>(a, b);
@@ -10530,7 +10530,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_range_round_sd() {
+    fn test_mm_mask_range_round_sd() {
         let a = _mm_set_sd(1.);
         let b = _mm_set_sd(2.);
         let c = _mm_set_sd(3.);
@@ -10540,7 +10540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_range_round_sd() {
+    fn test_mm_maskz_range_round_sd() {
         let a = _mm_set_sd(1.);
         let b = _mm_set_sd(2.);
         let r = _mm_maskz_range_round_sd::<0b0101, _MM_FROUND_NO_EXC>(0b0, a, b);
@@ -10549,7 +10549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_range_sd() {
+    fn test_mm_mask_range_sd() {
         let a = _mm_set_sd(1.);
         let b = _mm_set_sd(2.);
         let c = _mm_set_sd(3.);
@@ -10559,7 +10559,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_range_sd() {
+    fn test_mm_maskz_range_sd() {
         let a = _mm_set_sd(1.);
         let b = _mm_set_sd(2.);
         let r = _mm_maskz_range_sd::<0b0101>(0b0, a, b);
@@ -10568,7 +10568,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_range_round_ss() {
+    fn test_mm_range_round_ss() {
         let a = _mm_set_ss(1.);
         let b = _mm_set_ss(2.);
         let r = _mm_range_round_ss::<0b0101, _MM_FROUND_NO_EXC>(a, b);
@@ -10577,7 +10577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_range_round_ss() {
+    fn test_mm_mask_range_round_ss() {
         let a = _mm_set_ss(1.);
         let b = _mm_set_ss(2.);
         let c = _mm_set_ss(3.);
@@ -10587,7 +10587,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_range_round_ss() {
+    fn test_mm_maskz_range_round_ss() {
         let a = _mm_set_ss(1.);
         let b = _mm_set_ss(2.);
         let r = _mm_maskz_range_round_ss::<0b0101, _MM_FROUND_NO_EXC>(0b0, a, b);
@@ -10596,7 +10596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_range_ss() {
+    fn test_mm_mask_range_ss() {
         let a = _mm_set_ss(1.);
         let b = _mm_set_ss(2.);
         let c = _mm_set_ss(3.);
@@ -10606,7 +10606,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_range_ss() {
+    fn test_mm_maskz_range_ss() {
         let a = _mm_set_ss(1.);
         let b = _mm_set_ss(2.);
         let r = _mm_maskz_range_ss::<0b0101>(0b0, a, b);
@@ -10615,7 +10615,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_reduce_round_pd() {
+    fn test_mm512_reduce_round_pd() {
         let a = _mm512_set_pd(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let r = _mm512_reduce_round_pd::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_pd(0.25, 0., 0.25, 0., 0.25, 0., 0.25, 0.);
@@ -10623,7 +10623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_reduce_round_pd() {
+    fn test_mm512_mask_reduce_round_pd() {
         let a = _mm512_set_pd(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let src = _mm512_set_pd(3., 4., 5., 6., 7., 8., 9., 10.);
         let r = _mm512_mask_reduce_round_pd::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(
@@ -10634,7 +10634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_reduce_round_pd() {
+    fn test_mm512_maskz_reduce_round_pd() {
         let a = _mm512_set_pd(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let r = _mm512_maskz_reduce_round_pd::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(
             0b01101001, a,
@@ -10644,7 +10644,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_reduce_pd() {
+    fn test_mm_reduce_pd() {
         let a = _mm_set_pd(0.25, 0.50);
         let r = _mm_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm_set_pd(0.25, 0.);
@@ -10652,7 +10652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_reduce_pd() {
+    fn test_mm_mask_reduce_pd() {
         let a = _mm_set_pd(0.25, 0.50);
         let src = _mm_set_pd(3., 4.);
         let r = _mm_mask_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b01, a);
@@ -10661,7 +10661,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_reduce_pd() {
+    fn test_mm_maskz_reduce_pd() {
         let a = _mm_set_pd(0.25, 0.50);
         let r = _mm_maskz_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(0b01, a);
         let e = _mm_set_pd(0., 0.);
@@ -10669,7 +10669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_reduce_pd() {
+    fn test_mm256_reduce_pd() {
         let a = _mm256_set_pd(0.25, 0.50, 0.75, 1.0);
         let r = _mm256_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm256_set_pd(0.25, 0., 0.25, 0.);
@@ -10677,7 +10677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_reduce_pd() {
+    fn test_mm256_mask_reduce_pd() {
         let a = _mm256_set_pd(0.25, 0.50, 0.75, 1.0);
         let src = _mm256_set_pd(3., 4., 5., 6.);
         let r = _mm256_mask_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b0110, a);
@@ -10686,7 +10686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_reduce_pd() {
+    fn test_mm256_maskz_reduce_pd() {
         let a = _mm256_set_pd(0.25, 0.50, 0.75, 1.0);
         let r = _mm256_maskz_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(0b0110, a);
         let e = _mm256_set_pd(0., 0., 0.25, 0.);
@@ -10694,7 +10694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_reduce_pd() {
+    fn test_mm512_reduce_pd() {
         let a = _mm512_set_pd(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let r = _mm512_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm512_set_pd(0.25, 0., 0.25, 0., 0.25, 0., 0.25, 0.);
@@ -10702,7 +10702,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_reduce_pd() {
+    fn test_mm512_mask_reduce_pd() {
         let a = _mm512_set_pd(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let src = _mm512_set_pd(3., 4., 5., 6., 7., 8., 9., 10.);
         let r = _mm512_mask_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b01101001, a);
@@ -10711,7 +10711,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_reduce_pd() {
+    fn test_mm512_maskz_reduce_pd() {
         let a = _mm512_set_pd(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let r = _mm512_maskz_reduce_pd::<{ 16 | _MM_FROUND_TO_ZERO }>(0b01101001, a);
         let e = _mm512_set_pd(0., 0., 0.25, 0., 0.25, 0., 0., 0.);
@@ -10719,7 +10719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_reduce_round_ps() {
+    fn test_mm512_reduce_round_ps() {
         let a = _mm512_set_ps(
             0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0, 3.25, 3.50, 3.75,
             4.0,
@@ -10732,7 +10732,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_reduce_round_ps() {
+    fn test_mm512_mask_reduce_round_ps() {
         let a = _mm512_set_ps(
             0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0, 3.25, 3.50, 3.75,
             4.0,
@@ -10752,7 +10752,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_reduce_round_ps() {
+    fn test_mm512_maskz_reduce_round_ps() {
         let a = _mm512_set_ps(
             0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0, 3.25, 3.50, 3.75,
             4.0,
@@ -10768,7 +10768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_reduce_ps() {
+    fn test_mm_reduce_ps() {
         let a = _mm_set_ps(0.25, 0.50, 0.75, 1.0);
         let r = _mm_reduce_ps::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm_set_ps(0.25, 0., 0.25, 0.);
@@ -10776,7 +10776,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_reduce_ps() {
+    fn test_mm_mask_reduce_ps() {
         let a = _mm_set_ps(0.25, 0.50, 0.75, 1.0);
         let src = _mm_set_ps(2., 3., 4., 5.);
         let r = _mm_mask_reduce_ps::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b0110, a);
@@ -10785,7 +10785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_maskz_reduce_ps() {
+    fn test_mm_maskz_reduce_ps() {
         let a = _mm_set_ps(0.25, 0.50, 0.75, 1.0);
         let r = _mm_maskz_reduce_ps::<{ 16 | _MM_FROUND_TO_ZERO }>(0b0110, a);
         let e = _mm_set_ps(0., 0., 0.25, 0.);
@@ -10793,7 +10793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_reduce_ps() {
+    fn test_mm256_reduce_ps() {
         let a = _mm256_set_ps(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let r = _mm256_reduce_ps::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm256_set_ps(0.25, 0., 0.25, 0., 0.25, 0., 0.25, 0.);
@@ -10801,7 +10801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_reduce_ps() {
+    fn test_mm256_mask_reduce_ps() {
         let a = _mm256_set_ps(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let src = _mm256_set_ps(3., 4., 5., 6., 7., 8., 9., 10.);
         let r = _mm256_mask_reduce_ps::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b01101001, a);
@@ -10810,7 +10810,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_maskz_reduce_ps() {
+    fn test_mm256_maskz_reduce_ps() {
         let a = _mm256_set_ps(0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0);
         let r = _mm256_maskz_reduce_ps::<{ 16 | _MM_FROUND_TO_ZERO }>(0b01101001, a);
         let e = _mm256_set_ps(0., 0., 0.25, 0., 0.25, 0., 0., 0.);
@@ -10818,7 +10818,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_reduce_ps() {
+    fn test_mm512_reduce_ps() {
         let a = _mm512_set_ps(
             0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0, 3.25, 3.50, 3.75,
             4.0,
@@ -10831,7 +10831,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_reduce_ps() {
+    fn test_mm512_mask_reduce_ps() {
         let a = _mm512_set_ps(
             0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0, 3.25, 3.50, 3.75,
             4.0,
@@ -10847,7 +10847,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_maskz_reduce_ps() {
+    fn test_mm512_maskz_reduce_ps() {
         let a = _mm512_set_ps(
             0.25, 0.50, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0, 3.25, 3.50, 3.75,
             4.0,
@@ -10860,7 +10860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_reduce_round_sd() {
+    fn test_mm_reduce_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_sd(0.25);
         let r = _mm_reduce_round_sd::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(a, b);
@@ -10869,7 +10869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_reduce_round_sd() {
+    fn test_mm_mask_reduce_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_sd(0.25);
         let c = _mm_set_pd(3., 4.);
@@ -10881,7 +10881,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_reduce_round_sd() {
+    fn test_mm_maskz_reduce_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_sd(0.25);
         let r =
@@ -10891,7 +10891,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_reduce_sd() {
+    fn test_mm_reduce_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_sd(0.25);
         let r = _mm_reduce_sd::<{ 16 | _MM_FROUND_TO_ZERO }>(a, b);
@@ -10900,7 +10900,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_reduce_sd() {
+    fn test_mm_mask_reduce_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_sd(0.25);
         let c = _mm_set_pd(3., 4.);
@@ -10910,7 +10910,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_reduce_sd() {
+    fn test_mm_maskz_reduce_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_sd(0.25);
         let r = _mm_maskz_reduce_sd::<{ 16 | _MM_FROUND_TO_ZERO }>(0b0, a, b);
@@ -10919,7 +10919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_reduce_round_ss() {
+    fn test_mm_reduce_round_ss() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ss(0.25);
         let r = _mm_reduce_round_ss::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(a, b);
@@ -10928,7 +10928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_reduce_round_ss() {
+    fn test_mm_mask_reduce_round_ss() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ss(0.25);
         let c = _mm_set_ps(5., 6., 7., 8.);
@@ -10940,7 +10940,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_reduce_round_ss() {
+    fn test_mm_maskz_reduce_round_ss() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ss(0.25);
         let r =
@@ -10950,7 +10950,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_reduce_ss() {
+    fn test_mm_reduce_ss() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ss(0.25);
         let r = _mm_reduce_ss::<{ 16 | _MM_FROUND_TO_ZERO }>(a, b);
@@ -10959,7 +10959,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_reduce_ss() {
+    fn test_mm_mask_reduce_ss() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ss(0.25);
         let c = _mm_set_ps(5., 6., 7., 8.);
@@ -10969,7 +10969,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_maskz_reduce_ss() {
+    fn test_mm_maskz_reduce_ss() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ss(0.25);
         let r = _mm_maskz_reduce_ss::<{ 16 | _MM_FROUND_TO_ZERO }>(0b0, a, b);
@@ -10978,7 +10978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_fpclass_pd_mask() {
+    fn test_mm_fpclass_pd_mask() {
         let a = _mm_set_pd(1., f64::INFINITY);
         let r = _mm_fpclass_pd_mask::<0x18>(a);
         let e = 0b01;
@@ -10986,7 +10986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_fpclass_pd_mask() {
+    fn test_mm_mask_fpclass_pd_mask() {
         let a = _mm_set_pd(1., f64::INFINITY);
         let r = _mm_mask_fpclass_pd_mask::<0x18>(0b10, a);
         let e = 0b00;
@@ -10994,7 +10994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_fpclass_pd_mask() {
+    fn test_mm256_fpclass_pd_mask() {
         let a = _mm256_set_pd(1., f64::INFINITY, f64::NEG_INFINITY, 0.0);
         let r = _mm256_fpclass_pd_mask::<0x18>(a);
         let e = 0b0110;
@@ -11002,7 +11002,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_fpclass_pd_mask() {
+    fn test_mm256_mask_fpclass_pd_mask() {
         let a = _mm256_set_pd(1., f64::INFINITY, f64::NEG_INFINITY, 0.0);
         let r = _mm256_mask_fpclass_pd_mask::<0x18>(0b1010, a);
         let e = 0b0010;
@@ -11010,7 +11010,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_fpclass_pd_mask() {
+    fn test_mm512_fpclass_pd_mask() {
         let a = _mm512_set_pd(
             1.,
             f64::INFINITY,
@@ -11027,7 +11027,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_fpclass_pd_mask() {
+    fn test_mm512_mask_fpclass_pd_mask() {
         let a = _mm512_set_pd(
             1.,
             f64::INFINITY,
@@ -11044,7 +11044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_fpclass_ps_mask() {
+    fn test_mm_fpclass_ps_mask() {
         let a = _mm_set_ps(1., f32::INFINITY, f32::NEG_INFINITY, 0.0);
         let r = _mm_fpclass_ps_mask::<0x18>(a);
         let e = 0b0110;
@@ -11052,7 +11052,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm_mask_fpclass_ps_mask() {
+    fn test_mm_mask_fpclass_ps_mask() {
         let a = _mm_set_ps(1., f32::INFINITY, f32::NEG_INFINITY, 0.0);
         let r = _mm_mask_fpclass_ps_mask::<0x18>(0b1010, a);
         let e = 0b0010;
@@ -11060,7 +11060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_fpclass_ps_mask() {
+    fn test_mm256_fpclass_ps_mask() {
         let a = _mm256_set_ps(
             1.,
             f32::INFINITY,
@@ -11077,7 +11077,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq,avx512vl")]
-    unsafe fn test_mm256_mask_fpclass_ps_mask() {
+    fn test_mm256_mask_fpclass_ps_mask() {
         let a = _mm256_set_ps(
             1.,
             f32::INFINITY,
@@ -11094,7 +11094,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_fpclass_ps_mask() {
+    fn test_mm512_fpclass_ps_mask() {
         let a = _mm512_set_ps(
             1.,
             f32::INFINITY,
@@ -11119,7 +11119,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm512_mask_fpclass_ps_mask() {
+    fn test_mm512_mask_fpclass_ps_mask() {
         let a = _mm512_set_ps(
             1.,
             f32::INFINITY,
@@ -11144,7 +11144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_fpclass_sd_mask() {
+    fn test_mm_fpclass_sd_mask() {
         let a = _mm_set_pd(1., f64::INFINITY);
         let r = _mm_fpclass_sd_mask::<0x18>(a);
         let e = 0b1;
@@ -11152,7 +11152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_fpclass_sd_mask() {
+    fn test_mm_mask_fpclass_sd_mask() {
         let a = _mm_set_sd(f64::INFINITY);
         let r = _mm_mask_fpclass_sd_mask::<0x18>(0b0, a);
         let e = 0b0;
@@ -11160,7 +11160,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_fpclass_ss_mask() {
+    fn test_mm_fpclass_ss_mask() {
         let a = _mm_set_ss(f32::INFINITY);
         let r = _mm_fpclass_ss_mask::<0x18>(a);
         let e = 0b1;
@@ -11168,7 +11168,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512dq")]
-    unsafe fn test_mm_mask_fpclass_ss_mask() {
+    fn test_mm_mask_fpclass_ss_mask() {
         let a = _mm_set_ss(f32::INFINITY);
         let r = _mm_mask_fpclass_ss_mask::<0x18>(0b0, a);
         let e = 0b0;

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -45033,7 +45033,7 @@ mod tests {
     use crate::mem::{self};
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_abs_epi32() {
+    const fn test_mm512_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45053,7 +45053,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_abs_epi32() {
+    const fn test_mm512_mask_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45075,7 +45075,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_abs_epi32() {
+    const fn test_mm512_maskz_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45097,7 +45097,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_abs_epi32() {
+    const fn test_mm256_mask_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45115,7 +45115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_abs_epi32() {
+    const fn test_mm256_maskz_abs_epi32() {
         #[rustfmt::skip]
         let a = _mm256_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45133,7 +45133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_abs_epi32() {
+    const fn test_mm_mask_abs_epi32() {
         let a = _mm_setr_epi32(i32::MIN, 100, -100, -32);
         let r = _mm_mask_abs_epi32(a, 0, a);
         assert_eq_m128i(r, a);
@@ -45143,7 +45143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_abs_epi32() {
+    const fn test_mm_maskz_abs_epi32() {
         let a = _mm_setr_epi32(i32::MIN, 100, -100, -32);
         let r = _mm_maskz_abs_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -45153,7 +45153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_abs_ps() {
+    const fn test_mm512_abs_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45173,7 +45173,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_abs_ps() {
+    const fn test_mm512_mask_abs_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45195,7 +45195,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mov_epi32() {
+    const fn test_mm512_mask_mov_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(2);
         let r = _mm512_mask_mov_epi32(src, 0, a);
@@ -45205,7 +45205,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mov_epi32() {
+    const fn test_mm512_maskz_mov_epi32() {
         let a = _mm512_set1_epi32(2);
         let r = _mm512_maskz_mov_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -45214,7 +45214,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mov_epi32() {
+    const fn test_mm256_mask_mov_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(2);
         let r = _mm256_mask_mov_epi32(src, 0, a);
@@ -45224,7 +45224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mov_epi32() {
+    const fn test_mm256_maskz_mov_epi32() {
         let a = _mm256_set1_epi32(2);
         let r = _mm256_maskz_mov_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -45233,7 +45233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mov_epi32() {
+    const fn test_mm_mask_mov_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(2);
         let r = _mm_mask_mov_epi32(src, 0, a);
@@ -45243,7 +45243,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mov_epi32() {
+    const fn test_mm_maskz_mov_epi32() {
         let a = _mm_set1_epi32(2);
         let r = _mm_maskz_mov_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -45252,7 +45252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mov_ps() {
+    const fn test_mm512_mask_mov_ps() {
         let src = _mm512_set1_ps(1.);
         let a = _mm512_set1_ps(2.);
         let r = _mm512_mask_mov_ps(src, 0, a);
@@ -45262,7 +45262,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mov_ps() {
+    const fn test_mm512_maskz_mov_ps() {
         let a = _mm512_set1_ps(2.);
         let r = _mm512_maskz_mov_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -45271,7 +45271,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mov_ps() {
+    const fn test_mm256_mask_mov_ps() {
         let src = _mm256_set1_ps(1.);
         let a = _mm256_set1_ps(2.);
         let r = _mm256_mask_mov_ps(src, 0, a);
@@ -45281,7 +45281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mov_ps() {
+    const fn test_mm256_maskz_mov_ps() {
         let a = _mm256_set1_ps(2.);
         let r = _mm256_maskz_mov_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -45290,7 +45290,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mov_ps() {
+    const fn test_mm_mask_mov_ps() {
         let src = _mm_set1_ps(1.);
         let a = _mm_set1_ps(2.);
         let r = _mm_mask_mov_ps(src, 0, a);
@@ -45300,7 +45300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mov_ps() {
+    const fn test_mm_maskz_mov_ps() {
         let a = _mm_set1_ps(2.);
         let r = _mm_maskz_mov_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -45309,7 +45309,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_add_epi32() {
+    const fn test_mm512_add_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45330,7 +45330,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_add_epi32() {
+    const fn test_mm512_mask_add_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45353,7 +45353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_add_epi32() {
+    const fn test_mm512_maskz_add_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45376,7 +45376,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_add_epi32() {
+    const fn test_mm256_mask_add_epi32() {
         let a = _mm256_set_epi32(0, 1, -1, i32::MAX, i32::MIN, 100, -100, -32);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_mask_add_epi32(a, 0, a, b);
@@ -45387,7 +45387,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_epi32() {
+    const fn test_mm256_maskz_add_epi32() {
         let a = _mm256_setr_epi32(0, 1, -1, i32::MAX, i32::MIN, 100, -100, -32);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_maskz_add_epi32(0, a, b);
@@ -45398,7 +45398,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_add_epi32() {
+    const fn test_mm_mask_add_epi32() {
         let a = _mm_set_epi32(1, -1, i32::MAX, i32::MIN);
         let b = _mm_set1_epi32(1);
         let r = _mm_mask_add_epi32(a, 0, a, b);
@@ -45409,7 +45409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_add_epi32() {
+    const fn test_mm_maskz_add_epi32() {
         let a = _mm_setr_epi32(1, -1, i32::MAX, i32::MIN);
         let b = _mm_set1_epi32(1);
         let r = _mm_maskz_add_epi32(0, a, b);
@@ -45420,7 +45420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_add_ps() {
+    const fn test_mm512_add_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45441,7 +45441,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_add_ps() {
+    const fn test_mm512_mask_add_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45464,7 +45464,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_add_ps() {
+    const fn test_mm512_maskz_add_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45487,7 +45487,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_add_ps() {
+    const fn test_mm256_mask_add_ps() {
         let a = _mm256_set_ps(0., 1., -1., f32::MAX, f32::MIN, 100., -100., -32.);
         let b = _mm256_set1_ps(1.);
         let r = _mm256_mask_add_ps(a, 0, a, b);
@@ -45498,7 +45498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_ps() {
+    const fn test_mm256_maskz_add_ps() {
         let a = _mm256_set_ps(0., 1., -1., f32::MAX, f32::MIN, 100., -100., -32.);
         let b = _mm256_set1_ps(1.);
         let r = _mm256_maskz_add_ps(0, a, b);
@@ -45509,7 +45509,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_add_ps() {
+    const fn test_mm_mask_add_ps() {
         let a = _mm_set_ps(1., -1., f32::MAX, f32::MIN);
         let b = _mm_set1_ps(1.);
         let r = _mm_mask_add_ps(a, 0, a, b);
@@ -45520,7 +45520,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_add_ps() {
+    const fn test_mm_maskz_add_ps() {
         let a = _mm_set_ps(1., -1., f32::MAX, f32::MIN);
         let b = _mm_set1_ps(1.);
         let r = _mm_maskz_add_ps(0, a, b);
@@ -45531,7 +45531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_sub_epi32() {
+    const fn test_mm512_sub_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45552,7 +45552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_sub_epi32() {
+    const fn test_mm512_mask_sub_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45575,7 +45575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_sub_epi32() {
+    const fn test_mm512_maskz_sub_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45598,7 +45598,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_epi32() {
+    const fn test_mm256_mask_sub_epi32() {
         let a = _mm256_set_epi32(0, 1, -1, i32::MAX, i32::MIN, 100, -100, -32);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_mask_sub_epi32(a, 0, a, b);
@@ -45609,7 +45609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_epi32() {
+    const fn test_mm256_maskz_sub_epi32() {
         let a = _mm256_set_epi32(0, 1, -1, i32::MAX, i32::MIN, 100, -100, -32);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_maskz_sub_epi32(0, a, b);
@@ -45620,7 +45620,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_sub_epi32() {
+    const fn test_mm_mask_sub_epi32() {
         let a = _mm_set_epi32(1, -1, i32::MAX, i32::MIN);
         let b = _mm_set1_epi32(1);
         let r = _mm_mask_sub_epi32(a, 0, a, b);
@@ -45631,7 +45631,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_epi32() {
+    const fn test_mm_maskz_sub_epi32() {
         let a = _mm_set_epi32(1, -1, i32::MAX, i32::MIN);
         let b = _mm_set1_epi32(1);
         let r = _mm_maskz_sub_epi32(0, a, b);
@@ -45642,7 +45642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_sub_ps() {
+    const fn test_mm512_sub_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45663,7 +45663,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_sub_ps() {
+    const fn test_mm512_mask_sub_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45686,7 +45686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_sub_ps() {
+    const fn test_mm512_maskz_sub_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45709,7 +45709,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_ps() {
+    const fn test_mm256_mask_sub_ps() {
         let a = _mm256_set_ps(0., 1., -1., f32::MAX, f32::MIN, 100., -100., -32.);
         let b = _mm256_set1_ps(1.);
         let r = _mm256_mask_sub_ps(a, 0, a, b);
@@ -45720,7 +45720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_ps() {
+    const fn test_mm256_maskz_sub_ps() {
         let a = _mm256_set_ps(0., 1., -1., f32::MAX, f32::MIN, 100., -100., -32.);
         let b = _mm256_set1_ps(1.);
         let r = _mm256_maskz_sub_ps(0, a, b);
@@ -45731,7 +45731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_sub_ps() {
+    const fn test_mm_mask_sub_ps() {
         let a = _mm_set_ps(1., -1., f32::MAX, f32::MIN);
         let b = _mm_set1_ps(1.);
         let r = _mm_mask_sub_ps(a, 0, a, b);
@@ -45742,7 +45742,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_ps() {
+    const fn test_mm_maskz_sub_ps() {
         let a = _mm_set_ps(1., -1., f32::MAX, f32::MIN);
         let b = _mm_set1_ps(1.);
         let r = _mm_maskz_sub_ps(0, a, b);
@@ -45753,7 +45753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mullo_epi32() {
+    const fn test_mm512_mullo_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45770,7 +45770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mullo_epi32() {
+    const fn test_mm512_mask_mullo_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45793,7 +45793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mullo_epi32() {
+    const fn test_mm512_maskz_mullo_epi32() {
         #[rustfmt::skip]
         let a = _mm512_setr_epi32(
             0, 1, -1, i32::MAX,
@@ -45810,7 +45810,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mullo_epi32() {
+    const fn test_mm256_mask_mullo_epi32() {
         let a = _mm256_set_epi32(0, 1, -1, i32::MAX, i32::MIN, 100, -100, -32);
         let b = _mm256_set1_epi32(2);
         let r = _mm256_mask_mullo_epi32(a, 0, a, b);
@@ -45821,7 +45821,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mullo_epi32() {
+    const fn test_mm256_maskz_mullo_epi32() {
         let a = _mm256_set_epi32(0, 1, -1, i32::MAX, i32::MIN, 100, -100, -32);
         let b = _mm256_set1_epi32(2);
         let r = _mm256_maskz_mullo_epi32(0, a, b);
@@ -45832,7 +45832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mullo_epi32() {
+    const fn test_mm_mask_mullo_epi32() {
         let a = _mm_set_epi32(1, -1, i32::MAX, i32::MIN);
         let b = _mm_set1_epi32(2);
         let r = _mm_mask_mullo_epi32(a, 0, a, b);
@@ -45843,7 +45843,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mullo_epi32() {
+    const fn test_mm_maskz_mullo_epi32() {
         let a = _mm_set_epi32(1, -1, i32::MAX, i32::MIN);
         let b = _mm_set1_epi32(2);
         let r = _mm_maskz_mullo_epi32(0, a, b);
@@ -45854,7 +45854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mul_ps() {
+    const fn test_mm512_mul_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45876,7 +45876,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mul_ps() {
+    const fn test_mm512_mask_mul_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45899,7 +45899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mul_ps() {
+    const fn test_mm512_maskz_mul_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1., -1., f32::MAX,
@@ -45922,7 +45922,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mul_ps() {
+    const fn test_mm256_mask_mul_ps() {
         let a = _mm256_set_ps(0., 1., -1., f32::MAX, f32::MIN, 100., -100., -32.);
         let b = _mm256_set1_ps(2.);
         let r = _mm256_mask_mul_ps(a, 0, a, b);
@@ -45937,7 +45937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mul_ps() {
+    const fn test_mm256_maskz_mul_ps() {
         let a = _mm256_set_ps(0., 1., -1., f32::MAX, f32::MIN, 100., -100., -32.);
         let b = _mm256_set1_ps(2.);
         let r = _mm256_maskz_mul_ps(0, a, b);
@@ -45952,7 +45952,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mul_ps() {
+    const fn test_mm_mask_mul_ps() {
         let a = _mm_set_ps(1., -1., f32::MAX, f32::MIN);
         let b = _mm_set1_ps(2.);
         let r = _mm_mask_mul_ps(a, 0, a, b);
@@ -45963,7 +45963,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mul_ps() {
+    const fn test_mm_maskz_mul_ps() {
         let a = _mm_set_ps(1., -1., f32::MAX, f32::MIN);
         let b = _mm_set1_ps(2.);
         let r = _mm_maskz_mul_ps(0, a, b);
@@ -45974,7 +45974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_div_ps() {
+    const fn test_mm512_div_ps() {
         let a = _mm512_setr_ps(
             0., 1., -1., -2., 100., 100., -100., -32., 0., 1., -1., 1000., -131., 100., -100., -32.,
         );
@@ -45993,7 +45993,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_div_ps() {
+    const fn test_mm512_mask_div_ps() {
         let a = _mm512_setr_ps(
             0., 1., -1., -2., 100., 100., -100., -32., 0., 1., -1., 1000., -131., 100., -100., -32.,
         );
@@ -46014,7 +46014,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_div_ps() {
+    const fn test_mm512_maskz_div_ps() {
         let a = _mm512_setr_ps(
             0., 1., -1., -2., 100., 100., -100., -32., 0., 1., -1., 1000., -131., 100., -100., -32.,
         );
@@ -46035,7 +46035,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_div_ps() {
+    const fn test_mm256_mask_div_ps() {
         let a = _mm256_set_ps(0., 1., -1., -2., 100., 100., -100., -32.);
         let b = _mm256_set_ps(2., 2., 2., 2., 2., 0., 2., 2.);
         let r = _mm256_mask_div_ps(a, 0, a, b);
@@ -46046,7 +46046,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_div_ps() {
+    const fn test_mm256_maskz_div_ps() {
         let a = _mm256_set_ps(0., 1., -1., -2., 100., 100., -100., -32.);
         let b = _mm256_set_ps(2., 2., 2., 2., 2., 0., 2., 2.);
         let r = _mm256_maskz_div_ps(0, a, b);
@@ -46057,7 +46057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_div_ps() {
+    const fn test_mm_mask_div_ps() {
         let a = _mm_set_ps(100., 100., -100., -32.);
         let b = _mm_set_ps(2., 0., 2., 2.);
         let r = _mm_mask_div_ps(a, 0, a, b);
@@ -46068,7 +46068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_div_ps() {
+    const fn test_mm_maskz_div_ps() {
         let a = _mm_set_ps(100., 100., -100., -32.);
         let b = _mm_set_ps(2., 0., 2., 2.);
         let r = _mm_maskz_div_ps(0, a, b);
@@ -46079,7 +46079,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_max_epi32() {
+    const fn test_mm512_max_epi32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_max_epi32(a, b);
@@ -46088,7 +46088,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_max_epi32() {
+    const fn test_mm512_mask_max_epi32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_max_epi32(a, 0, a, b);
@@ -46099,7 +46099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_max_epi32() {
+    const fn test_mm512_maskz_max_epi32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_max_epi32(0, a, b);
@@ -46110,7 +46110,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epi32() {
+    const fn test_mm256_mask_max_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_max_epi32(a, 0, a, b);
@@ -46121,7 +46121,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epi32() {
+    const fn test_mm256_maskz_max_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_max_epi32(0, a, b);
@@ -46132,7 +46132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_max_epi32() {
+    const fn test_mm_mask_max_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_mask_max_epi32(a, 0, a, b);
@@ -46143,7 +46143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epi32() {
+    const fn test_mm_maskz_max_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_maskz_max_epi32(0, a, b);
@@ -46154,7 +46154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_max_ps() {
+    fn test_mm512_max_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -46169,7 +46169,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_max_ps() {
+    fn test_mm512_mask_max_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -46186,7 +46186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_max_ps() {
+    fn test_mm512_maskz_max_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -46203,7 +46203,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_max_ps() {
+    fn test_mm256_mask_max_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm256_set_ps(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm256_mask_max_ps(a, 0, a, b);
@@ -46214,7 +46214,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_max_ps() {
+    fn test_mm256_maskz_max_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm256_set_ps(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm256_maskz_max_ps(0, a, b);
@@ -46225,7 +46225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_max_ps() {
+    fn test_mm_mask_max_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(3., 2., 1., 0.);
         let r = _mm_mask_max_ps(a, 0, a, b);
@@ -46236,7 +46236,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_max_ps() {
+    fn test_mm_maskz_max_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(3., 2., 1., 0.);
         let r = _mm_maskz_max_ps(0, a, b);
@@ -46247,7 +46247,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_max_epu32() {
+    const fn test_mm512_max_epu32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_max_epu32(a, b);
@@ -46256,7 +46256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_max_epu32() {
+    const fn test_mm512_mask_max_epu32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_max_epu32(a, 0, a, b);
@@ -46267,7 +46267,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_max_epu32() {
+    const fn test_mm512_maskz_max_epu32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_max_epu32(0, a, b);
@@ -46278,7 +46278,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epu32() {
+    const fn test_mm256_mask_max_epu32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_max_epu32(a, 0, a, b);
@@ -46289,7 +46289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epu32() {
+    const fn test_mm256_maskz_max_epu32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_max_epu32(0, a, b);
@@ -46300,7 +46300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_max_epu32() {
+    const fn test_mm_mask_max_epu32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_mask_max_epu32(a, 0, a, b);
@@ -46311,7 +46311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epu32() {
+    const fn test_mm_maskz_max_epu32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_maskz_max_epu32(0, a, b);
@@ -46322,7 +46322,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_min_epi32() {
+    const fn test_mm512_min_epi32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_min_epi32(a, b);
@@ -46331,7 +46331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_min_epi32() {
+    const fn test_mm512_mask_min_epi32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_min_epi32(a, 0, a, b);
@@ -46342,7 +46342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_min_epi32() {
+    const fn test_mm512_maskz_min_epi32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_min_epi32(0, a, b);
@@ -46353,7 +46353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epi32() {
+    const fn test_mm256_mask_min_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_min_epi32(a, 0, a, b);
@@ -46364,7 +46364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epi32() {
+    const fn test_mm256_maskz_min_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_min_epi32(0, a, b);
@@ -46375,7 +46375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_min_epi32() {
+    const fn test_mm_mask_min_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_mask_min_epi32(a, 0, a, b);
@@ -46386,7 +46386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epi32() {
+    const fn test_mm_maskz_min_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_maskz_min_epi32(0, a, b);
@@ -46397,7 +46397,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_min_ps() {
+    fn test_mm512_min_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -46412,7 +46412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_min_ps() {
+    fn test_mm512_mask_min_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -46429,7 +46429,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_min_ps() {
+    fn test_mm512_maskz_min_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -46446,7 +46446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_min_ps() {
+    fn test_mm256_mask_min_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm256_set_ps(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm256_mask_min_ps(a, 0, a, b);
@@ -46457,7 +46457,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_min_ps() {
+    fn test_mm256_maskz_min_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm256_set_ps(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm256_maskz_min_ps(0, a, b);
@@ -46468,7 +46468,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_min_ps() {
+    fn test_mm_mask_min_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(3., 2., 1., 0.);
         let r = _mm_mask_min_ps(a, 0, a, b);
@@ -46479,7 +46479,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_min_ps() {
+    fn test_mm_maskz_min_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(3., 2., 1., 0.);
         let r = _mm_maskz_min_ps(0, a, b);
@@ -46490,7 +46490,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_min_epu32() {
+    const fn test_mm512_min_epu32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_min_epu32(a, b);
@@ -46499,7 +46499,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_min_epu32() {
+    const fn test_mm512_mask_min_epu32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_min_epu32(a, 0, a, b);
@@ -46510,7 +46510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_min_epu32() {
+    const fn test_mm512_maskz_min_epu32() {
         let a = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm512_setr_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_min_epu32(0, a, b);
@@ -46521,7 +46521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epu32() {
+    const fn test_mm256_mask_min_epu32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_mask_min_epu32(a, 0, a, b);
@@ -46532,7 +46532,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epu32() {
+    const fn test_mm256_maskz_min_epu32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_maskz_min_epu32(0, a, b);
@@ -46543,7 +46543,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_min_epu32() {
+    const fn test_mm_mask_min_epu32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_mask_min_epu32(a, 0, a, b);
@@ -46554,7 +46554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epu32() {
+    const fn test_mm_maskz_min_epu32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let b = _mm_set_epi32(3, 2, 1, 0);
         let r = _mm_maskz_min_epu32(0, a, b);
@@ -46565,7 +46565,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sqrt_ps() {
+    fn test_mm512_sqrt_ps() {
         let a = _mm512_setr_ps(
             0., 1., 4., 9., 16., 25., 36., 49., 64., 81., 100., 121., 144., 169., 196., 225.,
         );
@@ -46577,7 +46577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sqrt_ps() {
+    fn test_mm512_mask_sqrt_ps() {
         let a = _mm512_setr_ps(
             0., 1., 4., 9., 16., 25., 36., 49., 64., 81., 100., 121., 144., 169., 196., 225.,
         );
@@ -46591,7 +46591,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sqrt_ps() {
+    fn test_mm512_maskz_sqrt_ps() {
         let a = _mm512_setr_ps(
             0., 1., 4., 9., 16., 25., 36., 49., 64., 81., 100., 121., 144., 169., 196., 225.,
         );
@@ -46605,7 +46605,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_sqrt_ps() {
+    fn test_mm256_mask_sqrt_ps() {
         let a = _mm256_set_ps(0., 1., 4., 9., 16., 25., 36., 49.);
         let r = _mm256_mask_sqrt_ps(a, 0, a);
         assert_eq_m256(r, a);
@@ -46615,7 +46615,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_sqrt_ps() {
+    fn test_mm256_maskz_sqrt_ps() {
         let a = _mm256_set_ps(0., 1., 4., 9., 16., 25., 36., 49.);
         let r = _mm256_maskz_sqrt_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -46625,7 +46625,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_sqrt_ps() {
+    fn test_mm_mask_sqrt_ps() {
         let a = _mm_set_ps(0., 1., 4., 9.);
         let r = _mm_mask_sqrt_ps(a, 0, a);
         assert_eq_m128(r, a);
@@ -46635,7 +46635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_sqrt_ps() {
+    fn test_mm_maskz_sqrt_ps() {
         let a = _mm_set_ps(0., 1., 4., 9.);
         let r = _mm_maskz_sqrt_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -46645,7 +46645,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmadd_ps() {
+    const fn test_mm512_fmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46659,7 +46659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmadd_ps() {
+    const fn test_mm512_mask_fmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46675,7 +46675,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmadd_ps() {
+    const fn test_mm512_maskz_fmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46691,7 +46691,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmadd_ps() {
+    const fn test_mm512_mask3_fmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46707,7 +46707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmadd_ps() {
+    const fn test_mm256_mask_fmadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46719,7 +46719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmadd_ps() {
+    const fn test_mm256_maskz_fmadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46731,7 +46731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmadd_ps() {
+    const fn test_mm256_mask3_fmadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46743,7 +46743,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmadd_ps() {
+    const fn test_mm_mask_fmadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -46755,7 +46755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmadd_ps() {
+    const fn test_mm_maskz_fmadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -46767,7 +46767,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmadd_ps() {
+    const fn test_mm_mask3_fmadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -46779,7 +46779,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmsub_ps() {
+    const fn test_mm512_fmsub_ps() {
         let a = _mm512_setr_ps(
             1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
         );
@@ -46797,7 +46797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmsub_ps() {
+    const fn test_mm512_mask_fmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46813,7 +46813,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmsub_ps() {
+    const fn test_mm512_maskz_fmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46829,7 +46829,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmsub_ps() {
+    const fn test_mm512_mask3_fmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46847,7 +46847,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmsub_ps() {
+    const fn test_mm256_mask_fmsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46859,7 +46859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmsub_ps() {
+    const fn test_mm256_maskz_fmsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46871,7 +46871,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmsub_ps() {
+    const fn test_mm256_mask3_fmsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46883,7 +46883,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmsub_ps() {
+    const fn test_mm_mask_fmsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -46895,7 +46895,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsub_ps() {
+    const fn test_mm_maskz_fmsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -46907,7 +46907,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsub_ps() {
+    const fn test_mm_mask3_fmsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -46919,7 +46919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmaddsub_ps() {
+    const fn test_mm512_fmaddsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46933,7 +46933,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmaddsub_ps() {
+    const fn test_mm512_mask_fmaddsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46949,7 +46949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmaddsub_ps() {
+    const fn test_mm512_maskz_fmaddsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46965,7 +46965,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmaddsub_ps() {
+    const fn test_mm512_mask3_fmaddsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -46983,7 +46983,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmaddsub_ps() {
+    const fn test_mm256_mask_fmaddsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -46995,7 +46995,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmaddsub_ps() {
+    const fn test_mm256_maskz_fmaddsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47007,7 +47007,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmaddsub_ps() {
+    const fn test_mm256_mask3_fmaddsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47019,7 +47019,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmaddsub_ps() {
+    const fn test_mm_mask_fmaddsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47031,7 +47031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmaddsub_ps() {
+    const fn test_mm_maskz_fmaddsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47043,7 +47043,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmaddsub_ps() {
+    const fn test_mm_mask3_fmaddsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47055,7 +47055,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmsubadd_ps() {
+    const fn test_mm512_fmsubadd_ps() {
         let a = _mm512_setr_ps(
             1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
         );
@@ -47073,7 +47073,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmsubadd_ps() {
+    const fn test_mm512_mask_fmsubadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47089,7 +47089,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmsubadd_ps() {
+    const fn test_mm512_maskz_fmsubadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47105,7 +47105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmsubadd_ps() {
+    const fn test_mm512_mask3_fmsubadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47123,7 +47123,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmsubadd_ps() {
+    const fn test_mm256_mask_fmsubadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47135,7 +47135,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmsubadd_ps() {
+    const fn test_mm256_maskz_fmsubadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47147,7 +47147,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmsubadd_ps() {
+    const fn test_mm256_mask3_fmsubadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47159,7 +47159,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmsubadd_ps() {
+    const fn test_mm_mask_fmsubadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47171,7 +47171,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsubadd_ps() {
+    const fn test_mm_maskz_fmsubadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47183,7 +47183,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsubadd_ps() {
+    const fn test_mm_mask3_fmsubadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47195,7 +47195,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fnmadd_ps() {
+    const fn test_mm512_fnmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47209,7 +47209,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fnmadd_ps() {
+    const fn test_mm512_mask_fnmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47225,7 +47225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fnmadd_ps() {
+    const fn test_mm512_maskz_fnmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47241,7 +47241,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fnmadd_ps() {
+    const fn test_mm512_mask3_fnmadd_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47259,7 +47259,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fnmadd_ps() {
+    const fn test_mm256_mask_fnmadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47271,7 +47271,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fnmadd_ps() {
+    const fn test_mm256_maskz_fnmadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47283,7 +47283,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fnmadd_ps() {
+    const fn test_mm256_mask3_fnmadd_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47295,7 +47295,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fnmadd_ps() {
+    const fn test_mm_mask_fnmadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47307,7 +47307,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmadd_ps() {
+    const fn test_mm_maskz_fnmadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47319,7 +47319,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmadd_ps() {
+    const fn test_mm_mask3_fnmadd_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47331,7 +47331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fnmsub_ps() {
+    const fn test_mm512_fnmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47345,7 +47345,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fnmsub_ps() {
+    const fn test_mm512_mask_fnmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47361,7 +47361,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fnmsub_ps() {
+    const fn test_mm512_maskz_fnmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47377,7 +47377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fnmsub_ps() {
+    const fn test_mm512_mask3_fnmsub_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -47395,7 +47395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fnmsub_ps() {
+    const fn test_mm256_mask_fnmsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47407,7 +47407,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fnmsub_ps() {
+    const fn test_mm256_maskz_fnmsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47419,7 +47419,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fnmsub_ps() {
+    const fn test_mm256_mask3_fnmsub_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm256_set1_ps(1.);
@@ -47431,7 +47431,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fnmsub_ps() {
+    const fn test_mm_mask_fnmsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47443,7 +47443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmsub_ps() {
+    const fn test_mm_maskz_fnmsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47455,7 +47455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmsub_ps() {
+    const fn test_mm_mask3_fnmsub_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set_ps(0., 1., 2., 3.);
         let c = _mm_set1_ps(1.);
@@ -47467,7 +47467,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_rcp14_ps() {
+    fn test_mm512_rcp14_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_rcp14_ps(a);
         let e = _mm512_set1_ps(0.33333206);
@@ -47475,7 +47475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_rcp14_ps() {
+    fn test_mm512_mask_rcp14_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_mask_rcp14_ps(a, 0, a);
         assert_eq_m512(r, a);
@@ -47488,7 +47488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_rcp14_ps() {
+    fn test_mm512_maskz_rcp14_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_maskz_rcp14_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -47501,7 +47501,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_rcp14_ps() {
+    fn test_mm256_rcp14_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_rcp14_ps(a);
         let e = _mm256_set1_ps(0.33333206);
@@ -47509,7 +47509,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_rcp14_ps() {
+    fn test_mm256_mask_rcp14_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_mask_rcp14_ps(a, 0, a);
         assert_eq_m256(r, a);
@@ -47519,7 +47519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_rcp14_ps() {
+    fn test_mm256_maskz_rcp14_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_maskz_rcp14_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -47529,7 +47529,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_rcp14_ps() {
+    fn test_mm_rcp14_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_rcp14_ps(a);
         let e = _mm_set1_ps(0.33333206);
@@ -47537,7 +47537,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_rcp14_ps() {
+    fn test_mm_mask_rcp14_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_mask_rcp14_ps(a, 0, a);
         assert_eq_m128(r, a);
@@ -47547,7 +47547,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_rcp14_ps() {
+    fn test_mm_maskz_rcp14_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_maskz_rcp14_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -47557,7 +47557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_rsqrt14_ps() {
+    fn test_mm512_rsqrt14_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_rsqrt14_ps(a);
         let e = _mm512_set1_ps(0.5773392);
@@ -47565,7 +47565,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_rsqrt14_ps() {
+    fn test_mm512_mask_rsqrt14_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_mask_rsqrt14_ps(a, 0, a);
         assert_eq_m512(r, a);
@@ -47578,7 +47578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_rsqrt14_ps() {
+    fn test_mm512_maskz_rsqrt14_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_maskz_rsqrt14_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -47591,7 +47591,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_rsqrt14_ps() {
+    fn test_mm256_rsqrt14_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_rsqrt14_ps(a);
         let e = _mm256_set1_ps(0.5773392);
@@ -47599,7 +47599,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_rsqrt14_ps() {
+    fn test_mm256_mask_rsqrt14_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_mask_rsqrt14_ps(a, 0, a);
         assert_eq_m256(r, a);
@@ -47609,7 +47609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_rsqrt14_ps() {
+    fn test_mm256_maskz_rsqrt14_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_maskz_rsqrt14_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -47619,7 +47619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_rsqrt14_ps() {
+    fn test_mm_rsqrt14_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_rsqrt14_ps(a);
         let e = _mm_set1_ps(0.5773392);
@@ -47627,7 +47627,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_rsqrt14_ps() {
+    fn test_mm_mask_rsqrt14_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_mask_rsqrt14_ps(a, 0, a);
         assert_eq_m128(r, a);
@@ -47637,7 +47637,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_rsqrt14_ps() {
+    fn test_mm_maskz_rsqrt14_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_maskz_rsqrt14_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -47647,7 +47647,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getexp_ps() {
+    fn test_mm512_getexp_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_getexp_ps(a);
         let e = _mm512_set1_ps(1.);
@@ -47655,7 +47655,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getexp_ps() {
+    fn test_mm512_mask_getexp_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_mask_getexp_ps(a, 0, a);
         assert_eq_m512(r, a);
@@ -47667,7 +47667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getexp_ps() {
+    fn test_mm512_maskz_getexp_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_maskz_getexp_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -47679,7 +47679,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_getexp_ps() {
+    fn test_mm256_getexp_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_getexp_ps(a);
         let e = _mm256_set1_ps(1.);
@@ -47687,7 +47687,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_getexp_ps() {
+    fn test_mm256_mask_getexp_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_mask_getexp_ps(a, 0, a);
         assert_eq_m256(r, a);
@@ -47697,7 +47697,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_getexp_ps() {
+    fn test_mm256_maskz_getexp_ps() {
         let a = _mm256_set1_ps(3.);
         let r = _mm256_maskz_getexp_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -47707,7 +47707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_getexp_ps() {
+    fn test_mm_getexp_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_getexp_ps(a);
         let e = _mm_set1_ps(1.);
@@ -47715,7 +47715,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_getexp_ps() {
+    fn test_mm_mask_getexp_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_mask_getexp_ps(a, 0, a);
         assert_eq_m128(r, a);
@@ -47725,7 +47725,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_getexp_ps() {
+    fn test_mm_maskz_getexp_ps() {
         let a = _mm_set1_ps(3.);
         let r = _mm_maskz_getexp_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -47735,7 +47735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_roundscale_ps() {
+    fn test_mm512_roundscale_ps() {
         let a = _mm512_set1_ps(1.1);
         let r = _mm512_roundscale_ps::<0b00_00_00_00>(a);
         let e = _mm512_set1_ps(1.0);
@@ -47743,7 +47743,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_roundscale_ps() {
+    fn test_mm512_mask_roundscale_ps() {
         let a = _mm512_set1_ps(1.1);
         let r = _mm512_mask_roundscale_ps::<0b00_00_00_00>(a, 0, a);
         let e = _mm512_set1_ps(1.1);
@@ -47754,7 +47754,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_roundscale_ps() {
+    fn test_mm512_maskz_roundscale_ps() {
         let a = _mm512_set1_ps(1.1);
         let r = _mm512_maskz_roundscale_ps::<0b00_00_00_00>(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -47764,7 +47764,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_roundscale_ps() {
+    fn test_mm256_roundscale_ps() {
         let a = _mm256_set1_ps(1.1);
         let r = _mm256_roundscale_ps::<0b00_00_00_00>(a);
         let e = _mm256_set1_ps(1.0);
@@ -47772,7 +47772,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_roundscale_ps() {
+    fn test_mm256_mask_roundscale_ps() {
         let a = _mm256_set1_ps(1.1);
         let r = _mm256_mask_roundscale_ps::<0b00_00_00_00>(a, 0, a);
         let e = _mm256_set1_ps(1.1);
@@ -47783,7 +47783,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_roundscale_ps() {
+    fn test_mm256_maskz_roundscale_ps() {
         let a = _mm256_set1_ps(1.1);
         let r = _mm256_maskz_roundscale_ps::<0b00_00_00_00>(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -47793,7 +47793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_roundscale_ps() {
+    fn test_mm_roundscale_ps() {
         let a = _mm_set1_ps(1.1);
         let r = _mm_roundscale_ps::<0b00_00_00_00>(a);
         let e = _mm_set1_ps(1.0);
@@ -47801,7 +47801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_roundscale_ps() {
+    fn test_mm_mask_roundscale_ps() {
         let a = _mm_set1_ps(1.1);
         let r = _mm_mask_roundscale_ps::<0b00_00_00_00>(a, 0, a);
         let e = _mm_set1_ps(1.1);
@@ -47812,7 +47812,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_roundscale_ps() {
+    fn test_mm_maskz_roundscale_ps() {
         let a = _mm_set1_ps(1.1);
         let r = _mm_maskz_roundscale_ps::<0b00_00_00_00>(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -47822,7 +47822,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_scalef_ps() {
+    fn test_mm512_scalef_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_scalef_ps(a, b);
@@ -47831,7 +47831,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_scalef_ps() {
+    fn test_mm512_mask_scalef_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_mask_scalef_ps(a, 0, a, b);
@@ -47844,7 +47844,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_scalef_ps() {
+    fn test_mm512_maskz_scalef_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_maskz_scalef_ps(0, a, b);
@@ -47857,7 +47857,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_scalef_ps() {
+    fn test_mm256_scalef_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set1_ps(3.);
         let r = _mm256_scalef_ps(a, b);
@@ -47866,7 +47866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_scalef_ps() {
+    fn test_mm256_mask_scalef_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set1_ps(3.);
         let r = _mm256_mask_scalef_ps(a, 0, a, b);
@@ -47877,7 +47877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_scalef_ps() {
+    fn test_mm256_maskz_scalef_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set1_ps(3.);
         let r = _mm256_maskz_scalef_ps(0, a, b);
@@ -47888,7 +47888,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_scalef_ps() {
+    fn test_mm_scalef_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_scalef_ps(a, b);
@@ -47897,7 +47897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_scalef_ps() {
+    fn test_mm_mask_scalef_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_mask_scalef_ps(a, 0, a, b);
@@ -47908,7 +47908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_scalef_ps() {
+    fn test_mm_maskz_scalef_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_maskz_scalef_ps(0, a, b);
@@ -47919,7 +47919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fixupimm_ps() {
+    fn test_mm512_fixupimm_ps() {
         let a = _mm512_set1_ps(f32::NAN);
         let b = _mm512_set1_ps(f32::MAX);
         let c = _mm512_set1_epi32(i32::MAX);
@@ -47930,7 +47930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fixupimm_ps() {
+    fn test_mm512_mask_fixupimm_ps() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(
             f32::NAN, f32::NAN, f32::NAN, f32::NAN,
@@ -47948,7 +47948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fixupimm_ps() {
+    fn test_mm512_maskz_fixupimm_ps() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(
             f32::NAN, f32::NAN, f32::NAN, f32::NAN,
@@ -47966,7 +47966,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_fixupimm_ps() {
+    fn test_mm256_fixupimm_ps() {
         let a = _mm256_set1_ps(f32::NAN);
         let b = _mm256_set1_ps(f32::MAX);
         let c = _mm256_set1_epi32(i32::MAX);
@@ -47976,7 +47976,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_fixupimm_ps() {
+    fn test_mm256_mask_fixupimm_ps() {
         let a = _mm256_set1_ps(f32::NAN);
         let b = _mm256_set1_ps(f32::MAX);
         let c = _mm256_set1_epi32(i32::MAX);
@@ -47986,7 +47986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_fixupimm_ps() {
+    fn test_mm256_maskz_fixupimm_ps() {
         let a = _mm256_set1_ps(f32::NAN);
         let b = _mm256_set1_ps(f32::MAX);
         let c = _mm256_set1_epi32(i32::MAX);
@@ -47996,7 +47996,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_fixupimm_ps() {
+    fn test_mm_fixupimm_ps() {
         let a = _mm_set1_ps(f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -48006,7 +48006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_fixupimm_ps() {
+    fn test_mm_mask_fixupimm_ps() {
         let a = _mm_set1_ps(f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -48016,7 +48016,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_fixupimm_ps() {
+    fn test_mm_maskz_fixupimm_ps() {
         let a = _mm_set1_ps(f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -48050,7 +48050,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_ternarylogic_epi32() {
+    fn test_mm512_mask_ternarylogic_epi32() {
         let src = _mm512_set1_epi32(1 << 2);
         let a = _mm512_set1_epi32(1 << 1);
         let b = _mm512_set1_epi32(1 << 0);
@@ -48062,7 +48062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_ternarylogic_epi32() {
+    fn test_mm512_maskz_ternarylogic_epi32() {
         let a = _mm512_set1_epi32(1 << 2);
         let b = _mm512_set1_epi32(1 << 1);
         let c = _mm512_set1_epi32(1 << 0);
@@ -48100,7 +48100,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_ternarylogic_epi32() {
+    fn test_mm256_mask_ternarylogic_epi32() {
         let src = _mm256_set1_epi32(1 << 2);
         let a = _mm256_set1_epi32(1 << 1);
         let b = _mm256_set1_epi32(1 << 0);
@@ -48112,7 +48112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_ternarylogic_epi32() {
+    fn test_mm256_maskz_ternarylogic_epi32() {
         let a = _mm256_set1_epi32(1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let c = _mm256_set1_epi32(1 << 0);
@@ -48148,7 +48148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_ternarylogic_epi32() {
+    fn test_mm_mask_ternarylogic_epi32() {
         let src = _mm_set1_epi32(1 << 2);
         let a = _mm_set1_epi32(1 << 1);
         let b = _mm_set1_epi32(1 << 0);
@@ -48160,7 +48160,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_ternarylogic_epi32() {
+    fn test_mm_maskz_ternarylogic_epi32() {
         let a = _mm_set1_epi32(1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let c = _mm_set1_epi32(1 << 0);
@@ -48172,7 +48172,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getmant_ps() {
+    fn test_mm512_getmant_ps() {
         let a = _mm512_set1_ps(10.);
         let r = _mm512_getmant_ps::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a);
         let e = _mm512_set1_ps(1.25);
@@ -48180,7 +48180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getmant_ps() {
+    fn test_mm512_mask_getmant_ps() {
         let a = _mm512_set1_ps(10.);
         let r = _mm512_mask_getmant_ps::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a);
         assert_eq_m512(r, a);
@@ -48196,7 +48196,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getmant_ps() {
+    fn test_mm512_maskz_getmant_ps() {
         let a = _mm512_set1_ps(10.);
         let r = _mm512_maskz_getmant_ps::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -48209,7 +48209,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_getmant_ps() {
+    fn test_mm256_getmant_ps() {
         let a = _mm256_set1_ps(10.);
         let r = _mm256_getmant_ps::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a);
         let e = _mm256_set1_ps(1.25);
@@ -48217,7 +48217,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_getmant_ps() {
+    fn test_mm256_mask_getmant_ps() {
         let a = _mm256_set1_ps(10.);
         let r = _mm256_mask_getmant_ps::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a);
         assert_eq_m256(r, a);
@@ -48227,7 +48227,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_getmant_ps() {
+    fn test_mm256_maskz_getmant_ps() {
         let a = _mm256_set1_ps(10.);
         let r = _mm256_maskz_getmant_ps::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -48237,7 +48237,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_getmant_ps() {
+    fn test_mm_getmant_ps() {
         let a = _mm_set1_ps(10.);
         let r = _mm_getmant_ps::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a);
         let e = _mm_set1_ps(1.25);
@@ -48245,7 +48245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_getmant_ps() {
+    fn test_mm_mask_getmant_ps() {
         let a = _mm_set1_ps(10.);
         let r = _mm_mask_getmant_ps::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a);
         assert_eq_m128(r, a);
@@ -48255,7 +48255,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_getmant_ps() {
+    fn test_mm_maskz_getmant_ps() {
         let a = _mm_set1_ps(10.);
         let r = _mm_maskz_getmant_ps::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -48265,7 +48265,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_add_round_ps() {
+    fn test_mm512_add_round_ps() {
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
@@ -48287,7 +48287,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_add_round_ps() {
+    fn test_mm512_mask_add_round_ps() {
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
@@ -48311,7 +48311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_add_round_ps() {
+    fn test_mm512_maskz_add_round_ps() {
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
@@ -48334,7 +48334,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sub_round_ps() {
+    fn test_mm512_sub_round_ps() {
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
@@ -48356,7 +48356,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sub_round_ps() {
+    fn test_mm512_mask_sub_round_ps() {
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
@@ -48382,7 +48382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sub_round_ps() {
+    fn test_mm512_maskz_sub_round_ps() {
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 0.00000007,
         );
@@ -48406,7 +48406,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mul_round_ps() {
+    fn test_mm512_mul_round_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5,
@@ -48436,7 +48436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_mul_round_ps() {
+    fn test_mm512_mask_mul_round_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5,
@@ -48466,7 +48466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_mul_round_ps() {
+    fn test_mm512_maskz_mul_round_ps() {
         #[rustfmt::skip]
         let a = _mm512_setr_ps(
             0., 1.5, 2., 3.5,
@@ -48494,7 +48494,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_div_round_ps() {
+    fn test_mm512_div_round_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_div_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -48506,7 +48506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_div_round_ps() {
+    fn test_mm512_mask_div_round_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_mask_div_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -48527,7 +48527,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_div_round_ps() {
+    fn test_mm512_maskz_div_round_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r =
@@ -48546,7 +48546,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sqrt_round_ps() {
+    fn test_mm512_sqrt_round_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_sqrt_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set1_ps(1.7320508);
@@ -48557,7 +48557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sqrt_round_ps() {
+    fn test_mm512_mask_sqrt_round_ps() {
         let a = _mm512_set1_ps(3.);
         let r =
             _mm512_mask_sqrt_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, 0, a);
@@ -48575,7 +48575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sqrt_round_ps() {
+    fn test_mm512_maskz_sqrt_round_ps() {
         let a = _mm512_set1_ps(3.);
         let r =
             _mm512_maskz_sqrt_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(0, a);
@@ -48592,7 +48592,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmadd_round_ps() {
+    fn test_mm512_fmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48605,7 +48605,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmadd_round_ps() {
+    fn test_mm512_mask_fmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48630,7 +48630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmadd_round_ps() {
+    fn test_mm512_maskz_fmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48656,7 +48656,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmadd_round_ps() {
+    fn test_mm512_mask3_fmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48681,7 +48681,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmsub_round_ps() {
+    fn test_mm512_fmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -48694,7 +48694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmsub_round_ps() {
+    fn test_mm512_mask_fmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -48719,7 +48719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmsub_round_ps() {
+    fn test_mm512_maskz_fmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -48744,7 +48744,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmsub_round_ps() {
+    fn test_mm512_mask3_fmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -48769,7 +48769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmaddsub_round_ps() {
+    fn test_mm512_fmaddsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48792,7 +48792,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmaddsub_round_ps() {
+    fn test_mm512_mask_fmaddsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48817,7 +48817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmaddsub_round_ps() {
+    fn test_mm512_maskz_fmaddsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48842,7 +48842,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmaddsub_round_ps() {
+    fn test_mm512_mask3_fmaddsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48867,7 +48867,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmsubadd_round_ps() {
+    fn test_mm512_fmsubadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48890,7 +48890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmsubadd_round_ps() {
+    fn test_mm512_mask_fmsubadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48915,7 +48915,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmsubadd_round_ps() {
+    fn test_mm512_maskz_fmsubadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48940,7 +48940,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmsubadd_round_ps() {
+    fn test_mm512_mask3_fmsubadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -48965,7 +48965,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fnmadd_round_ps() {
+    fn test_mm512_fnmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -48979,7 +48979,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fnmadd_round_ps() {
+    fn test_mm512_mask_fnmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -49002,7 +49002,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fnmadd_round_ps() {
+    fn test_mm512_maskz_fnmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -49024,7 +49024,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fnmadd_round_ps() {
+    fn test_mm512_mask3_fnmadd_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(1.);
@@ -49046,7 +49046,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fnmsub_round_ps() {
+    fn test_mm512_fnmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -49060,7 +49060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fnmsub_round_ps() {
+    fn test_mm512_mask_fnmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -49083,7 +49083,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fnmsub_round_ps() {
+    fn test_mm512_maskz_fnmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -49105,7 +49105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fnmsub_round_ps() {
+    fn test_mm512_mask3_fnmsub_round_ps() {
         let a = _mm512_set1_ps(0.00000007);
         let b = _mm512_set1_ps(1.);
         let c = _mm512_set1_ps(-1.);
@@ -49127,7 +49127,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_max_round_ps() {
+    fn test_mm512_max_round_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -49142,7 +49142,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_max_round_ps() {
+    fn test_mm512_mask_max_round_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -49159,7 +49159,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_max_round_ps() {
+    fn test_mm512_maskz_max_round_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -49176,7 +49176,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_min_round_ps() {
+    fn test_mm512_min_round_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -49191,7 +49191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_min_round_ps() {
+    fn test_mm512_mask_min_round_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -49208,7 +49208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_min_round_ps() {
+    fn test_mm512_maskz_min_round_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -49225,7 +49225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getexp_round_ps() {
+    fn test_mm512_getexp_round_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_getexp_round_ps::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm512_set1_ps(1.);
@@ -49233,7 +49233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getexp_round_ps() {
+    fn test_mm512_mask_getexp_round_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_mask_getexp_round_ps::<_MM_FROUND_CUR_DIRECTION>(a, 0, a);
         assert_eq_m512(r, a);
@@ -49245,7 +49245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getexp_round_ps() {
+    fn test_mm512_maskz_getexp_round_ps() {
         let a = _mm512_set1_ps(3.);
         let r = _mm512_maskz_getexp_round_ps::<_MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -49257,7 +49257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_roundscale_round_ps() {
+    fn test_mm512_roundscale_round_ps() {
         let a = _mm512_set1_ps(1.1);
         let r = _mm512_roundscale_round_ps::<0, _MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm512_set1_ps(1.0);
@@ -49265,7 +49265,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_roundscale_round_ps() {
+    fn test_mm512_mask_roundscale_round_ps() {
         let a = _mm512_set1_ps(1.1);
         let r = _mm512_mask_roundscale_round_ps::<0, _MM_FROUND_CUR_DIRECTION>(a, 0, a);
         let e = _mm512_set1_ps(1.1);
@@ -49280,7 +49280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_roundscale_round_ps() {
+    fn test_mm512_maskz_roundscale_round_ps() {
         let a = _mm512_set1_ps(1.1);
         let r = _mm512_maskz_roundscale_round_ps::<0, _MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -49291,7 +49291,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_scalef_round_ps() {
+    fn test_mm512_scalef_round_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_scalef_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -49300,7 +49300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_scalef_round_ps() {
+    fn test_mm512_mask_scalef_round_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_mask_scalef_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -49320,7 +49320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_scalef_round_ps() {
+    fn test_mm512_maskz_scalef_round_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(3.);
         let r = _mm512_maskz_scalef_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -49339,7 +49339,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fixupimm_round_ps() {
+    fn test_mm512_fixupimm_round_ps() {
         let a = _mm512_set1_ps(f32::NAN);
         let b = _mm512_set1_ps(f32::MAX);
         let c = _mm512_set1_epi32(i32::MAX);
@@ -49349,7 +49349,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fixupimm_round_ps() {
+    fn test_mm512_mask_fixupimm_round_ps() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(
             f32::NAN, f32::NAN, f32::NAN, f32::NAN,
@@ -49372,7 +49372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fixupimm_round_ps() {
+    fn test_mm512_maskz_fixupimm_round_ps() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(
             f32::NAN, f32::NAN, f32::NAN, f32::NAN,
@@ -49395,7 +49395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getmant_round_ps() {
+    fn test_mm512_getmant_round_ps() {
         let a = _mm512_set1_ps(10.);
         let r = _mm512_getmant_round_ps::<
             _MM_MANT_NORM_1_2,
@@ -49407,7 +49407,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getmant_round_ps() {
+    fn test_mm512_mask_getmant_round_ps() {
         let a = _mm512_set1_ps(10.);
         let r = _mm512_mask_getmant_round_ps::<
             _MM_MANT_NORM_1_2,
@@ -49427,7 +49427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getmant_round_ps() {
+    fn test_mm512_maskz_getmant_round_ps() {
         let a = _mm512_set1_ps(10.);
         let r = _mm512_maskz_getmant_round_ps::<
             _MM_MANT_NORM_1_2,
@@ -49447,7 +49447,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtps_epi32() {
+    fn test_mm512_cvtps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.4, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -49457,7 +49457,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtps_epi32() {
+    fn test_mm512_mask_cvtps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.4, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -49470,7 +49470,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtps_epi32() {
+    fn test_mm512_maskz_cvtps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.4, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -49482,7 +49482,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtps_epi32() {
+    fn test_mm256_mask_cvtps_epi32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm256_mask_cvtps_epi32(src, 0, a);
@@ -49493,7 +49493,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtps_epi32() {
+    fn test_mm256_maskz_cvtps_epi32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let r = _mm256_maskz_cvtps_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -49503,7 +49503,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtps_epi32() {
+    fn test_mm_mask_cvtps_epi32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtps_epi32(src, 0, a);
@@ -49514,7 +49514,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtps_epi32() {
+    fn test_mm_maskz_cvtps_epi32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let r = _mm_maskz_cvtps_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -49524,7 +49524,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtps_epu32() {
+    fn test_mm512_cvtps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.4, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -49534,7 +49534,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtps_epu32() {
+    fn test_mm512_mask_cvtps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.4, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -49547,7 +49547,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtps_epu32() {
+    fn test_mm512_maskz_cvtps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.4, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -49559,7 +49559,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtps_epu32() {
+    fn test_mm256_cvtps_epu32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let r = _mm256_cvtps_epu32(a);
         let e = _mm256_set_epi32(8, 10, 10, 12, 12, 14, 14, 16);
@@ -49567,7 +49567,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtps_epu32() {
+    fn test_mm256_mask_cvtps_epu32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm256_mask_cvtps_epu32(src, 0, a);
@@ -49578,7 +49578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtps_epu32() {
+    fn test_mm256_maskz_cvtps_epu32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let r = _mm256_maskz_cvtps_epu32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -49588,7 +49588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtps_epu32() {
+    fn test_mm_cvtps_epu32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let r = _mm_cvtps_epu32(a);
         let e = _mm_set_epi32(12, 14, 14, 16);
@@ -49596,7 +49596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtps_epu32() {
+    fn test_mm_mask_cvtps_epu32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtps_epu32(src, 0, a);
@@ -49607,7 +49607,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtps_epu32() {
+    fn test_mm_maskz_cvtps_epu32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let r = _mm_maskz_cvtps_epu32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -49617,7 +49617,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi8_epi32() {
+    const fn test_mm512_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi8_epi32(a);
         let e = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -49625,7 +49625,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi8_epi32() {
+    const fn test_mm512_mask_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi32(-1);
         let r = _mm512_mask_cvtepi8_epi32(src, 0, a);
@@ -49636,7 +49636,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi8_epi32() {
+    const fn test_mm512_maskz_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi8_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -49646,7 +49646,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi8_epi32() {
+    const fn test_mm256_mask_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi32(-1);
         let r = _mm256_mask_cvtepi8_epi32(src, 0, a);
@@ -49657,7 +49657,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi8_epi32() {
+    const fn test_mm256_maskz_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepi8_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -49667,7 +49667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi8_epi32() {
+    const fn test_mm_mask_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi32(-1);
         let r = _mm_mask_cvtepi8_epi32(src, 0, a);
@@ -49678,7 +49678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi8_epi32() {
+    const fn test_mm_maskz_cvtepi8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepi8_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -49688,7 +49688,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu8_epi32() {
+    const fn test_mm512_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu8_epi32(a);
         let e = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -49696,7 +49696,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu8_epi32() {
+    const fn test_mm512_mask_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi32(-1);
         let r = _mm512_mask_cvtepu8_epi32(src, 0, a);
@@ -49707,7 +49707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu8_epi32() {
+    const fn test_mm512_maskz_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu8_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -49717,7 +49717,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu8_epi32() {
+    const fn test_mm256_mask_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi32(-1);
         let r = _mm256_mask_cvtepu8_epi32(src, 0, a);
@@ -49728,7 +49728,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu8_epi32() {
+    const fn test_mm256_maskz_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepu8_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -49738,7 +49738,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu8_epi32() {
+    const fn test_mm_mask_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi32(-1);
         let r = _mm_mask_cvtepu8_epi32(src, 0, a);
@@ -49749,7 +49749,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu8_epi32() {
+    const fn test_mm_maskz_cvtepu8_epi32() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepu8_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -49759,7 +49759,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi16_epi32() {
+    const fn test_mm512_cvtepi16_epi32() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi16_epi32(a);
         let e = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -49767,7 +49767,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi16_epi32() {
+    const fn test_mm512_mask_cvtepi16_epi32() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi32(-1);
         let r = _mm512_mask_cvtepi16_epi32(src, 0, a);
@@ -49778,7 +49778,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi16_epi32() {
+    const fn test_mm512_maskz_cvtepi16_epi32() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi16_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -49788,7 +49788,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi16_epi32() {
+    const fn test_mm256_mask_cvtepi16_epi32() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let src = _mm256_set1_epi32(-1);
         let r = _mm256_mask_cvtepi16_epi32(src, 0, a);
@@ -49799,7 +49799,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi16_epi32() {
+    const fn test_mm256_maskz_cvtepi16_epi32() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_cvtepi16_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -49809,7 +49809,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi16_epi32() {
+    const fn test_mm_mask_cvtepi16_epi32() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let src = _mm_set1_epi32(-1);
         let r = _mm_mask_cvtepi16_epi32(src, 0, a);
@@ -49820,7 +49820,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi16_epi32() {
+    const fn test_mm_maskz_cvtepi16_epi32() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_maskz_cvtepi16_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -49830,7 +49830,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu16_epi32() {
+    const fn test_mm512_cvtepu16_epi32() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu16_epi32(a);
         let e = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -49838,7 +49838,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu16_epi32() {
+    const fn test_mm512_mask_cvtepu16_epi32() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi32(-1);
         let r = _mm512_mask_cvtepu16_epi32(src, 0, a);
@@ -49849,7 +49849,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu16_epi32() {
+    const fn test_mm512_maskz_cvtepu16_epi32() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu16_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -49859,7 +49859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu16_epi32() {
+    const fn test_mm256_mask_cvtepu16_epi32() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi32(-1);
         let r = _mm256_mask_cvtepu16_epi32(src, 0, a);
@@ -49870,7 +49870,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu16_epi32() {
+    const fn test_mm256_maskz_cvtepu16_epi32() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepu16_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -49880,7 +49880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu16_epi32() {
+    const fn test_mm_mask_cvtepu16_epi32() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi32(-1);
         let r = _mm_mask_cvtepu16_epi32(src, 0, a);
@@ -49891,7 +49891,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu16_epi32() {
+    const fn test_mm_maskz_cvtepu16_epi32() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepu16_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -49901,7 +49901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi32_ps() {
+    const fn test_mm512_cvtepi32_ps() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi32_ps(a);
         let e = _mm512_set_ps(
@@ -49911,7 +49911,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi32_ps() {
+    const fn test_mm512_mask_cvtepi32_ps() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_ps(-1.);
         let r = _mm512_mask_cvtepi32_ps(src, 0, a);
@@ -49924,7 +49924,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi32_ps() {
+    const fn test_mm512_maskz_cvtepi32_ps() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi32_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -49936,7 +49936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi32_ps() {
+    const fn test_mm256_mask_cvtepi32_ps() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm256_set1_ps(-1.);
         let r = _mm256_mask_cvtepi32_ps(src, 0, a);
@@ -49947,7 +49947,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi32_ps() {
+    const fn test_mm256_maskz_cvtepi32_ps() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_cvtepi32_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -49957,7 +49957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi32_ps() {
+    const fn test_mm_mask_cvtepi32_ps() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let src = _mm_set1_ps(-1.);
         let r = _mm_mask_cvtepi32_ps(src, 0, a);
@@ -49968,7 +49968,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi32_ps() {
+    const fn test_mm_maskz_cvtepi32_ps() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_maskz_cvtepi32_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -49978,7 +49978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu32_ps() {
+    const fn test_mm512_cvtepu32_ps() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu32_ps(a);
         let e = _mm512_set_ps(
@@ -49988,7 +49988,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu32_ps() {
+    const fn test_mm512_mask_cvtepu32_ps() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_ps(-1.);
         let r = _mm512_mask_cvtepu32_ps(src, 0, a);
@@ -50001,7 +50001,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu32_ps() {
+    const fn test_mm512_maskz_cvtepu32_ps() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu32_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -50013,7 +50013,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi32_epi16() {
+    const fn test_mm512_cvtepi32_epi16() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi32_epi16(a);
         let e = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -50021,7 +50021,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi32_epi16() {
+    const fn test_mm512_mask_cvtepi32_epi16() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi16(-1);
         let r = _mm512_mask_cvtepi32_epi16(src, 0, a);
@@ -50032,7 +50032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi32_epi16() {
+    const fn test_mm512_maskz_cvtepi32_epi16() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi32_epi16(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -50042,7 +50042,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cvtepi32_epi16() {
+    const fn test_mm256_cvtepi32_epi16() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_cvtepi32_epi16(a);
         let e = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
@@ -50050,7 +50050,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi32_epi16() {
+    const fn test_mm256_mask_cvtepi32_epi16() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let src = _mm_set1_epi16(-1);
         let r = _mm256_mask_cvtepi32_epi16(src, 0, a);
@@ -50061,7 +50061,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi32_epi16() {
+    const fn test_mm256_maskz_cvtepi32_epi16() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_cvtepi32_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50071,7 +50071,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtepi32_epi16() {
+    fn test_mm_cvtepi32_epi16() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let r = _mm_cvtepi32_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 4, 5, 6, 7);
@@ -50079,7 +50079,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi32_epi16() {
+    fn test_mm_mask_cvtepi32_epi16() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtepi32_epi16(src, 0, a);
@@ -50090,7 +50090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi32_epi16() {
+    fn test_mm_maskz_cvtepi32_epi16() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let r = _mm_maskz_cvtepi32_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50100,7 +50100,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi32_epi8() {
+    const fn test_mm512_cvtepi32_epi8() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi32_epi8(a);
         let e = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -50108,7 +50108,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi32_epi8() {
+    const fn test_mm512_mask_cvtepi32_epi8() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi8(-1);
         let r = _mm512_mask_cvtepi32_epi8(src, 0, a);
@@ -50119,7 +50119,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi32_epi8() {
+    const fn test_mm512_maskz_cvtepi32_epi8() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50129,7 +50129,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtepi32_epi8() {
+    fn test_mm256_cvtepi32_epi8() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_cvtepi32_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7);
@@ -50137,7 +50137,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi32_epi8() {
+    fn test_mm256_mask_cvtepi32_epi8() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let src = _mm_set1_epi8(0);
         let r = _mm256_mask_cvtepi32_epi8(src, 0, a);
@@ -50148,7 +50148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi32_epi8() {
+    fn test_mm256_maskz_cvtepi32_epi8() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_cvtepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50158,7 +50158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtepi32_epi8() {
+    fn test_mm_cvtepi32_epi8() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let r = _mm_cvtepi32_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, 6, 7);
@@ -50166,7 +50166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi32_epi8() {
+    fn test_mm_mask_cvtepi32_epi8() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let src = _mm_set1_epi8(0);
         let r = _mm_mask_cvtepi32_epi8(src, 0, a);
@@ -50177,7 +50177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi32_epi8() {
+    fn test_mm_maskz_cvtepi32_epi8() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let r = _mm_maskz_cvtepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50187,7 +50187,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtsepi32_epi16() {
+    fn test_mm512_cvtsepi32_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50207,7 +50207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtsepi32_epi16() {
+    fn test_mm512_mask_cvtsepi32_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50230,7 +50230,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtsepi32_epi16() {
+    fn test_mm512_maskz_cvtsepi32_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50252,7 +50252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtsepi32_epi16() {
+    fn test_mm256_cvtsepi32_epi16() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_cvtsepi32_epi16(a);
         let e = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
@@ -50260,7 +50260,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtsepi32_epi16() {
+    fn test_mm256_mask_cvtsepi32_epi16() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let src = _mm_set1_epi16(-1);
         let r = _mm256_mask_cvtsepi32_epi16(src, 0, a);
@@ -50271,7 +50271,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtsepi32_epi16() {
+    fn test_mm256_maskz_cvtsepi32_epi16() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_cvtsepi32_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50281,7 +50281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtsepi32_epi16() {
+    fn test_mm_cvtsepi32_epi16() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let r = _mm_cvtsepi32_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 4, 5, 6, 7);
@@ -50289,7 +50289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtsepi32_epi16() {
+    fn test_mm_mask_cvtsepi32_epi16() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtsepi32_epi16(src, 0, a);
@@ -50300,7 +50300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsepi32_epi16() {
+    fn test_mm_maskz_cvtsepi32_epi16() {
         let a = _mm_set_epi32(4, 5, 6, 7);
         let r = _mm_maskz_cvtsepi32_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50310,7 +50310,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtsepi32_epi8() {
+    fn test_mm512_cvtsepi32_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50330,7 +50330,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtsepi32_epi8() {
+    fn test_mm512_mask_cvtsepi32_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50353,7 +50353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtsepi32_epi8() {
+    fn test_mm512_maskz_cvtsepi32_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50375,7 +50375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtsepi32_epi8() {
+    fn test_mm256_cvtsepi32_epi8() {
         let a = _mm256_set_epi32(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm256_cvtsepi32_epi8(a);
         #[rustfmt::skip]
@@ -50389,7 +50389,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtsepi32_epi8() {
+    fn test_mm256_mask_cvtsepi32_epi8() {
         let a = _mm256_set_epi32(9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm_set1_epi8(0);
         let r = _mm256_mask_cvtsepi32_epi8(src, 0, a);
@@ -50406,7 +50406,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtsepi32_epi8() {
+    fn test_mm256_maskz_cvtsepi32_epi8() {
         let a = _mm256_set_epi32(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm256_maskz_cvtsepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50422,7 +50422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtsepi32_epi8() {
+    fn test_mm_cvtsepi32_epi8() {
         let a = _mm_set_epi32(13, 14, 15, 16);
         let r = _mm_cvtsepi32_epi8(a);
         #[rustfmt::skip]
@@ -50436,7 +50436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtsepi32_epi8() {
+    fn test_mm_mask_cvtsepi32_epi8() {
         let a = _mm_set_epi32(13, 14, 15, 16);
         let src = _mm_set1_epi8(0);
         let r = _mm_mask_cvtsepi32_epi8(src, 0, a);
@@ -50453,7 +50453,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsepi32_epi8() {
+    fn test_mm_maskz_cvtsepi32_epi8() {
         let a = _mm_set_epi32(13, 14, 15, 16);
         let r = _mm_maskz_cvtsepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50469,7 +50469,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtusepi32_epi16() {
+    fn test_mm512_cvtusepi32_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50483,7 +50483,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtusepi32_epi16() {
+    fn test_mm512_mask_cvtusepi32_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50500,7 +50500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtusepi32_epi16() {
+    fn test_mm512_maskz_cvtusepi32_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50516,7 +50516,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtusepi32_epi16() {
+    fn test_mm256_cvtusepi32_epi16() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_cvtusepi32_epi16(a);
         let e = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
@@ -50524,7 +50524,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtusepi32_epi16() {
+    fn test_mm256_mask_cvtusepi32_epi16() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set1_epi16(0);
         let r = _mm256_mask_cvtusepi32_epi16(src, 0, a);
@@ -50535,7 +50535,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtusepi32_epi16() {
+    fn test_mm256_maskz_cvtusepi32_epi16() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_cvtusepi32_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50545,7 +50545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtusepi32_epi16() {
+    fn test_mm_cvtusepi32_epi16() {
         let a = _mm_set_epi32(5, 6, 7, 8);
         let r = _mm_cvtusepi32_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 5, 6, 7, 8);
@@ -50553,7 +50553,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtusepi32_epi16() {
+    fn test_mm_mask_cvtusepi32_epi16() {
         let a = _mm_set_epi32(5, 6, 7, 8);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtusepi32_epi16(src, 0, a);
@@ -50564,7 +50564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtusepi32_epi16() {
+    fn test_mm_maskz_cvtusepi32_epi16() {
         let a = _mm_set_epi32(5, 6, 7, 8);
         let r = _mm_maskz_cvtusepi32_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50574,7 +50574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtusepi32_epi8() {
+    fn test_mm512_cvtusepi32_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50588,7 +50588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtusepi32_epi8() {
+    fn test_mm512_mask_cvtusepi32_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50605,7 +50605,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtusepi32_epi8() {
+    fn test_mm512_maskz_cvtusepi32_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             0, 1, 2, 3,
@@ -50621,7 +50621,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtusepi32_epi8() {
+    fn test_mm256_cvtusepi32_epi8() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, i32::MAX);
         let r = _mm256_cvtusepi32_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, u8::MAX as i8);
@@ -50629,7 +50629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtusepi32_epi8() {
+    fn test_mm256_mask_cvtusepi32_epi8() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, i32::MAX);
         let src = _mm_set1_epi8(0);
         let r = _mm256_mask_cvtusepi32_epi8(src, 0, a);
@@ -50640,7 +50640,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtusepi32_epi8() {
+    fn test_mm256_maskz_cvtusepi32_epi8() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, i32::MAX);
         let r = _mm256_maskz_cvtusepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50650,7 +50650,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtusepi32_epi8() {
+    fn test_mm_cvtusepi32_epi8() {
         let a = _mm_set_epi32(5, 6, 7, i32::MAX);
         let r = _mm_cvtusepi32_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 6, 7, u8::MAX as i8);
@@ -50658,7 +50658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtusepi32_epi8() {
+    fn test_mm_mask_cvtusepi32_epi8() {
         let a = _mm_set_epi32(5, 6, 7, i32::MAX);
         let src = _mm_set1_epi8(0);
         let r = _mm_mask_cvtusepi32_epi8(src, 0, a);
@@ -50669,7 +50669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtusepi32_epi8() {
+    fn test_mm_maskz_cvtusepi32_epi8() {
         let a = _mm_set_epi32(5, 6, 7, i32::MAX);
         let r = _mm_maskz_cvtusepi32_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50679,7 +50679,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundps_epi32() {
+    fn test_mm512_cvt_roundps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -50692,7 +50692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundps_epi32() {
+    fn test_mm512_mask_cvt_roundps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -50711,7 +50711,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundps_epi32() {
+    fn test_mm512_maskz_cvt_roundps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -50728,7 +50728,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundps_epu32() {
+    fn test_mm512_cvt_roundps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -50741,7 +50741,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundps_epu32() {
+    fn test_mm512_mask_cvt_roundps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -50760,7 +50760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundps_epu32() {
+    fn test_mm512_maskz_cvt_roundps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -50777,7 +50777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundepi32_ps() {
+    fn test_mm512_cvt_roundepi32_ps() {
         let a = _mm512_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8, 8, 10, 10, 12, 12, 14, 14, 16);
         let r = _mm512_cvt_roundepi32_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_setr_ps(
@@ -50787,7 +50787,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundepi32_ps() {
+    fn test_mm512_mask_cvt_roundepi32_ps() {
         let a = _mm512_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8, 8, 10, 10, 12, 12, 14, 14, 16);
         let src = _mm512_set1_ps(0.);
         let r = _mm512_mask_cvt_roundepi32_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -50806,7 +50806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundepi32_ps() {
+    fn test_mm512_maskz_cvt_roundepi32_ps() {
         let a = _mm512_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8, 8, 10, 10, 12, 12, 14, 14, 16);
         let r = _mm512_maskz_cvt_roundepi32_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0, a,
@@ -50823,7 +50823,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundepu32_ps() {
+    fn test_mm512_cvt_roundepu32_ps() {
         let a = _mm512_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8, 8, 10, 10, 12, 12, 14, 14, 16);
         let r = _mm512_cvt_roundepu32_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         #[rustfmt::skip]
@@ -50837,7 +50837,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundepu32_ps() {
+    fn test_mm512_mask_cvt_roundepu32_ps() {
         let a = _mm512_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8, 8, 10, 10, 12, 12, 14, 14, 16);
         let src = _mm512_set1_ps(0.);
         let r = _mm512_mask_cvt_roundepu32_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -50860,7 +50860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundepu32_ps() {
+    fn test_mm512_maskz_cvt_roundepu32_ps() {
         let a = _mm512_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8, 8, 10, 10, 12, 12, 14, 14, 16);
         let r = _mm512_maskz_cvt_roundepu32_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0, a,
@@ -50881,7 +50881,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundps_ph() {
+    fn test_mm512_cvt_roundps_ph() {
         let a = _mm512_set1_ps(1.);
         let r = _mm512_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(a);
         let e = _mm256_setr_epi64x(
@@ -50894,7 +50894,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundps_ph() {
+    fn test_mm512_mask_cvt_roundps_ph() {
         let a = _mm512_set1_ps(1.);
         let src = _mm256_set1_epi16(0);
         let r = _mm512_mask_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -50905,7 +50905,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundps_ph() {
+    fn test_mm512_maskz_cvt_roundps_ph() {
         let a = _mm512_set1_ps(1.);
         let r = _mm512_maskz_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -50915,7 +50915,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvt_roundps_ph() {
+    fn test_mm256_mask_cvt_roundps_ph() {
         let a = _mm256_set1_ps(1.);
         let src = _mm_set1_epi16(0);
         let r = _mm256_mask_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -50926,7 +50926,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvt_roundps_ph() {
+    fn test_mm256_maskz_cvt_roundps_ph() {
         let a = _mm256_set1_ps(1.);
         let r = _mm256_maskz_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50936,7 +50936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvt_roundps_ph() {
+    fn test_mm_mask_cvt_roundps_ph() {
         let a = _mm_set1_ps(1.);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -50947,7 +50947,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvt_roundps_ph() {
+    fn test_mm_maskz_cvt_roundps_ph() {
         let a = _mm_set1_ps(1.);
         let r = _mm_maskz_cvt_roundps_ph::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -50957,7 +50957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtps_ph() {
+    fn test_mm512_cvtps_ph() {
         let a = _mm512_set1_ps(1.);
         let r = _mm512_cvtps_ph::<_MM_FROUND_NO_EXC>(a);
         let e = _mm256_setr_epi64x(
@@ -50970,7 +50970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtps_ph() {
+    fn test_mm512_mask_cvtps_ph() {
         let a = _mm512_set1_ps(1.);
         let src = _mm256_set1_epi16(0);
         let r = _mm512_mask_cvtps_ph::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -50981,7 +50981,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtps_ph() {
+    fn test_mm512_maskz_cvtps_ph() {
         let a = _mm512_set1_ps(1.);
         let r = _mm512_maskz_cvtps_ph::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -50991,7 +50991,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtps_ph() {
+    fn test_mm256_mask_cvtps_ph() {
         let a = _mm256_set1_ps(1.);
         let src = _mm_set1_epi16(0);
         let r = _mm256_mask_cvtps_ph::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -51002,7 +51002,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtps_ph() {
+    fn test_mm256_maskz_cvtps_ph() {
         let a = _mm256_set1_ps(1.);
         let r = _mm256_maskz_cvtps_ph::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -51012,7 +51012,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtps_ph() {
+    fn test_mm_mask_cvtps_ph() {
         let a = _mm_set1_ps(1.);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtps_ph::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -51023,7 +51023,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtps_ph() {
+    fn test_mm_maskz_cvtps_ph() {
         let a = _mm_set1_ps(1.);
         let r = _mm_maskz_cvtps_ph::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -51033,7 +51033,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundph_ps() {
+    fn test_mm512_cvt_roundph_ps() {
         let a = _mm256_setr_epi64x(
             4323521613979991040,
             4323521613979991040,
@@ -51046,7 +51046,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundph_ps() {
+    fn test_mm512_mask_cvt_roundph_ps() {
         let a = _mm256_setr_epi64x(
             4323521613979991040,
             4323521613979991040,
@@ -51064,7 +51064,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundph_ps() {
+    fn test_mm512_maskz_cvt_roundph_ps() {
         let a = _mm256_setr_epi64x(
             4323521613979991040,
             4323521613979991040,
@@ -51081,7 +51081,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtph_ps() {
+    fn test_mm512_cvtph_ps() {
         let a = _mm256_setr_epi64x(
             4323521613979991040,
             4323521613979991040,
@@ -51094,7 +51094,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtph_ps() {
+    fn test_mm512_mask_cvtph_ps() {
         let a = _mm256_setr_epi64x(
             4323521613979991040,
             4323521613979991040,
@@ -51112,7 +51112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtph_ps() {
+    fn test_mm512_maskz_cvtph_ps() {
         let a = _mm256_setr_epi64x(
             4323521613979991040,
             4323521613979991040,
@@ -51129,7 +51129,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_ps() {
+    fn test_mm256_mask_cvtph_ps() {
         let a = _mm_setr_epi64x(4323521613979991040, 4323521613979991040);
         let src = _mm256_set1_ps(0.);
         let r = _mm256_mask_cvtph_ps(src, 0, a);
@@ -51140,7 +51140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_ps() {
+    fn test_mm256_maskz_cvtph_ps() {
         let a = _mm_setr_epi64x(4323521613979991040, 4323521613979991040);
         let r = _mm256_maskz_cvtph_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -51150,7 +51150,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_ps() {
+    fn test_mm_mask_cvtph_ps() {
         let a = _mm_setr_epi64x(4323521613979991040, 4323521613979991040);
         let src = _mm_set1_ps(0.);
         let r = _mm_mask_cvtph_ps(src, 0, a);
@@ -51161,7 +51161,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_ps() {
+    fn test_mm_maskz_cvtph_ps() {
         let a = _mm_setr_epi64x(4323521613979991040, 4323521613979991040);
         let r = _mm_maskz_cvtph_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -51171,7 +51171,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtt_roundps_epi32() {
+    fn test_mm512_cvtt_roundps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51181,7 +51181,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtt_roundps_epi32() {
+    fn test_mm512_mask_cvtt_roundps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51194,7 +51194,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtt_roundps_epi32() {
+    fn test_mm512_maskz_cvtt_roundps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51206,7 +51206,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtt_roundps_epu32() {
+    fn test_mm512_cvtt_roundps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51216,7 +51216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtt_roundps_epu32() {
+    fn test_mm512_mask_cvtt_roundps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51229,7 +51229,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtt_roundps_epu32() {
+    fn test_mm512_maskz_cvtt_roundps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51241,7 +51241,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvttps_epi32() {
+    fn test_mm512_cvttps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51251,7 +51251,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvttps_epi32() {
+    fn test_mm512_mask_cvttps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51264,7 +51264,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvttps_epi32() {
+    fn test_mm512_maskz_cvttps_epi32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51276,7 +51276,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvttps_epi32() {
+    fn test_mm256_mask_cvttps_epi32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm256_mask_cvttps_epi32(src, 0, a);
@@ -51287,7 +51287,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttps_epi32() {
+    fn test_mm256_maskz_cvttps_epi32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let r = _mm256_maskz_cvttps_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -51297,7 +51297,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvttps_epi32() {
+    fn test_mm_mask_cvttps_epi32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvttps_epi32(src, 0, a);
@@ -51308,7 +51308,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvttps_epi32() {
+    fn test_mm_maskz_cvttps_epi32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let r = _mm_maskz_cvttps_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -51318,7 +51318,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvttps_epu32() {
+    fn test_mm512_cvttps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51328,7 +51328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvttps_epu32() {
+    fn test_mm512_mask_cvttps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51341,7 +51341,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvttps_epu32() {
+    fn test_mm512_maskz_cvttps_epu32() {
         let a = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5,
         );
@@ -51353,7 +51353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvttps_epu32() {
+    fn test_mm256_cvttps_epu32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let r = _mm256_cvttps_epu32(a);
         let e = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
@@ -51361,7 +51361,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvttps_epu32() {
+    fn test_mm256_mask_cvttps_epu32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm256_mask_cvttps_epu32(src, 0, a);
@@ -51372,7 +51372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttps_epu32() {
+    fn test_mm256_maskz_cvttps_epu32() {
         let a = _mm256_set_ps(8., 9.5, 10., 11.5, 12., 13.5, 14., 15.5);
         let r = _mm256_maskz_cvttps_epu32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -51382,7 +51382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvttps_epu32() {
+    fn test_mm_cvttps_epu32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let r = _mm_cvttps_epu32(a);
         let e = _mm_set_epi32(12, 13, 14, 15);
@@ -51390,7 +51390,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvttps_epu32() {
+    fn test_mm_mask_cvttps_epu32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvttps_epu32(src, 0, a);
@@ -51401,7 +51401,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvttps_epu32() {
+    fn test_mm_maskz_cvttps_epu32() {
         let a = _mm_set_ps(12., 13.5, 14., 15.5);
         let r = _mm_maskz_cvttps_epu32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -51539,7 +51539,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmplt_ps_mask() {
+    fn test_mm512_cmplt_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51549,7 +51549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmplt_ps_mask() {
+    fn test_mm512_mask_cmplt_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51560,7 +51560,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpnlt_ps_mask() {
+    fn test_mm512_cmpnlt_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51569,7 +51569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpnlt_ps_mask() {
+    fn test_mm512_mask_cmpnlt_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51579,7 +51579,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpnle_ps_mask() {
+    fn test_mm512_cmpnle_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51589,7 +51589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpnle_ps_mask() {
+    fn test_mm512_mask_cmpnle_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51600,7 +51600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmple_ps_mask() {
+    fn test_mm512_cmple_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51609,7 +51609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmple_ps_mask() {
+    fn test_mm512_mask_cmple_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.,
                               0., 1., -1., f32::MAX, f32::NAN, f32::MIN, 100., -100.);
@@ -51619,7 +51619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpeq_ps_mask() {
+    fn test_mm512_cmpeq_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.);
@@ -51631,7 +51631,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpeq_ps_mask() {
+    fn test_mm512_mask_cmpeq_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.);
@@ -51644,7 +51644,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpneq_ps_mask() {
+    fn test_mm512_cmpneq_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.);
@@ -51656,7 +51656,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpneq_ps_mask() {
+    fn test_mm512_mask_cmpneq_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, f32::NAN, -100.);
@@ -51669,7 +51669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmp_ps_mask() {
+    fn test_mm512_cmp_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.);
@@ -51679,7 +51679,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmp_ps_mask() {
+    fn test_mm512_mask_cmp_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.);
@@ -51690,7 +51690,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cmp_ps_mask() {
+    fn test_mm256_cmp_ps_mask() {
         let a = _mm256_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.);
         let b = _mm256_set1_ps(-1.);
         let m = _mm256_cmp_ps_mask::<_CMP_LT_OQ>(a, b);
@@ -51698,7 +51698,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cmp_ps_mask() {
+    fn test_mm256_mask_cmp_ps_mask() {
         let a = _mm256_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.);
         let b = _mm256_set1_ps(-1.);
         let mask = 0b01100110;
@@ -51707,7 +51707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cmp_ps_mask() {
+    fn test_mm_cmp_ps_mask() {
         let a = _mm_set_ps(0., 1., -1., 13.);
         let b = _mm_set1_ps(1.);
         let m = _mm_cmp_ps_mask::<_CMP_LT_OQ>(a, b);
@@ -51715,7 +51715,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cmp_ps_mask() {
+    fn test_mm_mask_cmp_ps_mask() {
         let a = _mm_set_ps(0., 1., -1., 13.);
         let b = _mm_set1_ps(1.);
         let mask = 0b11111111;
@@ -51724,7 +51724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmp_round_ps_mask() {
+    fn test_mm512_cmp_round_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.);
@@ -51734,7 +51734,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmp_round_ps_mask() {
+    fn test_mm512_mask_cmp_round_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.,
                               0., 1., -1., 13., f32::MAX, f32::MIN, 100., -100.);
@@ -51745,7 +51745,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpord_ps_mask() {
+    fn test_mm512_cmpord_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, -1., f32::NAN, 0.,
                               f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, 1., f32::NAN, 2.);
@@ -51757,7 +51757,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpord_ps_mask() {
+    fn test_mm512_mask_cmpord_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, -1., f32::NAN, 0.,
                               f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, 1., f32::NAN, 2.);
@@ -51770,7 +51770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpunord_ps_mask() {
+    fn test_mm512_cmpunord_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, -1., f32::NAN, 0.,
                               f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, 1., f32::NAN, 2.);
@@ -51783,7 +51783,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpunord_ps_mask() {
+    fn test_mm512_mask_cmpunord_ps_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_ps(f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, -1., f32::NAN, 0.,
                               f32::NAN, f32::MAX, f32::NAN, f32::MIN, f32::NAN, 1., f32::NAN, 2.);
@@ -51796,7 +51796,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cmp_ss_mask() {
+    fn test_mm_cmp_ss_mask() {
         let a = _mm_setr_ps(2., 1., 1., 1.);
         let b = _mm_setr_ps(1., 2., 2., 2.);
         let m = _mm_cmp_ss_mask::<_CMP_GE_OS>(a, b);
@@ -51804,7 +51804,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cmp_ss_mask() {
+    fn test_mm_mask_cmp_ss_mask() {
         let a = _mm_setr_ps(2., 1., 1., 1.);
         let b = _mm_setr_ps(1., 2., 2., 2.);
         let m = _mm_mask_cmp_ss_mask::<_CMP_GE_OS>(0b10, a, b);
@@ -51814,7 +51814,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cmp_round_ss_mask() {
+    fn test_mm_cmp_round_ss_mask() {
         let a = _mm_setr_ps(2., 1., 1., 1.);
         let b = _mm_setr_ps(1., 2., 2., 2.);
         let m = _mm_cmp_round_ss_mask::<_CMP_GE_OS, _MM_FROUND_CUR_DIRECTION>(a, b);
@@ -51822,7 +51822,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cmp_round_ss_mask() {
+    fn test_mm_mask_cmp_round_ss_mask() {
         let a = _mm_setr_ps(2., 1., 1., 1.);
         let b = _mm_setr_ps(1., 2., 2., 2.);
         let m = _mm_mask_cmp_round_ss_mask::<_CMP_GE_OS, _MM_FROUND_CUR_DIRECTION>(0b10, a, b);
@@ -51832,7 +51832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cmp_sd_mask() {
+    fn test_mm_cmp_sd_mask() {
         let a = _mm_setr_pd(2., 1.);
         let b = _mm_setr_pd(1., 2.);
         let m = _mm_cmp_sd_mask::<_CMP_GE_OS>(a, b);
@@ -51840,7 +51840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cmp_sd_mask() {
+    fn test_mm_mask_cmp_sd_mask() {
         let a = _mm_setr_pd(2., 1.);
         let b = _mm_setr_pd(1., 2.);
         let m = _mm_mask_cmp_sd_mask::<_CMP_GE_OS>(0b10, a, b);
@@ -51850,7 +51850,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cmp_round_sd_mask() {
+    fn test_mm_cmp_round_sd_mask() {
         let a = _mm_setr_pd(2., 1.);
         let b = _mm_setr_pd(1., 2.);
         let m = _mm_cmp_round_sd_mask::<_CMP_GE_OS, _MM_FROUND_CUR_DIRECTION>(a, b);
@@ -51858,7 +51858,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cmp_round_sd_mask() {
+    fn test_mm_mask_cmp_round_sd_mask() {
         let a = _mm_setr_pd(2., 1.);
         let b = _mm_setr_pd(1., 2.);
         let m = _mm_mask_cmp_round_sd_mask::<_CMP_GE_OS, _MM_FROUND_CUR_DIRECTION>(0b10, a, b);
@@ -51868,7 +51868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmplt_epu32_mask() {
+    const fn test_mm512_cmplt_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -51878,7 +51878,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmplt_epu32_mask() {
+    const fn test_mm512_mask_cmplt_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -51889,7 +51889,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epu32_mask() {
+    const fn test_mm256_cmplt_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 101, 100, 99);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_cmplt_epu32_mask(a, b);
@@ -51897,7 +51897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epu32_mask() {
+    const fn test_mm256_mask_cmplt_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 101, 100, 99);
         let b = _mm256_set1_epi32(1);
         let mask = 0b11111111;
@@ -51906,7 +51906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmplt_epu32_mask() {
+    const fn test_mm_cmplt_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let r = _mm_cmplt_epu32_mask(a, b);
@@ -51914,7 +51914,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epu32_mask() {
+    const fn test_mm_mask_cmplt_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let mask = 0b11111111;
@@ -51923,7 +51923,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpgt_epu32_mask() {
+    const fn test_mm512_cmpgt_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -51933,7 +51933,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpgt_epu32_mask() {
+    const fn test_mm512_mask_cmpgt_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -51944,7 +51944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epu32_mask() {
+    const fn test_mm256_cmpgt_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 99, 100, 101);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_cmpgt_epu32_mask(a, b);
@@ -51952,7 +51952,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epu32_mask() {
+    const fn test_mm256_mask_cmpgt_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 99, 100, 101);
         let b = _mm256_set1_epi32(1);
         let mask = 0b11111111;
@@ -51961,7 +51961,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epu32_mask() {
+    const fn test_mm_cmpgt_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let r = _mm_cmpgt_epu32_mask(a, b);
@@ -51969,7 +51969,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epu32_mask() {
+    const fn test_mm_mask_cmpgt_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let mask = 0b11111111;
@@ -51978,7 +51978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmple_epu32_mask() {
+    const fn test_mm512_cmple_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -51990,7 +51990,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmple_epu32_mask() {
+    const fn test_mm512_mask_cmple_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52003,7 +52003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmple_epu32_mask() {
+    const fn test_mm256_cmple_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 200, 100, 101);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_cmple_epu32_mask(a, b);
@@ -52011,7 +52011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epu32_mask() {
+    const fn test_mm256_mask_cmple_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 200, 100, 101);
         let b = _mm256_set1_epi32(1);
         let mask = 0b11111111;
@@ -52020,7 +52020,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmple_epu32_mask() {
+    const fn test_mm_cmple_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let r = _mm_cmple_epu32_mask(a, b);
@@ -52028,7 +52028,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epu32_mask() {
+    const fn test_mm_mask_cmple_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let mask = 0b11111111;
@@ -52037,7 +52037,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpge_epu32_mask() {
+    const fn test_mm512_cmpge_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52049,7 +52049,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpge_epu32_mask() {
+    const fn test_mm512_mask_cmpge_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52059,7 +52059,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epu32_mask() {
+    const fn test_mm256_cmpge_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 300, 100, 200);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_cmpge_epu32_mask(a, b);
@@ -52067,7 +52067,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epu32_mask() {
+    const fn test_mm256_mask_cmpge_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, 2, u32::MAX as i32, i32::MAX, 300, 100, 200);
         let b = _mm256_set1_epi32(1);
         let mask = 0b11111111;
@@ -52076,7 +52076,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpge_epu32_mask() {
+    const fn test_mm_cmpge_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let r = _mm_cmpge_epu32_mask(a, b);
@@ -52084,7 +52084,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epu32_mask() {
+    const fn test_mm_mask_cmpge_epu32_mask() {
         let a = _mm_set_epi32(0, 1, 2, u32::MAX as i32);
         let b = _mm_set1_epi32(1);
         let mask = 0b11111111;
@@ -52093,7 +52093,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpeq_epu32_mask() {
+    const fn test_mm512_cmpeq_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52105,7 +52105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpeq_epu32_mask() {
+    const fn test_mm512_mask_cmpeq_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52118,7 +52118,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epu32_mask() {
+    const fn test_mm256_cmpeq_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, 100, -100);
         let m = _mm256_cmpeq_epu32_mask(b, a);
@@ -52126,7 +52126,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epu32_mask() {
+    const fn test_mm256_mask_cmpeq_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, 100, -100);
         let mask = 0b01111010;
@@ -52135,7 +52135,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epu32_mask() {
+    const fn test_mm_cmpeq_epu32_mask() {
         let a = _mm_set_epi32(0, 1, -1, u32::MAX as i32);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let m = _mm_cmpeq_epu32_mask(b, a);
@@ -52143,7 +52143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epu32_mask() {
+    const fn test_mm_mask_cmpeq_epu32_mask() {
         let a = _mm_set_epi32(0, 1, -1, u32::MAX as i32);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -52152,7 +52152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpneq_epu32_mask() {
+    const fn test_mm512_cmpneq_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52164,7 +52164,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpneq_epu32_mask() {
+    const fn test_mm512_mask_cmpneq_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, -100, 100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, -100, 100);
@@ -52177,7 +52177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epu32_mask() {
+    const fn test_mm256_cmpneq_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, -100, 100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, -100, 100);
         let r = _mm256_cmpneq_epu32_mask(b, a);
@@ -52185,7 +52185,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epu32_mask() {
+    const fn test_mm256_mask_cmpneq_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, -100, 100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, -100, 100);
         let mask = 0b11111111;
@@ -52194,7 +52194,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epu32_mask() {
+    const fn test_mm_cmpneq_epu32_mask() {
         let a = _mm_set_epi32(0, 1, -1, u32::MAX as i32);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let r = _mm_cmpneq_epu32_mask(b, a);
@@ -52202,7 +52202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epu32_mask() {
+    const fn test_mm_mask_cmpneq_epu32_mask() {
         let a = _mm_set_epi32(0, 1, -1, u32::MAX as i32);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -52211,7 +52211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmp_epu32_mask() {
+    const fn test_mm512_cmp_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52221,7 +52221,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmp_epu32_mask() {
+    const fn test_mm512_mask_cmp_epu32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52232,7 +52232,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmp_epu32_mask() {
+    const fn test_mm256_cmp_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let m = _mm256_cmp_epu32_mask::<_MM_CMPINT_LT>(a, b);
@@ -52240,7 +52240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epu32_mask() {
+    const fn test_mm256_mask_cmp_epu32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52249,7 +52249,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmp_epu32_mask() {
+    const fn test_mm_cmp_epu32_mask() {
         let a = _mm_set_epi32(0, 1, -1, i32::MAX);
         let b = _mm_set1_epi32(1);
         let m = _mm_cmp_epu32_mask::<_MM_CMPINT_LT>(a, b);
@@ -52257,7 +52257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epu32_mask() {
+    const fn test_mm_mask_cmp_epu32_mask() {
         let a = _mm_set_epi32(0, 1, -1, i32::MAX);
         let b = _mm_set1_epi32(1);
         let mask = 0b11111111;
@@ -52266,7 +52266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmplt_epi32_mask() {
+    const fn test_mm512_cmplt_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52276,7 +52276,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmplt_epi32_mask() {
+    const fn test_mm512_mask_cmplt_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52287,7 +52287,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epi32_mask() {
+    const fn test_mm256_cmplt_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 101, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let r = _mm256_cmplt_epi32_mask(a, b);
@@ -52295,7 +52295,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epi32_mask() {
+    const fn test_mm256_mask_cmplt_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 101, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52304,7 +52304,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmplt_epi32_mask() {
+    const fn test_mm_cmplt_epi32_mask() {
         let a = _mm_set_epi32(i32::MAX, i32::MIN, 100, -100);
         let b = _mm_set1_epi32(-1);
         let r = _mm_cmplt_epi32_mask(a, b);
@@ -52312,7 +52312,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epi32_mask() {
+    const fn test_mm_mask_cmplt_epi32_mask() {
         let a = _mm_set_epi32(i32::MAX, i32::MIN, 100, -100);
         let b = _mm_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52321,7 +52321,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpgt_epi32_mask() {
+    const fn test_mm512_cmpgt_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52331,7 +52331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpgt_epi32_mask() {
+    const fn test_mm512_mask_cmpgt_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52342,7 +52342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epi32_mask() {
+    const fn test_mm256_cmpgt_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let r = _mm256_cmpgt_epi32_mask(a, b);
@@ -52350,7 +52350,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epi32_mask() {
+    const fn test_mm256_mask_cmpgt_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52359,7 +52359,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epi32_mask() {
+    const fn test_mm_cmpgt_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set1_epi32(-1);
         let r = _mm_cmpgt_epi32_mask(a, b);
@@ -52367,7 +52367,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epi32_mask() {
+    const fn test_mm_mask_cmpgt_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52376,7 +52376,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmple_epi32_mask() {
+    const fn test_mm512_cmple_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52388,7 +52388,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmple_epi32_mask() {
+    const fn test_mm512_mask_cmple_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52398,7 +52398,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmple_epi32_mask() {
+    const fn test_mm256_cmple_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 200, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let r = _mm256_cmple_epi32_mask(a, b);
@@ -52406,7 +52406,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epi32_mask() {
+    const fn test_mm256_mask_cmple_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 200, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52415,7 +52415,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmple_epi32_mask() {
+    const fn test_mm_cmple_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 200);
         let b = _mm_set1_epi32(-1);
         let r = _mm_cmple_epi32_mask(a, b);
@@ -52423,7 +52423,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epi32_mask() {
+    const fn test_mm_mask_cmple_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 200);
         let b = _mm_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52432,7 +52432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpge_epi32_mask() {
+    const fn test_mm512_cmpge_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52444,7 +52444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpge_epi32_mask() {
+    const fn test_mm512_mask_cmpge_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
@@ -52457,7 +52457,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epi32_mask() {
+    const fn test_mm256_cmpge_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let r = _mm256_cmpge_epi32_mask(a, b);
@@ -52465,7 +52465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epi32_mask() {
+    const fn test_mm256_mask_cmpge_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, u32::MAX as i32, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52474,7 +52474,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpge_epi32_mask() {
+    const fn test_mm_cmpge_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, u32::MAX as i32);
         let b = _mm_set1_epi32(-1);
         let r = _mm_cmpge_epi32_mask(a, b);
@@ -52482,7 +52482,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epi32_mask() {
+    const fn test_mm_mask_cmpge_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, u32::MAX as i32);
         let b = _mm_set1_epi32(-1);
         let mask = 0b11111111;
@@ -52491,7 +52491,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpeq_epi32_mask() {
+    const fn test_mm512_cmpeq_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52503,7 +52503,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpeq_epi32_mask() {
+    const fn test_mm512_mask_cmpeq_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52516,7 +52516,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epi32_mask() {
+    const fn test_mm256_cmpeq_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, 100, -100);
         let m = _mm256_cmpeq_epi32_mask(b, a);
@@ -52524,7 +52524,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epi32_mask() {
+    const fn test_mm256_mask_cmpeq_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, 100, -100);
         let mask = 0b01111010;
@@ -52533,7 +52533,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epi32_mask() {
+    const fn test_mm_cmpeq_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let m = _mm_cmpeq_epi32_mask(b, a);
@@ -52541,7 +52541,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epi32_mask() {
+    const fn test_mm_mask_cmpeq_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -52550,7 +52550,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpneq_epi32_mask() {
+    const fn test_mm512_cmpneq_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52562,7 +52562,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpneq_epi32_mask() {
+    const fn test_mm512_mask_cmpneq_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, -100, 100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, -100, 100);
@@ -52575,7 +52575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epi32_mask() {
+    const fn test_mm256_cmpneq_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, 100, -100);
         let m = _mm256_cmpneq_epi32_mask(b, a);
@@ -52583,7 +52583,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epi32_mask() {
+    const fn test_mm256_mask_cmpneq_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, -100, 100);
         let b = _mm256_set_epi32(0, 1, 13, 42, i32::MAX, i32::MIN, 100, -100);
         let mask = 0b11111111;
@@ -52592,7 +52592,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epi32_mask() {
+    const fn test_mm_cmpneq_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let r = _mm_cmpneq_epi32_mask(b, a);
@@ -52600,7 +52600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epi32_mask() {
+    const fn test_mm_mask_cmpneq_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set_epi32(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -52609,7 +52609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmp_epi32_mask() {
+    const fn test_mm512_cmp_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52619,7 +52619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmp_epi32_mask() {
+    const fn test_mm512_mask_cmp_epi32_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100,
                                  0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
@@ -52630,7 +52630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmp_epi32_mask() {
+    const fn test_mm256_cmp_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let m = _mm256_cmp_epi32_mask::<_MM_CMPINT_LT>(a, b);
@@ -52638,7 +52638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epi32_mask() {
+    const fn test_mm256_mask_cmp_epi32_mask() {
         let a = _mm256_set_epi32(0, 1, -1, 13, i32::MAX, i32::MIN, 100, -100);
         let b = _mm256_set1_epi32(-1);
         let mask = 0b01100110;
@@ -52647,7 +52647,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmp_epi32_mask() {
+    const fn test_mm_cmp_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set1_epi32(1);
         let m = _mm_cmp_epi32_mask::<_MM_CMPINT_LT>(a, b);
@@ -52655,7 +52655,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epi32_mask() {
+    const fn test_mm_mask_cmp_epi32_mask() {
         let a = _mm_set_epi32(0, 1, -1, 13);
         let b = _mm_set1_epi32(1);
         let mask = 0b11111111;
@@ -52664,7 +52664,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set_epi8() {
+    const fn test_mm512_set_epi8() {
         let r = _mm512_set1_epi8(2);
         assert_eq_m512i(
             r,
@@ -52677,7 +52677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set_epi16() {
+    const fn test_mm512_set_epi16() {
         let r = _mm512_set1_epi16(2);
         assert_eq_m512i(
             r,
@@ -52689,7 +52689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set_epi32() {
+    const fn test_mm512_set_epi32() {
         let r = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         assert_eq_m512i(
             r,
@@ -52698,7 +52698,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr_epi32() {
+    const fn test_mm512_setr_epi32() {
         let r = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         assert_eq_m512i(
             r,
@@ -52707,7 +52707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set1_epi8() {
+    const fn test_mm512_set1_epi8() {
         let r = _mm512_set_epi8(
             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -52717,7 +52717,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set1_epi16() {
+    const fn test_mm512_set1_epi16() {
         let r = _mm512_set_epi16(
             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
             2, 2, 2,
@@ -52726,23 +52726,23 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set1_epi32() {
+    const fn test_mm512_set1_epi32() {
         let r = _mm512_set_epi32(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         assert_eq_m512i(r, _mm512_set1_epi32(2));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setzero_si512() {
+    const fn test_mm512_setzero_si512() {
         assert_eq_m512i(_mm512_set1_epi32(0), _mm512_setzero_si512());
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setzero_epi32() {
+    const fn test_mm512_setzero_epi32() {
         assert_eq_m512i(_mm512_set1_epi32(0), _mm512_setzero_epi32());
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set_ps() {
+    const fn test_mm512_set_ps() {
         let r = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -52755,7 +52755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr_ps() {
+    const fn test_mm512_setr_ps() {
         let r = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -52768,7 +52768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set1_ps() {
+    const fn test_mm512_set1_ps() {
         #[rustfmt::skip]
         let expected = _mm512_set_ps(2., 2., 2., 2., 2., 2., 2., 2.,
                                      2., 2., 2., 2., 2., 2., 2., 2.);
@@ -52776,13 +52776,13 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set4_epi32() {
+    const fn test_mm512_set4_epi32() {
         let r = _mm512_set_epi32(4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1);
         assert_eq_m512i(r, _mm512_set4_epi32(4, 3, 2, 1));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set4_ps() {
+    const fn test_mm512_set4_ps() {
         let r = _mm512_set_ps(
             4., 3., 2., 1., 4., 3., 2., 1., 4., 3., 2., 1., 4., 3., 2., 1.,
         );
@@ -52790,13 +52790,13 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr4_epi32() {
+    const fn test_mm512_setr4_epi32() {
         let r = _mm512_set_epi32(4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1);
         assert_eq_m512i(r, _mm512_setr4_epi32(1, 2, 3, 4));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr4_ps() {
+    const fn test_mm512_setr4_ps() {
         let r = _mm512_set_ps(
             4., 3., 2., 1., 4., 3., 2., 1., 4., 3., 2., 1., 4., 3., 2., 1.,
         );
@@ -52804,12 +52804,12 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setzero_ps() {
+    const fn test_mm512_setzero_ps() {
         assert_eq_m512(_mm512_setzero_ps(), _mm512_set1_ps(0.));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setzero() {
+    const fn test_mm512_setzero() {
         assert_eq_m512(_mm512_setzero(), _mm512_set1_ps(0.));
     }
 
@@ -53899,19 +53899,19 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr_pd() {
+    const fn test_mm512_setr_pd() {
         let r = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         assert_eq_m512d(r, _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set_pd() {
+    const fn test_mm512_set_pd() {
         let r = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         assert_eq_m512d(r, _mm512_set_pd(7., 6., 5., 4., 3., 2., 1., 0.));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_rol_epi32() {
+    const fn test_mm512_rol_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm512_rol_epi32::<1>(a);
         let e = _mm512_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
@@ -53919,7 +53919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_rol_epi32() {
+    const fn test_mm512_mask_rol_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm512_mask_rol_epi32::<1>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -53929,7 +53929,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_rol_epi32() {
+    const fn test_mm512_maskz_rol_epi32() {
         let a = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 << 31);
         let r = _mm512_maskz_rol_epi32::<1>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -53939,7 +53939,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_rol_epi32() {
+    const fn test_mm256_rol_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm256_rol_epi32::<1>(a);
         let e = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
@@ -53947,7 +53947,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_rol_epi32() {
+    const fn test_mm256_mask_rol_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm256_mask_rol_epi32::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -53957,7 +53957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_rol_epi32() {
+    const fn test_mm256_maskz_rol_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm256_maskz_rol_epi32::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -53967,7 +53967,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_rol_epi32() {
+    const fn test_mm_rol_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let r = _mm_rol_epi32::<1>(a);
         let e = _mm_set_epi32(1 << 0, 2, 2, 2);
@@ -53975,7 +53975,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_rol_epi32() {
+    const fn test_mm_mask_rol_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let r = _mm_mask_rol_epi32::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -53985,7 +53985,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_rol_epi32() {
+    const fn test_mm_maskz_rol_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let r = _mm_maskz_rol_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -53995,7 +53995,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_ror_epi32() {
+    const fn test_mm512_ror_epi32() {
         let a = _mm512_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm512_ror_epi32::<1>(a);
         let e = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
@@ -54003,7 +54003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_ror_epi32() {
+    const fn test_mm512_mask_ror_epi32() {
         let a = _mm512_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm512_mask_ror_epi32::<1>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -54013,7 +54013,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_ror_epi32() {
+    const fn test_mm512_maskz_ror_epi32() {
         let a = _mm512_set_epi32(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1 << 0);
         let r = _mm512_maskz_ror_epi32::<1>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -54023,7 +54023,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_ror_epi32() {
+    const fn test_mm256_ror_epi32() {
         let a = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm256_ror_epi32::<1>(a);
         let e = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
@@ -54031,7 +54031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_ror_epi32() {
+    const fn test_mm256_mask_ror_epi32() {
         let a = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm256_mask_ror_epi32::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -54041,7 +54041,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_ror_epi32() {
+    const fn test_mm256_maskz_ror_epi32() {
         let a = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm256_maskz_ror_epi32::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -54051,7 +54051,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_ror_epi32() {
+    const fn test_mm_ror_epi32() {
         let a = _mm_set_epi32(1 << 0, 2, 2, 2);
         let r = _mm_ror_epi32::<1>(a);
         let e = _mm_set_epi32(1 << 31, 1, 1, 1);
@@ -54059,7 +54059,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_ror_epi32() {
+    const fn test_mm_mask_ror_epi32() {
         let a = _mm_set_epi32(1 << 0, 2, 2, 2);
         let r = _mm_mask_ror_epi32::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -54069,7 +54069,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_ror_epi32() {
+    const fn test_mm_maskz_ror_epi32() {
         let a = _mm_set_epi32(1 << 0, 2, 2, 2);
         let r = _mm_maskz_ror_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -54079,7 +54079,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_slli_epi32() {
+    const fn test_mm512_slli_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm512_slli_epi32::<1>(a);
         let e = _mm512_set_epi32(0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
@@ -54087,7 +54087,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_slli_epi32() {
+    const fn test_mm512_mask_slli_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm512_mask_slli_epi32::<1>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -54097,7 +54097,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_slli_epi32() {
+    const fn test_mm512_maskz_slli_epi32() {
         let a = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 << 31);
         let r = _mm512_maskz_slli_epi32::<1>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -54107,7 +54107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_slli_epi32() {
+    const fn test_mm256_mask_slli_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm256_mask_slli_epi32::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -54117,7 +54117,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_slli_epi32() {
+    const fn test_mm256_maskz_slli_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm256_maskz_slli_epi32::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -54127,7 +54127,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_slli_epi32() {
+    const fn test_mm_mask_slli_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let r = _mm_mask_slli_epi32::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -54137,7 +54137,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_slli_epi32() {
+    const fn test_mm_maskz_slli_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let r = _mm_maskz_slli_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -54147,7 +54147,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srli_epi32() {
+    const fn test_mm512_srli_epi32() {
         let a = _mm512_set_epi32(0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm512_srli_epi32::<1>(a);
         let e = _mm512_set_epi32(0 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
@@ -54155,7 +54155,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srli_epi32() {
+    const fn test_mm512_mask_srli_epi32() {
         let a = _mm512_set_epi32(0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let r = _mm512_mask_srli_epi32::<1>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -54165,7 +54165,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srli_epi32() {
+    const fn test_mm512_maskz_srli_epi32() {
         let a = _mm512_set_epi32(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0);
         let r = _mm512_maskz_srli_epi32::<1>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -54175,7 +54175,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srli_epi32() {
+    const fn test_mm256_mask_srli_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm256_mask_srli_epi32::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -54185,7 +54185,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srli_epi32() {
+    const fn test_mm256_maskz_srli_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm256_maskz_srli_epi32::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -54195,7 +54195,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srli_epi32() {
+    const fn test_mm_mask_srli_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let r = _mm_mask_srli_epi32::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -54205,7 +54205,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srli_epi32() {
+    const fn test_mm_maskz_srli_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let r = _mm_maskz_srli_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -54215,7 +54215,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_rolv_epi32() {
+    const fn test_mm512_rolv_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_rolv_epi32(a, b);
@@ -54224,7 +54224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_rolv_epi32() {
+    const fn test_mm512_mask_rolv_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_mask_rolv_epi32(a, 0, a, b);
@@ -54235,7 +54235,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_rolv_epi32() {
+    const fn test_mm512_maskz_rolv_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 << 31);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_maskz_rolv_epi32(0, a, b);
@@ -54246,7 +54246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_rolv_epi32() {
+    const fn test_mm256_rolv_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_rolv_epi32(a, b);
@@ -54255,7 +54255,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_rolv_epi32() {
+    const fn test_mm256_mask_rolv_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_mask_rolv_epi32(a, 0, a, b);
@@ -54266,7 +54266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_rolv_epi32() {
+    const fn test_mm256_maskz_rolv_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_maskz_rolv_epi32(0, a, b);
@@ -54277,7 +54277,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_rolv_epi32() {
+    const fn test_mm_rolv_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let b = _mm_set1_epi32(1);
         let r = _mm_rolv_epi32(a, b);
@@ -54286,7 +54286,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_rolv_epi32() {
+    const fn test_mm_mask_rolv_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let b = _mm_set1_epi32(1);
         let r = _mm_mask_rolv_epi32(a, 0, a, b);
@@ -54297,7 +54297,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_rolv_epi32() {
+    const fn test_mm_maskz_rolv_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let b = _mm_set1_epi32(1);
         let r = _mm_maskz_rolv_epi32(0, a, b);
@@ -54308,7 +54308,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_rorv_epi32() {
+    const fn test_mm512_rorv_epi32() {
         let a = _mm512_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_rorv_epi32(a, b);
@@ -54317,7 +54317,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_rorv_epi32() {
+    const fn test_mm512_mask_rorv_epi32() {
         let a = _mm512_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_mask_rorv_epi32(a, 0, a, b);
@@ -54328,7 +54328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_rorv_epi32() {
+    const fn test_mm512_maskz_rorv_epi32() {
         let a = _mm512_set_epi32(3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1 << 0);
         let b = _mm512_set1_epi32(1);
         let r = _mm512_maskz_rorv_epi32(0, a, b);
@@ -54339,7 +54339,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_rorv_epi32() {
+    const fn test_mm256_rorv_epi32() {
         let a = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_rorv_epi32(a, b);
@@ -54348,7 +54348,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_rorv_epi32() {
+    const fn test_mm256_mask_rorv_epi32() {
         let a = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_mask_rorv_epi32(a, 0, a, b);
@@ -54359,7 +54359,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_rorv_epi32() {
+    const fn test_mm256_maskz_rorv_epi32() {
         let a = _mm256_set_epi32(1 << 0, 2, 2, 2, 2, 2, 2, 2);
         let b = _mm256_set1_epi32(1);
         let r = _mm256_maskz_rorv_epi32(0, a, b);
@@ -54370,7 +54370,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_rorv_epi32() {
+    const fn test_mm_rorv_epi32() {
         let a = _mm_set_epi32(1 << 0, 2, 2, 2);
         let b = _mm_set1_epi32(1);
         let r = _mm_rorv_epi32(a, b);
@@ -54379,7 +54379,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_rorv_epi32() {
+    const fn test_mm_mask_rorv_epi32() {
         let a = _mm_set_epi32(1 << 0, 2, 2, 2);
         let b = _mm_set1_epi32(1);
         let r = _mm_mask_rorv_epi32(a, 0, a, b);
@@ -54390,7 +54390,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_rorv_epi32() {
+    const fn test_mm_maskz_rorv_epi32() {
         let a = _mm_set_epi32(1 << 0, 2, 2, 2);
         let b = _mm_set1_epi32(1);
         let r = _mm_maskz_rorv_epi32(0, a, b);
@@ -54401,7 +54401,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_sllv_epi32() {
+    const fn test_mm512_sllv_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let count = _mm512_set1_epi32(1);
         let r = _mm512_sllv_epi32(a, count);
@@ -54410,7 +54410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_sllv_epi32() {
+    const fn test_mm512_mask_sllv_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let count = _mm512_set1_epi32(1);
         let r = _mm512_mask_sllv_epi32(a, 0, a, count);
@@ -54421,7 +54421,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_sllv_epi32() {
+    const fn test_mm512_maskz_sllv_epi32() {
         let a = _mm512_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 << 31);
         let count = _mm512_set_epi32(0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm512_maskz_sllv_epi32(0, a, count);
@@ -54432,7 +54432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_sllv_epi32() {
+    const fn test_mm256_mask_sllv_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_mask_sllv_epi32(a, 0, a, count);
@@ -54443,7 +54443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_sllv_epi32() {
+    const fn test_mm256_maskz_sllv_epi32() {
         let a = _mm256_set_epi32(1 << 31, 1, 1, 1, 1, 1, 1, 1);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_maskz_sllv_epi32(0, a, count);
@@ -54454,7 +54454,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_sllv_epi32() {
+    const fn test_mm_mask_sllv_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let count = _mm_set1_epi32(1);
         let r = _mm_mask_sllv_epi32(a, 0, a, count);
@@ -54465,7 +54465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_sllv_epi32() {
+    const fn test_mm_maskz_sllv_epi32() {
         let a = _mm_set_epi32(1 << 31, 1, 1, 1);
         let count = _mm_set1_epi32(1);
         let r = _mm_maskz_sllv_epi32(0, a, count);
@@ -54476,7 +54476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srlv_epi32() {
+    const fn test_mm512_srlv_epi32() {
         let a = _mm512_set_epi32(0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let count = _mm512_set1_epi32(1);
         let r = _mm512_srlv_epi32(a, count);
@@ -54485,7 +54485,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srlv_epi32() {
+    const fn test_mm512_mask_srlv_epi32() {
         let a = _mm512_set_epi32(0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
         let count = _mm512_set1_epi32(1);
         let r = _mm512_mask_srlv_epi32(a, 0, a, count);
@@ -54496,7 +54496,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srlv_epi32() {
+    const fn test_mm512_maskz_srlv_epi32() {
         let a = _mm512_set_epi32(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0);
         let count = _mm512_set_epi32(0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         let r = _mm512_maskz_srlv_epi32(0, a, count);
@@ -54507,7 +54507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srlv_epi32() {
+    const fn test_mm256_mask_srlv_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_mask_srlv_epi32(a, 0, a, count);
@@ -54518,7 +54518,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srlv_epi32() {
+    const fn test_mm256_maskz_srlv_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_maskz_srlv_epi32(0, a, count);
@@ -54529,7 +54529,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srlv_epi32() {
+    const fn test_mm_mask_srlv_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set1_epi32(1);
         let r = _mm_mask_srlv_epi32(a, 0, a, count);
@@ -54540,7 +54540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srlv_epi32() {
+    const fn test_mm_maskz_srlv_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set1_epi32(1);
         let r = _mm_maskz_srlv_epi32(0, a, count);
@@ -54551,7 +54551,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sll_epi32() {
+    fn test_mm512_sll_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 31, 1 << 0, 1 << 1, 1 << 2,
@@ -54572,7 +54572,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sll_epi32() {
+    fn test_mm512_mask_sll_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 31, 1 << 0, 1 << 1, 1 << 2,
@@ -54595,7 +54595,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sll_epi32() {
+    fn test_mm512_maskz_sll_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 31, 1 << 0, 1 << 1, 1 << 2,
@@ -54612,7 +54612,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_sll_epi32() {
+    fn test_mm256_mask_sll_epi32() {
         let a = _mm256_set_epi32(1 << 13, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm256_mask_sll_epi32(a, 0, a, count);
@@ -54623,7 +54623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_sll_epi32() {
+    fn test_mm256_maskz_sll_epi32() {
         let a = _mm256_set_epi32(1 << 13, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm256_maskz_sll_epi32(0, a, count);
@@ -54634,7 +54634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_sll_epi32() {
+    fn test_mm_mask_sll_epi32() {
         let a = _mm_set_epi32(1 << 13, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm_mask_sll_epi32(a, 0, a, count);
@@ -54645,7 +54645,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_sll_epi32() {
+    fn test_mm_maskz_sll_epi32() {
         let a = _mm_set_epi32(1 << 13, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm_maskz_sll_epi32(0, a, count);
@@ -54656,7 +54656,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_srl_epi32() {
+    fn test_mm512_srl_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 31, 1 << 0, 1 << 1, 1 << 2,
@@ -54671,7 +54671,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_srl_epi32() {
+    fn test_mm512_mask_srl_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 31, 1 << 0, 1 << 1, 1 << 2,
@@ -54688,7 +54688,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_srl_epi32() {
+    fn test_mm512_maskz_srl_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 31, 1 << 0, 1 << 1, 1 << 2,
@@ -54705,7 +54705,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_srl_epi32() {
+    fn test_mm256_mask_srl_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm256_mask_srl_epi32(a, 0, a, count);
@@ -54716,7 +54716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_srl_epi32() {
+    fn test_mm256_maskz_srl_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm256_maskz_srl_epi32(0, a, count);
@@ -54727,7 +54727,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_srl_epi32() {
+    fn test_mm_mask_srl_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm_mask_srl_epi32(a, 0, a, count);
@@ -54738,7 +54738,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_srl_epi32() {
+    fn test_mm_maskz_srl_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm_maskz_srl_epi32(0, a, count);
@@ -54749,7 +54749,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sra_epi32() {
+    fn test_mm512_sra_epi32() {
         let a = _mm512_set_epi32(8, -8, 16, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
         let count = _mm_set_epi32(1, 0, 0, 2);
         let r = _mm512_sra_epi32(a, count);
@@ -54758,7 +54758,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sra_epi32() {
+    fn test_mm512_mask_sra_epi32() {
         let a = _mm512_set_epi32(8, -8, 16, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16);
         let count = _mm_set_epi32(0, 0, 0, 2);
         let r = _mm512_mask_sra_epi32(a, 0, a, count);
@@ -54769,7 +54769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sra_epi32() {
+    fn test_mm512_maskz_sra_epi32() {
         let a = _mm512_set_epi32(8, -8, 16, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -15, -14);
         let count = _mm_set_epi32(2, 0, 0, 2);
         let r = _mm512_maskz_sra_epi32(0, a, count);
@@ -54780,7 +54780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_sra_epi32() {
+    fn test_mm256_mask_sra_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm256_mask_sra_epi32(a, 0, a, count);
@@ -54791,7 +54791,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_sra_epi32() {
+    fn test_mm256_maskz_sra_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm256_maskz_sra_epi32(0, a, count);
@@ -54802,7 +54802,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_sra_epi32() {
+    fn test_mm_mask_sra_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm_mask_sra_epi32(a, 0, a, count);
@@ -54813,7 +54813,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_sra_epi32() {
+    fn test_mm_maskz_sra_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set_epi32(0, 0, 0, 1);
         let r = _mm_maskz_sra_epi32(0, a, count);
@@ -54824,7 +54824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srav_epi32() {
+    const fn test_mm512_srav_epi32() {
         let a = _mm512_set_epi32(8, -8, 16, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
         let count = _mm512_set_epi32(2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm512_srav_epi32(a, count);
@@ -54833,7 +54833,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srav_epi32() {
+    const fn test_mm512_mask_srav_epi32() {
         let a = _mm512_set_epi32(8, -8, 16, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16);
         let count = _mm512_set_epi32(2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
         let r = _mm512_mask_srav_epi32(a, 0, a, count);
@@ -54844,7 +54844,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srav_epi32() {
+    const fn test_mm512_maskz_srav_epi32() {
         let a = _mm512_set_epi32(8, -8, 16, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -15, -14);
         let count = _mm512_set_epi32(2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2);
         let r = _mm512_maskz_srav_epi32(0, a, count);
@@ -54855,7 +54855,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srav_epi32() {
+    const fn test_mm256_mask_srav_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_mask_srav_epi32(a, 0, a, count);
@@ -54866,7 +54866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srav_epi32() {
+    const fn test_mm256_maskz_srav_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let count = _mm256_set1_epi32(1);
         let r = _mm256_maskz_srav_epi32(0, a, count);
@@ -54877,7 +54877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srav_epi32() {
+    const fn test_mm_mask_srav_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set1_epi32(1);
         let r = _mm_mask_srav_epi32(a, 0, a, count);
@@ -54888,7 +54888,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srav_epi32() {
+    const fn test_mm_maskz_srav_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let count = _mm_set1_epi32(1);
         let r = _mm_maskz_srav_epi32(0, a, count);
@@ -54899,7 +54899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srai_epi32() {
+    const fn test_mm512_srai_epi32() {
         let a = _mm512_set_epi32(8, -8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, -15);
         let r = _mm512_srai_epi32::<2>(a);
         let e = _mm512_set_epi32(2, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, -4);
@@ -54907,7 +54907,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srai_epi32() {
+    const fn test_mm512_mask_srai_epi32() {
         let a = _mm512_set_epi32(8, -8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, -15);
         let r = _mm512_mask_srai_epi32::<2>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -54917,7 +54917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srai_epi32() {
+    const fn test_mm512_maskz_srai_epi32() {
         let a = _mm512_set_epi32(8, -8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, -15);
         let r = _mm512_maskz_srai_epi32::<2>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -54927,7 +54927,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srai_epi32() {
+    const fn test_mm256_mask_srai_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm256_mask_srai_epi32::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -54937,7 +54937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srai_epi32() {
+    const fn test_mm256_maskz_srai_epi32() {
         let a = _mm256_set_epi32(1 << 5, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm256_maskz_srai_epi32::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -54947,7 +54947,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srai_epi32() {
+    const fn test_mm_mask_srai_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let r = _mm_mask_srai_epi32::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -54957,7 +54957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srai_epi32() {
+    const fn test_mm_maskz_srai_epi32() {
         let a = _mm_set_epi32(1 << 5, 0, 0, 0);
         let r = _mm_maskz_srai_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -54967,7 +54967,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_permute_ps() {
+    const fn test_mm512_permute_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -54979,7 +54979,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_permute_ps() {
+    const fn test_mm512_mask_permute_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -54993,7 +54993,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_permute_ps() {
+    const fn test_mm512_maskz_permute_ps() {
         let a = _mm512_setr_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55007,7 +55007,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_permute_ps() {
+    const fn test_mm256_mask_permute_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_mask_permute_ps::<0b11_11_11_11>(a, 0, a);
         assert_eq_m256(r, a);
@@ -55017,7 +55017,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_permute_ps() {
+    const fn test_mm256_maskz_permute_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_maskz_permute_ps::<0b11_11_11_11>(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -55027,7 +55027,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_permute_ps() {
+    const fn test_mm_mask_permute_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let r = _mm_mask_permute_ps::<0b11_11_11_11>(a, 0, a);
         assert_eq_m128(r, a);
@@ -55037,7 +55037,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_permute_ps() {
+    const fn test_mm_maskz_permute_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let r = _mm_maskz_permute_ps::<0b11_11_11_11>(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -55047,7 +55047,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutevar_epi32() {
+    fn test_mm512_permutevar_epi32() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_permutevar_epi32(idx, a);
@@ -55056,7 +55056,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutevar_epi32() {
+    fn test_mm512_mask_permutevar_epi32() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_mask_permutevar_epi32(a, 0, idx, a);
@@ -55067,7 +55067,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutevar_ps() {
+    fn test_mm512_permutevar_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55080,7 +55080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutevar_ps() {
+    fn test_mm512_mask_permutevar_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55095,7 +55095,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutevar_ps() {
+    fn test_mm512_maskz_permutevar_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55110,7 +55110,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutevar_ps() {
+    fn test_mm256_mask_permutevar_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm256_set1_epi32(0b01);
         let r = _mm256_mask_permutevar_ps(a, 0, a, b);
@@ -55121,7 +55121,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutevar_ps() {
+    fn test_mm256_maskz_permutevar_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm256_set1_epi32(0b01);
         let r = _mm256_maskz_permutevar_ps(0, a, b);
@@ -55132,7 +55132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_permutevar_ps() {
+    fn test_mm_mask_permutevar_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set1_epi32(0b01);
         let r = _mm_mask_permutevar_ps(a, 0, a, b);
@@ -55143,7 +55143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_permutevar_ps() {
+    fn test_mm_maskz_permutevar_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set1_epi32(0b01);
         let r = _mm_maskz_permutevar_ps(0, a, b);
@@ -55154,7 +55154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutexvar_epi32() {
+    fn test_mm512_permutexvar_epi32() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_permutexvar_epi32(idx, a);
@@ -55163,7 +55163,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutexvar_epi32() {
+    fn test_mm512_mask_permutexvar_epi32() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_mask_permutexvar_epi32(a, 0, idx, a);
@@ -55174,7 +55174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutexvar_epi32() {
+    fn test_mm512_maskz_permutexvar_epi32() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_permutexvar_epi32(0, idx, a);
@@ -55185,7 +55185,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutexvar_epi32() {
+    fn test_mm256_permutexvar_epi32() {
         let idx = _mm256_set1_epi32(1);
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_permutexvar_epi32(idx, a);
@@ -55194,7 +55194,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutexvar_epi32() {
+    fn test_mm256_mask_permutexvar_epi32() {
         let idx = _mm256_set1_epi32(1);
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_mask_permutexvar_epi32(a, 0, idx, a);
@@ -55205,7 +55205,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutexvar_epi32() {
+    fn test_mm256_maskz_permutexvar_epi32() {
         let idx = _mm256_set1_epi32(1);
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_permutexvar_epi32(0, idx, a);
@@ -55216,7 +55216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutexvar_ps() {
+    fn test_mm512_permutexvar_ps() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -55227,7 +55227,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutexvar_ps() {
+    fn test_mm512_mask_permutexvar_ps() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -55240,7 +55240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutexvar_ps() {
+    fn test_mm512_maskz_permutexvar_ps() {
         let idx = _mm512_set1_epi32(1);
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -55255,7 +55255,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutexvar_ps() {
+    fn test_mm256_permutexvar_ps() {
         let idx = _mm256_set1_epi32(1);
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_permutexvar_ps(idx, a);
@@ -55264,7 +55264,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutexvar_ps() {
+    fn test_mm256_mask_permutexvar_ps() {
         let idx = _mm256_set1_epi32(1);
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_mask_permutexvar_ps(a, 0, idx, a);
@@ -55275,7 +55275,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutexvar_ps() {
+    fn test_mm256_maskz_permutexvar_ps() {
         let idx = _mm256_set1_epi32(1);
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_maskz_permutexvar_ps(0, idx, a);
@@ -55286,7 +55286,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutex2var_epi32() {
+    fn test_mm512_permutex2var_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm512_set_epi32(
@@ -55304,7 +55304,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutex2var_epi32() {
+    fn test_mm512_mask_permutex2var_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm512_set_epi32(
@@ -55324,7 +55324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutex2var_epi32() {
+    fn test_mm512_maskz_permutex2var_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm512_set_epi32(
@@ -55342,7 +55342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask2_permutex2var_epi32() {
+    fn test_mm512_mask2_permutex2var_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm512_set_epi32(
@@ -55366,7 +55366,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutex2var_epi32() {
+    fn test_mm256_permutex2var_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_epi32(100);
@@ -55376,7 +55376,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutex2var_epi32() {
+    fn test_mm256_mask_permutex2var_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_epi32(100);
@@ -55388,7 +55388,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutex2var_epi32() {
+    fn test_mm256_maskz_permutex2var_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_epi32(100);
@@ -55400,7 +55400,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask2_permutex2var_epi32() {
+    fn test_mm256_mask2_permutex2var_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_epi32(100);
@@ -55412,7 +55412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_permutex2var_epi32() {
+    fn test_mm_permutex2var_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_epi32(100);
@@ -55422,7 +55422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_permutex2var_epi32() {
+    fn test_mm_mask_permutex2var_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_epi32(100);
@@ -55434,7 +55434,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_permutex2var_epi32() {
+    fn test_mm_maskz_permutex2var_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_epi32(100);
@@ -55446,7 +55446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask2_permutex2var_epi32() {
+    fn test_mm_mask2_permutex2var_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_epi32(100);
@@ -55458,7 +55458,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutex2var_ps() {
+    fn test_mm512_permutex2var_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55478,7 +55478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutex2var_ps() {
+    fn test_mm512_mask_permutex2var_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55500,7 +55500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutex2var_ps() {
+    fn test_mm512_maskz_permutex2var_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55522,7 +55522,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask2_permutex2var_ps() {
+    fn test_mm512_mask2_permutex2var_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -55544,7 +55544,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutex2var_ps() {
+    fn test_mm256_permutex2var_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_ps(100.);
@@ -55554,7 +55554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutex2var_ps() {
+    fn test_mm256_mask_permutex2var_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_ps(100.);
@@ -55566,7 +55566,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutex2var_ps() {
+    fn test_mm256_maskz_permutex2var_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_ps(100.);
@@ -55578,7 +55578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask2_permutex2var_ps() {
+    fn test_mm256_mask2_permutex2var_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm256_set_epi32(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm256_set1_ps(100.);
@@ -55590,7 +55590,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_permutex2var_ps() {
+    fn test_mm_permutex2var_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_ps(100.);
@@ -55600,7 +55600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_permutex2var_ps() {
+    fn test_mm_mask_permutex2var_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_ps(100.);
@@ -55612,7 +55612,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_permutex2var_ps() {
+    fn test_mm_maskz_permutex2var_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_ps(100.);
@@ -55624,7 +55624,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask2_permutex2var_ps() {
+    fn test_mm_mask2_permutex2var_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let idx = _mm_set_epi32(1, 1 << 2, 2, 1 << 2);
         let b = _mm_set1_ps(100.);
@@ -55636,7 +55636,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_epi32() {
+    const fn test_mm512_shuffle_epi32() {
         let a = _mm512_setr_epi32(1, 4, 5, 8, 9, 12, 13, 16, 1, 4, 5, 8, 9, 12, 13, 16);
         let r = _mm512_shuffle_epi32::<_MM_PERM_AADD>(a);
         let e = _mm512_setr_epi32(8, 8, 1, 1, 16, 16, 9, 9, 8, 8, 1, 1, 16, 16, 9, 9);
@@ -55644,7 +55644,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_epi32() {
+    const fn test_mm512_mask_shuffle_epi32() {
         let a = _mm512_setr_epi32(1, 4, 5, 8, 9, 12, 13, 16, 1, 4, 5, 8, 9, 12, 13, 16);
         let r = _mm512_mask_shuffle_epi32::<_MM_PERM_AADD>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -55654,7 +55654,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_epi32() {
+    const fn test_mm512_maskz_shuffle_epi32() {
         let a = _mm512_setr_epi32(1, 4, 5, 8, 9, 12, 13, 16, 1, 4, 5, 8, 9, 12, 13, 16);
         let r = _mm512_maskz_shuffle_epi32::<_MM_PERM_AADD>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -55664,7 +55664,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_epi32() {
+    const fn test_mm256_mask_shuffle_epi32() {
         let a = _mm256_set_epi32(1, 4, 5, 8, 9, 12, 13, 16);
         let r = _mm256_mask_shuffle_epi32::<_MM_PERM_AADD>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -55674,7 +55674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_epi32() {
+    const fn test_mm256_maskz_shuffle_epi32() {
         let a = _mm256_set_epi32(1, 4, 5, 8, 9, 12, 13, 16);
         let r = _mm256_maskz_shuffle_epi32::<_MM_PERM_AADD>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -55684,7 +55684,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_shuffle_epi32() {
+    const fn test_mm_mask_shuffle_epi32() {
         let a = _mm_set_epi32(1, 4, 5, 8);
         let r = _mm_mask_shuffle_epi32::<_MM_PERM_AADD>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -55694,7 +55694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_shuffle_epi32() {
+    const fn test_mm_maskz_shuffle_epi32() {
         let a = _mm_set_epi32(1, 4, 5, 8);
         let r = _mm_maskz_shuffle_epi32::<_MM_PERM_AADD>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -55704,7 +55704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_ps() {
+    const fn test_mm512_shuffle_ps() {
         let a = _mm512_setr_ps(
             1., 4., 5., 8., 9., 12., 13., 16., 1., 4., 5., 8., 9., 12., 13., 16.,
         );
@@ -55719,7 +55719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_ps() {
+    const fn test_mm512_mask_shuffle_ps() {
         let a = _mm512_setr_ps(
             1., 4., 5., 8., 9., 12., 13., 16., 1., 4., 5., 8., 9., 12., 13., 16.,
         );
@@ -55736,7 +55736,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_ps() {
+    const fn test_mm512_maskz_shuffle_ps() {
         let a = _mm512_setr_ps(
             1., 4., 5., 8., 9., 12., 13., 16., 1., 4., 5., 8., 9., 12., 13., 16.,
         );
@@ -55753,7 +55753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_ps() {
+    const fn test_mm256_mask_shuffle_ps() {
         let a = _mm256_set_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_set_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_mask_shuffle_ps::<0b11_11_11_11>(a, 0, a, b);
@@ -55764,7 +55764,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_ps() {
+    const fn test_mm256_maskz_shuffle_ps() {
         let a = _mm256_set_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_set_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_maskz_shuffle_ps::<0b11_11_11_11>(0, a, b);
@@ -55775,7 +55775,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_shuffle_ps() {
+    const fn test_mm_mask_shuffle_ps() {
         let a = _mm_set_ps(1., 4., 5., 8.);
         let b = _mm_set_ps(2., 3., 6., 7.);
         let r = _mm_mask_shuffle_ps::<0b11_11_11_11>(a, 0, a, b);
@@ -55786,7 +55786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_shuffle_ps() {
+    const fn test_mm_maskz_shuffle_ps() {
         let a = _mm_set_ps(1., 4., 5., 8.);
         let b = _mm_set_ps(2., 3., 6., 7.);
         let r = _mm_maskz_shuffle_ps::<0b11_11_11_11>(0, a, b);
@@ -55797,7 +55797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_i32x4() {
+    const fn test_mm512_shuffle_i32x4() {
         let a = _mm512_setr_epi32(1, 4, 5, 8, 9, 12, 13, 16, 1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm512_setr_epi32(2, 3, 6, 7, 10, 11, 14, 15, 2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm512_shuffle_i32x4::<0b00_00_00_00>(a, b);
@@ -55806,7 +55806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_i32x4() {
+    const fn test_mm512_mask_shuffle_i32x4() {
         let a = _mm512_setr_epi32(1, 4, 5, 8, 9, 12, 13, 16, 1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm512_setr_epi32(2, 3, 6, 7, 10, 11, 14, 15, 2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm512_mask_shuffle_i32x4::<0b00_00_00_00>(a, 0, a, b);
@@ -55817,7 +55817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_i32x4() {
+    const fn test_mm512_maskz_shuffle_i32x4() {
         let a = _mm512_setr_epi32(1, 4, 5, 8, 9, 12, 13, 16, 1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm512_setr_epi32(2, 3, 6, 7, 10, 11, 14, 15, 2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm512_maskz_shuffle_i32x4::<0b00_00_00_00>(0, a, b);
@@ -55828,7 +55828,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_shuffle_i32x4() {
+    const fn test_mm256_shuffle_i32x4() {
         let a = _mm256_set_epi32(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm256_set_epi32(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm256_shuffle_i32x4::<0b00>(a, b);
@@ -55837,7 +55837,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_i32x4() {
+    const fn test_mm256_mask_shuffle_i32x4() {
         let a = _mm256_set_epi32(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm256_set_epi32(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm256_mask_shuffle_i32x4::<0b00>(a, 0, a, b);
@@ -55848,7 +55848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_i32x4() {
+    const fn test_mm256_maskz_shuffle_i32x4() {
         let a = _mm256_set_epi32(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm256_set_epi32(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm256_maskz_shuffle_i32x4::<0b00>(0, a, b);
@@ -55859,7 +55859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_f32x4() {
+    const fn test_mm512_shuffle_f32x4() {
         let a = _mm512_setr_ps(
             1., 4., 5., 8., 9., 12., 13., 16., 1., 4., 5., 8., 9., 12., 13., 16.,
         );
@@ -55874,7 +55874,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_f32x4() {
+    const fn test_mm512_mask_shuffle_f32x4() {
         let a = _mm512_setr_ps(
             1., 4., 5., 8., 9., 12., 13., 16., 1., 4., 5., 8., 9., 12., 13., 16.,
         );
@@ -55891,7 +55891,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_f32x4() {
+    const fn test_mm512_maskz_shuffle_f32x4() {
         let a = _mm512_setr_ps(
             1., 4., 5., 8., 9., 12., 13., 16., 1., 4., 5., 8., 9., 12., 13., 16.,
         );
@@ -55908,7 +55908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_shuffle_f32x4() {
+    const fn test_mm256_shuffle_f32x4() {
         let a = _mm256_set_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_set_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_shuffle_f32x4::<0b00>(a, b);
@@ -55917,7 +55917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_f32x4() {
+    const fn test_mm256_mask_shuffle_f32x4() {
         let a = _mm256_set_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_set_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_mask_shuffle_f32x4::<0b00>(a, 0, a, b);
@@ -55928,7 +55928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_f32x4() {
+    const fn test_mm256_maskz_shuffle_f32x4() {
         let a = _mm256_set_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_set_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_maskz_shuffle_f32x4::<0b00>(0, a, b);
@@ -55939,7 +55939,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_extractf32x4_ps() {
+    const fn test_mm512_extractf32x4_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -55949,7 +55949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_extractf32x4_ps() {
+    const fn test_mm512_mask_extractf32x4_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -55962,7 +55962,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_extractf32x4_ps() {
+    const fn test_mm512_maskz_extractf32x4_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -55974,7 +55974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_extractf32x4_ps() {
+    const fn test_mm256_extractf32x4_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_extractf32x4_ps::<1>(a);
         let e = _mm_set_ps(1., 2., 3., 4.);
@@ -55982,7 +55982,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_extractf32x4_ps() {
+    const fn test_mm256_mask_extractf32x4_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let src = _mm_set1_ps(100.);
         let r = _mm256_mask_extractf32x4_ps::<1>(src, 0, a);
@@ -55993,7 +55993,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_extractf32x4_ps() {
+    const fn test_mm256_maskz_extractf32x4_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_maskz_extractf32x4_ps::<1>(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -56003,7 +56003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_extracti32x4_epi32() {
+    const fn test_mm512_extracti32x4_epi32() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_extracti32x4_epi32::<1>(a);
         let e = _mm_setr_epi32(5, 6, 7, 8);
@@ -56011,7 +56011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_extracti32x4_epi32() {
+    const fn test_mm512_mask_extracti32x4_epi32() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm_set1_epi32(100);
         let r = _mm512_mask_extracti32x4_epi32::<1>(src, 0, a);
@@ -56022,7 +56022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm512_maskz_extracti32x4_epi32() {
+    const fn test_mm512_maskz_extracti32x4_epi32() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_extracti32x4_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -56032,7 +56032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_extracti32x4_epi32() {
+    const fn test_mm256_extracti32x4_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_extracti32x4_epi32::<1>(a);
         let e = _mm_set_epi32(1, 2, 3, 4);
@@ -56040,7 +56040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_extracti32x4_epi32() {
+    const fn test_mm256_mask_extracti32x4_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set1_epi32(100);
         let r = _mm256_mask_extracti32x4_epi32::<1>(src, 0, a);
@@ -56051,7 +56051,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_extracti32x4_epi32() {
+    const fn test_mm256_maskz_extracti32x4_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_extracti32x4_epi32::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -56061,7 +56061,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_moveldup_ps() {
+    const fn test_mm512_moveldup_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56073,7 +56073,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_moveldup_ps() {
+    const fn test_mm512_mask_moveldup_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56087,7 +56087,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_moveldup_ps() {
+    const fn test_mm512_maskz_moveldup_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56101,7 +56101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_moveldup_ps() {
+    const fn test_mm256_mask_moveldup_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_mask_moveldup_ps(a, 0, a);
         assert_eq_m256(r, a);
@@ -56111,7 +56111,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_moveldup_ps() {
+    const fn test_mm256_maskz_moveldup_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_maskz_moveldup_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -56121,7 +56121,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_moveldup_ps() {
+    const fn test_mm_mask_moveldup_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_mask_moveldup_ps(a, 0, a);
         assert_eq_m128(r, a);
@@ -56131,7 +56131,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_moveldup_ps() {
+    const fn test_mm_maskz_moveldup_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_maskz_moveldup_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -56141,7 +56141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_movehdup_ps() {
+    const fn test_mm512_movehdup_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56153,7 +56153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_movehdup_ps() {
+    const fn test_mm512_mask_movehdup_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56167,7 +56167,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_movehdup_ps() {
+    const fn test_mm512_maskz_movehdup_ps() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56181,7 +56181,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_movehdup_ps() {
+    const fn test_mm256_mask_movehdup_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_mask_movehdup_ps(a, 0, a);
         assert_eq_m256(r, a);
@@ -56191,7 +56191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_movehdup_ps() {
+    const fn test_mm256_maskz_movehdup_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_maskz_movehdup_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -56201,7 +56201,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_movehdup_ps() {
+    const fn test_mm_mask_movehdup_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_mask_movehdup_ps(a, 0, a);
         assert_eq_m128(r, a);
@@ -56211,7 +56211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_movehdup_ps() {
+    const fn test_mm_maskz_movehdup_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let r = _mm_maskz_movehdup_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -56221,7 +56221,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_inserti32x4() {
+    const fn test_mm512_inserti32x4() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_setr_epi32(17, 18, 19, 20);
         let r = _mm512_inserti32x4::<0>(a, b);
@@ -56230,7 +56230,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_inserti32x4() {
+    const fn test_mm512_mask_inserti32x4() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_setr_epi32(17, 18, 19, 20);
         let r = _mm512_mask_inserti32x4::<0>(a, 0, a, b);
@@ -56241,7 +56241,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_inserti32x4() {
+    const fn test_mm512_maskz_inserti32x4() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm_setr_epi32(17, 18, 19, 20);
         let r = _mm512_maskz_inserti32x4::<0>(0, a, b);
@@ -56252,7 +56252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_inserti32x4() {
+    const fn test_mm256_inserti32x4() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_inserti32x4::<1>(a, b);
@@ -56261,7 +56261,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_inserti32x4() {
+    const fn test_mm256_mask_inserti32x4() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_mask_inserti32x4::<0>(a, 0, a, b);
@@ -56272,7 +56272,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_inserti32x4() {
+    const fn test_mm256_maskz_inserti32x4() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_maskz_inserti32x4::<0>(0, a, b);
@@ -56283,7 +56283,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_insertf32x4() {
+    const fn test_mm512_insertf32x4() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56296,7 +56296,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_insertf32x4() {
+    const fn test_mm512_mask_insertf32x4() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56311,7 +56311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_insertf32x4() {
+    const fn test_mm512_maskz_insertf32x4() {
         let a = _mm512_setr_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56326,7 +56326,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_insertf32x4() {
+    const fn test_mm256_insertf32x4() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_insertf32x4::<1>(a, b);
@@ -56335,7 +56335,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_insertf32x4() {
+    const fn test_mm256_mask_insertf32x4() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_mask_insertf32x4::<0>(a, 0, a, b);
@@ -56346,7 +56346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_insertf32x4() {
+    const fn test_mm256_maskz_insertf32x4() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_maskz_insertf32x4::<0>(0, a, b);
@@ -56357,21 +56357,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castps128_ps512() {
+    const fn test_mm512_castps128_ps512() {
         let a = _mm_setr_ps(17., 18., 19., 20.);
         let r = _mm512_castps128_ps512(a);
         assert_eq_m128(_mm512_castps512_ps128(r), a);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castps256_ps512() {
+    const fn test_mm512_castps256_ps512() {
         let a = _mm256_setr_ps(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_castps256_ps512(a);
         assert_eq_m256(_mm512_castps512_ps256(r), a);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_zextps128_ps512() {
+    const fn test_mm512_zextps128_ps512() {
         let a = _mm_setr_ps(17., 18., 19., 20.);
         let r = _mm512_zextps128_ps512(a);
         let e = _mm512_setr_ps(
@@ -56381,7 +56381,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_zextps256_ps512() {
+    const fn test_mm512_zextps256_ps512() {
         let a = _mm256_setr_ps(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_zextps256_ps512(a);
         let e = _mm512_setr_ps(
@@ -56391,7 +56391,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castps512_ps128() {
+    const fn test_mm512_castps512_ps128() {
         let a = _mm512_setr_ps(
             17., 18., 19., 20., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1.,
         );
@@ -56401,7 +56401,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castps512_ps256() {
+    const fn test_mm512_castps512_ps256() {
         let a = _mm512_setr_ps(
             17., 18., 19., 20., 21., 22., 23., 24., -1., -1., -1., -1., -1., -1., -1., -1.,
         );
@@ -56411,7 +56411,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castps_pd() {
+    const fn test_mm512_castps_pd() {
         let a = _mm512_set1_ps(1.);
         let r = _mm512_castps_pd(a);
         let e = _mm512_set1_pd(0.007812501848093234);
@@ -56419,7 +56419,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castps_si512() {
+    const fn test_mm512_castps_si512() {
         let a = _mm512_set1_ps(1.);
         let r = _mm512_castps_si512(a);
         let e = _mm512_set1_epi32(1065353216);
@@ -56427,7 +56427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcastd_epi32() {
+    const fn test_mm512_broadcastd_epi32() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm512_broadcastd_epi32(a);
         let e = _mm512_set1_epi32(20);
@@ -56435,7 +56435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcastd_epi32() {
+    const fn test_mm512_mask_broadcastd_epi32() {
         let src = _mm512_set1_epi32(20);
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm512_mask_broadcastd_epi32(src, 0, a);
@@ -56446,7 +56446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcastd_epi32() {
+    const fn test_mm512_maskz_broadcastd_epi32() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm512_maskz_broadcastd_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -56456,7 +56456,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcastd_epi32() {
+    const fn test_mm256_mask_broadcastd_epi32() {
         let src = _mm256_set1_epi32(20);
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_mask_broadcastd_epi32(src, 0, a);
@@ -56467,7 +56467,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcastd_epi32() {
+    const fn test_mm256_maskz_broadcastd_epi32() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_maskz_broadcastd_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -56477,7 +56477,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_broadcastd_epi32() {
+    const fn test_mm_mask_broadcastd_epi32() {
         let src = _mm_set1_epi32(20);
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm_mask_broadcastd_epi32(src, 0, a);
@@ -56488,7 +56488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_broadcastd_epi32() {
+    const fn test_mm_maskz_broadcastd_epi32() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm_maskz_broadcastd_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -56498,7 +56498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcastss_ps() {
+    const fn test_mm512_broadcastss_ps() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm512_broadcastss_ps(a);
         let e = _mm512_set1_ps(20.);
@@ -56506,7 +56506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcastss_ps() {
+    const fn test_mm512_mask_broadcastss_ps() {
         let src = _mm512_set1_ps(20.);
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm512_mask_broadcastss_ps(src, 0, a);
@@ -56517,7 +56517,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcastss_ps() {
+    const fn test_mm512_maskz_broadcastss_ps() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm512_maskz_broadcastss_ps(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -56529,7 +56529,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcastss_ps() {
+    const fn test_mm256_mask_broadcastss_ps() {
         let src = _mm256_set1_ps(20.);
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_mask_broadcastss_ps(src, 0, a);
@@ -56540,7 +56540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcastss_ps() {
+    const fn test_mm256_maskz_broadcastss_ps() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_maskz_broadcastss_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -56550,7 +56550,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_broadcastss_ps() {
+    const fn test_mm_mask_broadcastss_ps() {
         let src = _mm_set1_ps(20.);
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm_mask_broadcastss_ps(src, 0, a);
@@ -56561,7 +56561,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_broadcastss_ps() {
+    const fn test_mm_maskz_broadcastss_ps() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm_maskz_broadcastss_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -56571,7 +56571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcast_i32x4() {
+    const fn test_mm512_broadcast_i32x4() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm512_broadcast_i32x4(a);
         let e = _mm512_set_epi32(
@@ -56581,7 +56581,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcast_i32x4() {
+    const fn test_mm512_mask_broadcast_i32x4() {
         let src = _mm512_set1_epi32(20);
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm512_mask_broadcast_i32x4(src, 0, a);
@@ -56594,7 +56594,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcast_i32x4() {
+    const fn test_mm512_maskz_broadcast_i32x4() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm512_maskz_broadcast_i32x4(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -56604,7 +56604,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_broadcast_i32x4() {
+    const fn test_mm256_broadcast_i32x4() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_broadcast_i32x4(a);
         let e = _mm256_set_epi32(17, 18, 19, 20, 17, 18, 19, 20);
@@ -56612,7 +56612,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcast_i32x4() {
+    const fn test_mm256_mask_broadcast_i32x4() {
         let src = _mm256_set1_epi32(20);
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_mask_broadcast_i32x4(src, 0, a);
@@ -56623,7 +56623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcast_i32x4() {
+    const fn test_mm256_maskz_broadcast_i32x4() {
         let a = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm256_maskz_broadcast_i32x4(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -56633,7 +56633,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcast_f32x4() {
+    const fn test_mm512_broadcast_f32x4() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm512_broadcast_f32x4(a);
         let e = _mm512_set_ps(
@@ -56643,7 +56643,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcast_f32x4() {
+    const fn test_mm512_mask_broadcast_f32x4() {
         let src = _mm512_set1_ps(20.);
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm512_mask_broadcast_f32x4(src, 0, a);
@@ -56656,7 +56656,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcast_f32x4() {
+    const fn test_mm512_maskz_broadcast_f32x4() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm512_maskz_broadcast_f32x4(0, a);
         assert_eq_m512(r, _mm512_setzero_ps());
@@ -56668,7 +56668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_broadcast_f32x4() {
+    const fn test_mm256_broadcast_f32x4() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_broadcast_f32x4(a);
         let e = _mm256_set_ps(17., 18., 19., 20., 17., 18., 19., 20.);
@@ -56676,7 +56676,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcast_f32x4() {
+    const fn test_mm256_mask_broadcast_f32x4() {
         let src = _mm256_set1_ps(20.);
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_mask_broadcast_f32x4(src, 0, a);
@@ -56687,7 +56687,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcast_f32x4() {
+    const fn test_mm256_maskz_broadcast_f32x4() {
         let a = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm256_maskz_broadcast_f32x4(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -56697,7 +56697,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_blend_epi32() {
+    const fn test_mm512_mask_blend_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(2);
         let r = _mm512_mask_blend_epi32(0b11111111_00000000, a, b);
@@ -56706,7 +56706,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_epi32() {
+    const fn test_mm256_mask_blend_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(2);
         let r = _mm256_mask_blend_epi32(0b11111111, a, b);
@@ -56715,7 +56715,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_blend_epi32() {
+    const fn test_mm_mask_blend_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(2);
         let r = _mm_mask_blend_epi32(0b00001111, a, b);
@@ -56724,7 +56724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_blend_ps() {
+    const fn test_mm512_mask_blend_ps() {
         let a = _mm512_set1_ps(1.);
         let b = _mm512_set1_ps(2.);
         let r = _mm512_mask_blend_ps(0b11111111_00000000, a, b);
@@ -56735,7 +56735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_ps() {
+    const fn test_mm256_mask_blend_ps() {
         let a = _mm256_set1_ps(1.);
         let b = _mm256_set1_ps(2.);
         let r = _mm256_mask_blend_ps(0b11111111, a, b);
@@ -56744,7 +56744,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_blend_ps() {
+    const fn test_mm_mask_blend_ps() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let r = _mm_mask_blend_ps(0b00001111, a, b);
@@ -56753,7 +56753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpackhi_epi32() {
+    const fn test_mm512_unpackhi_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm512_set_epi32(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -56764,7 +56764,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpackhi_epi32() {
+    const fn test_mm512_mask_unpackhi_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm512_set_epi32(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -56777,7 +56777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpackhi_epi32() {
+    const fn test_mm512_maskz_unpackhi_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm512_set_epi32(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -56790,7 +56790,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpackhi_epi32() {
+    const fn test_mm256_mask_unpackhi_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm256_mask_unpackhi_epi32(a, 0, a, b);
@@ -56801,7 +56801,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpackhi_epi32() {
+    const fn test_mm256_maskz_unpackhi_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm256_maskz_unpackhi_epi32(0, a, b);
@@ -56812,7 +56812,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpackhi_epi32() {
+    const fn test_mm_mask_unpackhi_epi32() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm_mask_unpackhi_epi32(a, 0, a, b);
@@ -56823,7 +56823,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpackhi_epi32() {
+    const fn test_mm_maskz_unpackhi_epi32() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm_maskz_unpackhi_epi32(0, a, b);
@@ -56834,7 +56834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpackhi_ps() {
+    const fn test_mm512_unpackhi_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56849,7 +56849,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpackhi_ps() {
+    const fn test_mm512_mask_unpackhi_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56866,7 +56866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpackhi_ps() {
+    const fn test_mm512_maskz_unpackhi_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -56883,7 +56883,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpackhi_ps() {
+    const fn test_mm256_mask_unpackhi_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm256_mask_unpackhi_ps(a, 0, a, b);
@@ -56894,7 +56894,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpackhi_ps() {
+    const fn test_mm256_maskz_unpackhi_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm256_maskz_unpackhi_ps(0, a, b);
@@ -56905,7 +56905,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpackhi_ps() {
+    const fn test_mm_mask_unpackhi_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm_mask_unpackhi_ps(a, 0, a, b);
@@ -56916,7 +56916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpackhi_ps() {
+    const fn test_mm_maskz_unpackhi_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm_maskz_unpackhi_ps(0, a, b);
@@ -56927,7 +56927,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpacklo_epi32() {
+    const fn test_mm512_unpacklo_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm512_set_epi32(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -56938,7 +56938,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpacklo_epi32() {
+    const fn test_mm512_mask_unpacklo_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm512_set_epi32(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -56951,7 +56951,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpacklo_epi32() {
+    const fn test_mm512_maskz_unpacklo_epi32() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let b = _mm512_set_epi32(
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
@@ -56964,7 +56964,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpacklo_epi32() {
+    const fn test_mm256_mask_unpacklo_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm256_mask_unpacklo_epi32(a, 0, a, b);
@@ -56975,7 +56975,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpacklo_epi32() {
+    const fn test_mm256_maskz_unpacklo_epi32() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_set_epi32(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm256_maskz_unpacklo_epi32(0, a, b);
@@ -56986,7 +56986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpacklo_epi32() {
+    const fn test_mm_mask_unpacklo_epi32() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm_mask_unpacklo_epi32(a, 0, a, b);
@@ -56997,7 +56997,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpacklo_epi32() {
+    const fn test_mm_maskz_unpacklo_epi32() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let b = _mm_set_epi32(17, 18, 19, 20);
         let r = _mm_maskz_unpacklo_epi32(0, a, b);
@@ -57008,7 +57008,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpacklo_ps() {
+    const fn test_mm512_unpacklo_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -57023,7 +57023,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpacklo_ps() {
+    const fn test_mm512_mask_unpacklo_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -57040,7 +57040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpacklo_ps() {
+    const fn test_mm512_maskz_unpacklo_ps() {
         let a = _mm512_set_ps(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -57057,7 +57057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpacklo_ps() {
+    const fn test_mm256_mask_unpacklo_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm256_mask_unpacklo_ps(a, 0, a, b);
@@ -57068,7 +57068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpacklo_ps() {
+    const fn test_mm256_maskz_unpacklo_ps() {
         let a = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_set_ps(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm256_maskz_unpacklo_ps(0, a, b);
@@ -57079,7 +57079,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpacklo_ps() {
+    const fn test_mm_mask_unpacklo_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm_mask_unpacklo_ps(a, 0, a, b);
@@ -57090,7 +57090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpacklo_ps() {
+    const fn test_mm_maskz_unpacklo_ps() {
         let a = _mm_set_ps(1., 2., 3., 4.);
         let b = _mm_set_ps(17., 18., 19., 20.);
         let r = _mm_maskz_unpacklo_ps(0, a, b);
@@ -57101,7 +57101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_alignr_epi32() {
+    const fn test_mm512_alignr_epi32() {
         let a = _mm512_set_epi32(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm512_set_epi32(
             32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -57118,7 +57118,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_alignr_epi32() {
+    const fn test_mm512_mask_alignr_epi32() {
         let a = _mm512_set_epi32(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm512_set_epi32(
             32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -57133,7 +57133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_alignr_epi32() {
+    const fn test_mm512_maskz_alignr_epi32() {
         let a = _mm512_set_epi32(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm512_set_epi32(
             32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -57146,7 +57146,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_alignr_epi32() {
+    const fn test_mm256_alignr_epi32() {
         let a = _mm256_set_epi32(8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm256_set_epi32(16, 15, 14, 13, 12, 11, 10, 9);
         let r = _mm256_alignr_epi32::<0>(a, b);
@@ -57157,7 +57157,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_alignr_epi32() {
+    const fn test_mm256_mask_alignr_epi32() {
         let a = _mm256_set_epi32(8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm256_set_epi32(16, 15, 14, 13, 12, 11, 10, 9);
         let r = _mm256_mask_alignr_epi32::<1>(a, 0, a, b);
@@ -57168,7 +57168,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_alignr_epi32() {
+    const fn test_mm256_maskz_alignr_epi32() {
         let a = _mm256_set_epi32(8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm256_set_epi32(16, 15, 14, 13, 12, 11, 10, 9);
         let r = _mm256_maskz_alignr_epi32::<1>(0, a, b);
@@ -57179,7 +57179,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_alignr_epi32() {
+    const fn test_mm_alignr_epi32() {
         let a = _mm_set_epi32(4, 3, 2, 1);
         let b = _mm_set_epi32(8, 7, 6, 5);
         let r = _mm_alignr_epi32::<0>(a, b);
@@ -57190,7 +57190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_alignr_epi32() {
+    const fn test_mm_mask_alignr_epi32() {
         let a = _mm_set_epi32(4, 3, 2, 1);
         let b = _mm_set_epi32(8, 7, 6, 5);
         let r = _mm_mask_alignr_epi32::<1>(a, 0, a, b);
@@ -57201,7 +57201,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_alignr_epi32() {
+    const fn test_mm_maskz_alignr_epi32() {
         let a = _mm_set_epi32(4, 3, 2, 1);
         let b = _mm_set_epi32(8, 7, 6, 5);
         let r = _mm_maskz_alignr_epi32::<1>(0, a, b);
@@ -57212,7 +57212,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_and_epi32() {
+    const fn test_mm512_and_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57233,7 +57233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_and_epi32() {
+    const fn test_mm512_mask_and_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57262,7 +57262,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_and_epi32() {
+    const fn test_mm512_maskz_and_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57285,7 +57285,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_and_epi32() {
+    const fn test_mm256_mask_and_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_mask_and_epi32(a, 0, a, b);
@@ -57296,7 +57296,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_and_epi32() {
+    const fn test_mm256_maskz_and_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_maskz_and_epi32(0, a, b);
@@ -57307,7 +57307,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_and_epi32() {
+    const fn test_mm_mask_and_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_mask_and_epi32(a, 0, a, b);
@@ -57318,7 +57318,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_and_epi32() {
+    const fn test_mm_maskz_and_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_maskz_and_epi32(0, a, b);
@@ -57329,7 +57329,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_and_si512() {
+    const fn test_mm512_and_si512() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57350,7 +57350,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_or_epi32() {
+    const fn test_mm512_or_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57377,7 +57377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_or_epi32() {
+    const fn test_mm512_mask_or_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57406,7 +57406,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_or_epi32() {
+    const fn test_mm512_maskz_or_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57435,7 +57435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_or_epi32() {
+    const fn test_mm256_or_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_or_epi32(a, b);
@@ -57444,7 +57444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_or_epi32() {
+    const fn test_mm256_mask_or_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_mask_or_epi32(a, 0, a, b);
@@ -57455,7 +57455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_or_epi32() {
+    const fn test_mm256_maskz_or_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_maskz_or_epi32(0, a, b);
@@ -57466,7 +57466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_or_epi32() {
+    const fn test_mm_or_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_or_epi32(a, b);
@@ -57475,7 +57475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_or_epi32() {
+    const fn test_mm_mask_or_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_mask_or_epi32(a, 0, a, b);
@@ -57486,7 +57486,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_or_epi32() {
+    const fn test_mm_maskz_or_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_maskz_or_epi32(0, a, b);
@@ -57497,7 +57497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_or_si512() {
+    const fn test_mm512_or_si512() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57524,7 +57524,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_xor_epi32() {
+    const fn test_mm512_xor_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57551,7 +57551,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_xor_epi32() {
+    const fn test_mm512_mask_xor_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57580,7 +57580,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_xor_epi32() {
+    const fn test_mm512_maskz_xor_epi32() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57603,7 +57603,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_xor_epi32() {
+    const fn test_mm256_xor_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_xor_epi32(a, b);
@@ -57612,7 +57612,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_xor_epi32() {
+    const fn test_mm256_mask_xor_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_mask_xor_epi32(a, 0, a, b);
@@ -57623,7 +57623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_xor_epi32() {
+    const fn test_mm256_maskz_xor_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_maskz_xor_epi32(0, a, b);
@@ -57634,7 +57634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_xor_epi32() {
+    const fn test_mm_xor_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_xor_epi32(a, b);
@@ -57643,7 +57643,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_xor_epi32() {
+    const fn test_mm_mask_xor_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_mask_xor_epi32(a, 0, a, b);
@@ -57654,7 +57654,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_xor_epi32() {
+    const fn test_mm_maskz_xor_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_maskz_xor_epi32(0, a, b);
@@ -57665,7 +57665,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_xor_si512() {
+    const fn test_mm512_xor_si512() {
         #[rustfmt::skip]
         let a = _mm512_set_epi32(
             1 << 1 | 1 << 2, 0, 0, 0,
@@ -57692,7 +57692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_andnot_epi32() {
+    const fn test_mm512_andnot_epi32() {
         let a = _mm512_set1_epi32(0);
         let b = _mm512_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm512_andnot_epi32(a, b);
@@ -57701,7 +57701,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_andnot_epi32() {
+    const fn test_mm512_mask_andnot_epi32() {
         let a = _mm512_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm512_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm512_mask_andnot_epi32(a, 0, a, b);
@@ -57712,7 +57712,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_andnot_epi32() {
+    const fn test_mm512_maskz_andnot_epi32() {
         let a = _mm512_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm512_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm512_maskz_andnot_epi32(0, a, b);
@@ -57729,7 +57729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_andnot_epi32() {
+    const fn test_mm256_mask_andnot_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm256_mask_andnot_epi32(a, 0, a, b);
@@ -57740,7 +57740,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_andnot_epi32() {
+    const fn test_mm256_maskz_andnot_epi32() {
         let a = _mm256_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm256_maskz_andnot_epi32(0, a, b);
@@ -57751,7 +57751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_andnot_epi32() {
+    const fn test_mm_mask_andnot_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm_mask_andnot_epi32(a, 0, a, b);
@@ -57762,7 +57762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_andnot_epi32() {
+    const fn test_mm_maskz_andnot_epi32() {
         let a = _mm_set1_epi32(1 << 1 | 1 << 2);
         let b = _mm_set1_epi32(1 << 3 | 1 << 4);
         let r = _mm_maskz_andnot_epi32(0, a, b);
@@ -57773,7 +57773,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_cvtmask16_u32() {
+    const fn test_cvtmask16_u32() {
         let a: __mmask16 = 0b11001100_00110011;
         let r = _cvtmask16_u32(a);
         let e: u32 = 0b11001100_00110011;
@@ -57781,7 +57781,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_cvtu32_mask16() {
+    const fn test_cvtu32_mask16() {
         let a: u32 = 0b11001100_00110011;
         let r = _cvtu32_mask16(a);
         let e: __mmask16 = 0b11001100_00110011;
@@ -57789,7 +57789,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kand() {
+    const fn test_mm512_kand() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b11001100_00110011;
         let r = _mm512_kand(a, b);
@@ -57798,7 +57798,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kand_mask16() {
+    const fn test_kand_mask16() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b11001100_00110011;
         let r = _kand_mask16(a, b);
@@ -57807,7 +57807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kor() {
+    const fn test_mm512_kor() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kor(a, b);
@@ -57816,7 +57816,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kor_mask16() {
+    const fn test_kor_mask16() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _kor_mask16(a, b);
@@ -57825,7 +57825,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kxor() {
+    const fn test_mm512_kxor() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kxor(a, b);
@@ -57834,7 +57834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kxor_mask16() {
+    const fn test_kxor_mask16() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _kxor_mask16(a, b);
@@ -57843,7 +57843,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_knot() {
+    const fn test_mm512_knot() {
         let a: u16 = 0b11001100_00110011;
         let r = _mm512_knot(a);
         let e: u16 = 0b00110011_11001100;
@@ -57851,7 +57851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_knot_mask16() {
+    const fn test_knot_mask16() {
         let a: u16 = 0b11001100_00110011;
         let r = _knot_mask16(a);
         let e: u16 = 0b00110011_11001100;
@@ -57859,7 +57859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kandn() {
+    const fn test_mm512_kandn() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kandn(a, b);
@@ -57868,7 +57868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kandn_mask16() {
+    const fn test_kandn_mask16() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _kandn_mask16(a, b);
@@ -57877,7 +57877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kxnor() {
+    const fn test_mm512_kxnor() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kxnor(a, b);
@@ -57886,7 +57886,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kxnor_mask16() {
+    const fn test_kxnor_mask16() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _kxnor_mask16(a, b);
@@ -57905,7 +57905,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kortestc_mask16_u8() {
+    const fn test_kortestc_mask16_u8() {
         let a: __mmask16 = 0b0110100101101001;
         let b: __mmask16 = 0b1011011010110110;
         let r = _kortestc_mask16_u8(a, b);
@@ -57913,7 +57913,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kortestz_mask16_u8() {
+    const fn test_kortestz_mask16_u8() {
         let a: __mmask16 = 0b0110100101101001;
         let b: __mmask16 = 0b1011011010110110;
         let r = _kortestz_mask16_u8(a, b);
@@ -57921,7 +57921,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kshiftli_mask16() {
+    const fn test_kshiftli_mask16() {
         let a: __mmask16 = 0b1001011011000011;
         let r = _kshiftli_mask16::<3>(a);
         let e: __mmask16 = 0b1011011000011000;
@@ -57941,7 +57941,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_kshiftri_mask16() {
+    const fn test_kshiftri_mask16() {
         let a: __mmask16 = 0b1010100100111100;
         let r = _kshiftri_mask16::<3>(a);
         let e: __mmask16 = 0b0001010100100111;
@@ -57978,7 +57978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kmov() {
+    const fn test_mm512_kmov() {
         let a: u16 = 0b11001100_00110011;
         let r = _mm512_kmov(a);
         let e: u16 = 0b11001100_00110011;
@@ -57986,7 +57986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_int2mask() {
+    const fn test_mm512_int2mask() {
         let a: i32 = 0b11001100_00110011;
         let r = _mm512_int2mask(a);
         let e: u16 = 0b11001100_00110011;
@@ -57994,7 +57994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask2int() {
+    const fn test_mm512_mask2int() {
         let k1: __mmask16 = 0b11001100_00110011;
         let r = _mm512_mask2int(k1);
         let e: i32 = 0b11001100_00110011;
@@ -58002,7 +58002,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kunpackb() {
+    const fn test_mm512_kunpackb() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kunpackb(a, b);
@@ -58011,7 +58011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kortestc() {
+    const fn test_mm512_kortestc() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kortestc(a, b);
@@ -58022,7 +58022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_kortestz() {
+    const fn test_mm512_kortestz() {
         let a: u16 = 0b11001100_00110011;
         let b: u16 = 0b00101110_00001011;
         let r = _mm512_kortestz(a, b);
@@ -58032,7 +58032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_test_epi32_mask() {
+    const fn test_mm512_test_epi32_mask() {
         let a = _mm512_set1_epi32(1 << 0);
         let b = _mm512_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm512_test_epi32_mask(a, b);
@@ -58041,7 +58041,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_test_epi32_mask() {
+    const fn test_mm512_mask_test_epi32_mask() {
         let a = _mm512_set1_epi32(1 << 0);
         let b = _mm512_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm512_mask_test_epi32_mask(0, a, b);
@@ -58052,7 +58052,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_test_epi32_mask() {
+    const fn test_mm256_test_epi32_mask() {
         let a = _mm256_set1_epi32(1 << 0);
         let b = _mm256_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm256_test_epi32_mask(a, b);
@@ -58061,7 +58061,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_test_epi32_mask() {
+    const fn test_mm256_mask_test_epi32_mask() {
         let a = _mm256_set1_epi32(1 << 0);
         let b = _mm256_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm256_mask_test_epi32_mask(0, a, b);
@@ -58072,7 +58072,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_test_epi32_mask() {
+    const fn test_mm_test_epi32_mask() {
         let a = _mm_set1_epi32(1 << 0);
         let b = _mm_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm_test_epi32_mask(a, b);
@@ -58081,7 +58081,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_test_epi32_mask() {
+    const fn test_mm_mask_test_epi32_mask() {
         let a = _mm_set1_epi32(1 << 0);
         let b = _mm_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm_mask_test_epi32_mask(0, a, b);
@@ -58092,7 +58092,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_testn_epi32_mask() {
+    const fn test_mm512_testn_epi32_mask() {
         let a = _mm512_set1_epi32(1 << 0);
         let b = _mm512_set1_epi32(1 << 0 | 1 << 1);
         let r = _mm512_testn_epi32_mask(a, b);
@@ -58101,7 +58101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_testn_epi32_mask() {
+    const fn test_mm512_mask_testn_epi32_mask() {
         let a = _mm512_set1_epi32(1 << 0);
         let b = _mm512_set1_epi32(1 << 1);
         let r = _mm512_mask_test_epi32_mask(0, a, b);
@@ -58112,7 +58112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_testn_epi32_mask() {
+    const fn test_mm256_testn_epi32_mask() {
         let a = _mm256_set1_epi32(1 << 0);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_testn_epi32_mask(a, b);
@@ -58121,7 +58121,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_testn_epi32_mask() {
+    const fn test_mm256_mask_testn_epi32_mask() {
         let a = _mm256_set1_epi32(1 << 0);
         let b = _mm256_set1_epi32(1 << 1);
         let r = _mm256_mask_test_epi32_mask(0, a, b);
@@ -58132,7 +58132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_testn_epi32_mask() {
+    const fn test_mm_testn_epi32_mask() {
         let a = _mm_set1_epi32(1 << 0);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_testn_epi32_mask(a, b);
@@ -58141,7 +58141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_testn_epi32_mask() {
+    const fn test_mm_mask_testn_epi32_mask() {
         let a = _mm_set1_epi32(1 << 0);
         let b = _mm_set1_epi32(1 << 1);
         let r = _mm_mask_test_epi32_mask(0, a, b);
@@ -58210,91 +58210,91 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_add_epi32() {
+    const fn test_mm512_reduce_add_epi32() {
         let a = _mm512_set1_epi32(1);
         let e: i32 = _mm512_reduce_add_epi32(a);
         assert_eq!(16, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_add_epi32() {
+    const fn test_mm512_mask_reduce_add_epi32() {
         let a = _mm512_set1_epi32(1);
         let e: i32 = _mm512_mask_reduce_add_epi32(0b11111111_00000000, a);
         assert_eq!(8, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_add_ps() {
+    const fn test_mm512_reduce_add_ps() {
         let a = _mm512_set1_ps(1.);
         let e: f32 = _mm512_reduce_add_ps(a);
         assert_eq!(16., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_add_ps() {
+    const fn test_mm512_mask_reduce_add_ps() {
         let a = _mm512_set1_ps(1.);
         let e: f32 = _mm512_mask_reduce_add_ps(0b11111111_00000000, a);
         assert_eq!(8., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_mul_epi32() {
+    const fn test_mm512_reduce_mul_epi32() {
         let a = _mm512_set1_epi32(2);
         let e: i32 = _mm512_reduce_mul_epi32(a);
         assert_eq!(65536, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_mul_epi32() {
+    const fn test_mm512_mask_reduce_mul_epi32() {
         let a = _mm512_set1_epi32(2);
         let e: i32 = _mm512_mask_reduce_mul_epi32(0b11111111_00000000, a);
         assert_eq!(256, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_mul_ps() {
+    const fn test_mm512_reduce_mul_ps() {
         let a = _mm512_set1_ps(2.);
         let e: f32 = _mm512_reduce_mul_ps(a);
         assert_eq!(65536., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_mul_ps() {
+    const fn test_mm512_mask_reduce_mul_ps() {
         let a = _mm512_set1_ps(2.);
         let e: f32 = _mm512_mask_reduce_mul_ps(0b11111111_00000000, a);
         assert_eq!(256., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_max_epi32() {
+    const fn test_mm512_reduce_max_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i32 = _mm512_reduce_max_epi32(a);
         assert_eq!(15, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_max_epi32() {
+    const fn test_mm512_mask_reduce_max_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i32 = _mm512_mask_reduce_max_epi32(0b11111111_00000000, a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_max_epu32() {
+    const fn test_mm512_reduce_max_epu32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u32 = _mm512_reduce_max_epu32(a);
         assert_eq!(15, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_max_epu32() {
+    const fn test_mm512_mask_reduce_max_epu32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u32 = _mm512_mask_reduce_max_epu32(0b11111111_00000000, a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_reduce_max_ps() {
+    fn test_mm512_reduce_max_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -58303,7 +58303,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_reduce_max_ps() {
+    fn test_mm512_mask_reduce_max_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -58312,35 +58312,35 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_min_epi32() {
+    const fn test_mm512_reduce_min_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i32 = _mm512_reduce_min_epi32(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_min_epi32() {
+    const fn test_mm512_mask_reduce_min_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: i32 = _mm512_mask_reduce_min_epi32(0b11111111_00000000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_min_epu32() {
+    const fn test_mm512_reduce_min_epu32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u32 = _mm512_reduce_min_epu32(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_min_epu32() {
+    const fn test_mm512_mask_reduce_min_epu32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let e: u32 = _mm512_mask_reduce_min_epu32(0b11111111_00000000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_reduce_min_ps() {
+    fn test_mm512_reduce_min_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -58349,7 +58349,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_reduce_min_ps() {
+    fn test_mm512_mask_reduce_min_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -58358,35 +58358,35 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_and_epi32() {
+    const fn test_mm512_reduce_and_epi32() {
         let a = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e: i32 = _mm512_reduce_and_epi32(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_and_epi32() {
+    const fn test_mm512_mask_reduce_and_epi32() {
         let a = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e: i32 = _mm512_mask_reduce_and_epi32(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_or_epi32() {
+    const fn test_mm512_reduce_or_epi32() {
         let a = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e: i32 = _mm512_reduce_or_epi32(a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_or_epi32() {
+    const fn test_mm512_mask_reduce_or_epi32() {
         let a = _mm512_set_epi32(1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2);
         let e: i32 = _mm512_mask_reduce_and_epi32(0b11111111_00000000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_compress_epi32() {
+    fn test_mm512_mask_compress_epi32() {
         let src = _mm512_set1_epi32(200);
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_mask_compress_epi32(src, 0, a);
@@ -58399,7 +58399,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_compress_epi32() {
+    fn test_mm512_maskz_compress_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_compress_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -58409,7 +58409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_compress_epi32() {
+    fn test_mm256_mask_compress_epi32() {
         let src = _mm256_set1_epi32(200);
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_mask_compress_epi32(src, 0, a);
@@ -58420,7 +58420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_compress_epi32() {
+    fn test_mm256_maskz_compress_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_compress_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -58430,7 +58430,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_compress_epi32() {
+    fn test_mm_mask_compress_epi32() {
         let src = _mm_set1_epi32(200);
         let a = _mm_set_epi32(0, 1, 2, 3);
         let r = _mm_mask_compress_epi32(src, 0, a);
@@ -58441,7 +58441,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_compress_epi32() {
+    fn test_mm_maskz_compress_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let r = _mm_maskz_compress_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -58451,7 +58451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_compress_ps() {
+    fn test_mm512_mask_compress_ps() {
         let src = _mm512_set1_ps(200.);
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -58466,7 +58466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_compress_ps() {
+    fn test_mm512_maskz_compress_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -58480,7 +58480,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_compress_ps() {
+    fn test_mm256_mask_compress_ps() {
         let src = _mm256_set1_ps(200.);
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_mask_compress_ps(src, 0, a);
@@ -58491,7 +58491,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_compress_ps() {
+    fn test_mm256_maskz_compress_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_maskz_compress_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -58501,7 +58501,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_compress_ps() {
+    fn test_mm_mask_compress_ps() {
         let src = _mm_set1_ps(200.);
         let a = _mm_set_ps(0., 1., 2., 3.);
         let r = _mm_mask_compress_ps(src, 0, a);
@@ -58512,7 +58512,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_compress_ps() {
+    fn test_mm_maskz_compress_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let r = _mm_maskz_compress_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -58667,7 +58667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_expand_epi32() {
+    fn test_mm512_maskz_expand_epi32() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_expand_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -58677,7 +58677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_expand_epi32() {
+    fn test_mm256_mask_expand_epi32() {
         let src = _mm256_set1_epi32(200);
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_mask_expand_epi32(src, 0, a);
@@ -58688,7 +58688,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_expand_epi32() {
+    fn test_mm256_maskz_expand_epi32() {
         let a = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_maskz_expand_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -58698,7 +58698,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_expand_epi32() {
+    fn test_mm_mask_expand_epi32() {
         let src = _mm_set1_epi32(200);
         let a = _mm_set_epi32(0, 1, 2, 3);
         let r = _mm_mask_expand_epi32(src, 0, a);
@@ -58709,7 +58709,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_expand_epi32() {
+    fn test_mm_maskz_expand_epi32() {
         let a = _mm_set_epi32(0, 1, 2, 3);
         let r = _mm_maskz_expand_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -58719,7 +58719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_expand_ps() {
+    fn test_mm512_mask_expand_ps() {
         let src = _mm512_set1_ps(200.);
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
@@ -58734,7 +58734,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_expand_ps() {
+    fn test_mm512_maskz_expand_ps() {
         let a = _mm512_set_ps(
             0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
         );
@@ -58748,7 +58748,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_expand_ps() {
+    fn test_mm256_mask_expand_ps() {
         let src = _mm256_set1_ps(200.);
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_mask_expand_ps(src, 0, a);
@@ -58759,7 +58759,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_expand_ps() {
+    fn test_mm256_maskz_expand_ps() {
         let a = _mm256_set_ps(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm256_maskz_expand_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -58769,7 +58769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_expand_ps() {
+    fn test_mm_mask_expand_ps() {
         let src = _mm_set1_ps(200.);
         let a = _mm_set_ps(0., 1., 2., 3.);
         let r = _mm_mask_expand_ps(src, 0, a);
@@ -58780,7 +58780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_expand_ps() {
+    fn test_mm_maskz_expand_ps() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let r = _mm_maskz_expand_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -59170,7 +59170,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_set1_epi32() {
+    const fn test_mm512_mask_set1_epi32() {
         let src = _mm512_set1_epi32(2);
         let a: i32 = 11;
         let r = _mm512_mask_set1_epi32(src, 0, a);
@@ -59181,7 +59181,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_set1_epi32() {
+    const fn test_mm512_maskz_set1_epi32() {
         let a: i32 = 11;
         let r = _mm512_maskz_set1_epi32(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -59191,7 +59191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_set1_epi32() {
+    const fn test_mm256_mask_set1_epi32() {
         let src = _mm256_set1_epi32(2);
         let a: i32 = 11;
         let r = _mm256_mask_set1_epi32(src, 0, a);
@@ -59202,7 +59202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_set1_epi32() {
+    const fn test_mm256_maskz_set1_epi32() {
         let a: i32 = 11;
         let r = _mm256_maskz_set1_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -59212,7 +59212,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_set1_epi32() {
+    const fn test_mm_mask_set1_epi32() {
         let src = _mm_set1_epi32(2);
         let a: i32 = 11;
         let r = _mm_mask_set1_epi32(src, 0, a);
@@ -59223,7 +59223,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_set1_epi32() {
+    const fn test_mm_maskz_set1_epi32() {
         let a: i32 = 11;
         let r = _mm_maskz_set1_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -59233,7 +59233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_move_ss() {
+    const fn test_mm_mask_move_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -59246,7 +59246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_move_ss() {
+    const fn test_mm_maskz_move_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_move_ss(0, a, b);
@@ -59258,7 +59258,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_move_sd() {
+    const fn test_mm_mask_move_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59271,7 +59271,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_move_sd() {
+    const fn test_mm_maskz_move_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_move_sd(0, a, b);
@@ -59283,7 +59283,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_add_ss() {
+    const fn test_mm_mask_add_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -59296,7 +59296,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_add_ss() {
+    const fn test_mm_maskz_add_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_add_ss(0, a, b);
@@ -59308,7 +59308,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_add_sd() {
+    const fn test_mm_mask_add_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59321,7 +59321,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_add_sd() {
+    const fn test_mm_maskz_add_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_add_sd(0, a, b);
@@ -59333,7 +59333,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_sub_ss() {
+    const fn test_mm_mask_sub_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -59346,7 +59346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_sub_ss() {
+    const fn test_mm_maskz_sub_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_sub_ss(0, a, b);
@@ -59358,7 +59358,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_sub_sd() {
+    const fn test_mm_mask_sub_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59371,7 +59371,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_sub_sd() {
+    const fn test_mm_maskz_sub_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_sub_sd(0, a, b);
@@ -59383,7 +59383,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_mul_ss() {
+    const fn test_mm_mask_mul_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -59396,7 +59396,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_mul_ss() {
+    const fn test_mm_maskz_mul_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_mul_ss(0, a, b);
@@ -59408,7 +59408,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_mul_sd() {
+    const fn test_mm_mask_mul_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59421,7 +59421,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_mul_sd() {
+    const fn test_mm_maskz_mul_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_mul_sd(0, a, b);
@@ -59433,7 +59433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_div_ss() {
+    const fn test_mm_mask_div_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -59446,7 +59446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_div_ss() {
+    const fn test_mm_maskz_div_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_div_ss(0, a, b);
@@ -59458,7 +59458,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_div_sd() {
+    const fn test_mm_mask_div_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59471,7 +59471,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_div_sd() {
+    const fn test_mm_maskz_div_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_div_sd(0, a, b);
@@ -59483,7 +59483,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_max_ss() {
+    fn test_mm_mask_max_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_mask_max_ss(a, 0, a, b);
@@ -59495,7 +59495,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_max_ss() {
+    fn test_mm_maskz_max_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_maskz_max_ss(0, a, b);
@@ -59507,7 +59507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_max_sd() {
+    fn test_mm_mask_max_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_mask_max_sd(a, 0, a, b);
@@ -59519,7 +59519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_max_sd() {
+    fn test_mm_maskz_max_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_maskz_max_sd(0, a, b);
@@ -59531,7 +59531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_min_ss() {
+    fn test_mm_mask_min_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_mask_min_ss(a, 0, a, b);
@@ -59543,7 +59543,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_min_ss() {
+    fn test_mm_maskz_min_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_maskz_min_ss(0, a, b);
@@ -59555,7 +59555,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_min_sd() {
+    fn test_mm_mask_min_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_mask_min_sd(a, 0, a, b);
@@ -59567,7 +59567,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_min_sd() {
+    fn test_mm_maskz_min_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_maskz_min_sd(0, a, b);
@@ -59579,7 +59579,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_sqrt_ss() {
+    fn test_mm_mask_sqrt_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
@@ -59592,7 +59592,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_sqrt_ss() {
+    fn test_mm_maskz_sqrt_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_maskz_sqrt_ss(0, a, b);
@@ -59604,7 +59604,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_sqrt_sd() {
+    fn test_mm_mask_sqrt_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59617,7 +59617,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_sqrt_sd() {
+    fn test_mm_maskz_sqrt_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_sqrt_sd(0, a, b);
@@ -59629,7 +59629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_rsqrt14_ss() {
+    fn test_mm_rsqrt14_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_rsqrt14_ss(a, b);
@@ -59638,7 +59638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_rsqrt14_ss() {
+    fn test_mm_mask_rsqrt14_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
@@ -59651,7 +59651,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_rsqrt14_ss() {
+    fn test_mm_maskz_rsqrt14_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_maskz_rsqrt14_ss(0, a, b);
@@ -59663,7 +59663,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_rsqrt14_sd() {
+    fn test_mm_rsqrt14_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_rsqrt14_sd(a, b);
@@ -59672,7 +59672,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_rsqrt14_sd() {
+    fn test_mm_mask_rsqrt14_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59685,7 +59685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_rsqrt14_sd() {
+    fn test_mm_maskz_rsqrt14_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_rsqrt14_sd(0, a, b);
@@ -59697,7 +59697,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_rcp14_ss() {
+    fn test_mm_rcp14_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_rcp14_ss(a, b);
@@ -59706,7 +59706,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_rcp14_ss() {
+    fn test_mm_mask_rcp14_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
@@ -59719,7 +59719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_rcp14_ss() {
+    fn test_mm_maskz_rcp14_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_maskz_rcp14_ss(0, a, b);
@@ -59731,7 +59731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_rcp14_sd() {
+    fn test_mm_rcp14_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_rcp14_sd(a, b);
@@ -59740,7 +59740,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_rcp14_sd() {
+    fn test_mm_mask_rcp14_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -59753,7 +59753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_rcp14_sd() {
+    fn test_mm_maskz_rcp14_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_rcp14_sd(0, a, b);
@@ -59765,7 +59765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getexp_ss() {
+    fn test_mm_getexp_ss() {
         let a = _mm_set1_ps(2.);
         let b = _mm_set1_ps(3.);
         let r = _mm_getexp_ss(a, b);
@@ -59774,7 +59774,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getexp_ss() {
+    fn test_mm_mask_getexp_ss() {
         let a = _mm_set1_ps(2.);
         let b = _mm_set1_ps(3.);
         let r = _mm_mask_getexp_ss(a, 0, a, b);
@@ -59786,7 +59786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getexp_ss() {
+    fn test_mm_maskz_getexp_ss() {
         let a = _mm_set1_ps(2.);
         let b = _mm_set1_ps(3.);
         let r = _mm_maskz_getexp_ss(0, a, b);
@@ -59798,7 +59798,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getexp_sd() {
+    fn test_mm_getexp_sd() {
         let a = _mm_set1_pd(2.);
         let b = _mm_set1_pd(3.);
         let r = _mm_getexp_sd(a, b);
@@ -59807,7 +59807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getexp_sd() {
+    fn test_mm_mask_getexp_sd() {
         let a = _mm_set1_pd(2.);
         let b = _mm_set1_pd(3.);
         let r = _mm_mask_getexp_sd(a, 0, a, b);
@@ -59819,7 +59819,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getexp_sd() {
+    fn test_mm_maskz_getexp_sd() {
         let a = _mm_set1_pd(2.);
         let b = _mm_set1_pd(3.);
         let r = _mm_maskz_getexp_sd(0, a, b);
@@ -59831,7 +59831,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getmant_ss() {
+    fn test_mm_getmant_ss() {
         let a = _mm_set1_ps(20.);
         let b = _mm_set1_ps(10.);
         let r = _mm_getmant_ss::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, b);
@@ -59840,7 +59840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getmant_ss() {
+    fn test_mm_mask_getmant_ss() {
         let a = _mm_set1_ps(20.);
         let b = _mm_set1_ps(10.);
         let r = _mm_mask_getmant_ss::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a, b);
@@ -59852,7 +59852,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getmant_ss() {
+    fn test_mm_maskz_getmant_ss() {
         let a = _mm_set1_ps(20.);
         let b = _mm_set1_ps(10.);
         let r = _mm_maskz_getmant_ss::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a, b);
@@ -59864,7 +59864,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getmant_sd() {
+    fn test_mm_getmant_sd() {
         let a = _mm_set1_pd(20.);
         let b = _mm_set1_pd(10.);
         let r = _mm_getmant_sd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, b);
@@ -59873,7 +59873,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getmant_sd() {
+    fn test_mm_mask_getmant_sd() {
         let a = _mm_set1_pd(20.);
         let b = _mm_set1_pd(10.);
         let r = _mm_mask_getmant_sd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a, b);
@@ -59885,7 +59885,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getmant_sd() {
+    fn test_mm_maskz_getmant_sd() {
         let a = _mm_set1_pd(20.);
         let b = _mm_set1_pd(10.);
         let r = _mm_maskz_getmant_sd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a, b);
@@ -59897,7 +59897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_roundscale_ss() {
+    fn test_mm_roundscale_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_roundscale_ss::<0>(a, b);
@@ -59906,7 +59906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_roundscale_ss() {
+    fn test_mm_mask_roundscale_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_mask_roundscale_ss::<0>(a, 0, a, b);
@@ -59918,7 +59918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_roundscale_ss() {
+    fn test_mm_maskz_roundscale_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_maskz_roundscale_ss::<0>(0, a, b);
@@ -59930,7 +59930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_roundscale_sd() {
+    fn test_mm_roundscale_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_roundscale_sd::<0>(a, b);
@@ -59939,7 +59939,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_roundscale_sd() {
+    fn test_mm_mask_roundscale_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_mask_roundscale_sd::<0>(a, 0, a, b);
@@ -59951,7 +59951,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_roundscale_sd() {
+    fn test_mm_maskz_roundscale_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_maskz_roundscale_sd::<0>(0, a, b);
@@ -59963,7 +59963,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_scalef_ss() {
+    fn test_mm_scalef_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_scalef_ss(a, b);
@@ -59972,7 +59972,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_scalef_ss() {
+    fn test_mm_mask_scalef_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_mask_scalef_ss(a, 0, a, b);
@@ -59984,7 +59984,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_scalef_ss() {
+    fn test_mm_maskz_scalef_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_maskz_scalef_ss(0, a, b);
@@ -59996,7 +59996,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_scalef_sd() {
+    fn test_mm_scalef_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_scalef_sd(a, b);
@@ -60005,7 +60005,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_scalef_sd() {
+    fn test_mm_mask_scalef_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_mask_scalef_sd(a, 0, a, b);
@@ -60017,7 +60017,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_scalef_sd() {
+    fn test_mm_maskz_scalef_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_maskz_scalef_sd(0, a, b);
@@ -60029,7 +60029,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fmadd_ss() {
+    const fn test_mm_mask_fmadd_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60041,7 +60041,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fmadd_ss() {
+    const fn test_mm_maskz_fmadd_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60054,7 +60054,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fmadd_ss() {
+    const fn test_mm_mask3_fmadd_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60066,7 +60066,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fmadd_sd() {
+    const fn test_mm_mask_fmadd_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60078,7 +60078,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fmadd_sd() {
+    const fn test_mm_maskz_fmadd_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60091,7 +60091,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fmadd_sd() {
+    const fn test_mm_mask3_fmadd_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60103,7 +60103,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fmsub_ss() {
+    const fn test_mm_mask_fmsub_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60115,7 +60115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fmsub_ss() {
+    const fn test_mm_maskz_fmsub_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60128,7 +60128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fmsub_ss() {
+    const fn test_mm_mask3_fmsub_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60140,7 +60140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fmsub_sd() {
+    const fn test_mm_mask_fmsub_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60152,7 +60152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fmsub_sd() {
+    const fn test_mm_maskz_fmsub_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60165,7 +60165,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fmsub_sd() {
+    const fn test_mm_mask3_fmsub_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60177,7 +60177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fnmadd_ss() {
+    const fn test_mm_mask_fnmadd_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60189,7 +60189,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fnmadd_ss() {
+    const fn test_mm_maskz_fnmadd_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60202,7 +60202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fnmadd_ss() {
+    const fn test_mm_mask3_fnmadd_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60214,7 +60214,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fnmadd_sd() {
+    const fn test_mm_mask_fnmadd_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60226,7 +60226,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fnmadd_sd() {
+    const fn test_mm_maskz_fnmadd_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60239,7 +60239,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fnmadd_sd() {
+    const fn test_mm_mask3_fnmadd_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60251,7 +60251,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fnmsub_ss() {
+    const fn test_mm_mask_fnmsub_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60263,7 +60263,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fnmsub_ss() {
+    const fn test_mm_maskz_fnmsub_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60276,7 +60276,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fnmsub_ss() {
+    const fn test_mm_mask3_fnmsub_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -60288,7 +60288,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask_fnmsub_sd() {
+    const fn test_mm_mask_fnmsub_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60300,7 +60300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_maskz_fnmsub_sd() {
+    const fn test_mm_maskz_fnmsub_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60313,7 +60313,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_mask3_fnmsub_sd() {
+    const fn test_mm_mask3_fnmsub_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -60325,7 +60325,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_add_round_ss() {
+    fn test_mm_add_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_add_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60334,7 +60334,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_add_round_ss() {
+    fn test_mm_mask_add_round_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -60349,7 +60349,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_add_round_ss() {
+    fn test_mm_maskz_add_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_add_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60362,7 +60362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_add_round_sd() {
+    fn test_mm_add_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_add_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60371,7 +60371,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_add_round_sd() {
+    fn test_mm_mask_add_round_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -60386,7 +60386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_add_round_sd() {
+    fn test_mm_maskz_add_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_add_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60399,7 +60399,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_sub_round_ss() {
+    fn test_mm_sub_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_sub_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60408,7 +60408,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_sub_round_ss() {
+    fn test_mm_mask_sub_round_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -60423,7 +60423,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_sub_round_ss() {
+    fn test_mm_maskz_sub_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_sub_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60436,7 +60436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_sub_round_sd() {
+    fn test_mm_sub_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_sub_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60445,7 +60445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_sub_round_sd() {
+    fn test_mm_mask_sub_round_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -60460,7 +60460,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_sub_round_sd() {
+    fn test_mm_maskz_sub_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_sub_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60473,7 +60473,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mul_round_ss() {
+    fn test_mm_mul_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_mul_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60482,7 +60482,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_mul_round_ss() {
+    fn test_mm_mask_mul_round_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -60497,7 +60497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_mul_round_ss() {
+    fn test_mm_maskz_mul_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_mul_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60510,7 +60510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mul_round_sd() {
+    fn test_mm_mul_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_mul_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60519,7 +60519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_mul_round_sd() {
+    fn test_mm_mask_mul_round_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -60534,7 +60534,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_mul_round_sd() {
+    fn test_mm_maskz_mul_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_mul_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60547,7 +60547,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_div_round_ss() {
+    fn test_mm_div_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_div_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60556,7 +60556,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_div_round_ss() {
+    fn test_mm_mask_div_round_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
@@ -60571,7 +60571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_div_round_ss() {
+    fn test_mm_maskz_div_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 40.);
         let r = _mm_maskz_div_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60584,7 +60584,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_div_round_sd() {
+    fn test_mm_div_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_div_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60593,7 +60593,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_div_round_sd() {
+    fn test_mm_mask_div_round_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -60608,7 +60608,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_div_round_sd() {
+    fn test_mm_maskz_div_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_div_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60621,7 +60621,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_max_round_ss() {
+    fn test_mm_max_round_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_max_round_ss::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -60630,7 +60630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_max_round_ss() {
+    fn test_mm_mask_max_round_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_mask_max_round_ss::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -60642,7 +60642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_max_round_ss() {
+    fn test_mm_maskz_max_round_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_maskz_max_round_ss::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -60654,7 +60654,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_max_round_sd() {
+    fn test_mm_max_round_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_max_round_sd::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -60663,7 +60663,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_max_round_sd() {
+    fn test_mm_mask_max_round_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_mask_max_round_sd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -60675,7 +60675,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_max_round_sd() {
+    fn test_mm_maskz_max_round_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_maskz_max_round_sd::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -60687,7 +60687,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_min_round_ss() {
+    fn test_mm_min_round_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_min_round_ss::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -60696,7 +60696,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_min_round_ss() {
+    fn test_mm_mask_min_round_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_mask_min_round_ss::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -60708,7 +60708,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_min_round_ss() {
+    fn test_mm_maskz_min_round_ss() {
         let a = _mm_set_ps(0., 1., 2., 3.);
         let b = _mm_set_ps(4., 5., 6., 7.);
         let r = _mm_maskz_min_round_ss::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -60720,7 +60720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_min_round_sd() {
+    fn test_mm_min_round_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_min_round_sd::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -60729,7 +60729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_min_round_sd() {
+    fn test_mm_mask_min_round_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_mask_min_round_sd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -60741,7 +60741,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_min_round_sd() {
+    fn test_mm_maskz_min_round_sd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_maskz_min_round_sd::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -60753,7 +60753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_sqrt_round_ss() {
+    fn test_mm_sqrt_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_sqrt_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60762,7 +60762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_sqrt_round_ss() {
+    fn test_mm_mask_sqrt_round_ss() {
         let src = _mm_set_ps(10., 11., 100., 110.);
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
@@ -60777,7 +60777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_sqrt_round_ss() {
+    fn test_mm_maskz_sqrt_round_ss() {
         let a = _mm_set_ps(1., 2., 10., 20.);
         let b = _mm_set_ps(3., 4., 30., 4.);
         let r = _mm_maskz_sqrt_round_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60790,7 +60790,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_sqrt_round_sd() {
+    fn test_mm_sqrt_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_sqrt_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -60799,7 +60799,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_sqrt_round_sd() {
+    fn test_mm_mask_sqrt_round_sd() {
         let src = _mm_set_pd(10., 11.);
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
@@ -60814,7 +60814,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_sqrt_round_sd() {
+    fn test_mm_maskz_sqrt_round_sd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(3., 4.);
         let r = _mm_maskz_sqrt_round_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -60827,7 +60827,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getexp_round_ss() {
+    fn test_mm_getexp_round_ss() {
         let a = _mm_set1_ps(2.);
         let b = _mm_set1_ps(3.);
         let r = _mm_getexp_round_ss::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -60836,7 +60836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getexp_round_ss() {
+    fn test_mm_mask_getexp_round_ss() {
         let a = _mm_set1_ps(2.);
         let b = _mm_set1_ps(3.);
         let r = _mm_mask_getexp_round_ss::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -60848,7 +60848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getexp_round_ss() {
+    fn test_mm_maskz_getexp_round_ss() {
         let a = _mm_set1_ps(2.);
         let b = _mm_set1_ps(3.);
         let r = _mm_maskz_getexp_round_ss::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -60860,7 +60860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getexp_round_sd() {
+    fn test_mm_getexp_round_sd() {
         let a = _mm_set1_pd(2.);
         let b = _mm_set1_pd(3.);
         let r = _mm_getexp_round_sd::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -60869,7 +60869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getexp_round_sd() {
+    fn test_mm_mask_getexp_round_sd() {
         let a = _mm_set1_pd(2.);
         let b = _mm_set1_pd(3.);
         let r = _mm_mask_getexp_round_sd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -60881,7 +60881,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getexp_round_sd() {
+    fn test_mm_maskz_getexp_round_sd() {
         let a = _mm_set1_pd(2.);
         let b = _mm_set1_pd(3.);
         let r = _mm_maskz_getexp_round_sd::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -60893,7 +60893,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getmant_round_ss() {
+    fn test_mm_getmant_round_ss() {
         let a = _mm_set1_ps(20.);
         let b = _mm_set1_ps(10.);
         let r =
@@ -60905,7 +60905,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getmant_round_ss() {
+    fn test_mm_mask_getmant_round_ss() {
         let a = _mm_set1_ps(20.);
         let b = _mm_set1_ps(10.);
         let r = _mm_mask_getmant_round_ss::<
@@ -60925,7 +60925,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getmant_round_ss() {
+    fn test_mm_maskz_getmant_round_ss() {
         let a = _mm_set1_ps(20.);
         let b = _mm_set1_ps(10.);
         let r = _mm_maskz_getmant_round_ss::<
@@ -60945,7 +60945,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_getmant_round_sd() {
+    fn test_mm_getmant_round_sd() {
         let a = _mm_set1_pd(20.);
         let b = _mm_set1_pd(10.);
         let r =
@@ -60957,7 +60957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_getmant_round_sd() {
+    fn test_mm_mask_getmant_round_sd() {
         let a = _mm_set1_pd(20.);
         let b = _mm_set1_pd(10.);
         let r = _mm_mask_getmant_round_sd::<
@@ -60977,7 +60977,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_getmant_round_sd() {
+    fn test_mm_maskz_getmant_round_sd() {
         let a = _mm_set1_pd(20.);
         let b = _mm_set1_pd(10.);
         let r = _mm_maskz_getmant_round_sd::<
@@ -60997,7 +60997,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_roundscale_round_ss() {
+    fn test_mm_roundscale_round_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_roundscale_round_ss::<0, _MM_FROUND_CUR_DIRECTION>(a, b);
@@ -61006,7 +61006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_roundscale_round_ss() {
+    fn test_mm_mask_roundscale_round_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_mask_roundscale_round_ss::<0, _MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -61018,7 +61018,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_roundscale_round_ss() {
+    fn test_mm_maskz_roundscale_round_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_maskz_roundscale_round_ss::<0, _MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -61030,7 +61030,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_roundscale_round_sd() {
+    fn test_mm_roundscale_round_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_roundscale_round_sd::<0, _MM_FROUND_CUR_DIRECTION>(a, b);
@@ -61039,7 +61039,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_roundscale_round_sd() {
+    fn test_mm_mask_roundscale_round_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_mask_roundscale_round_sd::<0, _MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -61051,7 +61051,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_roundscale_round_sd() {
+    fn test_mm_maskz_roundscale_round_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_maskz_roundscale_round_sd::<0, _MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -61063,7 +61063,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_scalef_round_ss() {
+    fn test_mm_scalef_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_scalef_round_ss::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -61072,7 +61072,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_scalef_round_ss() {
+    fn test_mm_mask_scalef_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r = _mm_mask_scalef_round_ss::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -61088,7 +61088,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_scalef_round_ss() {
+    fn test_mm_maskz_scalef_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(3.);
         let r =
@@ -61103,7 +61103,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_scalef_round_sd() {
+    fn test_mm_scalef_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_scalef_round_sd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -61112,7 +61112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_scalef_round_sd() {
+    fn test_mm_mask_scalef_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_mask_scalef_round_sd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -61128,7 +61128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_scalef_round_sd() {
+    fn test_mm_maskz_scalef_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r =
@@ -61143,7 +61143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fmadd_round_ss() {
+    fn test_mm_fmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61153,7 +61153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fmadd_round_ss() {
+    fn test_mm_mask_fmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61169,7 +61169,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fmadd_round_ss() {
+    fn test_mm_maskz_fmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61186,7 +61186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fmadd_round_ss() {
+    fn test_mm_mask3_fmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61202,7 +61202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fmadd_round_sd() {
+    fn test_mm_fmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61212,7 +61212,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fmadd_round_sd() {
+    fn test_mm_mask_fmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61228,7 +61228,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fmadd_round_sd() {
+    fn test_mm_maskz_fmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61245,7 +61245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fmadd_round_sd() {
+    fn test_mm_mask3_fmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61261,7 +61261,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fmsub_round_ss() {
+    fn test_mm_fmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61271,7 +61271,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fmsub_round_ss() {
+    fn test_mm_mask_fmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61287,7 +61287,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fmsub_round_ss() {
+    fn test_mm_maskz_fmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61304,7 +61304,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fmsub_round_ss() {
+    fn test_mm_mask3_fmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61320,7 +61320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fmsub_round_sd() {
+    fn test_mm_fmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61330,7 +61330,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fmsub_round_sd() {
+    fn test_mm_mask_fmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61346,7 +61346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fmsub_round_sd() {
+    fn test_mm_maskz_fmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61363,7 +61363,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fmsub_round_sd() {
+    fn test_mm_mask3_fmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61379,7 +61379,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fnmadd_round_ss() {
+    fn test_mm_fnmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61389,7 +61389,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fnmadd_round_ss() {
+    fn test_mm_mask_fnmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61405,7 +61405,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fnmadd_round_ss() {
+    fn test_mm_maskz_fnmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61422,7 +61422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fnmadd_round_ss() {
+    fn test_mm_mask3_fnmadd_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61438,7 +61438,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fnmadd_round_sd() {
+    fn test_mm_fnmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61448,7 +61448,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fnmadd_round_sd() {
+    fn test_mm_mask_fnmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61464,7 +61464,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fnmadd_round_sd() {
+    fn test_mm_maskz_fnmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61481,7 +61481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fnmadd_round_sd() {
+    fn test_mm_mask3_fnmadd_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61497,7 +61497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fnmsub_round_ss() {
+    fn test_mm_fnmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61507,7 +61507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fnmsub_round_ss() {
+    fn test_mm_mask_fnmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61523,7 +61523,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fnmsub_round_ss() {
+    fn test_mm_maskz_fnmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61540,7 +61540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fnmsub_round_ss() {
+    fn test_mm_mask3_fnmsub_round_ss() {
         let a = _mm_set1_ps(1.);
         let b = _mm_set1_ps(2.);
         let c = _mm_set1_ps(3.);
@@ -61556,7 +61556,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fnmsub_round_sd() {
+    fn test_mm_fnmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61566,7 +61566,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fnmsub_round_sd() {
+    fn test_mm_mask_fnmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61582,7 +61582,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fnmsub_round_sd() {
+    fn test_mm_maskz_fnmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61599,7 +61599,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask3_fnmsub_round_sd() {
+    fn test_mm_mask3_fnmsub_round_sd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let c = _mm_set1_pd(3.);
@@ -61615,7 +61615,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fixupimm_ss() {
+    fn test_mm_fixupimm_ss() {
         let a = _mm_set_ps(0., 0., 0., f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -61625,7 +61625,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fixupimm_ss() {
+    fn test_mm_mask_fixupimm_ss() {
         let a = _mm_set_ps(0., 0., 0., f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -61635,7 +61635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fixupimm_ss() {
+    fn test_mm_maskz_fixupimm_ss() {
         let a = _mm_set_ps(0., 0., 0., f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -61648,7 +61648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fixupimm_sd() {
+    fn test_mm_fixupimm_sd() {
         let a = _mm_set_pd(0., f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -61658,7 +61658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fixupimm_sd() {
+    fn test_mm_mask_fixupimm_sd() {
         let a = _mm_set_pd(0., f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -61668,7 +61668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fixupimm_sd() {
+    fn test_mm_maskz_fixupimm_sd() {
         let a = _mm_set_pd(0., f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -61681,7 +61681,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fixupimm_round_ss() {
+    fn test_mm_fixupimm_round_ss() {
         let a = _mm_set_ps(1., 0., 0., f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -61691,7 +61691,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fixupimm_round_ss() {
+    fn test_mm_mask_fixupimm_round_ss() {
         let a = _mm_set_ps(0., 0., 0., f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -61701,7 +61701,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fixupimm_round_ss() {
+    fn test_mm_maskz_fixupimm_round_ss() {
         let a = _mm_set_ps(0., 0., 0., f32::NAN);
         let b = _mm_set1_ps(f32::MAX);
         let c = _mm_set1_epi32(i32::MAX);
@@ -61714,7 +61714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_fixupimm_round_sd() {
+    fn test_mm_fixupimm_round_sd() {
         let a = _mm_set_pd(0., f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -61724,7 +61724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_fixupimm_round_sd() {
+    fn test_mm_mask_fixupimm_round_sd() {
         let a = _mm_set_pd(0., f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -61734,7 +61734,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_fixupimm_round_sd() {
+    fn test_mm_maskz_fixupimm_round_sd() {
         let a = _mm_set_pd(0., f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -61747,7 +61747,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cvtss_sd() {
+    fn test_mm_mask_cvtss_sd() {
         let a = _mm_set_pd(6., -7.5);
         let b = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_mask_cvtss_sd(a, 0, a, b);
@@ -61758,7 +61758,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_cvtss_sd() {
+    fn test_mm_maskz_cvtss_sd() {
         let a = _mm_set_pd(6., -7.5);
         let b = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_maskz_cvtss_sd(0, a, b);
@@ -61770,7 +61770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cvtsd_ss() {
+    fn test_mm_mask_cvtsd_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b = _mm_set_pd(6., -7.5);
         let r = _mm_mask_cvtsd_ss(a, 0, a, b);
@@ -61781,7 +61781,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_cvtsd_ss() {
+    fn test_mm_maskz_cvtsd_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b = _mm_set_pd(6., -7.5);
         let r = _mm_maskz_cvtsd_ss(0, a, b);
@@ -61793,7 +61793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_sd() {
+    fn test_mm_cvt_roundss_sd() {
         let a = _mm_set_pd(6., -7.5);
         let b = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_sd::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -61802,7 +61802,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cvt_roundss_sd() {
+    fn test_mm_mask_cvt_roundss_sd() {
         let a = _mm_set_pd(6., -7.5);
         let b = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_mask_cvt_roundss_sd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -61813,7 +61813,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_cvt_roundss_sd() {
+    fn test_mm_maskz_cvt_roundss_sd() {
         let a = _mm_set_pd(6., -7.5);
         let b = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_maskz_cvt_roundss_sd::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -61825,7 +61825,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_ss() {
+    fn test_mm_cvt_roundsd_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b = _mm_set_pd(6., -7.5);
         let r = _mm_cvt_roundsd_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -61834,7 +61834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_mask_cvt_roundsd_ss() {
+    fn test_mm_mask_cvt_roundsd_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b = _mm_set_pd(6., -7.5);
         let r = _mm_mask_cvt_roundsd_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, 0, a, b);
@@ -61847,7 +61847,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_maskz_cvt_roundsd_ss() {
+    fn test_mm_maskz_cvt_roundsd_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b = _mm_set_pd(6., -7.5);
         let r = _mm_maskz_cvt_roundsd_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(0, a, b);
@@ -61861,7 +61861,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_si32() {
+    fn test_mm_cvt_roundss_si32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_si32::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i32 = -1;
@@ -61869,7 +61869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_i32() {
+    fn test_mm_cvt_roundss_i32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_i32::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i32 = -1;
@@ -61877,7 +61877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_u32() {
+    fn test_mm_cvt_roundss_u32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_u32::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: u32 = u32::MAX;
@@ -61885,7 +61885,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtss_i32() {
+    fn test_mm_cvtss_i32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtss_i32(a);
         let e: i32 = -2;
@@ -61893,7 +61893,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtss_u32() {
+    fn test_mm_cvtss_u32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtss_u32(a);
         let e: u32 = u32::MAX;
@@ -61901,7 +61901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_si32() {
+    fn test_mm_cvt_roundsd_si32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvt_roundsd_si32::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i32 = -1;
@@ -61909,7 +61909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_i32() {
+    fn test_mm_cvt_roundsd_i32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvt_roundsd_i32::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i32 = -1;
@@ -61917,7 +61917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_u32() {
+    fn test_mm_cvt_roundsd_u32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvt_roundsd_u32::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: u32 = u32::MAX;
@@ -61925,7 +61925,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtsd_i32() {
+    fn test_mm_cvtsd_i32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtsd_i32(a);
         let e: i32 = -2;
@@ -61933,7 +61933,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtsd_u32() {
+    fn test_mm_cvtsd_u32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtsd_u32(a);
         let e: u32 = u32::MAX;
@@ -61941,7 +61941,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundi32_ss() {
+    fn test_mm_cvt_roundi32_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: i32 = 9;
         let r = _mm_cvt_roundi32_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -61950,7 +61950,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsi32_ss() {
+    fn test_mm_cvt_roundsi32_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: i32 = 9;
         let r = _mm_cvt_roundsi32_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -61959,7 +61959,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundu32_ss() {
+    fn test_mm_cvt_roundu32_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: u32 = 9;
         let r = _mm_cvt_roundu32_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -61968,7 +61968,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvti32_ss() {
+    const fn test_mm_cvti32_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: i32 = 9;
         let r = _mm_cvti32_ss(a, b);
@@ -61977,7 +61977,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvti32_sd() {
+    const fn test_mm_cvti32_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: i32 = 9;
         let r = _mm_cvti32_sd(a, b);
@@ -61986,7 +61986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundss_si32() {
+    fn test_mm_cvtt_roundss_si32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtt_roundss_si32::<_MM_FROUND_NO_EXC>(a);
         let e: i32 = -1;
@@ -61994,7 +61994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundss_i32() {
+    fn test_mm_cvtt_roundss_i32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtt_roundss_i32::<_MM_FROUND_NO_EXC>(a);
         let e: i32 = -1;
@@ -62002,7 +62002,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundss_u32() {
+    fn test_mm_cvtt_roundss_u32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtt_roundss_u32::<_MM_FROUND_NO_EXC>(a);
         let e: u32 = u32::MAX;
@@ -62010,7 +62010,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttss_i32() {
+    fn test_mm_cvttss_i32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvttss_i32(a);
         let e: i32 = -1;
@@ -62018,7 +62018,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttss_u32() {
+    fn test_mm_cvttss_u32() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvttss_u32(a);
         let e: u32 = u32::MAX;
@@ -62026,7 +62026,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundsd_si32() {
+    fn test_mm_cvtt_roundsd_si32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtt_roundsd_si32::<_MM_FROUND_NO_EXC>(a);
         let e: i32 = -1;
@@ -62034,7 +62034,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundsd_i32() {
+    fn test_mm_cvtt_roundsd_i32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtt_roundsd_i32::<_MM_FROUND_NO_EXC>(a);
         let e: i32 = -1;
@@ -62042,7 +62042,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundsd_u32() {
+    fn test_mm_cvtt_roundsd_u32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtt_roundsd_u32::<_MM_FROUND_NO_EXC>(a);
         let e: u32 = u32::MAX;
@@ -62050,7 +62050,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttsd_i32() {
+    fn test_mm_cvttsd_i32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvttsd_i32(a);
         let e: i32 = -1;
@@ -62058,7 +62058,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttsd_u32() {
+    fn test_mm_cvttsd_u32() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvttsd_u32(a);
         let e: u32 = u32::MAX;
@@ -62066,7 +62066,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvtu32_ss() {
+    const fn test_mm_cvtu32_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: u32 = 9;
         let r = _mm_cvtu32_ss(a, b);
@@ -62075,7 +62075,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvtu32_sd() {
+    const fn test_mm_cvtu32_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: u32 = 9;
         let r = _mm_cvtu32_sd(a, b);
@@ -62084,7 +62084,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_comi_round_ss() {
+    fn test_mm_comi_round_ss() {
         let a = _mm_set1_ps(2.2);
         let b = _mm_set1_ps(1.1);
         let r = _mm_comi_round_ss::<0, _MM_FROUND_CUR_DIRECTION>(a, b);
@@ -62093,7 +62093,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_comi_round_sd() {
+    fn test_mm_comi_round_sd() {
         let a = _mm_set1_pd(2.2);
         let b = _mm_set1_pd(1.1);
         let r = _mm_comi_round_sd::<0, _MM_FROUND_CUR_DIRECTION>(a, b);
@@ -62102,7 +62102,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtsi512_si32() {
+    const fn test_mm512_cvtsi512_si32() {
         let a = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_cvtsi512_si32(a);
         let e: i32 = 1;
@@ -62110,7 +62110,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtss_f32() {
+    const fn test_mm512_cvtss_f32() {
         let a = _mm512_setr_ps(
             312.0134, 3., 2., 5., 8., 9., 64., 50., -4., -3., -2., -5., -8., -9., -64., -50.,
         );
@@ -62118,13 +62118,13 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtsd_f64() {
+    const fn test_mm512_cvtsd_f64() {
         let r = _mm512_cvtsd_f64(_mm512_setr_pd(-1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8));
         assert_eq!(r, -1.1);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_pd() {
+    const fn test_mm512_shuffle_pd() {
         let a = _mm512_setr_pd(1., 4., 5., 8., 1., 4., 5., 8.);
         let b = _mm512_setr_pd(2., 3., 6., 7., 2., 3., 6., 7.);
         let r = _mm512_shuffle_pd::<0b11_11_11_11>(a, b);
@@ -62133,7 +62133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_pd() {
+    const fn test_mm512_mask_shuffle_pd() {
         let a = _mm512_setr_pd(1., 4., 5., 8., 1., 4., 5., 8.);
         let b = _mm512_setr_pd(2., 3., 6., 7., 2., 3., 6., 7.);
         let r = _mm512_mask_shuffle_pd::<0b11_11_11_11>(a, 0, a, b);
@@ -62144,7 +62144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_pd() {
+    const fn test_mm512_maskz_shuffle_pd() {
         let a = _mm512_setr_pd(1., 4., 5., 8., 1., 4., 5., 8.);
         let b = _mm512_setr_pd(2., 3., 6., 7., 2., 3., 6., 7.);
         let r = _mm512_maskz_shuffle_pd::<0b11_11_11_11>(0, a, b);

--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -16960,14 +16960,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_set_ph() {
+    const fn test_mm_set_ph() {
         let r = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let e = _mm_setr_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         assert_eq_m128h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_set_ph() {
+    const fn test_mm256_set_ph() {
         let r = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -16978,7 +16978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_set_ph() {
+    const fn test_mm512_set_ph() {
         let r = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -16993,21 +16993,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_set_sh() {
+    const fn test_mm_set_sh() {
         let r = _mm_set_sh(1.0);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
         assert_eq_m128h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_set1_ph() {
+    const fn test_mm_set1_ph() {
         let r = _mm_set1_ph(1.0);
         let e = _mm_set_ph(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
         assert_eq_m128h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_set1_ph() {
+    const fn test_mm256_set1_ph() {
         let r = _mm256_set1_ph(1.0);
         let e = _mm256_set_ph(
             1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
@@ -17016,7 +17016,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_set1_ph() {
+    const fn test_mm512_set1_ph() {
         let r = _mm512_set1_ph(1.0);
         let e = _mm512_set_ph(
             1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
@@ -17026,14 +17026,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_setr_ph() {
+    const fn test_mm_setr_ph() {
         let r = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let e = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         assert_eq_m128h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_setr_ph() {
+    const fn test_mm256_setr_ph() {
         let r = _mm256_setr_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -17044,7 +17044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_setr_ph() {
+    const fn test_mm512_setr_ph() {
         let r = _mm512_setr_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17059,28 +17059,28 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_setzero_ph() {
+    const fn test_mm_setzero_ph() {
         let r = _mm_setzero_ph();
         let e = _mm_set1_ph(0.0);
         assert_eq_m128h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_setzero_ph() {
+    const fn test_mm256_setzero_ph() {
         let r = _mm256_setzero_ph();
         let e = _mm256_set1_ph(0.0);
         assert_eq_m256h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_setzero_ph() {
+    const fn test_mm512_setzero_ph() {
         let r = _mm512_setzero_ph();
         let e = _mm512_set1_ph(0.0);
         assert_eq_m512h(r, e);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_castsi128_ph() {
+    const fn test_mm_castsi128_ph() {
         let a = _mm_set1_epi16(0x3c00);
         let r = _mm_castsi128_ph(a);
         let e = _mm_set1_ph(1.0);
@@ -17088,7 +17088,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_castsi256_ph() {
+    const fn test_mm256_castsi256_ph() {
         let a = _mm256_set1_epi16(0x3c00);
         let r = _mm256_castsi256_ph(a);
         let e = _mm256_set1_ph(1.0);
@@ -17096,7 +17096,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_castsi512_ph() {
+    const fn test_mm512_castsi512_ph() {
         let a = _mm512_set1_epi16(0x3c00);
         let r = _mm512_castsi512_ph(a);
         let e = _mm512_set1_ph(1.0);
@@ -17104,7 +17104,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm_castph_si128() {
+    const fn test_mm_castph_si128() {
         let a = _mm_set1_ph(1.0);
         let r = _mm_castph_si128(a);
         let e = _mm_set1_epi16(0x3c00);
@@ -17112,7 +17112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm256_castph_si256() {
+    const fn test_mm256_castph_si256() {
         let a = _mm256_set1_ph(1.0);
         let r = _mm256_castph_si256(a);
         let e = _mm256_set1_epi16(0x3c00);
@@ -17120,7 +17120,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_castph_si512() {
+    const fn test_mm512_castph_si512() {
         let a = _mm512_set1_ph(1.0);
         let r = _mm512_castph_si512(a);
         let e = _mm512_set1_epi16(0x3c00);
@@ -17128,7 +17128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_castps_ph() {
+    const fn test_mm_castps_ph() {
         let a = _mm_castsi128_ps(_mm_set1_epi16(0x3c00));
         let r = _mm_castps_ph(a);
         let e = _mm_set1_ph(1.0);
@@ -17136,7 +17136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_castps_ph() {
+    const fn test_mm256_castps_ph() {
         let a = _mm256_castsi256_ps(_mm256_set1_epi16(0x3c00));
         let r = _mm256_castps_ph(a);
         let e = _mm256_set1_ph(1.0);
@@ -17144,7 +17144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_castps_ph() {
+    const fn test_mm512_castps_ph() {
         let a = _mm512_castsi512_ps(_mm512_set1_epi16(0x3c00));
         let r = _mm512_castps_ph(a);
         let e = _mm512_set1_ph(1.0);
@@ -17152,7 +17152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm_castph_ps() {
+    const fn test_mm_castph_ps() {
         let a = _mm_castsi128_ph(_mm_set1_epi32(0x3f800000));
         let r = _mm_castph_ps(a);
         let e = _mm_set1_ps(1.0);
@@ -17160,7 +17160,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm256_castph_ps() {
+    const fn test_mm256_castph_ps() {
         let a = _mm256_castsi256_ph(_mm256_set1_epi32(0x3f800000));
         let r = _mm256_castph_ps(a);
         let e = _mm256_set1_ps(1.0);
@@ -17168,7 +17168,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_castph_ps() {
+    const fn test_mm512_castph_ps() {
         let a = _mm512_castsi512_ph(_mm512_set1_epi32(0x3f800000));
         let r = _mm512_castph_ps(a);
         let e = _mm512_set1_ps(1.0);
@@ -17176,7 +17176,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_castpd_ph() {
+    const fn test_mm_castpd_ph() {
         let a = _mm_castsi128_pd(_mm_set1_epi16(0x3c00));
         let r = _mm_castpd_ph(a);
         let e = _mm_set1_ph(1.0);
@@ -17184,7 +17184,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_castpd_ph() {
+    const fn test_mm256_castpd_ph() {
         let a = _mm256_castsi256_pd(_mm256_set1_epi16(0x3c00));
         let r = _mm256_castpd_ph(a);
         let e = _mm256_set1_ph(1.0);
@@ -17192,7 +17192,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_castpd_ph() {
+    const fn test_mm512_castpd_ph() {
         let a = _mm512_castsi512_pd(_mm512_set1_epi16(0x3c00));
         let r = _mm512_castpd_ph(a);
         let e = _mm512_set1_ph(1.0);
@@ -17200,7 +17200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm_castph_pd() {
+    const fn test_mm_castph_pd() {
         let a = _mm_castsi128_ph(_mm_set1_epi64x(0x3ff0000000000000));
         let r = _mm_castph_pd(a);
         let e = _mm_set1_pd(1.0);
@@ -17208,7 +17208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm256_castph_pd() {
+    const fn test_mm256_castph_pd() {
         let a = _mm256_castsi256_ph(_mm256_set1_epi64x(0x3ff0000000000000));
         let r = _mm256_castph_pd(a);
         let e = _mm256_set1_pd(1.0);
@@ -17216,7 +17216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_castph_pd() {
+    const fn test_mm512_castph_pd() {
         let a = _mm512_castsi512_ph(_mm512_set1_epi64(0x3ff0000000000000));
         let r = _mm512_castph_pd(a);
         let e = _mm512_set1_pd(1.0);
@@ -17224,7 +17224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_castph256_ph128() {
+    const fn test_mm256_castph256_ph128() {
         let a = _mm256_setr_ph(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -17234,7 +17234,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm512_castph512_ph128() {
+    const fn test_mm512_castph512_ph128() {
         let a = _mm512_setr_ph(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
             20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32.,
@@ -17245,7 +17245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm512_castph512_ph256() {
+    const fn test_mm512_castph512_ph256() {
         let a = _mm512_setr_ph(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19.,
             20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32.,
@@ -17258,21 +17258,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_castph128_ph256() {
+    const fn test_mm256_castph128_ph256() {
         let a = _mm_setr_ph(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_castph128_ph256(a);
         assert_eq_m128h(_mm256_castph256_ph128(r), a);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm512_castph128_ph512() {
+    const fn test_mm512_castph128_ph512() {
         let a = _mm_setr_ph(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_castph128_ph512(a);
         assert_eq_m128h(_mm512_castph512_ph128(r), a);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm512_castph256_ph512() {
+    const fn test_mm512_castph256_ph512() {
         let a = _mm256_setr_ph(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -17281,7 +17281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_zextph128_ph256() {
+    const fn test_mm256_zextph128_ph256() {
         let a = _mm_setr_ph(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm256_zextph128_ph256(a);
         let e = _mm256_setr_ph(
@@ -17291,7 +17291,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_zextph128_ph512() {
+    const fn test_mm512_zextph128_ph512() {
         let a = _mm_setr_ph(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_zextph128_ph512(a);
         let e = _mm512_setr_ph(
@@ -17302,7 +17302,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_zextph256_ph512() {
+    const fn test_mm512_zextph256_ph512() {
         let a = _mm256_setr_ph(
             1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.,
         );
@@ -17315,7 +17315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cmp_ph_mask() {
+    fn test_mm_cmp_ph_mask() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(1.0, 2.0, 3.0, 4.0, -5.0, -6.0, -7.0, -8.0);
         let r = _mm_cmp_ph_mask::<_CMP_EQ_OQ>(a, b);
@@ -17323,7 +17323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cmp_ph_mask() {
+    fn test_mm_mask_cmp_ph_mask() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(1.0, 2.0, 3.0, 4.0, -5.0, -6.0, -7.0, -8.0);
         let r = _mm_mask_cmp_ph_mask::<_CMP_EQ_OQ>(0b01010101, a, b);
@@ -17331,7 +17331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cmp_ph_mask() {
+    fn test_mm256_cmp_ph_mask() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -17344,7 +17344,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cmp_ph_mask() {
+    fn test_mm256_mask_cmp_ph_mask() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -17357,7 +17357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cmp_ph_mask() {
+    fn test_mm512_cmp_ph_mask() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17373,7 +17373,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cmp_ph_mask() {
+    fn test_mm512_mask_cmp_ph_mask() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17389,7 +17389,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cmp_round_ph_mask() {
+    fn test_mm512_cmp_round_ph_mask() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17405,7 +17405,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cmp_round_ph_mask() {
+    fn test_mm512_mask_cmp_round_ph_mask() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17425,7 +17425,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cmp_round_sh_mask() {
+    fn test_mm_cmp_round_sh_mask() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_cmp_round_sh_mask::<_CMP_EQ_OQ, _MM_FROUND_NO_EXC>(a, b);
@@ -17433,7 +17433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_cmp_round_sh_mask() {
+    fn test_mm_mask_cmp_round_sh_mask() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_mask_cmp_round_sh_mask::<_CMP_EQ_OQ, _MM_FROUND_NO_EXC>(0, a, b);
@@ -17441,7 +17441,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cmp_sh_mask() {
+    fn test_mm_cmp_sh_mask() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_cmp_sh_mask::<_CMP_EQ_OQ>(a, b);
@@ -17449,7 +17449,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_cmp_sh_mask() {
+    fn test_mm_mask_cmp_sh_mask() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_mask_cmp_sh_mask::<_CMP_EQ_OQ>(0, a, b);
@@ -17457,7 +17457,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comi_round_sh() {
+    fn test_mm_comi_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_comi_round_sh::<_CMP_EQ_OQ, _MM_FROUND_NO_EXC>(a, b);
@@ -17465,7 +17465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comi_sh() {
+    fn test_mm_comi_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_comi_sh::<_CMP_EQ_OQ>(a, b);
@@ -17473,7 +17473,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comieq_sh() {
+    fn test_mm_comieq_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_comieq_sh(a, b);
@@ -17481,7 +17481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comige_sh() {
+    fn test_mm_comige_sh() {
         let a = _mm_set_sh(2.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_comige_sh(a, b);
@@ -17489,7 +17489,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comigt_sh() {
+    fn test_mm_comigt_sh() {
         let a = _mm_set_sh(2.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_comigt_sh(a, b);
@@ -17497,7 +17497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comile_sh() {
+    fn test_mm_comile_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_comile_sh(a, b);
@@ -17505,7 +17505,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comilt_sh() {
+    fn test_mm_comilt_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_comilt_sh(a, b);
@@ -17513,7 +17513,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_comineq_sh() {
+    fn test_mm_comineq_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_comineq_sh(a, b);
@@ -17521,7 +17521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_ucomieq_sh() {
+    fn test_mm_ucomieq_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_ucomieq_sh(a, b);
@@ -17529,7 +17529,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_ucomige_sh() {
+    fn test_mm_ucomige_sh() {
         let a = _mm_set_sh(2.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_ucomige_sh(a, b);
@@ -17537,7 +17537,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_ucomigt_sh() {
+    fn test_mm_ucomigt_sh() {
         let a = _mm_set_sh(2.0);
         let b = _mm_set_sh(1.0);
         let r = _mm_ucomigt_sh(a, b);
@@ -17545,7 +17545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_ucomile_sh() {
+    fn test_mm_ucomile_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_ucomile_sh(a, b);
@@ -17553,7 +17553,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_ucomilt_sh() {
+    fn test_mm_ucomilt_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_ucomilt_sh(a, b);
@@ -17561,7 +17561,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_ucomineq_sh() {
+    fn test_mm_ucomineq_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_ucomineq_sh(a, b);
@@ -17658,7 +17658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_move_sh() {
+    const fn test_mm_move_sh() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_sh(9.0);
         let r = _mm_move_sh(a, b);
@@ -17667,7 +17667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_move_sh() {
+    const fn test_mm_mask_move_sh() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_sh(9.0);
         let src = _mm_set_sh(10.0);
@@ -17677,7 +17677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_move_sh() {
+    const fn test_mm_maskz_move_sh() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_sh(9.0);
         let r = _mm_maskz_move_sh(0, a, b);
@@ -17764,7 +17764,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_add_ph() {
+    const fn test_mm_add_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let r = _mm_add_ph(a, b);
@@ -17773,7 +17773,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_add_ph() {
+    const fn test_mm_mask_add_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
@@ -17783,7 +17783,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_add_ph() {
+    const fn test_mm_maskz_add_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let r = _mm_maskz_add_ph(0b01010101, a, b);
@@ -17792,7 +17792,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_add_ph() {
+    const fn test_mm256_add_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -17805,7 +17805,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_add_ph() {
+    const fn test_mm256_mask_add_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -17823,7 +17823,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_ph() {
+    const fn test_mm256_maskz_add_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -17838,7 +17838,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_add_ph() {
+    const fn test_mm512_add_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17855,7 +17855,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_add_ph() {
+    const fn test_mm512_mask_add_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17879,7 +17879,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_add_ph() {
+    const fn test_mm512_maskz_add_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17899,7 +17899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_add_round_ph() {
+    fn test_mm512_add_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17916,7 +17916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_add_round_ph() {
+    fn test_mm512_mask_add_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17945,7 +17945,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_add_round_ph() {
+    fn test_mm512_maskz_add_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -17969,7 +17969,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_add_round_sh() {
+    fn test_mm_add_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_add_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -17978,7 +17978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_add_round_sh() {
+    fn test_mm_mask_add_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -17995,7 +17995,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_add_round_sh() {
+    fn test_mm_maskz_add_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r =
@@ -18009,7 +18009,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_add_sh() {
+    const fn test_mm_add_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_add_sh(a, b);
@@ -18018,7 +18018,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_add_sh() {
+    const fn test_mm_mask_add_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18031,7 +18031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_add_sh() {
+    const fn test_mm_maskz_add_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_maskz_add_sh(0, a, b);
@@ -18043,7 +18043,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_sub_ph() {
+    const fn test_mm_sub_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let r = _mm_sub_ph(a, b);
@@ -18052,7 +18052,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_sub_ph() {
+    const fn test_mm_mask_sub_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
@@ -18062,7 +18062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_ph() {
+    const fn test_mm_maskz_sub_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let r = _mm_maskz_sub_ph(0b01010101, a, b);
@@ -18071,7 +18071,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_sub_ph() {
+    const fn test_mm256_sub_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -18087,7 +18087,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_ph() {
+    const fn test_mm256_mask_sub_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -18105,7 +18105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_ph() {
+    const fn test_mm256_maskz_sub_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -18120,7 +18120,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_sub_ph() {
+    const fn test_mm512_sub_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18141,7 +18141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_sub_ph() {
+    const fn test_mm512_mask_sub_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18165,7 +18165,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_sub_ph() {
+    const fn test_mm512_maskz_sub_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18185,7 +18185,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_sub_round_ph() {
+    fn test_mm512_sub_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18206,7 +18206,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_sub_round_ph() {
+    fn test_mm512_mask_sub_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18235,7 +18235,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_sub_round_ph() {
+    fn test_mm512_maskz_sub_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18259,7 +18259,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_sub_round_sh() {
+    fn test_mm_sub_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_sub_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -18268,7 +18268,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_sub_round_sh() {
+    fn test_mm_mask_sub_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18285,7 +18285,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_sub_round_sh() {
+    fn test_mm_maskz_sub_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r =
@@ -18299,7 +18299,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_sub_sh() {
+    const fn test_mm_sub_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_sub_sh(a, b);
@@ -18308,7 +18308,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_sub_sh() {
+    const fn test_mm_mask_sub_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18321,7 +18321,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_sh() {
+    const fn test_mm_maskz_sub_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_maskz_sub_sh(0, a, b);
@@ -18333,7 +18333,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mul_ph() {
+    const fn test_mm_mul_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let r = _mm_mul_ph(a, b);
@@ -18342,7 +18342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_mul_ph() {
+    const fn test_mm_mask_mul_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
@@ -18352,7 +18352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_mul_ph() {
+    const fn test_mm_maskz_mul_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
         let r = _mm_maskz_mul_ph(0b01010101, a, b);
@@ -18361,7 +18361,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mul_ph() {
+    const fn test_mm256_mul_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -18377,7 +18377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_mul_ph() {
+    const fn test_mm256_mask_mul_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -18395,7 +18395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_mul_ph() {
+    const fn test_mm256_maskz_mul_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -18410,7 +18410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mul_ph() {
+    const fn test_mm512_mul_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18431,7 +18431,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_mul_ph() {
+    const fn test_mm512_mask_mul_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18455,7 +18455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_mul_ph() {
+    const fn test_mm512_maskz_mul_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18475,7 +18475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mul_round_ph() {
+    fn test_mm512_mul_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18496,7 +18496,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_mul_round_ph() {
+    fn test_mm512_mask_mul_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18525,7 +18525,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_mul_round_ph() {
+    fn test_mm512_maskz_mul_round_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -18549,7 +18549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mul_round_sh() {
+    fn test_mm_mul_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_mul_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -18558,7 +18558,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_mul_round_sh() {
+    fn test_mm_mask_mul_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18575,7 +18575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_mul_round_sh() {
+    fn test_mm_maskz_mul_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r =
@@ -18589,7 +18589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mul_sh() {
+    const fn test_mm_mul_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_mul_sh(a, b);
@@ -18598,7 +18598,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_mul_sh() {
+    const fn test_mm_mask_mul_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18611,7 +18611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_mul_sh() {
+    const fn test_mm_maskz_mul_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_maskz_mul_sh(0, a, b);
@@ -18623,7 +18623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_div_ph() {
+    const fn test_mm_div_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let r = _mm_div_ph(a, b);
@@ -18632,7 +18632,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_div_ph() {
+    const fn test_mm_mask_div_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let src = _mm_set_ph(4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0);
@@ -18642,7 +18642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_div_ph() {
+    const fn test_mm_maskz_div_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let r = _mm_maskz_div_ph(0b01010101, a, b);
@@ -18651,7 +18651,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_div_ph() {
+    const fn test_mm256_div_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let r = _mm256_div_ph(a, b);
@@ -18660,7 +18660,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_div_ph() {
+    const fn test_mm256_mask_div_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let src = _mm256_set_ph(
@@ -18675,7 +18675,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_div_ph() {
+    const fn test_mm256_maskz_div_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let r = _mm256_maskz_div_ph(0b0101010101010101, a, b);
@@ -18686,7 +18686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_div_ph() {
+    const fn test_mm512_div_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let r = _mm512_div_ph(a, b);
@@ -18695,7 +18695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_div_ph() {
+    const fn test_mm512_mask_div_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let src = _mm512_set_ph(
@@ -18712,7 +18712,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_div_ph() {
+    const fn test_mm512_maskz_div_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let r = _mm512_maskz_div_ph(0b01010101010101010101010101010101, a, b);
@@ -18724,7 +18724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_div_round_ph() {
+    fn test_mm512_div_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let r = _mm512_div_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -18733,7 +18733,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_div_round_ph() {
+    fn test_mm512_mask_div_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let src = _mm512_set_ph(
@@ -18755,7 +18755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_div_round_ph() {
+    fn test_mm512_maskz_div_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let r = _mm512_maskz_div_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -18771,7 +18771,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_div_round_sh() {
+    fn test_mm_div_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_div_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -18780,7 +18780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_div_round_sh() {
+    fn test_mm_mask_div_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18797,7 +18797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_div_round_sh() {
+    fn test_mm_maskz_div_round_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r =
@@ -18811,7 +18811,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_div_sh() {
+    const fn test_mm_div_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_div_sh(a, b);
@@ -18820,7 +18820,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_div_sh() {
+    const fn test_mm_mask_div_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let src = _mm_set_sh(4.0);
@@ -18833,7 +18833,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_div_sh() {
+    const fn test_mm_maskz_div_sh() {
         let a = _mm_set_sh(1.0);
         let b = _mm_set_sh(2.0);
         let r = _mm_maskz_div_sh(0, a, b);
@@ -18845,7 +18845,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mul_pch() {
+    fn test_mm_mul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 1.0);
         let r = _mm_mul_pch(a, b);
@@ -18854,7 +18854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_mul_pch() {
+    fn test_mm_mask_mul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 1.0);
         let src = _mm_setr_ph(2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
@@ -18864,7 +18864,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_mul_pch() {
+    fn test_mm_maskz_mul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 1.0);
         let r = _mm_maskz_mul_pch(0b0101, a, b);
@@ -18873,7 +18873,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mul_pch() {
+    fn test_mm256_mul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 1.0);
         let r = _mm256_mul_pch(a, b);
@@ -18882,7 +18882,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_mul_pch() {
+    fn test_mm256_mask_mul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 1.0);
         let src = _mm256_setr_ph(
@@ -18896,7 +18896,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_mul_pch() {
+    fn test_mm256_maskz_mul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 1.0);
         let r = _mm256_maskz_mul_pch(0b01010101, a, b);
@@ -18907,7 +18907,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mul_pch() {
+    fn test_mm512_mul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_mul_pch(a, b);
@@ -18916,7 +18916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_mul_pch() {
+    fn test_mm512_mask_mul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let src = _mm512_setr_ph(
@@ -18934,7 +18934,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_mul_pch() {
+    fn test_mm512_maskz_mul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_maskz_mul_pch(0b0101010101010101, a, b);
@@ -18946,7 +18946,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mul_round_pch() {
+    fn test_mm512_mul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_mul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -18955,7 +18955,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_mul_round_pch() {
+    fn test_mm512_mask_mul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let src = _mm512_setr_ph(
@@ -18978,7 +18978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_mul_round_pch() {
+    fn test_mm512_maskz_mul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_maskz_mul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -18994,7 +18994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mul_round_sch() {
+    fn test_mm_mul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r = _mm_mul_round_sch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19003,7 +19003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_mul_round_sch() {
+    fn test_mm_mask_mul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19015,7 +19015,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_mul_round_sch() {
+    fn test_mm_maskz_mul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r =
@@ -19025,7 +19025,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mul_sch() {
+    fn test_mm_mul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r = _mm_mul_sch(a, b);
@@ -19034,7 +19034,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_mul_sch() {
+    fn test_mm_mask_mul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19044,7 +19044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_mul_sch() {
+    fn test_mm_maskz_mul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r = _mm_maskz_mul_sch(0, a, b);
@@ -19053,7 +19053,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmul_pch() {
+    fn test_mm_fmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 1.0);
         let r = _mm_fmul_pch(a, b);
@@ -19062,7 +19062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmul_pch() {
+    fn test_mm_mask_fmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 1.0);
         let src = _mm_setr_ph(2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
@@ -19072,7 +19072,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmul_pch() {
+    fn test_mm_maskz_fmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 1.0);
         let r = _mm_maskz_fmul_pch(0b0101, a, b);
@@ -19081,7 +19081,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_fmul_pch() {
+    fn test_mm256_fmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 1.0);
         let r = _mm256_fmul_pch(a, b);
@@ -19090,7 +19090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_fmul_pch() {
+    fn test_mm256_mask_fmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 1.0);
         let src = _mm256_setr_ph(
@@ -19104,7 +19104,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_fmul_pch() {
+    fn test_mm256_maskz_fmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 1.0);
         let r = _mm256_maskz_fmul_pch(0b01010101, a, b);
@@ -19115,7 +19115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmul_pch() {
+    fn test_mm512_fmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_fmul_pch(a, b);
@@ -19124,7 +19124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmul_pch() {
+    fn test_mm512_mask_fmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let src = _mm512_setr_ph(
@@ -19142,7 +19142,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmul_pch() {
+    fn test_mm512_maskz_fmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_maskz_fmul_pch(0b0101010101010101, a, b);
@@ -19154,7 +19154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmul_round_pch() {
+    fn test_mm512_fmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_fmul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19163,7 +19163,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmul_round_pch() {
+    fn test_mm512_mask_fmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let src = _mm512_setr_ph(
@@ -19186,7 +19186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmul_round_pch() {
+    fn test_mm512_maskz_fmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_maskz_fmul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -19202,7 +19202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmul_round_sch() {
+    fn test_mm_fmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r = _mm_fmul_round_sch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19211,7 +19211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmul_round_sch() {
+    fn test_mm_mask_fmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19223,7 +19223,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmul_round_sch() {
+    fn test_mm_maskz_fmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r =
@@ -19233,7 +19233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmul_sch() {
+    fn test_mm_fmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r = _mm_fmul_sch(a, b);
@@ -19242,7 +19242,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmul_sch() {
+    fn test_mm_mask_fmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19252,7 +19252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmul_sch() {
+    fn test_mm_maskz_fmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 1.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let r = _mm_maskz_fmul_sch(0, a, b);
@@ -19261,7 +19261,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cmul_pch() {
+    fn test_mm_cmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, -1.0);
         let r = _mm_cmul_pch(a, b);
@@ -19270,7 +19270,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cmul_pch() {
+    fn test_mm_mask_cmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, -1.0);
         let src = _mm_setr_ph(2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
@@ -19280,7 +19280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cmul_pch() {
+    fn test_mm_maskz_cmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, -1.0);
         let r = _mm_maskz_cmul_pch(0b0101, a, b);
@@ -19289,7 +19289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cmul_pch() {
+    fn test_mm256_cmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, -1.0);
         let r = _mm256_cmul_pch(a, b);
@@ -19298,7 +19298,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cmul_pch() {
+    fn test_mm256_mask_cmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, -1.0);
         let src = _mm256_setr_ph(
@@ -19312,7 +19312,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cmul_pch() {
+    fn test_mm256_maskz_cmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, -1.0);
         let r = _mm256_maskz_cmul_pch(0b01010101, a, b);
@@ -19323,7 +19323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cmul_pch() {
+    fn test_mm512_cmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_cmul_pch(a, b);
@@ -19332,7 +19332,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cmul_pch() {
+    fn test_mm512_mask_cmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let src = _mm512_setr_ph(
@@ -19350,7 +19350,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cmul_pch() {
+    fn test_mm512_maskz_cmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_maskz_cmul_pch(0b0101010101010101, a, b);
@@ -19362,7 +19362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cmul_round_pch() {
+    fn test_mm512_cmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_cmul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19371,7 +19371,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cmul_round_pch() {
+    fn test_mm512_mask_cmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let src = _mm512_setr_ph(
@@ -19394,7 +19394,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cmul_round_pch() {
+    fn test_mm512_maskz_cmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_maskz_cmul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -19410,7 +19410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cmul_sch() {
+    fn test_mm_cmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r = _mm_cmul_sch(a, b);
@@ -19419,7 +19419,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cmul_sch() {
+    fn test_mm_mask_cmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19429,7 +19429,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cmul_sch() {
+    fn test_mm_maskz_cmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r = _mm_maskz_cmul_sch(0, a, b);
@@ -19438,7 +19438,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cmul_round_sch() {
+    fn test_mm_cmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r = _mm_cmul_round_sch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19447,7 +19447,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cmul_round_sch() {
+    fn test_mm_mask_cmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19459,7 +19459,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cmul_round_sch() {
+    fn test_mm_maskz_cmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r =
@@ -19469,7 +19469,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fcmul_pch() {
+    fn test_mm_fcmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, -1.0);
         let r = _mm_fcmul_pch(a, b);
@@ -19478,7 +19478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fcmul_pch() {
+    fn test_mm_mask_fcmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, -1.0);
         let src = _mm_setr_ph(2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
@@ -19488,7 +19488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fcmul_pch() {
+    fn test_mm_maskz_fcmul_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, -1.0);
         let r = _mm_maskz_fcmul_pch(0b0101, a, b);
@@ -19497,7 +19497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_fcmul_pch() {
+    fn test_mm256_fcmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, -1.0);
         let r = _mm256_fcmul_pch(a, b);
@@ -19506,7 +19506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_fcmul_pch() {
+    fn test_mm256_mask_fcmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, -1.0);
         let src = _mm256_setr_ph(
@@ -19520,7 +19520,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_fcmul_pch() {
+    fn test_mm256_maskz_fcmul_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, -1.0);
         let r = _mm256_maskz_fcmul_pch(0b01010101, a, b);
@@ -19531,7 +19531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fcmul_pch() {
+    fn test_mm512_fcmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_fcmul_pch(a, b);
@@ -19540,7 +19540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fcmul_pch() {
+    fn test_mm512_mask_fcmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let src = _mm512_setr_ph(
@@ -19558,7 +19558,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fcmul_pch() {
+    fn test_mm512_maskz_fcmul_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_maskz_fcmul_pch(0b0101010101010101, a, b);
@@ -19570,7 +19570,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fcmul_round_pch() {
+    fn test_mm512_fcmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_fcmul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19579,7 +19579,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fcmul_round_pch() {
+    fn test_mm512_mask_fcmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let src = _mm512_setr_ph(
@@ -19602,7 +19602,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fcmul_round_pch() {
+    fn test_mm512_maskz_fcmul_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, -1.0);
         let r = _mm512_maskz_fcmul_round_pch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -19618,7 +19618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fcmul_sch() {
+    fn test_mm_fcmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r = _mm_fcmul_sch(a, b);
@@ -19627,7 +19627,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fcmul_sch() {
+    fn test_mm_mask_fcmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19637,7 +19637,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fcmul_sch() {
+    fn test_mm_maskz_fcmul_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r = _mm_maskz_fcmul_sch(0, a, b);
@@ -19646,7 +19646,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fcmul_round_sch() {
+    fn test_mm_fcmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r = _mm_fcmul_round_sch::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -19655,7 +19655,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fcmul_round_sch() {
+    fn test_mm_mask_fcmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let src = _mm_setr_ph(14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0);
@@ -19667,7 +19667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fcmul_round_sch() {
+    fn test_mm_maskz_fcmul_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, -1.0, 8.0, -9.0, 10.0, -11.0, 12.0, -13.0);
         let r =
@@ -19677,7 +19677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_abs_ph() {
+    const fn test_mm_abs_ph() {
         let a = _mm_set_ph(-1.0, 0.0, 1.0, -2.0, 3.0, -4.0, 5.0, -6.0);
         let r = _mm_abs_ph(a);
         let e = _mm_set_ph(1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
@@ -19685,7 +19685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_abs_ph() {
+    const fn test_mm256_abs_ph() {
         let a = _mm256_set_ph(
             -1.0, 0.0, 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0, 11.0, -12.0, 13.0,
             -14.0,
@@ -19698,7 +19698,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_abs_ph() {
+    const fn test_mm512_abs_ph() {
         let a = _mm512_set_ph(
             -1.0, 0.0, 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0, 11.0, -12.0, 13.0,
             -14.0, 15.0, -16.0, 17.0, -18.0, 19.0, -20.0, 21.0, -22.0, 23.0, -24.0, 25.0, -26.0,
@@ -19714,7 +19714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_conj_pch() {
+    const fn test_mm_conj_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let r = _mm_conj_pch(a);
         let e = _mm_set1_pch(0.0, -1.0);
@@ -19722,7 +19722,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_conj_pch() {
+    const fn test_mm_mask_conj_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let src = _mm_setr_ph(2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
         let r = _mm_mask_conj_pch(src, 0b0101, a);
@@ -19731,7 +19731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_conj_pch() {
+    const fn test_mm_maskz_conj_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let r = _mm_maskz_conj_pch(0b0101, a);
         let e = _mm_setr_ph(0.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0);
@@ -19739,7 +19739,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_conj_pch() {
+    const fn test_mm256_conj_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let r = _mm256_conj_pch(a);
         let e = _mm256_set1_pch(0.0, -1.0);
@@ -19747,7 +19747,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_conj_pch() {
+    const fn test_mm256_mask_conj_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let src = _mm256_setr_ph(
             2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
@@ -19760,7 +19760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_conj_pch() {
+    const fn test_mm256_maskz_conj_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let r = _mm256_maskz_conj_pch(0b01010101, a);
         let e = _mm256_setr_ph(
@@ -19770,7 +19770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_conj_pch() {
+    const fn test_mm512_conj_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_conj_pch(a);
         let e = _mm512_set1_pch(0.0, -1.0);
@@ -19778,7 +19778,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_conj_pch() {
+    const fn test_mm512_mask_conj_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let src = _mm512_setr_ph(
             2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
@@ -19795,7 +19795,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_conj_pch() {
+    const fn test_mm512_maskz_conj_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let r = _mm512_maskz_conj_pch(0b0101010101010101, a);
         let e = _mm512_setr_ph(
@@ -19806,7 +19806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmadd_pch() {
+    fn test_mm_fmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -19816,7 +19816,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmadd_pch() {
+    fn test_mm_mask_fmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -19826,7 +19826,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fmadd_pch() {
+    fn test_mm_mask3_fmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -19836,7 +19836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmadd_pch() {
+    fn test_mm_maskz_fmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -19846,7 +19846,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_fmadd_pch() {
+    fn test_mm256_fmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -19856,7 +19856,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_fmadd_pch() {
+    fn test_mm256_mask_fmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -19868,7 +19868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask3_fmadd_pch() {
+    fn test_mm256_mask3_fmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -19880,7 +19880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_fmadd_pch() {
+    fn test_mm256_maskz_fmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -19892,7 +19892,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmadd_pch() {
+    fn test_mm512_fmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19902,7 +19902,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmadd_pch() {
+    fn test_mm512_mask_fmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19915,7 +19915,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fmadd_pch() {
+    fn test_mm512_mask3_fmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19928,7 +19928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmadd_pch() {
+    fn test_mm512_maskz_fmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19941,7 +19941,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmadd_round_pch() {
+    fn test_mm512_fmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19952,7 +19952,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmadd_round_pch() {
+    fn test_mm512_mask_fmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19970,7 +19970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fmadd_round_pch() {
+    fn test_mm512_mask3_fmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -19988,7 +19988,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmadd_round_pch() {
+    fn test_mm512_maskz_fmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20006,7 +20006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmadd_sch() {
+    fn test_mm_fmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20016,7 +20016,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmadd_sch() {
+    fn test_mm_mask_fmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20029,7 +20029,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fmadd_sch() {
+    fn test_mm_mask3_fmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20042,7 +20042,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmadd_sch() {
+    fn test_mm_maskz_fmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20055,7 +20055,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmadd_round_sch() {
+    fn test_mm_fmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20065,7 +20065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmadd_round_sch() {
+    fn test_mm_mask_fmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20082,7 +20082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fmadd_round_sch() {
+    fn test_mm_mask3_fmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20099,7 +20099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmadd_round_sch() {
+    fn test_mm_maskz_fmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20116,7 +20116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fcmadd_pch() {
+    fn test_mm_fcmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -20126,7 +20126,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fcmadd_pch() {
+    fn test_mm_mask_fcmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -20136,7 +20136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fcmadd_pch() {
+    fn test_mm_mask3_fcmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -20146,7 +20146,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fcmadd_pch() {
+    fn test_mm_maskz_fcmadd_pch() {
         let a = _mm_set1_pch(0.0, 1.0);
         let b = _mm_set1_pch(0.0, 2.0);
         let c = _mm_set1_pch(0.0, 3.0);
@@ -20156,7 +20156,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_fcmadd_pch() {
+    fn test_mm256_fcmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -20166,7 +20166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_fcmadd_pch() {
+    fn test_mm256_mask_fcmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -20178,7 +20178,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask3_fcmadd_pch() {
+    fn test_mm256_mask3_fcmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -20190,7 +20190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_fcmadd_pch() {
+    fn test_mm256_maskz_fcmadd_pch() {
         let a = _mm256_set1_pch(0.0, 1.0);
         let b = _mm256_set1_pch(0.0, 2.0);
         let c = _mm256_set1_pch(0.0, 3.0);
@@ -20202,7 +20202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fcmadd_pch() {
+    fn test_mm512_fcmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20212,7 +20212,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fcmadd_pch() {
+    fn test_mm512_mask_fcmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20225,7 +20225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fcmadd_pch() {
+    fn test_mm512_mask3_fcmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20238,7 +20238,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fcmadd_pch() {
+    fn test_mm512_maskz_fcmadd_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20251,7 +20251,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fcmadd_round_pch() {
+    fn test_mm512_fcmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20262,7 +20262,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fcmadd_round_pch() {
+    fn test_mm512_mask_fcmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20280,7 +20280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fcmadd_round_pch() {
+    fn test_mm512_mask3_fcmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20298,7 +20298,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fcmadd_round_pch() {
+    fn test_mm512_maskz_fcmadd_round_pch() {
         let a = _mm512_set1_pch(0.0, 1.0);
         let b = _mm512_set1_pch(0.0, 2.0);
         let c = _mm512_set1_pch(0.0, 3.0);
@@ -20316,7 +20316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fcmadd_sch() {
+    fn test_mm_fcmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20326,7 +20326,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fcmadd_sch() {
+    fn test_mm_mask_fcmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20339,7 +20339,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fcmadd_sch() {
+    fn test_mm_mask3_fcmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20352,7 +20352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fcmadd_sch() {
+    fn test_mm_maskz_fcmadd_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20365,7 +20365,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fcmadd_round_sch() {
+    fn test_mm_fcmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20375,7 +20375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fcmadd_round_sch() {
+    fn test_mm_mask_fcmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20392,7 +20392,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fcmadd_round_sch() {
+    fn test_mm_mask3_fcmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20409,7 +20409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fcmadd_round_sch() {
+    fn test_mm_maskz_fcmadd_round_sch() {
         let a = _mm_setr_ph(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
         let b = _mm_setr_ph(0.0, 2.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0);
         let c = _mm_setr_ph(0.0, 3.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0);
@@ -20426,7 +20426,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fmadd_ph() {
+    const fn test_mm_fmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20436,7 +20436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fmadd_ph() {
+    const fn test_mm_mask_fmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20446,7 +20446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fmadd_ph() {
+    const fn test_mm_mask3_fmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20456,7 +20456,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fmadd_ph() {
+    const fn test_mm_maskz_fmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20466,7 +20466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_fmadd_ph() {
+    const fn test_mm256_fmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20476,7 +20476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_fmadd_ph() {
+    const fn test_mm256_mask_fmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20488,7 +20488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmadd_ph() {
+    const fn test_mm256_mask3_fmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20500,7 +20500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmadd_ph() {
+    const fn test_mm256_maskz_fmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20512,7 +20512,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_fmadd_ph() {
+    const fn test_mm512_fmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20522,7 +20522,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_fmadd_ph() {
+    const fn test_mm512_mask_fmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20535,7 +20535,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask3_fmadd_ph() {
+    const fn test_mm512_mask3_fmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20548,7 +20548,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_fmadd_ph() {
+    const fn test_mm512_maskz_fmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20561,7 +20561,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmadd_round_ph() {
+    fn test_mm512_fmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20571,7 +20571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmadd_round_ph() {
+    fn test_mm512_mask_fmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20589,7 +20589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fmadd_round_ph() {
+    fn test_mm512_mask3_fmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20607,7 +20607,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmadd_round_ph() {
+    fn test_mm512_maskz_fmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20625,7 +20625,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fmadd_sh() {
+    const fn test_mm_fmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20635,7 +20635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fmadd_sh() {
+    const fn test_mm_mask_fmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20648,7 +20648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fmadd_sh() {
+    const fn test_mm_mask3_fmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20661,7 +20661,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fmadd_sh() {
+    const fn test_mm_maskz_fmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20674,7 +20674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmadd_round_sh() {
+    fn test_mm_fmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20684,7 +20684,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmadd_round_sh() {
+    fn test_mm_mask_fmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20701,7 +20701,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fmadd_round_sh() {
+    fn test_mm_mask3_fmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20718,7 +20718,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmadd_round_sh() {
+    fn test_mm_maskz_fmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20735,7 +20735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fmsub_ph() {
+    const fn test_mm_fmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20745,7 +20745,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fmsub_ph() {
+    const fn test_mm_mask_fmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20755,7 +20755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsub_ph() {
+    const fn test_mm_mask3_fmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20765,7 +20765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsub_ph() {
+    const fn test_mm_maskz_fmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -20775,7 +20775,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_fmsub_ph() {
+    const fn test_mm256_fmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20785,7 +20785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_fmsub_ph() {
+    const fn test_mm256_mask_fmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20797,7 +20797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmsub_ph() {
+    const fn test_mm256_mask3_fmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20809,7 +20809,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmsub_ph() {
+    const fn test_mm256_maskz_fmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -20821,7 +20821,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_fmsub_ph() {
+    const fn test_mm512_fmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20831,7 +20831,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_fmsub_ph() {
+    const fn test_mm512_mask_fmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20844,7 +20844,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask3_fmsub_ph() {
+    const fn test_mm512_mask3_fmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20857,7 +20857,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_fmsub_ph() {
+    const fn test_mm512_maskz_fmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20870,7 +20870,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmsub_round_ph() {
+    fn test_mm512_fmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20880,7 +20880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmsub_round_ph() {
+    fn test_mm512_mask_fmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20898,7 +20898,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fmsub_round_ph() {
+    fn test_mm512_mask3_fmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20916,7 +20916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmsub_round_ph() {
+    fn test_mm512_maskz_fmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -20934,7 +20934,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fmsub_sh() {
+    const fn test_mm_fmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20944,7 +20944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fmsub_sh() {
+    const fn test_mm_mask_fmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20957,7 +20957,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsub_sh() {
+    const fn test_mm_mask3_fmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20970,7 +20970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsub_sh() {
+    const fn test_mm_maskz_fmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20983,7 +20983,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fmsub_round_sh() {
+    fn test_mm_fmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -20993,7 +20993,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fmsub_round_sh() {
+    fn test_mm_mask_fmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21010,7 +21010,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fmsub_round_sh() {
+    fn test_mm_mask3_fmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21027,7 +21027,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fmsub_round_sh() {
+    fn test_mm_maskz_fmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21044,7 +21044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fnmadd_ph() {
+    const fn test_mm_fnmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21054,7 +21054,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fnmadd_ph() {
+    const fn test_mm_mask_fnmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21064,7 +21064,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmadd_ph() {
+    const fn test_mm_mask3_fnmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21074,7 +21074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmadd_ph() {
+    const fn test_mm_maskz_fnmadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21084,7 +21084,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_fnmadd_ph() {
+    const fn test_mm256_fnmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21094,7 +21094,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_fnmadd_ph() {
+    const fn test_mm256_mask_fnmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21106,7 +21106,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask3_fnmadd_ph() {
+    const fn test_mm256_mask3_fnmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21118,7 +21118,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_fnmadd_ph() {
+    const fn test_mm256_maskz_fnmadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21130,7 +21130,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_fnmadd_ph() {
+    const fn test_mm512_fnmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21140,7 +21140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_fnmadd_ph() {
+    const fn test_mm512_mask_fnmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21153,7 +21153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask3_fnmadd_ph() {
+    const fn test_mm512_mask3_fnmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21166,7 +21166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_fnmadd_ph() {
+    const fn test_mm512_maskz_fnmadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21179,7 +21179,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fnmadd_round_ph() {
+    fn test_mm512_fnmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21190,7 +21190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fnmadd_round_ph() {
+    fn test_mm512_mask_fnmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21208,7 +21208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fnmadd_round_ph() {
+    fn test_mm512_mask3_fnmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21226,7 +21226,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fnmadd_round_ph() {
+    fn test_mm512_maskz_fnmadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21244,7 +21244,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fnmadd_sh() {
+    const fn test_mm_fnmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21254,7 +21254,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fnmadd_sh() {
+    const fn test_mm_mask_fnmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21267,7 +21267,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmadd_sh() {
+    const fn test_mm_mask3_fnmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21280,7 +21280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmadd_sh() {
+    const fn test_mm_maskz_fnmadd_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21293,7 +21293,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fnmadd_round_sh() {
+    fn test_mm_fnmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21303,7 +21303,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fnmadd_round_sh() {
+    fn test_mm_mask_fnmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21320,7 +21320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fnmadd_round_sh() {
+    fn test_mm_mask3_fnmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21337,7 +21337,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fnmadd_round_sh() {
+    fn test_mm_maskz_fnmadd_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21354,7 +21354,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fnmsub_ph() {
+    const fn test_mm_fnmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21364,7 +21364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fnmsub_ph() {
+    const fn test_mm_mask_fnmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21374,7 +21374,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmsub_ph() {
+    const fn test_mm_mask3_fnmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21384,7 +21384,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmsub_ph() {
+    const fn test_mm_maskz_fnmsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21394,7 +21394,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_fnmsub_ph() {
+    const fn test_mm256_fnmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21404,7 +21404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_fnmsub_ph() {
+    const fn test_mm256_mask_fnmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21416,7 +21416,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask3_fnmsub_ph() {
+    const fn test_mm256_mask3_fnmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21428,7 +21428,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_fnmsub_ph() {
+    const fn test_mm256_maskz_fnmsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21440,7 +21440,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_fnmsub_ph() {
+    const fn test_mm512_fnmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21450,7 +21450,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_fnmsub_ph() {
+    const fn test_mm512_mask_fnmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21463,7 +21463,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask3_fnmsub_ph() {
+    const fn test_mm512_mask3_fnmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21476,7 +21476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_fnmsub_ph() {
+    const fn test_mm512_maskz_fnmsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21489,7 +21489,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fnmsub_round_ph() {
+    fn test_mm512_fnmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21500,7 +21500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fnmsub_round_ph() {
+    fn test_mm512_mask_fnmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21518,7 +21518,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fnmsub_round_ph() {
+    fn test_mm512_mask3_fnmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21536,7 +21536,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fnmsub_round_ph() {
+    fn test_mm512_maskz_fnmsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21554,7 +21554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fnmsub_sh() {
+    const fn test_mm_fnmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21564,7 +21564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fnmsub_sh() {
+    const fn test_mm_mask_fnmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21577,7 +21577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmsub_sh() {
+    const fn test_mm_mask3_fnmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21590,7 +21590,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmsub_sh() {
+    const fn test_mm_maskz_fnmsub_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21603,7 +21603,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fnmsub_round_sh() {
+    fn test_mm_fnmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21613,7 +21613,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fnmsub_round_sh() {
+    fn test_mm_mask_fnmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21630,7 +21630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask3_fnmsub_round_sh() {
+    fn test_mm_mask3_fnmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21647,7 +21647,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_fnmsub_round_sh() {
+    fn test_mm_maskz_fnmsub_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(2.0, 20., 21., 22., 23., 24., 25., 26.);
         let c = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -21664,7 +21664,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fmaddsub_ph() {
+    const fn test_mm_fmaddsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21674,7 +21674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fmaddsub_ph() {
+    const fn test_mm_mask_fmaddsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21684,7 +21684,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fmaddsub_ph() {
+    const fn test_mm_mask3_fmaddsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21694,7 +21694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fmaddsub_ph() {
+    const fn test_mm_maskz_fmaddsub_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21704,7 +21704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_fmaddsub_ph() {
+    const fn test_mm256_fmaddsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21716,7 +21716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_fmaddsub_ph() {
+    const fn test_mm256_mask_fmaddsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21728,7 +21728,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmaddsub_ph() {
+    const fn test_mm256_mask3_fmaddsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21740,7 +21740,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmaddsub_ph() {
+    const fn test_mm256_maskz_fmaddsub_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21752,7 +21752,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_fmaddsub_ph() {
+    const fn test_mm512_fmaddsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21765,7 +21765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_fmaddsub_ph() {
+    const fn test_mm512_mask_fmaddsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21778,7 +21778,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask3_fmaddsub_ph() {
+    const fn test_mm512_mask3_fmaddsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21791,7 +21791,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_fmaddsub_ph() {
+    const fn test_mm512_maskz_fmaddsub_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21804,7 +21804,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmaddsub_round_ph() {
+    fn test_mm512_fmaddsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21818,7 +21818,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmaddsub_round_ph() {
+    fn test_mm512_mask_fmaddsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21836,7 +21836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fmaddsub_round_ph() {
+    fn test_mm512_mask3_fmaddsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21854,7 +21854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmaddsub_round_ph() {
+    fn test_mm512_maskz_fmaddsub_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21872,7 +21872,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_fmsubadd_ph() {
+    const fn test_mm_fmsubadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21882,7 +21882,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_fmsubadd_ph() {
+    const fn test_mm_mask_fmsubadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21892,7 +21892,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsubadd_ph() {
+    const fn test_mm_mask3_fmsubadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21902,7 +21902,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsubadd_ph() {
+    const fn test_mm_maskz_fmsubadd_ph() {
         let a = _mm_set1_ph(1.0);
         let b = _mm_set1_ph(2.0);
         let c = _mm_set1_ph(3.0);
@@ -21912,7 +21912,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_fmsubadd_ph() {
+    const fn test_mm256_fmsubadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21924,7 +21924,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_fmsubadd_ph() {
+    const fn test_mm256_mask_fmsubadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21936,7 +21936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmsubadd_ph() {
+    const fn test_mm256_mask3_fmsubadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21948,7 +21948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmsubadd_ph() {
+    const fn test_mm256_maskz_fmsubadd_ph() {
         let a = _mm256_set1_ph(1.0);
         let b = _mm256_set1_ph(2.0);
         let c = _mm256_set1_ph(3.0);
@@ -21960,7 +21960,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_fmsubadd_ph() {
+    const fn test_mm512_fmsubadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21973,7 +21973,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_fmsubadd_ph() {
+    const fn test_mm512_mask_fmsubadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21986,7 +21986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask3_fmsubadd_ph() {
+    const fn test_mm512_mask3_fmsubadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -21999,7 +21999,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_maskz_fmsubadd_ph() {
+    const fn test_mm512_maskz_fmsubadd_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -22012,7 +22012,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fmsubadd_round_ph() {
+    fn test_mm512_fmsubadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -22026,7 +22026,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fmsubadd_round_ph() {
+    fn test_mm512_mask_fmsubadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -22044,7 +22044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask3_fmsubadd_round_ph() {
+    fn test_mm512_mask3_fmsubadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -22062,7 +22062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_fmsubadd_round_ph() {
+    fn test_mm512_maskz_fmsubadd_round_ph() {
         let a = _mm512_set1_ph(1.0);
         let b = _mm512_set1_ph(2.0);
         let c = _mm512_set1_ph(3.0);
@@ -22080,7 +22080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_rcp_ph() {
+    fn test_mm_rcp_ph() {
         let a = _mm_set1_ph(2.0);
         let r = _mm_rcp_ph(a);
         let e = _mm_set1_ph(0.5);
@@ -22088,7 +22088,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_rcp_ph() {
+    fn test_mm_mask_rcp_ph() {
         let a = _mm_set1_ph(2.0);
         let src = _mm_set1_ph(1.0);
         let r = _mm_mask_rcp_ph(src, 0b01010101, a);
@@ -22097,7 +22097,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_rcp_ph() {
+    fn test_mm_maskz_rcp_ph() {
         let a = _mm_set1_ph(2.0);
         let r = _mm_maskz_rcp_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5);
@@ -22105,7 +22105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_rcp_ph() {
+    fn test_mm256_rcp_ph() {
         let a = _mm256_set1_ph(2.0);
         let r = _mm256_rcp_ph(a);
         let e = _mm256_set1_ph(0.5);
@@ -22113,7 +22113,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_rcp_ph() {
+    fn test_mm256_mask_rcp_ph() {
         let a = _mm256_set1_ph(2.0);
         let src = _mm256_set1_ph(1.0);
         let r = _mm256_mask_rcp_ph(src, 0b0101010101010101, a);
@@ -22124,7 +22124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_rcp_ph() {
+    fn test_mm256_maskz_rcp_ph() {
         let a = _mm256_set1_ph(2.0);
         let r = _mm256_maskz_rcp_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -22134,7 +22134,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_rcp_ph() {
+    fn test_mm512_rcp_ph() {
         let a = _mm512_set1_ph(2.0);
         let r = _mm512_rcp_ph(a);
         let e = _mm512_set1_ph(0.5);
@@ -22142,7 +22142,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_rcp_ph() {
+    fn test_mm512_mask_rcp_ph() {
         let a = _mm512_set1_ph(2.0);
         let src = _mm512_set1_ph(1.0);
         let r = _mm512_mask_rcp_ph(src, 0b01010101010101010101010101010101, a);
@@ -22154,7 +22154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_rcp_ph() {
+    fn test_mm512_maskz_rcp_ph() {
         let a = _mm512_set1_ph(2.0);
         let r = _mm512_maskz_rcp_ph(0b01010101010101010101010101010101, a);
         let e = _mm512_set_ph(
@@ -22165,7 +22165,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_rcp_sh() {
+    fn test_mm_rcp_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_rcp_sh(a, b);
@@ -22174,7 +22174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_rcp_sh() {
+    fn test_mm_mask_rcp_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22187,7 +22187,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_rcp_sh() {
+    fn test_mm_maskz_rcp_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_maskz_rcp_sh(0, a, b);
@@ -22199,7 +22199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_rsqrt_ph() {
+    fn test_mm_rsqrt_ph() {
         let a = _mm_set1_ph(4.0);
         let r = _mm_rsqrt_ph(a);
         let e = _mm_set1_ph(0.5);
@@ -22207,7 +22207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_rsqrt_ph() {
+    fn test_mm_mask_rsqrt_ph() {
         let a = _mm_set1_ph(4.0);
         let src = _mm_set1_ph(1.0);
         let r = _mm_mask_rsqrt_ph(src, 0b01010101, a);
@@ -22216,7 +22216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_rsqrt_ph() {
+    fn test_mm_maskz_rsqrt_ph() {
         let a = _mm_set1_ph(4.0);
         let r = _mm_maskz_rsqrt_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5);
@@ -22224,7 +22224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_rsqrt_ph() {
+    fn test_mm256_rsqrt_ph() {
         let a = _mm256_set1_ph(4.0);
         let r = _mm256_rsqrt_ph(a);
         let e = _mm256_set1_ph(0.5);
@@ -22232,7 +22232,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_rsqrt_ph() {
+    fn test_mm256_mask_rsqrt_ph() {
         let a = _mm256_set1_ph(4.0);
         let src = _mm256_set1_ph(1.0);
         let r = _mm256_mask_rsqrt_ph(src, 0b0101010101010101, a);
@@ -22243,7 +22243,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_rsqrt_ph() {
+    fn test_mm256_maskz_rsqrt_ph() {
         let a = _mm256_set1_ph(4.0);
         let r = _mm256_maskz_rsqrt_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -22253,7 +22253,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_rsqrt_ph() {
+    fn test_mm512_rsqrt_ph() {
         let a = _mm512_set1_ph(4.0);
         let r = _mm512_rsqrt_ph(a);
         let e = _mm512_set1_ph(0.5);
@@ -22261,7 +22261,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_rsqrt_ph() {
+    fn test_mm512_mask_rsqrt_ph() {
         let a = _mm512_set1_ph(4.0);
         let src = _mm512_set1_ph(1.0);
         let r = _mm512_mask_rsqrt_ph(src, 0b01010101010101010101010101010101, a);
@@ -22273,7 +22273,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_rsqrt_ph() {
+    fn test_mm512_maskz_rsqrt_ph() {
         let a = _mm512_set1_ph(4.0);
         let r = _mm512_maskz_rsqrt_ph(0b01010101010101010101010101010101, a);
         let e = _mm512_set_ph(
@@ -22284,7 +22284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_rsqrt_sh() {
+    fn test_mm_rsqrt_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let r = _mm_rsqrt_sh(a, b);
@@ -22293,7 +22293,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_rsqrt_sh() {
+    fn test_mm_mask_rsqrt_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22306,7 +22306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_rsqrt_sh() {
+    fn test_mm_maskz_rsqrt_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let r = _mm_maskz_rsqrt_sh(0, a, b);
@@ -22318,7 +22318,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_sqrt_ph() {
+    fn test_mm_sqrt_ph() {
         let a = _mm_set1_ph(4.0);
         let r = _mm_sqrt_ph(a);
         let e = _mm_set1_ph(2.0);
@@ -22326,7 +22326,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_sqrt_ph() {
+    fn test_mm_mask_sqrt_ph() {
         let a = _mm_set1_ph(4.0);
         let src = _mm_set1_ph(1.0);
         let r = _mm_mask_sqrt_ph(src, 0b01010101, a);
@@ -22335,7 +22335,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_sqrt_ph() {
+    fn test_mm_maskz_sqrt_ph() {
         let a = _mm_set1_ph(4.0);
         let r = _mm_maskz_sqrt_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2.0, 0.0, 2.0, 0.0, 2.0, 0.0, 2.0);
@@ -22343,7 +22343,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_sqrt_ph() {
+    fn test_mm256_sqrt_ph() {
         let a = _mm256_set1_ph(4.0);
         let r = _mm256_sqrt_ph(a);
         let e = _mm256_set1_ph(2.0);
@@ -22351,7 +22351,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_sqrt_ph() {
+    fn test_mm256_mask_sqrt_ph() {
         let a = _mm256_set1_ph(4.0);
         let src = _mm256_set1_ph(1.0);
         let r = _mm256_mask_sqrt_ph(src, 0b0101010101010101, a);
@@ -22362,7 +22362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_sqrt_ph() {
+    fn test_mm256_maskz_sqrt_ph() {
         let a = _mm256_set1_ph(4.0);
         let r = _mm256_maskz_sqrt_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -22372,7 +22372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_sqrt_ph() {
+    fn test_mm512_sqrt_ph() {
         let a = _mm512_set1_ph(4.0);
         let r = _mm512_sqrt_ph(a);
         let e = _mm512_set1_ph(2.0);
@@ -22380,7 +22380,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_sqrt_ph() {
+    fn test_mm512_mask_sqrt_ph() {
         let a = _mm512_set1_ph(4.0);
         let src = _mm512_set1_ph(1.0);
         let r = _mm512_mask_sqrt_ph(src, 0b01010101010101010101010101010101, a);
@@ -22392,7 +22392,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_sqrt_ph() {
+    fn test_mm512_maskz_sqrt_ph() {
         let a = _mm512_set1_ph(4.0);
         let r = _mm512_maskz_sqrt_ph(0b01010101010101010101010101010101, a);
         let e = _mm512_set_ph(
@@ -22403,7 +22403,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_sqrt_round_ph() {
+    fn test_mm512_sqrt_round_ph() {
         let a = _mm512_set1_ph(4.0);
         let r = _mm512_sqrt_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set1_ph(2.0);
@@ -22411,7 +22411,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_sqrt_round_ph() {
+    fn test_mm512_mask_sqrt_round_ph() {
         let a = _mm512_set1_ph(4.0);
         let src = _mm512_set1_ph(1.0);
         let r = _mm512_mask_sqrt_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -22427,7 +22427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_sqrt_round_ph() {
+    fn test_mm512_maskz_sqrt_round_ph() {
         let a = _mm512_set1_ph(4.0);
         let r = _mm512_maskz_sqrt_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01010101010101010101010101010101,
@@ -22441,7 +22441,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_sqrt_sh() {
+    fn test_mm_sqrt_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let r = _mm_sqrt_sh(a, b);
@@ -22450,7 +22450,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_sqrt_sh() {
+    fn test_mm_mask_sqrt_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22463,7 +22463,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_sqrt_sh() {
+    fn test_mm_maskz_sqrt_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let r = _mm_maskz_sqrt_sh(0, a, b);
@@ -22475,7 +22475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_sqrt_round_sh() {
+    fn test_mm_sqrt_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let r = _mm_sqrt_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -22484,7 +22484,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_sqrt_round_sh() {
+    fn test_mm_mask_sqrt_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22501,7 +22501,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_sqrt_round_sh() {
+    fn test_mm_maskz_sqrt_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(4.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0);
         let r =
@@ -22515,7 +22515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_max_ph() {
+    fn test_mm_max_ph() {
         let a = _mm_set1_ph(2.0);
         let b = _mm_set1_ph(1.0);
         let r = _mm_max_ph(a, b);
@@ -22524,7 +22524,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_max_ph() {
+    fn test_mm_mask_max_ph() {
         let a = _mm_set1_ph(2.0);
         let b = _mm_set1_ph(1.0);
         let src = _mm_set1_ph(3.0);
@@ -22534,7 +22534,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_max_ph() {
+    fn test_mm_maskz_max_ph() {
         let a = _mm_set1_ph(2.0);
         let b = _mm_set1_ph(1.0);
         let r = _mm_maskz_max_ph(0b01010101, a, b);
@@ -22543,7 +22543,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_max_ph() {
+    fn test_mm256_max_ph() {
         let a = _mm256_set1_ph(2.0);
         let b = _mm256_set1_ph(1.0);
         let r = _mm256_max_ph(a, b);
@@ -22552,7 +22552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_max_ph() {
+    fn test_mm256_mask_max_ph() {
         let a = _mm256_set1_ph(2.0);
         let b = _mm256_set1_ph(1.0);
         let src = _mm256_set1_ph(3.0);
@@ -22564,7 +22564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_max_ph() {
+    fn test_mm256_maskz_max_ph() {
         let a = _mm256_set1_ph(2.0);
         let b = _mm256_set1_ph(1.0);
         let r = _mm256_maskz_max_ph(0b0101010101010101, a, b);
@@ -22575,7 +22575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_max_ph() {
+    fn test_mm512_max_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_max_ph(a, b);
@@ -22584,7 +22584,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_max_ph() {
+    fn test_mm512_mask_max_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let src = _mm512_set1_ph(3.0);
@@ -22597,7 +22597,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_max_ph() {
+    fn test_mm512_maskz_max_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_maskz_max_ph(0b01010101010101010101010101010101, a, b);
@@ -22609,7 +22609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_max_round_ph() {
+    fn test_mm512_max_round_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_max_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -22618,7 +22618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_max_round_ph() {
+    fn test_mm512_mask_max_round_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let src = _mm512_set1_ph(3.0);
@@ -22636,7 +22636,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_max_round_ph() {
+    fn test_mm512_maskz_max_round_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_maskz_max_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -22652,7 +22652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_max_sh() {
+    fn test_mm_max_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_max_sh(a, b);
@@ -22661,7 +22661,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_max_sh() {
+    fn test_mm_mask_max_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22674,7 +22674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_max_sh() {
+    fn test_mm_maskz_max_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_maskz_max_sh(0, a, b);
@@ -22686,7 +22686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_max_round_sh() {
+    fn test_mm_max_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_max_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -22695,7 +22695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_max_round_sh() {
+    fn test_mm_mask_max_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22712,7 +22712,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_max_round_sh() {
+    fn test_mm_maskz_max_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r =
@@ -22726,7 +22726,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_min_ph() {
+    fn test_mm_min_ph() {
         let a = _mm_set1_ph(2.0);
         let b = _mm_set1_ph(1.0);
         let r = _mm_min_ph(a, b);
@@ -22735,7 +22735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_min_ph() {
+    fn test_mm_mask_min_ph() {
         let a = _mm_set1_ph(2.0);
         let b = _mm_set1_ph(1.0);
         let src = _mm_set1_ph(3.0);
@@ -22745,7 +22745,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_min_ph() {
+    fn test_mm_maskz_min_ph() {
         let a = _mm_set1_ph(2.0);
         let b = _mm_set1_ph(1.0);
         let r = _mm_maskz_min_ph(0b01010101, a, b);
@@ -22754,7 +22754,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_min_ph() {
+    fn test_mm256_min_ph() {
         let a = _mm256_set1_ph(2.0);
         let b = _mm256_set1_ph(1.0);
         let r = _mm256_min_ph(a, b);
@@ -22763,7 +22763,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_min_ph() {
+    fn test_mm256_mask_min_ph() {
         let a = _mm256_set1_ph(2.0);
         let b = _mm256_set1_ph(1.0);
         let src = _mm256_set1_ph(3.0);
@@ -22775,7 +22775,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_min_ph() {
+    fn test_mm256_maskz_min_ph() {
         let a = _mm256_set1_ph(2.0);
         let b = _mm256_set1_ph(1.0);
         let r = _mm256_maskz_min_ph(0b0101010101010101, a, b);
@@ -22786,7 +22786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_min_ph() {
+    fn test_mm512_min_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_min_ph(a, b);
@@ -22795,7 +22795,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_min_ph() {
+    fn test_mm512_mask_min_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let src = _mm512_set1_ph(3.0);
@@ -22808,7 +22808,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_min_ph() {
+    fn test_mm512_maskz_min_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_maskz_min_ph(0b01010101010101010101010101010101, a, b);
@@ -22820,7 +22820,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_min_round_ph() {
+    fn test_mm512_min_round_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_min_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -22829,7 +22829,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_min_round_ph() {
+    fn test_mm512_mask_min_round_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let src = _mm512_set1_ph(3.0);
@@ -22847,7 +22847,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_min_round_ph() {
+    fn test_mm512_maskz_min_round_ph() {
         let a = _mm512_set1_ph(2.0);
         let b = _mm512_set1_ph(1.0);
         let r = _mm512_maskz_min_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -22863,7 +22863,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_min_sh() {
+    fn test_mm_min_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_min_sh(a, b);
@@ -22872,7 +22872,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_min_sh() {
+    fn test_mm_mask_min_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22885,7 +22885,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_min_sh() {
+    fn test_mm_maskz_min_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_maskz_min_sh(0, a, b);
@@ -22897,7 +22897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_min_round_sh() {
+    fn test_mm_min_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r = _mm_min_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -22906,7 +22906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_min_round_sh() {
+    fn test_mm_mask_min_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let src = _mm_setr_ph(3.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0);
@@ -22923,7 +22923,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_min_round_sh() {
+    fn test_mm_maskz_min_round_sh() {
         let a = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let b = _mm_setr_ph(2.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0);
         let r =
@@ -22937,7 +22937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_getexp_ph() {
+    fn test_mm_getexp_ph() {
         let a = _mm_set1_ph(3.0);
         let r = _mm_getexp_ph(a);
         let e = _mm_set1_ph(1.0);
@@ -22945,7 +22945,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_getexp_ph() {
+    fn test_mm_mask_getexp_ph() {
         let a = _mm_set1_ph(3.0);
         let src = _mm_set1_ph(4.0);
         let r = _mm_mask_getexp_ph(src, 0b01010101, a);
@@ -22954,7 +22954,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_getexp_ph() {
+    fn test_mm_maskz_getexp_ph() {
         let a = _mm_set1_ph(3.0);
         let r = _mm_maskz_getexp_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0);
@@ -22962,7 +22962,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_getexp_ph() {
+    fn test_mm256_getexp_ph() {
         let a = _mm256_set1_ph(3.0);
         let r = _mm256_getexp_ph(a);
         let e = _mm256_set1_ph(1.0);
@@ -22970,7 +22970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_getexp_ph() {
+    fn test_mm256_mask_getexp_ph() {
         let a = _mm256_set1_ph(3.0);
         let src = _mm256_set1_ph(4.0);
         let r = _mm256_mask_getexp_ph(src, 0b0101010101010101, a);
@@ -22981,7 +22981,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_getexp_ph() {
+    fn test_mm256_maskz_getexp_ph() {
         let a = _mm256_set1_ph(3.0);
         let r = _mm256_maskz_getexp_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -22991,7 +22991,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_getexp_ph() {
+    fn test_mm512_getexp_ph() {
         let a = _mm512_set1_ph(3.0);
         let r = _mm512_getexp_ph(a);
         let e = _mm512_set1_ph(1.0);
@@ -22999,7 +22999,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_getexp_ph() {
+    fn test_mm512_mask_getexp_ph() {
         let a = _mm512_set1_ph(3.0);
         let src = _mm512_set1_ph(4.0);
         let r = _mm512_mask_getexp_ph(src, 0b01010101010101010101010101010101, a);
@@ -23011,7 +23011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_getexp_ph() {
+    fn test_mm512_maskz_getexp_ph() {
         let a = _mm512_set1_ph(3.0);
         let r = _mm512_maskz_getexp_ph(0b01010101010101010101010101010101, a);
         let e = _mm512_set_ph(
@@ -23022,7 +23022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_getexp_round_ph() {
+    fn test_mm512_getexp_round_ph() {
         let a = _mm512_set1_ph(3.0);
         let r = _mm512_getexp_round_ph::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set1_ph(1.0);
@@ -23030,7 +23030,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_getexp_round_ph() {
+    fn test_mm512_mask_getexp_round_ph() {
         let a = _mm512_set1_ph(3.0);
         let src = _mm512_set1_ph(4.0);
         let r = _mm512_mask_getexp_round_ph::<_MM_FROUND_NO_EXC>(
@@ -23046,7 +23046,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_getexp_round_ph() {
+    fn test_mm512_maskz_getexp_round_ph() {
         let a = _mm512_set1_ph(3.0);
         let r = _mm512_maskz_getexp_round_ph::<_MM_FROUND_NO_EXC>(
             0b01010101010101010101010101010101,
@@ -23060,7 +23060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_getexp_sh() {
+    fn test_mm_getexp_sh() {
         let a = _mm_setr_ph(4.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_getexp_sh(a, b);
@@ -23069,7 +23069,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_getexp_sh() {
+    fn test_mm_mask_getexp_sh() {
         let a = _mm_setr_ph(4.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(4.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23082,7 +23082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_getexp_sh() {
+    fn test_mm_maskz_getexp_sh() {
         let a = _mm_setr_ph(4.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_getexp_sh(0, a, b);
@@ -23094,7 +23094,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_getexp_round_sh() {
+    fn test_mm_getexp_round_sh() {
         let a = _mm_setr_ph(4.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_getexp_round_sh::<_MM_FROUND_NO_EXC>(a, b);
@@ -23103,7 +23103,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_getexp_round_sh() {
+    fn test_mm_mask_getexp_round_sh() {
         let a = _mm_setr_ph(4.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(4.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23116,7 +23116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_getexp_round_sh() {
+    fn test_mm_maskz_getexp_round_sh() {
         let a = _mm_setr_ph(4.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_getexp_round_sh::<_MM_FROUND_NO_EXC>(0, a, b);
@@ -23128,7 +23128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_getmant_ph() {
+    fn test_mm_getmant_ph() {
         let a = _mm_set1_ph(10.0);
         let r = _mm_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a);
         let e = _mm_set1_ph(1.25);
@@ -23136,7 +23136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_getmant_ph() {
+    fn test_mm_mask_getmant_ph() {
         let a = _mm_set1_ph(10.0);
         let src = _mm_set1_ph(20.0);
         let r = _mm_mask_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(src, 0b01010101, a);
@@ -23145,7 +23145,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_getmant_ph() {
+    fn test_mm_maskz_getmant_ph() {
         let a = _mm_set1_ph(10.0);
         let r = _mm_maskz_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(0b01010101, a);
         let e = _mm_set_ph(0.0, 1.25, 0.0, 1.25, 0.0, 1.25, 0.0, 1.25);
@@ -23153,7 +23153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_getmant_ph() {
+    fn test_mm256_getmant_ph() {
         let a = _mm256_set1_ph(10.0);
         let r = _mm256_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a);
         let e = _mm256_set1_ph(1.25);
@@ -23161,7 +23161,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_getmant_ph() {
+    fn test_mm256_mask_getmant_ph() {
         let a = _mm256_set1_ph(10.0);
         let src = _mm256_set1_ph(20.0);
         let r = _mm256_mask_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(
@@ -23177,7 +23177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_getmant_ph() {
+    fn test_mm256_maskz_getmant_ph() {
         let a = _mm256_set1_ph(10.0);
         let r = _mm256_maskz_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(
             0b0101010101010101,
@@ -23190,7 +23190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_getmant_ph() {
+    fn test_mm512_getmant_ph() {
         let a = _mm512_set1_ph(10.0);
         let r = _mm512_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a);
         let e = _mm512_set1_ph(1.25);
@@ -23198,7 +23198,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_getmant_ph() {
+    fn test_mm512_mask_getmant_ph() {
         let a = _mm512_set1_ph(10.0);
         let src = _mm512_set1_ph(20.0);
         let r = _mm512_mask_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(
@@ -23215,7 +23215,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_getmant_ph() {
+    fn test_mm512_maskz_getmant_ph() {
         let a = _mm512_set1_ph(10.0);
         let r = _mm512_maskz_getmant_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(
             0b01010101010101010101010101010101,
@@ -23229,7 +23229,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_getmant_round_ph() {
+    fn test_mm512_getmant_round_ph() {
         let a = _mm512_set1_ph(10.0);
         let r =
             _mm512_getmant_round_ph::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN, _MM_FROUND_NO_EXC>(
@@ -23240,7 +23240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_getmant_round_ph() {
+    fn test_mm512_mask_getmant_round_ph() {
         let a = _mm512_set1_ph(10.0);
         let src = _mm512_set1_ph(20.0);
         let r = _mm512_mask_getmant_round_ph::<
@@ -23257,7 +23257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_getmant_round_ph() {
+    fn test_mm512_maskz_getmant_round_ph() {
         let a = _mm512_set1_ph(10.0);
         let r = _mm512_maskz_getmant_round_ph::<
             _MM_MANT_NORM_P75_1P5,
@@ -23272,7 +23272,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_getmant_sh() {
+    fn test_mm_getmant_sh() {
         let a = _mm_setr_ph(15.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(10.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_getmant_sh::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(a, b);
@@ -23281,7 +23281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_getmant_sh() {
+    fn test_mm_mask_getmant_sh() {
         let a = _mm_setr_ph(15.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(10.0, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(20.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23294,7 +23294,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_getmant_sh() {
+    fn test_mm_maskz_getmant_sh() {
         let a = _mm_setr_ph(15.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(10.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_getmant_sh::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN>(0, a, b);
@@ -23306,7 +23306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_getmant_round_sh() {
+    fn test_mm_getmant_round_sh() {
         let a = _mm_setr_ph(15.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(10.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_getmant_round_sh::<_MM_MANT_NORM_P75_1P5, _MM_MANT_SIGN_NAN, _MM_FROUND_NO_EXC>(
@@ -23317,7 +23317,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_getmant_round_sh() {
+    fn test_mm_mask_getmant_round_sh() {
         let a = _mm_setr_ph(15.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(10.0, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(20.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23338,7 +23338,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_getmant_round_sh() {
+    fn test_mm_maskz_getmant_round_sh() {
         let a = _mm_setr_ph(15.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(10.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_getmant_round_sh::<
@@ -23358,7 +23358,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_roundscale_ph() {
+    fn test_mm_roundscale_ph() {
         let a = _mm_set1_ph(1.1);
         let r = _mm_roundscale_ph::<0>(a);
         let e = _mm_set1_ph(1.0);
@@ -23366,7 +23366,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_roundscale_ph() {
+    fn test_mm_mask_roundscale_ph() {
         let a = _mm_set1_ph(1.1);
         let src = _mm_set1_ph(2.0);
         let r = _mm_mask_roundscale_ph::<0>(src, 0b01010101, a);
@@ -23375,7 +23375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_roundscale_ph() {
+    fn test_mm_maskz_roundscale_ph() {
         let a = _mm_set1_ph(1.1);
         let r = _mm_maskz_roundscale_ph::<0>(0b01010101, a);
         let e = _mm_set_ph(0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0);
@@ -23383,7 +23383,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_roundscale_ph() {
+    fn test_mm256_roundscale_ph() {
         let a = _mm256_set1_ph(1.1);
         let r = _mm256_roundscale_ph::<0>(a);
         let e = _mm256_set1_ph(1.0);
@@ -23391,7 +23391,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_roundscale_ph() {
+    fn test_mm256_mask_roundscale_ph() {
         let a = _mm256_set1_ph(1.1);
         let src = _mm256_set1_ph(2.0);
         let r = _mm256_mask_roundscale_ph::<0>(src, 0b0101010101010101, a);
@@ -23402,7 +23402,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_roundscale_ph() {
+    fn test_mm256_maskz_roundscale_ph() {
         let a = _mm256_set1_ph(1.1);
         let r = _mm256_maskz_roundscale_ph::<0>(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -23412,7 +23412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_roundscale_ph() {
+    fn test_mm512_roundscale_ph() {
         let a = _mm512_set1_ph(1.1);
         let r = _mm512_roundscale_ph::<0>(a);
         let e = _mm512_set1_ph(1.0);
@@ -23420,7 +23420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_roundscale_ph() {
+    fn test_mm512_mask_roundscale_ph() {
         let a = _mm512_set1_ph(1.1);
         let src = _mm512_set1_ph(2.0);
         let r = _mm512_mask_roundscale_ph::<0>(src, 0b01010101010101010101010101010101, a);
@@ -23432,7 +23432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_roundscale_ph() {
+    fn test_mm512_maskz_roundscale_ph() {
         let a = _mm512_set1_ph(1.1);
         let r = _mm512_maskz_roundscale_ph::<0>(0b01010101010101010101010101010101, a);
         let e = _mm512_set_ph(
@@ -23443,7 +23443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_roundscale_round_ph() {
+    fn test_mm512_roundscale_round_ph() {
         let a = _mm512_set1_ph(1.1);
         let r = _mm512_roundscale_round_ph::<0, _MM_FROUND_NO_EXC>(a);
         let e = _mm512_set1_ph(1.0);
@@ -23451,7 +23451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_roundscale_round_ph() {
+    fn test_mm512_mask_roundscale_round_ph() {
         let a = _mm512_set1_ph(1.1);
         let src = _mm512_set1_ph(2.0);
         let r = _mm512_mask_roundscale_round_ph::<0, _MM_FROUND_NO_EXC>(
@@ -23467,7 +23467,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_roundscale_round_ph() {
+    fn test_mm512_maskz_roundscale_round_ph() {
         let a = _mm512_set1_ph(1.1);
         let r = _mm512_maskz_roundscale_round_ph::<0, _MM_FROUND_NO_EXC>(
             0b01010101010101010101010101010101,
@@ -23481,7 +23481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_roundscale_sh() {
+    fn test_mm_roundscale_sh() {
         let a = _mm_setr_ph(2.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.1, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_roundscale_sh::<0>(a, b);
@@ -23490,7 +23490,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_roundscale_sh() {
+    fn test_mm_mask_roundscale_sh() {
         let a = _mm_setr_ph(2.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.1, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23503,7 +23503,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_roundscale_sh() {
+    fn test_mm_maskz_roundscale_sh() {
         let a = _mm_setr_ph(2.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.1, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_roundscale_sh::<0>(0, a, b);
@@ -23515,7 +23515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_roundscale_round_sh() {
+    fn test_mm_roundscale_round_sh() {
         let a = _mm_setr_ph(2.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.1, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_roundscale_round_sh::<0, _MM_FROUND_NO_EXC>(a, b);
@@ -23524,7 +23524,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_roundscale_round_sh() {
+    fn test_mm_mask_roundscale_round_sh() {
         let a = _mm_setr_ph(2.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.1, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(3.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23537,7 +23537,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_roundscale_round_sh() {
+    fn test_mm_maskz_roundscale_round_sh() {
         let a = _mm_setr_ph(2.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.1, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_roundscale_round_sh::<0, _MM_FROUND_NO_EXC>(0, a, b);
@@ -23549,7 +23549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_scalef_ph() {
+    fn test_mm_scalef_ph() {
         let a = _mm_set1_ph(1.);
         let b = _mm_set1_ph(3.);
         let r = _mm_scalef_ph(a, b);
@@ -23558,7 +23558,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_scalef_ph() {
+    fn test_mm_mask_scalef_ph() {
         let a = _mm_set1_ph(1.);
         let b = _mm_set1_ph(3.);
         let src = _mm_set1_ph(2.);
@@ -23568,7 +23568,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_scalef_ph() {
+    fn test_mm_maskz_scalef_ph() {
         let a = _mm_set1_ph(1.);
         let b = _mm_set1_ph(3.);
         let r = _mm_maskz_scalef_ph(0b01010101, a, b);
@@ -23577,7 +23577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_scalef_ph() {
+    fn test_mm256_scalef_ph() {
         let a = _mm256_set1_ph(1.);
         let b = _mm256_set1_ph(3.);
         let r = _mm256_scalef_ph(a, b);
@@ -23586,7 +23586,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_scalef_ph() {
+    fn test_mm256_mask_scalef_ph() {
         let a = _mm256_set1_ph(1.);
         let b = _mm256_set1_ph(3.);
         let src = _mm256_set1_ph(2.);
@@ -23598,7 +23598,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_scalef_ph() {
+    fn test_mm256_maskz_scalef_ph() {
         let a = _mm256_set1_ph(1.);
         let b = _mm256_set1_ph(3.);
         let r = _mm256_maskz_scalef_ph(0b0101010101010101, a, b);
@@ -23609,7 +23609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_scalef_ph() {
+    fn test_mm512_scalef_ph() {
         let a = _mm512_set1_ph(1.);
         let b = _mm512_set1_ph(3.);
         let r = _mm512_scalef_ph(a, b);
@@ -23618,7 +23618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_scalef_ph() {
+    fn test_mm512_mask_scalef_ph() {
         let a = _mm512_set1_ph(1.);
         let b = _mm512_set1_ph(3.);
         let src = _mm512_set1_ph(2.);
@@ -23631,7 +23631,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_scalef_ph() {
+    fn test_mm512_maskz_scalef_ph() {
         let a = _mm512_set1_ph(1.);
         let b = _mm512_set1_ph(3.);
         let r = _mm512_maskz_scalef_ph(0b01010101010101010101010101010101, a, b);
@@ -23643,7 +23643,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_scalef_round_ph() {
+    fn test_mm512_scalef_round_ph() {
         let a = _mm512_set1_ph(1.);
         let b = _mm512_set1_ph(3.);
         let r = _mm512_scalef_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -23652,7 +23652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_scalef_round_ph() {
+    fn test_mm512_mask_scalef_round_ph() {
         let a = _mm512_set1_ph(1.);
         let b = _mm512_set1_ph(3.);
         let src = _mm512_set1_ph(2.);
@@ -23670,7 +23670,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_scalef_round_ph() {
+    fn test_mm512_maskz_scalef_round_ph() {
         let a = _mm512_set1_ph(1.);
         let b = _mm512_set1_ph(3.);
         let r = _mm512_maskz_scalef_round_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -23686,7 +23686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_scalef_sh() {
+    fn test_mm_scalef_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_scalef_sh(a, b);
@@ -23695,7 +23695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_scalef_sh() {
+    fn test_mm_mask_scalef_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(2.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23708,7 +23708,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_scalef_sh() {
+    fn test_mm_maskz_scalef_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_scalef_sh(0, a, b);
@@ -23720,7 +23720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_scalef_round_sh() {
+    fn test_mm_scalef_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_scalef_round_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -23729,7 +23729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_scalef_round_sh() {
+    fn test_mm_mask_scalef_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(2.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23746,7 +23746,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_scalef_round_sh() {
+    fn test_mm_maskz_scalef_round_sh() {
         let a = _mm_setr_ph(1.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(3.0, 20., 21., 22., 23., 24., 25., 26.);
         let r =
@@ -23760,7 +23760,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_reduce_ph() {
+    fn test_mm_reduce_ph() {
         let a = _mm_set1_ph(1.25);
         let r = _mm_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm_set1_ph(0.25);
@@ -23768,7 +23768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_reduce_ph() {
+    fn test_mm_mask_reduce_ph() {
         let a = _mm_set1_ph(1.25);
         let src = _mm_set1_ph(2.0);
         let r = _mm_mask_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b01010101, a);
@@ -23777,7 +23777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_reduce_ph() {
+    fn test_mm_maskz_reduce_ph() {
         let a = _mm_set1_ph(1.25);
         let r = _mm_maskz_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(0b01010101, a);
         let e = _mm_set_ph(0.0, 0.25, 0.0, 0.25, 0.0, 0.25, 0.0, 0.25);
@@ -23785,7 +23785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_reduce_ph() {
+    fn test_mm256_reduce_ph() {
         let a = _mm256_set1_ph(1.25);
         let r = _mm256_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm256_set1_ph(0.25);
@@ -23793,7 +23793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_reduce_ph() {
+    fn test_mm256_mask_reduce_ph() {
         let a = _mm256_set1_ph(1.25);
         let src = _mm256_set1_ph(2.0);
         let r = _mm256_mask_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(src, 0b0101010101010101, a);
@@ -23804,7 +23804,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_reduce_ph() {
+    fn test_mm256_maskz_reduce_ph() {
         let a = _mm256_set1_ph(1.25);
         let r = _mm256_maskz_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -23814,7 +23814,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_reduce_ph() {
+    fn test_mm512_reduce_ph() {
         let a = _mm512_set1_ph(1.25);
         let r = _mm512_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(a);
         let e = _mm512_set1_ph(0.25);
@@ -23822,7 +23822,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_reduce_ph() {
+    fn test_mm512_mask_reduce_ph() {
         let a = _mm512_set1_ph(1.25);
         let src = _mm512_set1_ph(2.0);
         let r = _mm512_mask_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(
@@ -23838,7 +23838,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_reduce_ph() {
+    fn test_mm512_maskz_reduce_ph() {
         let a = _mm512_set1_ph(1.25);
         let r = _mm512_maskz_reduce_ph::<{ 16 | _MM_FROUND_TO_ZERO }>(
             0b01010101010101010101010101010101,
@@ -23852,7 +23852,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_reduce_round_ph() {
+    fn test_mm512_reduce_round_ph() {
         let a = _mm512_set1_ph(1.25);
         let r = _mm512_reduce_round_ph::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(a);
         let e = _mm512_set1_ph(0.25);
@@ -23860,7 +23860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_reduce_round_ph() {
+    fn test_mm512_mask_reduce_round_ph() {
         let a = _mm512_set1_ph(1.25);
         let src = _mm512_set1_ph(2.0);
         let r = _mm512_mask_reduce_round_ph::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(
@@ -23876,7 +23876,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_reduce_round_ph() {
+    fn test_mm512_maskz_reduce_round_ph() {
         let a = _mm512_set1_ph(1.25);
         let r = _mm512_maskz_reduce_round_ph::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(
             0b01010101010101010101010101010101,
@@ -23890,7 +23890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_reduce_sh() {
+    fn test_mm_reduce_sh() {
         let a = _mm_setr_ph(3.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.25, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_reduce_sh::<{ 16 | _MM_FROUND_TO_ZERO }>(a, b);
@@ -23899,7 +23899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_reduce_sh() {
+    fn test_mm_mask_reduce_sh() {
         let a = _mm_setr_ph(3.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.25, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(2.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23912,7 +23912,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_reduce_sh() {
+    fn test_mm_maskz_reduce_sh() {
         let a = _mm_setr_ph(3.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.25, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_maskz_reduce_sh::<{ 16 | _MM_FROUND_TO_ZERO }>(0, a, b);
@@ -23924,7 +23924,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_reduce_round_sh() {
+    fn test_mm_reduce_round_sh() {
         let a = _mm_setr_ph(3.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.25, 20., 21., 22., 23., 24., 25., 26.);
         let r = _mm_reduce_round_sh::<{ 16 | _MM_FROUND_TO_ZERO }, _MM_FROUND_NO_EXC>(a, b);
@@ -23933,7 +23933,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_reduce_round_sh() {
+    fn test_mm_mask_reduce_round_sh() {
         let a = _mm_setr_ph(3.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.25, 20., 21., 22., 23., 24., 25., 26.);
         let src = _mm_setr_ph(2.0, 30., 31., 32., 33., 34., 35., 36.);
@@ -23950,7 +23950,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_reduce_round_sh() {
+    fn test_mm_maskz_reduce_round_sh() {
         let a = _mm_setr_ph(3.0, 10., 11., 12., 13., 14., 15., 16.);
         let b = _mm_setr_ph(1.25, 20., 21., 22., 23., 24., 25., 26.);
         let r =
@@ -23964,56 +23964,56 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_reduce_add_ph() {
+    const fn test_mm_reduce_add_ph() {
         let a = _mm_set1_ph(2.0);
         let r = _mm_reduce_add_ph(a);
         assert_eq!(r, 16.0);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_reduce_add_ph() {
+    const fn test_mm256_reduce_add_ph() {
         let a = _mm256_set1_ph(2.0);
         let r = _mm256_reduce_add_ph(a);
         assert_eq!(r, 32.0);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_reduce_add_ph() {
+    const fn test_mm512_reduce_add_ph() {
         let a = _mm512_set1_ph(2.0);
         let r = _mm512_reduce_add_ph(a);
         assert_eq!(r, 64.0);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_reduce_mul_ph() {
+    const fn test_mm_reduce_mul_ph() {
         let a = _mm_set1_ph(2.0);
         let r = _mm_reduce_mul_ph(a);
         assert_eq!(r, 256.0);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_reduce_mul_ph() {
+    const fn test_mm256_reduce_mul_ph() {
         let a = _mm256_set1_ph(2.0);
         let r = _mm256_reduce_mul_ph(a);
         assert_eq!(r, 65536.0);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_reduce_mul_ph() {
+    const fn test_mm512_reduce_mul_ph() {
         let a = _mm512_set1_ph(2.0);
         let r = _mm512_reduce_mul_ph(a);
         assert_eq!(r, 16777216.0);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_reduce_max_ph() {
+    fn test_mm_reduce_max_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_reduce_max_ph(a);
         assert_eq!(r, 8.0);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_reduce_max_ph() {
+    fn test_mm256_reduce_max_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -24022,7 +24022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_reduce_max_ph() {
+    fn test_mm512_reduce_max_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -24033,14 +24033,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_reduce_min_ph() {
+    fn test_mm_reduce_min_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_reduce_min_ph(a);
         assert_eq!(r, 1.0);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_reduce_min_ph() {
+    fn test_mm256_reduce_min_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -24049,7 +24049,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_reduce_min_ph() {
+    fn test_mm512_reduce_min_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -24060,7 +24060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_fpclass_ph_mask() {
+    fn test_mm_fpclass_ph_mask() {
         let a = _mm_set_ph(
             1.,
             f16::INFINITY,
@@ -24076,7 +24076,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_fpclass_ph_mask() {
+    fn test_mm_mask_fpclass_ph_mask() {
         let a = _mm_set_ph(
             1.,
             f16::INFINITY,
@@ -24092,7 +24092,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_fpclass_ph_mask() {
+    fn test_mm256_fpclass_ph_mask() {
         let a = _mm256_set_ph(
             1.,
             f16::INFINITY,
@@ -24116,7 +24116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_fpclass_ph_mask() {
+    fn test_mm256_mask_fpclass_ph_mask() {
         let a = _mm256_set_ph(
             1.,
             f16::INFINITY,
@@ -24140,7 +24140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_fpclass_ph_mask() {
+    fn test_mm512_fpclass_ph_mask() {
         let a = _mm512_set_ph(
             1.,
             f16::INFINITY,
@@ -24180,7 +24180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_fpclass_ph_mask() {
+    fn test_mm512_mask_fpclass_ph_mask() {
         let a = _mm512_set_ph(
             1.,
             f16::INFINITY,
@@ -24220,14 +24220,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_fpclass_sh_mask() {
+    fn test_mm_fpclass_sh_mask() {
         let a = _mm_set_sh(f16::INFINITY);
         let r = _mm_fpclass_sh_mask::<0x18>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_fpclass_sh_mask() {
+    fn test_mm_mask_fpclass_sh_mask() {
         let a = _mm_set_sh(f16::INFINITY);
         let r = _mm_mask_fpclass_sh_mask::<0x18>(0, a);
         assert_eq!(r, 0);
@@ -24236,7 +24236,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm_mask_blend_ph() {
+    const fn test_mm_mask_blend_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_set_ph(-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0);
         let r = _mm_mask_blend_ph(0b01010101, a, b);
@@ -24245,7 +24245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_ph() {
+    const fn test_mm256_mask_blend_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -24262,7 +24262,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_mask_blend_ph() {
+    const fn test_mm512_mask_blend_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -24283,7 +24283,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_permutex2var_ph() {
+    fn test_mm_permutex2var_ph() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let b = _mm_setr_ph(9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let idx = _mm_setr_epi16(0, 2, 4, 6, 8, 10, 12, 14);
@@ -24293,7 +24293,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_permutex2var_ph() {
+    fn test_mm256_permutex2var_ph() {
         let a = _mm256_setr_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -24311,7 +24311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_permutex2var_ph() {
+    fn test_mm512_permutex2var_ph() {
         let a = _mm512_setr_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -24336,7 +24336,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_permutexvar_ph() {
+    fn test_mm_permutexvar_ph() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let idx = _mm_set_epi16(0, 2, 4, 6, 1, 3, 5, 7);
         let r = _mm_permutexvar_ph(idx, a);
@@ -24345,7 +24345,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_permutexvar_ph() {
+    fn test_mm256_permutexvar_ph() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -24358,7 +24358,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_permutexvar_ph() {
+    fn test_mm512_permutexvar_ph() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -24378,7 +24378,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtepi16_ph() {
+    fn test_mm_cvtepi16_ph() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm_cvtepi16_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24386,7 +24386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi16_ph() {
+    fn test_mm_mask_cvtepi16_ph() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtepi16_ph(src, 0b01010101, a);
@@ -24395,7 +24395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi16_ph() {
+    fn test_mm_maskz_cvtepi16_ph() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm_maskz_cvtepi16_ph(0b01010101, a);
         let e = _mm_set_ph(0., 2., 0., 4., 0., 6., 0., 8.);
@@ -24403,7 +24403,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtepi16_ph() {
+    fn test_mm256_cvtepi16_ph() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm256_cvtepi16_ph(a);
         let e = _mm256_set_ph(
@@ -24413,7 +24413,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi16_ph() {
+    fn test_mm256_mask_cvtepi16_ph() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm256_set_ph(
             10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
@@ -24426,7 +24426,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi16_ph() {
+    fn test_mm256_maskz_cvtepi16_ph() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm256_maskz_cvtepi16_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -24436,7 +24436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtepi16_ph() {
+    fn test_mm512_cvtepi16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24451,7 +24451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtepi16_ph() {
+    fn test_mm512_mask_cvtepi16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24469,7 +24469,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtepi16_ph() {
+    fn test_mm512_maskz_cvtepi16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24483,7 +24483,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundepi16_ph() {
+    fn test_mm512_cvt_roundepi16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24498,7 +24498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundepi16_ph() {
+    fn test_mm512_mask_cvt_roundepi16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24520,7 +24520,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundepi16_ph() {
+    fn test_mm512_maskz_cvt_roundepi16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24537,7 +24537,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtepu16_ph() {
+    fn test_mm_cvtepu16_ph() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm_cvtepu16_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24545,7 +24545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtepu16_ph() {
+    fn test_mm_mask_cvtepu16_ph() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtepu16_ph(src, 0b01010101, a);
@@ -24554,7 +24554,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepu16_ph() {
+    fn test_mm_maskz_cvtepu16_ph() {
         let a = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm_maskz_cvtepu16_ph(0b01010101, a);
         let e = _mm_set_ph(0., 2., 0., 4., 0., 6., 0., 8.);
@@ -24562,7 +24562,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtepu16_ph() {
+    fn test_mm256_cvtepu16_ph() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm256_cvtepu16_ph(a);
         let e = _mm256_set_ph(
@@ -24572,7 +24572,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepu16_ph() {
+    fn test_mm256_mask_cvtepu16_ph() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm256_set_ph(
             10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
@@ -24585,7 +24585,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepu16_ph() {
+    fn test_mm256_maskz_cvtepu16_ph() {
         let a = _mm256_set_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm256_maskz_cvtepu16_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -24595,7 +24595,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtepu16_ph() {
+    fn test_mm512_cvtepu16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24610,7 +24610,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtepu16_ph() {
+    fn test_mm512_mask_cvtepu16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24628,7 +24628,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtepu16_ph() {
+    fn test_mm512_maskz_cvtepu16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24642,7 +24642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundepu16_ph() {
+    fn test_mm512_cvt_roundepu16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24657,7 +24657,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundepu16_ph() {
+    fn test_mm512_mask_cvt_roundepu16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24679,7 +24679,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundepu16_ph() {
+    fn test_mm512_maskz_cvt_roundepu16_ph() {
         let a = _mm512_set_epi16(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
@@ -24696,7 +24696,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtepi32_ph() {
+    fn test_mm_cvtepi32_ph() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_cvtepi32_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
@@ -24704,7 +24704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi32_ph() {
+    fn test_mm_mask_cvtepi32_ph() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtepi32_ph(src, 0b0101, a);
@@ -24713,7 +24713,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi32_ph() {
+    fn test_mm_maskz_cvtepi32_ph() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_maskz_cvtepi32_ph(0b0101, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 2., 0.0, 4.);
@@ -24721,7 +24721,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtepi32_ph() {
+    fn test_mm256_cvtepi32_ph() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_cvtepi32_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24729,7 +24729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi32_ph() {
+    fn test_mm256_mask_cvtepi32_ph() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm256_mask_cvtepi32_ph(src, 0b01010101, a);
@@ -24738,7 +24738,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi32_ph() {
+    fn test_mm256_maskz_cvtepi32_ph() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_cvtepi32_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2.0, 0.0, 4.0, 0.0, 6.0, 0.0, 8.0);
@@ -24746,7 +24746,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtepi32_ph() {
+    fn test_mm512_cvtepi32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_cvtepi32_ph(a);
         let e = _mm256_set_ph(
@@ -24756,7 +24756,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtepi32_ph() {
+    fn test_mm512_mask_cvtepi32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm256_set_ph(
             10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
@@ -24769,7 +24769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtepi32_ph() {
+    fn test_mm512_maskz_cvtepi32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_cvtepi32_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -24779,7 +24779,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvt_roundepi32_ph() {
+    fn test_mm512_cvt_roundepi32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_cvt_roundepi32_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm256_set_ph(
@@ -24789,7 +24789,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvt_roundepi32_ph() {
+    fn test_mm512_mask_cvt_roundepi32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm256_set_ph(
             10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
@@ -24806,7 +24806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvt_roundepi32_ph() {
+    fn test_mm512_maskz_cvt_roundepi32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_cvt_roundepi32_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b0101010101010101,
@@ -24819,7 +24819,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvti32_sh() {
+    fn test_mm_cvti32_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvti32_sh(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24827,7 +24827,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvt_roundi32_sh() {
+    fn test_mm_cvt_roundi32_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundi32_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24835,7 +24835,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtepu32_ph() {
+    fn test_mm_cvtepu32_ph() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_cvtepu32_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
@@ -24843,7 +24843,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtepu32_ph() {
+    fn test_mm_mask_cvtepu32_ph() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtepu32_ph(src, 0b0101, a);
@@ -24852,7 +24852,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepu32_ph() {
+    fn test_mm_maskz_cvtepu32_ph() {
         let a = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_maskz_cvtepu32_ph(0b0101, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 2., 0.0, 4.);
@@ -24860,7 +24860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtepu32_ph() {
+    fn test_mm256_cvtepu32_ph() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_cvtepu32_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24868,7 +24868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepu32_ph() {
+    fn test_mm256_mask_cvtepu32_ph() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm256_mask_cvtepu32_ph(src, 0b01010101, a);
@@ -24877,7 +24877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepu32_ph() {
+    fn test_mm256_maskz_cvtepu32_ph() {
         let a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_cvtepu32_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2.0, 0.0, 4.0, 0.0, 6.0, 0.0, 8.0);
@@ -24885,7 +24885,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvtepu32_ph() {
+    fn test_mm512_cvtepu32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_cvtepu32_ph(a);
         let e = _mm256_set_ph(
@@ -24895,7 +24895,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtepu32_ph() {
+    fn test_mm512_mask_cvtepu32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm256_set_ph(
             10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
@@ -24908,7 +24908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtepu32_ph() {
+    fn test_mm512_maskz_cvtepu32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_cvtepu32_ph(0b0101010101010101, a);
         let e = _mm256_set_ph(
@@ -24918,7 +24918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvt_roundepu32_ph() {
+    fn test_mm512_cvt_roundepu32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_cvt_roundepu32_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm256_set_ph(
@@ -24928,7 +24928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvt_roundepu32_ph() {
+    fn test_mm512_mask_cvt_roundepu32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let src = _mm256_set_ph(
             10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
@@ -24946,7 +24946,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvt_roundepu32_ph() {
+    fn test_mm512_maskz_cvt_roundepu32_ph() {
         let a = _mm512_set_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_cvt_roundepu32_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b0101010101010101,
@@ -24959,7 +24959,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtu32_sh() {
+    fn test_mm_cvtu32_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtu32_sh(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24967,7 +24967,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvt_roundu32_sh() {
+    fn test_mm_cvt_roundu32_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundu32_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -24975,7 +24975,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtepi64_ph() {
+    fn test_mm_cvtepi64_ph() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_cvtepi64_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
@@ -24983,7 +24983,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi64_ph() {
+    fn test_mm_mask_cvtepi64_ph() {
         let a = _mm_set_epi64x(1, 2);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtepi64_ph(src, 0b01, a);
@@ -24992,7 +24992,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi64_ph() {
+    fn test_mm_maskz_cvtepi64_ph() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_maskz_cvtepi64_ph(0b01, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.);
@@ -25000,7 +25000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtepi64_ph() {
+    fn test_mm256_cvtepi64_ph() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepi64_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
@@ -25008,7 +25008,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi64_ph() {
+    fn test_mm256_mask_cvtepi64_ph() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm256_mask_cvtepi64_ph(src, 0b0101, a);
@@ -25017,7 +25017,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi64_ph() {
+    fn test_mm256_maskz_cvtepi64_ph() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepi64_ph(0b0101, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0);
@@ -25025,7 +25025,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvtepi64_ph() {
+    fn test_mm512_cvtepi64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvtepi64_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25033,7 +25033,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtepi64_ph() {
+    fn test_mm512_mask_cvtepi64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm512_mask_cvtepi64_ph(src, 0b01010101, a);
@@ -25042,7 +25042,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtepi64_ph() {
+    fn test_mm512_maskz_cvtepi64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvtepi64_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2., 0.0, 4., 0.0, 6., 0.0, 8.);
@@ -25050,7 +25050,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvt_roundepi64_ph() {
+    fn test_mm512_cvt_roundepi64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvt_roundepi64_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25058,7 +25058,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundepi64_ph() {
+    fn test_mm512_mask_cvt_roundepi64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm512_mask_cvt_roundepi64_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -25069,7 +25069,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvt_roundepi64_ph() {
+    fn test_mm512_maskz_cvt_roundepi64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvt_roundepi64_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01010101, a,
@@ -25079,7 +25079,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtepu64_ph() {
+    fn test_mm_cvtepu64_ph() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_cvtepu64_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
@@ -25087,7 +25087,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtepu64_ph() {
+    fn test_mm_mask_cvtepu64_ph() {
         let a = _mm_set_epi64x(1, 2);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtepu64_ph(src, 0b01, a);
@@ -25096,7 +25096,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepu64_ph() {
+    fn test_mm_maskz_cvtepu64_ph() {
         let a = _mm_set_epi64x(1, 2);
         let r = _mm_maskz_cvtepu64_ph(0b01, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0);
@@ -25104,7 +25104,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtepu64_ph() {
+    fn test_mm256_cvtepu64_ph() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepu64_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
@@ -25112,7 +25112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepu64_ph() {
+    fn test_mm256_mask_cvtepu64_ph() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm256_mask_cvtepu64_ph(src, 0b0101, a);
@@ -25121,7 +25121,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepu64_ph() {
+    fn test_mm256_maskz_cvtepu64_ph() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepu64_ph(0b0101, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0);
@@ -25129,7 +25129,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvtepu64_ph() {
+    fn test_mm512_cvtepu64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvtepu64_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25137,7 +25137,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtepu64_ph() {
+    fn test_mm512_mask_cvtepu64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm512_mask_cvtepu64_ph(src, 0b01010101, a);
@@ -25146,7 +25146,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtepu64_ph() {
+    fn test_mm512_maskz_cvtepu64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvtepu64_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2., 0.0, 4., 0.0, 6., 0.0, 8.);
@@ -25154,7 +25154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvt_roundepu64_ph() {
+    fn test_mm512_cvt_roundepu64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_cvt_roundepu64_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25162,7 +25162,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvt_roundepu64_ph() {
+    fn test_mm512_mask_cvt_roundepu64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm512_mask_cvt_roundepu64_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -25173,7 +25173,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvt_roundepu64_ph() {
+    fn test_mm512_maskz_cvt_roundepu64_ph() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_cvt_roundepu64_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01010101, a,
@@ -25183,7 +25183,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtxps_ph() {
+    fn test_mm_cvtxps_ph() {
         let a = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtxps_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
@@ -25191,7 +25191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtxps_ph() {
+    fn test_mm_mask_cvtxps_ph() {
         let a = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtxps_ph(src, 0b0101, a);
@@ -25200,7 +25200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtxps_ph() {
+    fn test_mm_maskz_cvtxps_ph() {
         let a = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvtxps_ph(0b0101, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0);
@@ -25208,7 +25208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtxps_ph() {
+    fn test_mm256_cvtxps_ph() {
         let a = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvtxps_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25216,7 +25216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtxps_ph() {
+    fn test_mm256_mask_cvtxps_ph() {
         let a = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm256_mask_cvtxps_ph(src, 0b01010101, a);
@@ -25225,7 +25225,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtxps_ph() {
+    fn test_mm256_maskz_cvtxps_ph() {
         let a = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_maskz_cvtxps_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2.0, 0.0, 4.0, 0.0, 6.0, 0.0, 8.0);
@@ -25233,7 +25233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvtxps_ph() {
+    fn test_mm512_cvtxps_ph() {
         let a = _mm512_set_ps(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25245,7 +25245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtxps_ph() {
+    fn test_mm512_mask_cvtxps_ph() {
         let a = _mm512_set_ps(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25260,7 +25260,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtxps_ph() {
+    fn test_mm512_maskz_cvtxps_ph() {
         let a = _mm512_set_ps(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25272,7 +25272,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvtx_roundps_ph() {
+    fn test_mm512_cvtx_roundps_ph() {
         let a = _mm512_set_ps(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25284,7 +25284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtx_roundps_ph() {
+    fn test_mm512_mask_cvtx_roundps_ph() {
         let a = _mm512_set_ps(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25304,7 +25304,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtx_roundps_ph() {
+    fn test_mm512_maskz_cvtx_roundps_ph() {
         let a = _mm512_set_ps(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25319,7 +25319,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtss_sh() {
+    fn test_mm_cvtss_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtss_sh(a, b);
@@ -25328,7 +25328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtss_sh() {
+    fn test_mm_mask_cvtss_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let src = _mm_setr_ph(20., 21., 22., 23., 24., 25., 26., 27.);
@@ -25341,7 +25341,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtss_sh() {
+    fn test_mm_maskz_cvtss_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvtss_sh(0, a, b);
@@ -25353,7 +25353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvt_roundss_sh() {
+    fn test_mm_cvt_roundss_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvt_roundss_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -25362,7 +25362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvt_roundss_sh() {
+    fn test_mm_mask_cvt_roundss_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let src = _mm_setr_ph(20., 21., 22., 23., 24., 25., 26., 27.);
@@ -25379,7 +25379,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvt_roundss_sh() {
+    fn test_mm_maskz_cvt_roundss_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r =
@@ -25393,7 +25393,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtpd_ph() {
+    fn test_mm_cvtpd_ph() {
         let a = _mm_set_pd(1.0, 2.0);
         let r = _mm_cvtpd_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
@@ -25401,7 +25401,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtpd_ph() {
+    fn test_mm_mask_cvtpd_ph() {
         let a = _mm_set_pd(1.0, 2.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm_mask_cvtpd_ph(src, 0b01, a);
@@ -25410,7 +25410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpd_ph() {
+    fn test_mm_maskz_cvtpd_ph() {
         let a = _mm_set_pd(1.0, 2.0);
         let r = _mm_maskz_cvtpd_ph(0b01, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0);
@@ -25418,7 +25418,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtpd_ph() {
+    fn test_mm256_cvtpd_ph() {
         let a = _mm256_set_pd(1.0, 2.0, 3.0, 4.0);
         let r = _mm256_cvtpd_ph(a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
@@ -25426,7 +25426,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpd_ph() {
+    fn test_mm256_mask_cvtpd_ph() {
         let a = _mm256_set_pd(1.0, 2.0, 3.0, 4.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm256_mask_cvtpd_ph(src, 0b0101, a);
@@ -25435,7 +25435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpd_ph() {
+    fn test_mm256_maskz_cvtpd_ph() {
         let a = _mm256_set_pd(1.0, 2.0, 3.0, 4.0);
         let r = _mm256_maskz_cvtpd_ph(0b0101, a);
         let e = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0);
@@ -25443,7 +25443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvtpd_ph() {
+    fn test_mm512_cvtpd_ph() {
         let a = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvtpd_ph(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25451,7 +25451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvtpd_ph() {
+    fn test_mm512_mask_cvtpd_ph() {
         let a = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm512_mask_cvtpd_ph(src, 0b01010101, a);
@@ -25460,7 +25460,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvtpd_ph() {
+    fn test_mm512_maskz_cvtpd_ph() {
         let a = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvtpd_ph(0b01010101, a);
         let e = _mm_set_ph(0.0, 2., 0.0, 4., 0.0, 6., 0.0, 8.);
@@ -25468,7 +25468,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_cvt_roundpd_ph() {
+    fn test_mm512_cvt_roundpd_ph() {
         let a = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvt_roundpd_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -25476,7 +25476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_mask_cvt_roundpd_ph() {
+    fn test_mm512_mask_cvt_roundpd_ph() {
         let a = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let r = _mm512_mask_cvt_roundpd_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -25487,7 +25487,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm512_maskz_cvt_roundpd_ph() {
+    fn test_mm512_maskz_cvt_roundpd_ph() {
         let a = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvt_roundpd_ph::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01010101, a,
@@ -25497,7 +25497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtsd_sh() {
+    fn test_mm_cvtsd_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_pd(1.0, 2.0);
         let r = _mm_cvtsd_sh(a, b);
@@ -25506,7 +25506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtsd_sh() {
+    fn test_mm_mask_cvtsd_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_pd(1.0, 2.0);
         let src = _mm_setr_ph(20., 21., 22., 23., 24., 25., 26., 27.);
@@ -25519,7 +25519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsd_sh() {
+    fn test_mm_maskz_cvtsd_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_pd(1.0, 2.0);
         let r = _mm_maskz_cvtsd_sh(0, a, b);
@@ -25531,7 +25531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvt_roundsd_sh() {
+    fn test_mm_cvt_roundsd_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_pd(1.0, 2.0);
         let r = _mm_cvt_roundsd_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -25540,7 +25540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvt_roundsd_sh() {
+    fn test_mm_mask_cvt_roundsd_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_pd(1.0, 2.0);
         let src = _mm_setr_ph(20., 21., 22., 23., 24., 25., 26., 27.);
@@ -25557,7 +25557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvt_roundsd_sh() {
+    fn test_mm_maskz_cvt_roundsd_sh() {
         let a = _mm_setr_ph(10., 11., 12., 13., 14., 15., 16., 17.);
         let b = _mm_setr_pd(1.0, 2.0);
         let r =
@@ -25571,7 +25571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_epi16() {
+    fn test_mm_cvtph_epi16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttph_epi16(a);
         let e = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
@@ -25579,7 +25579,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_epi16() {
+    fn test_mm_mask_cvtph_epi16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_epi16(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm_mask_cvttph_epi16(src, 0b01010101, a);
@@ -25588,7 +25588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_epi16() {
+    fn test_mm_maskz_cvtph_epi16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_maskz_cvttph_epi16(0b01010101, a);
         let e = _mm_set_epi16(0, 2, 0, 4, 0, 6, 0, 8);
@@ -25596,7 +25596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_epi16() {
+    fn test_mm256_cvtph_epi16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25606,7 +25606,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_epi16() {
+    fn test_mm256_mask_cvtph_epi16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25619,7 +25619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_epi16() {
+    fn test_mm256_maskz_cvtph_epi16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25629,7 +25629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_epi16() {
+    fn test_mm512_cvtph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25644,7 +25644,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_epi16() {
+    fn test_mm512_mask_cvtph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25663,7 +25663,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_epi16() {
+    fn test_mm512_maskz_cvtph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25678,7 +25678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_epi16() {
+    fn test_mm512_cvt_roundph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25693,7 +25693,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_epi16() {
+    fn test_mm512_mask_cvt_roundph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25716,7 +25716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_epi16() {
+    fn test_mm512_maskz_cvt_roundph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25734,7 +25734,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_epu16() {
+    fn test_mm_cvtph_epu16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttph_epu16(a);
         let e = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
@@ -25742,7 +25742,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_epu16() {
+    fn test_mm_mask_cvtph_epu16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_epi16(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm_mask_cvttph_epu16(src, 0b01010101, a);
@@ -25751,7 +25751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_epu16() {
+    fn test_mm_maskz_cvtph_epu16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_maskz_cvttph_epu16(0b01010101, a);
         let e = _mm_set_epi16(0, 2, 0, 4, 0, 6, 0, 8);
@@ -25759,7 +25759,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_epu16() {
+    fn test_mm256_cvtph_epu16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25769,7 +25769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_epu16() {
+    fn test_mm256_mask_cvtph_epu16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25782,7 +25782,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_epu16() {
+    fn test_mm256_maskz_cvtph_epu16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25792,7 +25792,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_epu16() {
+    fn test_mm512_cvtph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25807,7 +25807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_epu16() {
+    fn test_mm512_mask_cvtph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25826,7 +25826,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_epu16() {
+    fn test_mm512_maskz_cvtph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25841,7 +25841,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_epu16() {
+    fn test_mm512_cvt_roundph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25856,7 +25856,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_epu16() {
+    fn test_mm512_mask_cvt_roundph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25879,7 +25879,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_epu16() {
+    fn test_mm512_maskz_cvt_roundph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25897,7 +25897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvttph_epi16() {
+    fn test_mm_cvttph_epi16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttph_epi16(a);
         let e = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
@@ -25905,7 +25905,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvttph_epi16() {
+    fn test_mm_mask_cvttph_epi16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_epi16(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm_mask_cvttph_epi16(src, 0b01010101, a);
@@ -25914,7 +25914,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvttph_epi16() {
+    fn test_mm_maskz_cvttph_epi16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_maskz_cvttph_epi16(0b01010101, a);
         let e = _mm_set_epi16(0, 2, 0, 4, 0, 6, 0, 8);
@@ -25922,7 +25922,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvttph_epi16() {
+    fn test_mm256_cvttph_epi16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25932,7 +25932,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvttph_epi16() {
+    fn test_mm256_mask_cvttph_epi16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25945,7 +25945,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttph_epi16() {
+    fn test_mm256_maskz_cvttph_epi16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -25955,7 +25955,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvttph_epi16() {
+    fn test_mm512_cvttph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25970,7 +25970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvttph_epi16() {
+    fn test_mm512_mask_cvttph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -25989,7 +25989,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvttph_epi16() {
+    fn test_mm512_maskz_cvttph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26004,7 +26004,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtt_roundph_epi16() {
+    fn test_mm512_cvtt_roundph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26019,7 +26019,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtt_roundph_epi16() {
+    fn test_mm512_mask_cvtt_roundph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26042,7 +26042,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtt_roundph_epi16() {
+    fn test_mm512_maskz_cvtt_roundph_epi16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26060,7 +26060,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvttph_epu16() {
+    fn test_mm_cvttph_epu16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttph_epu16(a);
         let e = _mm_set_epi16(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26068,7 +26068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvttph_epu16() {
+    fn test_mm_mask_cvttph_epu16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm_set_epi16(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm_mask_cvttph_epu16(src, 0b01010101, a);
@@ -26077,7 +26077,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvttph_epu16() {
+    fn test_mm_maskz_cvttph_epu16() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_maskz_cvttph_epu16(0b01010101, a);
         let e = _mm_set_epi16(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26085,7 +26085,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvttph_epu16() {
+    fn test_mm256_cvttph_epu16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26095,7 +26095,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvttph_epu16() {
+    fn test_mm256_mask_cvttph_epu16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26108,7 +26108,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttph_epu16() {
+    fn test_mm256_maskz_cvttph_epu16() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26118,7 +26118,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvttph_epu16() {
+    fn test_mm512_cvttph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26133,7 +26133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvttph_epu16() {
+    fn test_mm512_mask_cvttph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26152,7 +26152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvttph_epu16() {
+    fn test_mm512_maskz_cvttph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26167,7 +26167,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtt_roundph_epu16() {
+    fn test_mm512_cvtt_roundph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26182,7 +26182,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtt_roundph_epu16() {
+    fn test_mm512_mask_cvtt_roundph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26205,7 +26205,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtt_roundph_epu16() {
+    fn test_mm512_maskz_cvtt_roundph_epu16() {
         let a = _mm512_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -26223,7 +26223,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_epi32() {
+    fn test_mm_cvtph_epi32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtph_epi32(a);
         let e = _mm_set_epi32(1, 2, 3, 4);
@@ -26231,7 +26231,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_epi32() {
+    fn test_mm_mask_cvtph_epi32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let src = _mm_set_epi32(10, 11, 12, 13);
         let r = _mm_mask_cvtph_epi32(src, 0b0101, a);
@@ -26240,7 +26240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_epi32() {
+    fn test_mm_maskz_cvtph_epi32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvtph_epi32(0b0101, a);
         let e = _mm_set_epi32(0, 2, 0, 4);
@@ -26248,7 +26248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_epi32() {
+    fn test_mm256_cvtph_epi32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvtph_epi32(a);
         let e = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26256,7 +26256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_epi32() {
+    fn test_mm256_mask_cvtph_epi32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm256_set_epi32(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm256_mask_cvtph_epi32(src, 0b01010101, a);
@@ -26265,7 +26265,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_epi32() {
+    fn test_mm256_maskz_cvtph_epi32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_maskz_cvtph_epi32(0b01010101, a);
         let e = _mm256_set_epi32(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26273,7 +26273,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_epi32() {
+    fn test_mm512_cvtph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26283,7 +26283,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_epi32() {
+    fn test_mm512_mask_cvtph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26296,7 +26296,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_epi32() {
+    fn test_mm512_maskz_cvtph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26306,7 +26306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_epi32() {
+    fn test_mm512_cvt_roundph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26316,7 +26316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_epi32() {
+    fn test_mm512_mask_cvt_roundph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26333,7 +26333,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_epi32() {
+    fn test_mm512_maskz_cvt_roundph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26346,21 +26346,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtsh_i32() {
+    fn test_mm_cvtsh_i32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtsh_i32(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvt_roundsh_i32() {
+    fn test_mm_cvt_roundsh_i32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundsh_i32::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_epu32() {
+    fn test_mm_cvtph_epu32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtph_epu32(a);
         let e = _mm_set_epi32(1, 2, 3, 4);
@@ -26368,7 +26368,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_epu32() {
+    fn test_mm_mask_cvtph_epu32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let src = _mm_set_epi32(10, 11, 12, 13);
         let r = _mm_mask_cvtph_epu32(src, 0b0101, a);
@@ -26377,7 +26377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_epu32() {
+    fn test_mm_maskz_cvtph_epu32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvtph_epu32(0b0101, a);
         let e = _mm_set_epi32(0, 2, 0, 4);
@@ -26385,7 +26385,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_epu32() {
+    fn test_mm256_cvtph_epu32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvtph_epu32(a);
         let e = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26393,7 +26393,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_epu32() {
+    fn test_mm256_mask_cvtph_epu32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm256_set_epi32(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm256_mask_cvtph_epu32(src, 0b01010101, a);
@@ -26402,7 +26402,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_epu32() {
+    fn test_mm256_maskz_cvtph_epu32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_maskz_cvtph_epu32(0b01010101, a);
         let e = _mm256_set_epi32(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26410,7 +26410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_epu32() {
+    fn test_mm512_cvtph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26420,7 +26420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_epu32() {
+    fn test_mm512_mask_cvtph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26433,7 +26433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_epu32() {
+    fn test_mm512_maskz_cvtph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26443,7 +26443,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_epu32() {
+    fn test_mm512_cvt_roundph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26453,7 +26453,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_epu32() {
+    fn test_mm512_mask_cvt_roundph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26470,7 +26470,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_epu32() {
+    fn test_mm512_maskz_cvt_roundph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26483,21 +26483,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtsh_u32() {
+    fn test_mm_cvtsh_u32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtsh_u32(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvt_roundsh_u32() {
+    fn test_mm_cvt_roundsh_u32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundsh_u32::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvttph_epi32() {
+    fn test_mm_cvttph_epi32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvttph_epi32(a);
         let e = _mm_set_epi32(1, 2, 3, 4);
@@ -26505,7 +26505,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvttph_epi32() {
+    fn test_mm_mask_cvttph_epi32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let src = _mm_set_epi32(10, 11, 12, 13);
         let r = _mm_mask_cvttph_epi32(src, 0b0101, a);
@@ -26514,7 +26514,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvttph_epi32() {
+    fn test_mm_maskz_cvttph_epi32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvttph_epi32(0b0101, a);
         let e = _mm_set_epi32(0, 2, 0, 4);
@@ -26522,7 +26522,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvttph_epi32() {
+    fn test_mm256_cvttph_epi32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvttph_epi32(a);
         let e = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26530,7 +26530,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvttph_epi32() {
+    fn test_mm256_mask_cvttph_epi32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm256_set_epi32(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm256_mask_cvttph_epi32(src, 0b01010101, a);
@@ -26539,7 +26539,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttph_epi32() {
+    fn test_mm256_maskz_cvttph_epi32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_maskz_cvttph_epi32(0b01010101, a);
         let e = _mm256_set_epi32(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26547,7 +26547,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvttph_epi32() {
+    fn test_mm512_cvttph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26557,7 +26557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvttph_epi32() {
+    fn test_mm512_mask_cvttph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26570,7 +26570,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvttph_epi32() {
+    fn test_mm512_maskz_cvttph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26580,7 +26580,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtt_roundph_epi32() {
+    fn test_mm512_cvtt_roundph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26590,7 +26590,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtt_roundph_epi32() {
+    fn test_mm512_mask_cvtt_roundph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26603,7 +26603,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtt_roundph_epi32() {
+    fn test_mm512_maskz_cvtt_roundph_epi32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26613,21 +26613,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvttsh_i32() {
+    fn test_mm_cvttsh_i32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttsh_i32(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtt_roundsh_i32() {
+    fn test_mm_cvtt_roundsh_i32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtt_roundsh_i32::<_MM_FROUND_NO_EXC>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvttph_epu32() {
+    fn test_mm_cvttph_epu32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvttph_epu32(a);
         let e = _mm_set_epi32(1, 2, 3, 4);
@@ -26635,7 +26635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvttph_epu32() {
+    fn test_mm_mask_cvttph_epu32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let src = _mm_set_epi32(10, 11, 12, 13);
         let r = _mm_mask_cvttph_epu32(src, 0b0101, a);
@@ -26644,7 +26644,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvttph_epu32() {
+    fn test_mm_maskz_cvttph_epu32() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvttph_epu32(0b0101, a);
         let e = _mm_set_epi32(0, 2, 0, 4);
@@ -26652,7 +26652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvttph_epu32() {
+    fn test_mm256_cvttph_epu32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvttph_epu32(a);
         let e = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26660,7 +26660,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvttph_epu32() {
+    fn test_mm256_mask_cvttph_epu32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let src = _mm256_set_epi32(10, 11, 12, 13, 14, 15, 16, 17);
         let r = _mm256_mask_cvttph_epu32(src, 0b01010101, a);
@@ -26669,7 +26669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttph_epu32() {
+    fn test_mm256_maskz_cvttph_epu32() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_maskz_cvttph_epu32(0b01010101, a);
         let e = _mm256_set_epi32(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26677,7 +26677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvttph_epu32() {
+    fn test_mm512_cvttph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26687,7 +26687,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvttph_epu32() {
+    fn test_mm512_mask_cvttph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26700,7 +26700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvttph_epu32() {
+    fn test_mm512_maskz_cvttph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26710,7 +26710,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtt_roundph_epu32() {
+    fn test_mm512_cvtt_roundph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26720,7 +26720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtt_roundph_epu32() {
+    fn test_mm512_mask_cvtt_roundph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26733,7 +26733,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtt_roundph_epu32() {
+    fn test_mm512_maskz_cvtt_roundph_epu32() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -26743,21 +26743,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvttsh_u32() {
+    fn test_mm_cvttsh_u32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttsh_u32(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtt_roundsh_u32() {
+    fn test_mm_cvtt_roundsh_u32() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtt_roundsh_u32::<_MM_FROUND_NO_EXC>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_epi64() {
+    fn test_mm_cvtph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_cvtph_epi64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -26765,7 +26765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_epi64() {
+    fn test_mm_mask_cvtph_epi64() {
         let src = _mm_set_epi64x(3, 4);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_mask_cvtph_epi64(src, 0b01, a);
@@ -26774,7 +26774,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_epi64() {
+    fn test_mm_maskz_cvtph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_maskz_cvtph_epi64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -26782,7 +26782,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_epi64() {
+    fn test_mm256_cvtph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_cvtph_epi64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -26790,7 +26790,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_epi64() {
+    fn test_mm256_mask_cvtph_epi64() {
         let src = _mm256_set_epi64x(5, 6, 7, 8);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_mask_cvtph_epi64(src, 0b0101, a);
@@ -26799,7 +26799,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_epi64() {
+    fn test_mm256_maskz_cvtph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_maskz_cvtph_epi64(0b0101, a);
         let e = _mm256_set_epi64x(0, 2, 0, 4);
@@ -26807,7 +26807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_epi64() {
+    fn test_mm512_cvtph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvtph_epi64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26815,7 +26815,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_epi64() {
+    fn test_mm512_mask_cvtph_epi64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvtph_epi64(src, 0b01010101, a);
@@ -26824,7 +26824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_epi64() {
+    fn test_mm512_maskz_cvtph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvtph_epi64(0b01010101, a);
         let e = _mm512_set_epi64(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26832,7 +26832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_epi64() {
+    fn test_mm512_cvt_roundph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvt_roundph_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26840,7 +26840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_epi64() {
+    fn test_mm512_mask_cvt_roundph_epi64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvt_roundph_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -26851,7 +26851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_epi64() {
+    fn test_mm512_maskz_cvt_roundph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvt_roundph_epi64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01010101, a,
@@ -26861,7 +26861,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_epu64() {
+    fn test_mm_cvtph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_cvtph_epu64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -26869,7 +26869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_epu64() {
+    fn test_mm_mask_cvtph_epu64() {
         let src = _mm_set_epi64x(3, 4);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_mask_cvtph_epu64(src, 0b01, a);
@@ -26878,7 +26878,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_epu64() {
+    fn test_mm_maskz_cvtph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_maskz_cvtph_epu64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -26886,7 +26886,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_epu64() {
+    fn test_mm256_cvtph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_cvtph_epu64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -26894,7 +26894,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_epu64() {
+    fn test_mm256_mask_cvtph_epu64() {
         let src = _mm256_set_epi64x(5, 6, 7, 8);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_mask_cvtph_epu64(src, 0b0101, a);
@@ -26903,7 +26903,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_epu64() {
+    fn test_mm256_maskz_cvtph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_maskz_cvtph_epu64(0b0101, a);
         let e = _mm256_set_epi64x(0, 2, 0, 4);
@@ -26911,7 +26911,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_epu64() {
+    fn test_mm512_cvtph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvtph_epu64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26919,7 +26919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_epu64() {
+    fn test_mm512_mask_cvtph_epu64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvtph_epu64(src, 0b01010101, a);
@@ -26928,7 +26928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_epu64() {
+    fn test_mm512_maskz_cvtph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvtph_epu64(0b01010101, a);
         let e = _mm512_set_epi64(0, 2, 0, 4, 0, 6, 0, 8);
@@ -26936,7 +26936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_epu64() {
+    fn test_mm512_cvt_roundph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvt_roundph_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -26944,7 +26944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_epu64() {
+    fn test_mm512_mask_cvt_roundph_epu64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvt_roundph_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -26955,7 +26955,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_epu64() {
+    fn test_mm512_maskz_cvt_roundph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvt_roundph_epu64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
             0b01010101, a,
@@ -26965,7 +26965,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvttph_epi64() {
+    fn test_mm_cvttph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_cvttph_epi64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -26973,7 +26973,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvttph_epi64() {
+    fn test_mm_mask_cvttph_epi64() {
         let src = _mm_set_epi64x(3, 4);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_mask_cvttph_epi64(src, 0b01, a);
@@ -26982,7 +26982,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvttph_epi64() {
+    fn test_mm_maskz_cvttph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_maskz_cvttph_epi64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -26990,7 +26990,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvttph_epi64() {
+    fn test_mm256_cvttph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_cvttph_epi64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -26998,7 +26998,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvttph_epi64() {
+    fn test_mm256_mask_cvttph_epi64() {
         let src = _mm256_set_epi64x(5, 6, 7, 8);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_mask_cvttph_epi64(src, 0b0101, a);
@@ -27007,7 +27007,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttph_epi64() {
+    fn test_mm256_maskz_cvttph_epi64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_maskz_cvttph_epi64(0b0101, a);
         let e = _mm256_set_epi64x(0, 2, 0, 4);
@@ -27015,7 +27015,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvttph_epi64() {
+    fn test_mm512_cvttph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvttph_epi64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -27023,7 +27023,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvttph_epi64() {
+    fn test_mm512_mask_cvttph_epi64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvttph_epi64(src, 0b01010101, a);
@@ -27032,7 +27032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvttph_epi64() {
+    fn test_mm512_maskz_cvttph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvttph_epi64(0b01010101, a);
         let e = _mm512_set_epi64(0, 2, 0, 4, 0, 6, 0, 8);
@@ -27040,7 +27040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtt_roundph_epi64() {
+    fn test_mm512_cvtt_roundph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvtt_roundph_epi64::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -27048,7 +27048,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtt_roundph_epi64() {
+    fn test_mm512_mask_cvtt_roundph_epi64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvtt_roundph_epi64::<_MM_FROUND_NO_EXC>(src, 0b01010101, a);
@@ -27057,7 +27057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtt_roundph_epi64() {
+    fn test_mm512_maskz_cvtt_roundph_epi64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvtt_roundph_epi64::<_MM_FROUND_NO_EXC>(0b01010101, a);
         let e = _mm512_set_epi64(0, 2, 0, 4, 0, 6, 0, 8);
@@ -27065,7 +27065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvttph_epu64() {
+    fn test_mm_cvttph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_cvttph_epu64(a);
         let e = _mm_set_epi64x(1, 2);
@@ -27073,7 +27073,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvttph_epu64() {
+    fn test_mm_mask_cvttph_epu64() {
         let src = _mm_set_epi64x(3, 4);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_mask_cvttph_epu64(src, 0b01, a);
@@ -27082,7 +27082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvttph_epu64() {
+    fn test_mm_maskz_cvttph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_maskz_cvttph_epu64(0b01, a);
         let e = _mm_set_epi64x(0, 2);
@@ -27090,7 +27090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvttph_epu64() {
+    fn test_mm256_cvttph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_cvttph_epu64(a);
         let e = _mm256_set_epi64x(1, 2, 3, 4);
@@ -27098,7 +27098,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvttph_epu64() {
+    fn test_mm256_mask_cvttph_epu64() {
         let src = _mm256_set_epi64x(5, 6, 7, 8);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_mask_cvttph_epu64(src, 0b0101, a);
@@ -27107,7 +27107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttph_epu64() {
+    fn test_mm256_maskz_cvttph_epu64() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_maskz_cvttph_epu64(0b0101, a);
         let e = _mm256_set_epi64x(0, 2, 0, 4);
@@ -27115,7 +27115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvttph_epu64() {
+    fn test_mm512_cvttph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvttph_epu64(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -27123,7 +27123,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvttph_epu64() {
+    fn test_mm512_mask_cvttph_epu64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvttph_epu64(src, 0b01010101, a);
@@ -27132,7 +27132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvttph_epu64() {
+    fn test_mm512_maskz_cvttph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvttph_epu64(0b01010101, a);
         let e = _mm512_set_epi64(0, 2, 0, 4, 0, 6, 0, 8);
@@ -27140,7 +27140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtt_roundph_epu64() {
+    fn test_mm512_cvtt_roundph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvtt_roundph_epu64::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
@@ -27148,7 +27148,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtt_roundph_epu64() {
+    fn test_mm512_mask_cvtt_roundph_epu64() {
         let src = _mm512_set_epi64(9, 10, 11, 12, 13, 14, 15, 16);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvtt_roundph_epu64::<_MM_FROUND_NO_EXC>(src, 0b01010101, a);
@@ -27157,7 +27157,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtt_roundph_epu64() {
+    fn test_mm512_maskz_cvtt_roundph_epu64() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvtt_roundph_epu64::<_MM_FROUND_NO_EXC>(0b01010101, a);
         let e = _mm512_set_epi64(0, 2, 0, 4, 0, 6, 0, 8);
@@ -27165,7 +27165,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtxph_ps() {
+    fn test_mm_cvtxph_ps() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtxph_ps(a);
         let e = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
@@ -27173,7 +27173,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtxph_ps() {
+    fn test_mm_mask_cvtxph_ps() {
         let src = _mm_set_ps(10.0, 11.0, 12.0, 13.0);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_mask_cvtxph_ps(src, 0b0101, a);
@@ -27182,7 +27182,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtxph_ps() {
+    fn test_mm_maskz_cvtxph_ps() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm_maskz_cvtxph_ps(0b0101, a);
         let e = _mm_set_ps(0.0, 2.0, 0.0, 4.0);
@@ -27190,7 +27190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtxph_ps() {
+    fn test_mm256_cvtxph_ps() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvtxph_ps(a);
         let e = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -27198,7 +27198,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtxph_ps() {
+    fn test_mm256_mask_cvtxph_ps() {
         let src = _mm256_set_ps(10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_mask_cvtxph_ps(src, 0b01010101, a);
@@ -27207,7 +27207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtxph_ps() {
+    fn test_mm256_maskz_cvtxph_ps() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_maskz_cvtxph_ps(0b01010101, a);
         let e = _mm256_set_ps(0.0, 2.0, 0.0, 4.0, 0.0, 6.0, 0.0, 8.0);
@@ -27215,7 +27215,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtxph_ps() {
+    fn test_mm512_cvtxph_ps() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -27227,7 +27227,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtxph_ps() {
+    fn test_mm512_mask_cvtxph_ps() {
         let src = _mm512_set_ps(
             10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
             24.0, 25.0,
@@ -27244,7 +27244,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtxph_ps() {
+    fn test_mm512_maskz_cvtxph_ps() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -27256,7 +27256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtx_roundph_ps() {
+    fn test_mm512_cvtx_roundph_ps() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -27268,7 +27268,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtx_roundph_ps() {
+    fn test_mm512_mask_cvtx_roundph_ps() {
         let src = _mm512_set_ps(
             10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
             24.0, 25.0,
@@ -27285,7 +27285,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtx_roundph_ps() {
+    fn test_mm512_maskz_cvtx_roundph_ps() {
         let a = _mm256_set_ph(
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -27297,7 +27297,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtsh_ss() {
+    fn test_mm_cvtsh_ss() {
         let a = _mm_setr_ps(2.0, 20.0, 21.0, 22.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_cvtsh_ss(a, b);
@@ -27306,7 +27306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_cvtsh_ss() {
+    fn test_mm_mask_cvtsh_ss() {
         let src = _mm_setr_ps(3.0, 11.0, 12.0, 13.0);
         let a = _mm_setr_ps(2.0, 20.0, 21.0, 22.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
@@ -27319,7 +27319,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_maskz_cvtsh_ss() {
+    fn test_mm_maskz_cvtsh_ss() {
         let a = _mm_setr_ps(2.0, 20.0, 21.0, 22.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_maskz_cvtsh_ss(0, a, b);
@@ -27331,7 +27331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvt_roundsh_ss() {
+    fn test_mm_cvt_roundsh_ss() {
         let a = _mm_setr_ps(2.0, 20.0, 21.0, 22.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_cvt_roundsh_ss::<_MM_FROUND_NO_EXC>(a, b);
@@ -27340,7 +27340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_cvt_roundsh_ss() {
+    fn test_mm_mask_cvt_roundsh_ss() {
         let src = _mm_setr_ps(3.0, 11.0, 12.0, 13.0);
         let a = _mm_setr_ps(2.0, 20.0, 21.0, 22.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
@@ -27353,7 +27353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_maskz_cvt_roundsh_ss() {
+    fn test_mm_maskz_cvt_roundsh_ss() {
         let a = _mm_setr_ps(2.0, 20.0, 21.0, 22.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_maskz_cvt_roundsh_ss::<_MM_FROUND_NO_EXC>(0, a, b);
@@ -27365,7 +27365,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtph_pd() {
+    fn test_mm_cvtph_pd() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_cvtph_pd(a);
         let e = _mm_set_pd(1.0, 2.0);
@@ -27373,7 +27373,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_mask_cvtph_pd() {
+    fn test_mm_mask_cvtph_pd() {
         let src = _mm_set_pd(10.0, 11.0);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_mask_cvtph_pd(src, 0b01, a);
@@ -27382,7 +27382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_maskz_cvtph_pd() {
+    fn test_mm_maskz_cvtph_pd() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0);
         let r = _mm_maskz_cvtph_pd(0b01, a);
         let e = _mm_set_pd(0.0, 2.0);
@@ -27390,7 +27390,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_cvtph_pd() {
+    fn test_mm256_cvtph_pd() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_cvtph_pd(a);
         let e = _mm256_set_pd(1.0, 2.0, 3.0, 4.0);
@@ -27398,7 +27398,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_mask_cvtph_pd() {
+    fn test_mm256_mask_cvtph_pd() {
         let src = _mm256_set_pd(10.0, 11.0, 12.0, 13.0);
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_mask_cvtph_pd(src, 0b0101, a);
@@ -27407,7 +27407,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtph_pd() {
+    fn test_mm256_maskz_cvtph_pd() {
         let a = _mm_set_ph(0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0);
         let r = _mm256_maskz_cvtph_pd(0b0101, a);
         let e = _mm256_set_pd(0.0, 2.0, 0.0, 4.0);
@@ -27415,7 +27415,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvtph_pd() {
+    fn test_mm512_cvtph_pd() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvtph_pd(a);
         let e = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -27423,7 +27423,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvtph_pd() {
+    fn test_mm512_mask_cvtph_pd() {
         let src = _mm512_set_pd(10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvtph_pd(src, 0b01010101, a);
@@ -27432,7 +27432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvtph_pd() {
+    fn test_mm512_maskz_cvtph_pd() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvtph_pd(0b01010101, a);
         let e = _mm512_set_pd(0.0, 2.0, 0.0, 4.0, 0.0, 6.0, 0.0, 8.0);
@@ -27440,7 +27440,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_cvt_roundph_pd() {
+    fn test_mm512_cvt_roundph_pd() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_cvt_roundph_pd::<_MM_FROUND_NO_EXC>(a);
         let e = _mm512_set_pd(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -27448,7 +27448,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_mask_cvt_roundph_pd() {
+    fn test_mm512_mask_cvt_roundph_pd() {
         let src = _mm512_set_pd(10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0);
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_mask_cvt_roundph_pd::<_MM_FROUND_NO_EXC>(src, 0b01010101, a);
@@ -27457,7 +27457,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm512_maskz_cvt_roundph_pd() {
+    fn test_mm512_maskz_cvt_roundph_pd() {
         let a = _mm_set_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm512_maskz_cvt_roundph_pd::<_MM_FROUND_NO_EXC>(0b01010101, a);
         let e = _mm512_set_pd(0.0, 2.0, 0.0, 4.0, 0.0, 6.0, 0.0, 8.0);
@@ -27465,7 +27465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtsh_sd() {
+    fn test_mm_cvtsh_sd() {
         let a = _mm_setr_pd(2.0, 20.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_cvtsh_sd(a, b);
@@ -27474,7 +27474,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_cvtsh_sd() {
+    fn test_mm_mask_cvtsh_sd() {
         let src = _mm_setr_pd(3.0, 11.0);
         let a = _mm_setr_pd(2.0, 20.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
@@ -27487,7 +27487,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_maskz_cvtsh_sd() {
+    fn test_mm_maskz_cvtsh_sd() {
         let a = _mm_setr_pd(2.0, 20.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_maskz_cvtsh_sd(0, a, b);
@@ -27499,7 +27499,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvt_roundsh_sd() {
+    fn test_mm_cvt_roundsh_sd() {
         let a = _mm_setr_pd(2.0, 20.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_cvt_roundsh_sd::<_MM_FROUND_NO_EXC>(a, b);
@@ -27508,7 +27508,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_mask_cvt_roundsh_sd() {
+    fn test_mm_mask_cvt_roundsh_sd() {
         let src = _mm_setr_pd(3.0, 11.0);
         let a = _mm_setr_pd(2.0, 20.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
@@ -27521,7 +27521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_maskz_cvt_roundsh_sd() {
+    fn test_mm_maskz_cvt_roundsh_sd() {
         let a = _mm_setr_pd(2.0, 20.0);
         let b = _mm_setr_ph(1.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = _mm_maskz_cvt_roundsh_sd::<_MM_FROUND_NO_EXC>(0, a, b);
@@ -27533,14 +27533,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm_cvtsh_h() {
+    const fn test_mm_cvtsh_h() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 42.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtsh_h(a);
         assert_eq!(r, 1.0);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm256_cvtsh_h() {
+    const fn test_mm256_cvtsh_h() {
         let a = _mm256_setr_ph(
             1.0, 2.0, 3.0, 42.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         );
@@ -27549,7 +27549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm512_cvtsh_h() {
+    const fn test_mm512_cvtsh_h() {
         let a = _mm512_setr_ph(
             1.0, 2.0, 3.0, 42.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
             17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
@@ -27560,14 +27560,14 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm_cvtsi128_si16() {
+    const fn test_mm_cvtsi128_si16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm_cvtsi128_si16(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    const unsafe fn test_mm_cvtsi16_si128() {
+    const fn test_mm_cvtsi16_si128() {
         let a = 1;
         let r = _mm_cvtsi16_si128(a);
         let e = _mm_setr_epi16(1, 0, 0, 0, 0, 0, 0, 0);

--- a/crates/core_arch/src/x86/avx512ifma.rs
+++ b/crates/core_arch/src/x86/avx512ifma.rs
@@ -372,7 +372,7 @@ mod tests {
     const K: __mmask8 = 0b01101101;
 
     #[simd_test(enable = "avx512ifma")]
-    unsafe fn test_mm512_madd52hi_epu64() {
+    fn test_mm512_madd52hi_epu64() {
         let a = _mm512_set1_epi64(10 << 40);
         let b = _mm512_set1_epi64((11 << 40) + 4);
         let c = _mm512_set1_epi64((12 << 40) + 3);
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma")]
-    unsafe fn test_mm512_mask_madd52hi_epu64() {
+    fn test_mm512_mask_madd52hi_epu64() {
         let a = _mm512_set1_epi64(10 << 40);
         let b = _mm512_set1_epi64((11 << 40) + 4);
         let c = _mm512_set1_epi64((12 << 40) + 3);
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma")]
-    unsafe fn test_mm512_maskz_madd52hi_epu64() {
+    fn test_mm512_maskz_madd52hi_epu64() {
         let a = _mm512_set1_epi64(10 << 40);
         let b = _mm512_set1_epi64((11 << 40) + 4);
         let c = _mm512_set1_epi64((12 << 40) + 3);
@@ -416,7 +416,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma")]
-    unsafe fn test_mm512_madd52lo_epu64() {
+    fn test_mm512_madd52lo_epu64() {
         let a = _mm512_set1_epi64(10 << 40);
         let b = _mm512_set1_epi64((11 << 40) + 4);
         let c = _mm512_set1_epi64((12 << 40) + 3);
@@ -430,7 +430,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma")]
-    unsafe fn test_mm512_mask_madd52lo_epu64() {
+    fn test_mm512_mask_madd52lo_epu64() {
         let a = _mm512_set1_epi64(10 << 40);
         let b = _mm512_set1_epi64((11 << 40) + 4);
         let c = _mm512_set1_epi64((12 << 40) + 3);
@@ -445,7 +445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma")]
-    unsafe fn test_mm512_maskz_madd52lo_epu64() {
+    fn test_mm512_maskz_madd52lo_epu64() {
         let a = _mm512_set1_epi64(10 << 40);
         let b = _mm512_set1_epi64((11 << 40) + 4);
         let c = _mm512_set1_epi64((12 << 40) + 3);
@@ -460,7 +460,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxifma")]
-    unsafe fn test_mm256_madd52hi_avx_epu64() {
+    fn test_mm256_madd52hi_avx_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm256_madd52hi_epu64() {
+    fn test_mm256_madd52hi_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -488,7 +488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm256_mask_madd52hi_epu64() {
+    fn test_mm256_mask_madd52hi_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -503,7 +503,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm256_maskz_madd52hi_epu64() {
+    fn test_mm256_maskz_madd52hi_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -518,7 +518,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxifma")]
-    unsafe fn test_mm256_madd52lo_avx_epu64() {
+    fn test_mm256_madd52lo_avx_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -532,7 +532,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm256_madd52lo_epu64() {
+    fn test_mm256_madd52lo_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -546,7 +546,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm256_mask_madd52lo_epu64() {
+    fn test_mm256_mask_madd52lo_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -561,7 +561,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm256_maskz_madd52lo_epu64() {
+    fn test_mm256_maskz_madd52lo_epu64() {
         let a = _mm256_set1_epi64x(10 << 40);
         let b = _mm256_set1_epi64x((11 << 40) + 4);
         let c = _mm256_set1_epi64x((12 << 40) + 3);
@@ -576,7 +576,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxifma")]
-    unsafe fn test_mm_madd52hi_avx_epu64() {
+    fn test_mm_madd52hi_avx_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -590,7 +590,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm_madd52hi_epu64() {
+    fn test_mm_madd52hi_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -604,7 +604,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm_mask_madd52hi_epu64() {
+    fn test_mm_mask_madd52hi_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -619,7 +619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm_maskz_madd52hi_epu64() {
+    fn test_mm_maskz_madd52hi_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -634,7 +634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxifma")]
-    unsafe fn test_mm_madd52lo_avx_epu64() {
+    fn test_mm_madd52lo_avx_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -648,7 +648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm_madd52lo_epu64() {
+    fn test_mm_madd52lo_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -662,7 +662,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm_mask_madd52lo_epu64() {
+    fn test_mm_mask_madd52lo_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);
@@ -677,7 +677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512ifma,avx512vl")]
-    unsafe fn test_mm_maskz_madd52lo_epu64() {
+    fn test_mm_maskz_madd52lo_epu64() {
         let a = _mm_set1_epi64x(10 << 40);
         let b = _mm_set1_epi64x((11 << 40) + 4);
         let c = _mm_set1_epi64x((12 << 40) + 3);

--- a/crates/core_arch/src/x86/avx512vbmi.rs
+++ b/crates/core_arch/src/x86/avx512vbmi.rs
@@ -484,7 +484,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_permutex2var_epi8() {
+    fn test_mm512_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -508,7 +508,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_mask_permutex2var_epi8() {
+    fn test_mm512_mask_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -539,7 +539,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_maskz_permutex2var_epi8() {
+    fn test_mm512_maskz_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -570,7 +570,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_mask2_permutex2var_epi8() {
+    fn test_mm512_mask2_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -601,7 +601,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_permutex2var_epi8() {
+    fn test_mm256_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -619,7 +619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_mask_permutex2var_epi8() {
+    fn test_mm256_mask_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -639,7 +639,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_maskz_permutex2var_epi8() {
+    fn test_mm256_maskz_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -659,7 +659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_mask2_permutex2var_epi8() {
+    fn test_mm256_mask2_permutex2var_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -679,7 +679,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_permutex2var_epi8() {
+    fn test_mm_permutex2var_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm_set_epi8(1, 1 << 4, 2, 1 << 4, 3, 1 << 4, 4, 1 << 4, 5, 1 << 4, 6, 1 << 4, 7, 1 << 4, 8, 1 << 4);
@@ -692,7 +692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_mask_permutex2var_epi8() {
+    fn test_mm_mask_permutex2var_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm_set_epi8(1, 1 << 4, 2, 1 << 4, 3, 1 << 4, 4, 1 << 4, 5, 1 << 4, 6, 1 << 4, 7, 1 << 4, 8, 1 << 4);
@@ -707,7 +707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_maskz_permutex2var_epi8() {
+    fn test_mm_maskz_permutex2var_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm_set_epi8(1, 1 << 4, 2, 1 << 4, 3, 1 << 4, 4, 1 << 4, 5, 1 << 4, 6, 1 << 4, 7, 1 << 4, 8, 1 << 4);
@@ -722,7 +722,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_mask2_permutex2var_epi8() {
+    fn test_mm_mask2_permutex2var_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let idx = _mm_set_epi8(1, 1 << 4, 2, 1 << 4, 3, 1 << 4, 4, 1 << 4, 5, 1 << 4, 6, 1 << 4, 7, 1 << 4, 8, 1 << 4);
@@ -737,7 +737,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_permutexvar_epi8() {
+    fn test_mm512_permutexvar_epi8() {
         let idx = _mm512_set1_epi8(1);
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -750,7 +750,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_mask_permutexvar_epi8() {
+    fn test_mm512_mask_permutexvar_epi8() {
         let idx = _mm512_set1_epi8(1);
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -770,7 +770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_maskz_permutexvar_epi8() {
+    fn test_mm512_maskz_permutexvar_epi8() {
         let idx = _mm512_set1_epi8(1);
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -789,7 +789,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_permutexvar_epi8() {
+    fn test_mm256_permutexvar_epi8() {
         let idx = _mm256_set1_epi8(1);
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -800,7 +800,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_mask_permutexvar_epi8() {
+    fn test_mm256_mask_permutexvar_epi8() {
         let idx = _mm256_set1_epi8(1);
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -813,7 +813,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_maskz_permutexvar_epi8() {
+    fn test_mm256_maskz_permutexvar_epi8() {
         let idx = _mm256_set1_epi8(1);
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_permutexvar_epi8() {
+    fn test_mm_permutexvar_epi8() {
         let idx = _mm_set1_epi8(1);
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_permutexvar_epi8(idx, a);
@@ -835,7 +835,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_mask_permutexvar_epi8() {
+    fn test_mm_mask_permutexvar_epi8() {
         let idx = _mm_set1_epi8(1);
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_mask_permutexvar_epi8(a, 0, idx, a);
@@ -846,7 +846,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_maskz_permutexvar_epi8() {
+    fn test_mm_maskz_permutexvar_epi8() {
         let idx = _mm_set1_epi8(1);
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_permutexvar_epi8(0, idx, a);
@@ -857,7 +857,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_multishift_epi64_epi8() {
+    fn test_mm512_multishift_epi64_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_multishift_epi64_epi8(a, b);
@@ -866,7 +866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_mask_multishift_epi64_epi8() {
+    fn test_mm512_mask_multishift_epi64_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_mask_multishift_epi64_epi8(a, 0, a, b);
@@ -882,7 +882,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi")]
-    unsafe fn test_mm512_maskz_multishift_epi64_epi8() {
+    fn test_mm512_maskz_multishift_epi64_epi8() {
         let a = _mm512_set1_epi8(1);
         let b = _mm512_set1_epi8(1);
         let r = _mm512_maskz_multishift_epi64_epi8(0, a, b);
@@ -897,7 +897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_multishift_epi64_epi8() {
+    fn test_mm256_multishift_epi64_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_multishift_epi64_epi8(a, b);
@@ -906,7 +906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_mask_multishift_epi64_epi8() {
+    fn test_mm256_mask_multishift_epi64_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_mask_multishift_epi64_epi8(a, 0, a, b);
@@ -917,7 +917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm256_maskz_multishift_epi64_epi8() {
+    fn test_mm256_maskz_multishift_epi64_epi8() {
         let a = _mm256_set1_epi8(1);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_maskz_multishift_epi64_epi8(0, a, b);
@@ -928,7 +928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_multishift_epi64_epi8() {
+    fn test_mm_multishift_epi64_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let r = _mm_multishift_epi64_epi8(a, b);
@@ -937,7 +937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_mask_multishift_epi64_epi8() {
+    fn test_mm_mask_multishift_epi64_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let r = _mm_mask_multishift_epi64_epi8(a, 0, a, b);
@@ -948,7 +948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi,avx512vl")]
-    unsafe fn test_mm_maskz_multishift_epi64_epi8() {
+    fn test_mm_maskz_multishift_epi64_epi8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(1);
         let r = _mm_maskz_multishift_epi64_epi8(0, a, b);

--- a/crates/core_arch/src/x86/avx512vbmi2.rs
+++ b/crates/core_arch/src/x86/avx512vbmi2.rs
@@ -2450,7 +2450,7 @@ mod tests {
     use crate::hint::black_box;
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_mask_compress_epi16() {
+    fn test_mm512_mask_compress_epi16() {
         let src = _mm512_set1_epi16(200);
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -2465,7 +2465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_maskz_compress_epi16() {
+    fn test_mm512_maskz_compress_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2479,7 +2479,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_mask_compress_epi16() {
+    fn test_mm256_mask_compress_epi16() {
         let src = _mm256_set1_epi16(200);
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_mask_compress_epi16(src, 0b01010101_01010101, a);
@@ -2490,7 +2490,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_maskz_compress_epi16() {
+    fn test_mm256_maskz_compress_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_compress_epi16(0b01010101_01010101, a);
         let e = _mm256_set_epi16(0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 5, 7, 9, 11, 13, 15);
@@ -2498,7 +2498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_mask_compress_epi16() {
+    fn test_mm_mask_compress_epi16() {
         let src = _mm_set1_epi16(200);
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_mask_compress_epi16(src, 0b01010101, a);
@@ -2507,7 +2507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_maskz_compress_epi16() {
+    fn test_mm_maskz_compress_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_maskz_compress_epi16(0b01010101, a);
         let e = _mm_set_epi16(0, 0, 0, 0, 1, 3, 5, 7);
@@ -2515,7 +2515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_mask_compress_epi8() {
+    fn test_mm512_mask_compress_epi8() {
         let src = _mm512_set1_epi8(100);
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -2538,7 +2538,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_maskz_compress_epi8() {
+    fn test_mm512_maskz_compress_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -2559,7 +2559,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_mask_compress_epi8() {
+    fn test_mm256_mask_compress_epi8() {
         let src = _mm256_set1_epi8(100);
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -2574,7 +2574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_maskz_compress_epi8() {
+    fn test_mm256_maskz_compress_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2588,7 +2588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_mask_compress_epi8() {
+    fn test_mm_mask_compress_epi8() {
         let src = _mm_set1_epi8(100);
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_mask_compress_epi8(src, 0b01010101_01010101, a);
@@ -2599,7 +2599,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_maskz_compress_epi8() {
+    fn test_mm_maskz_compress_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_compress_epi8(0b01010101_01010101, a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 5, 7, 9, 11, 13, 15);
@@ -2607,7 +2607,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_mask_expand_epi16() {
+    fn test_mm512_mask_expand_epi16() {
         let src = _mm512_set1_epi16(200);
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -2622,7 +2622,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_maskz_expand_epi16() {
+    fn test_mm512_maskz_expand_epi16() {
         #[rustfmt::skip]
         let a = _mm512_set_epi16(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2634,7 +2634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_mask_expand_epi16() {
+    fn test_mm256_mask_expand_epi16() {
         let src = _mm256_set1_epi16(200);
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_mask_expand_epi16(src, 0b01010101_01010101, a);
@@ -2645,7 +2645,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_maskz_expand_epi16() {
+    fn test_mm256_maskz_expand_epi16() {
         let a = _mm256_set_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_expand_epi16(0b01010101_01010101, a);
         let e = _mm256_set_epi16(0, 8, 0, 9, 0, 10, 0, 11, 0, 12, 0, 13, 0, 14, 0, 15);
@@ -2653,7 +2653,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_mask_expand_epi16() {
+    fn test_mm_mask_expand_epi16() {
         let src = _mm_set1_epi16(200);
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_mask_expand_epi16(src, 0b01010101, a);
@@ -2662,7 +2662,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_maskz_expand_epi16() {
+    fn test_mm_maskz_expand_epi16() {
         let a = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_maskz_expand_epi16(0b01010101, a);
         let e = _mm_set_epi16(0, 4, 0, 5, 0, 6, 0, 7);
@@ -2670,7 +2670,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_mask_expand_epi8() {
+    fn test_mm512_mask_expand_epi8() {
         let src = _mm512_set1_epi8(100);
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -2693,7 +2693,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    unsafe fn test_mm512_maskz_expand_epi8() {
+    fn test_mm512_maskz_expand_epi8() {
         #[rustfmt::skip]
         let a = _mm512_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -2714,7 +2714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_mask_expand_epi8() {
+    fn test_mm256_mask_expand_epi8() {
         let src = _mm256_set1_epi8(100);
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -2729,7 +2729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm256_maskz_expand_epi8() {
+    fn test_mm256_maskz_expand_epi8() {
         #[rustfmt::skip]
         let a = _mm256_set_epi8(0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
                                 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2743,7 +2743,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_mask_expand_epi8() {
+    fn test_mm_mask_expand_epi8() {
         let src = _mm_set1_epi8(100);
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_mask_expand_epi8(src, 0b01010101_01010101, a);
@@ -2754,7 +2754,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    unsafe fn test_mm_maskz_expand_epi8() {
+    fn test_mm_maskz_expand_epi8() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_expand_epi8(0b01010101_01010101, a);
         let e = _mm_set_epi8(0, 8, 0, 9, 0, 10, 0, 11, 0, 12, 0, 13, 0, 14, 0, 15);
@@ -2762,7 +2762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shldv_epi64() {
+    const fn test_mm512_shldv_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(1 << 63);
         let c = _mm512_set1_epi64(2);
@@ -2772,7 +2772,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shldv_epi64() {
+    const fn test_mm512_mask_shldv_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(1 << 63);
         let c = _mm512_set1_epi64(2);
@@ -2784,7 +2784,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shldv_epi64() {
+    const fn test_mm512_maskz_shldv_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(1 << 63);
         let c = _mm512_set1_epi64(2);
@@ -2796,7 +2796,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shldv_epi64() {
+    const fn test_mm256_shldv_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(1 << 63);
         let c = _mm256_set1_epi64x(2);
@@ -2806,7 +2806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shldv_epi64() {
+    const fn test_mm256_mask_shldv_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(1 << 63);
         let c = _mm256_set1_epi64x(2);
@@ -2818,7 +2818,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shldv_epi64() {
+    const fn test_mm256_maskz_shldv_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(1 << 63);
         let c = _mm256_set1_epi64x(2);
@@ -2830,7 +2830,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shldv_epi64() {
+    const fn test_mm_shldv_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(1 << 63);
         let c = _mm_set1_epi64x(2);
@@ -2840,7 +2840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shldv_epi64() {
+    const fn test_mm_mask_shldv_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(1 << 63);
         let c = _mm_set1_epi64x(2);
@@ -2852,7 +2852,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shldv_epi64() {
+    const fn test_mm_maskz_shldv_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(1 << 63);
         let c = _mm_set1_epi64x(2);
@@ -2864,7 +2864,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shldv_epi32() {
+    const fn test_mm512_shldv_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(1 << 31);
         let c = _mm512_set1_epi32(2);
@@ -2874,7 +2874,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shldv_epi32() {
+    const fn test_mm512_mask_shldv_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(1 << 31);
         let c = _mm512_set1_epi32(2);
@@ -2886,7 +2886,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shldv_epi32() {
+    const fn test_mm512_maskz_shldv_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(1 << 31);
         let c = _mm512_set1_epi32(2);
@@ -2898,7 +2898,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shldv_epi32() {
+    const fn test_mm256_shldv_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(1 << 31);
         let c = _mm256_set1_epi32(2);
@@ -2908,7 +2908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shldv_epi32() {
+    const fn test_mm256_mask_shldv_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(1 << 31);
         let c = _mm256_set1_epi32(2);
@@ -2920,7 +2920,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shldv_epi32() {
+    const fn test_mm256_maskz_shldv_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(1 << 31);
         let c = _mm256_set1_epi32(2);
@@ -2932,7 +2932,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shldv_epi32() {
+    const fn test_mm_shldv_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(1 << 31);
         let c = _mm_set1_epi32(2);
@@ -2942,7 +2942,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shldv_epi32() {
+    const fn test_mm_mask_shldv_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(1 << 31);
         let c = _mm_set1_epi32(2);
@@ -2954,7 +2954,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shldv_epi32() {
+    const fn test_mm_maskz_shldv_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(1 << 31);
         let c = _mm_set1_epi32(2);
@@ -2966,7 +2966,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shldv_epi16() {
+    const fn test_mm512_shldv_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1 << 15);
         let c = _mm512_set1_epi16(2);
@@ -2976,7 +2976,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shldv_epi16() {
+    const fn test_mm512_mask_shldv_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1 << 15);
         let c = _mm512_set1_epi16(2);
@@ -2988,7 +2988,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shldv_epi16() {
+    const fn test_mm512_maskz_shldv_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1 << 15);
         let c = _mm512_set1_epi16(2);
@@ -3000,7 +3000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shldv_epi16() {
+    const fn test_mm256_shldv_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1 << 15);
         let c = _mm256_set1_epi16(2);
@@ -3010,7 +3010,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shldv_epi16() {
+    const fn test_mm256_mask_shldv_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1 << 15);
         let c = _mm256_set1_epi16(2);
@@ -3022,7 +3022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shldv_epi16() {
+    const fn test_mm256_maskz_shldv_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1 << 15);
         let c = _mm256_set1_epi16(2);
@@ -3034,7 +3034,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shldv_epi16() {
+    const fn test_mm_shldv_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1 << 15);
         let c = _mm_set1_epi16(2);
@@ -3044,7 +3044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shldv_epi16() {
+    const fn test_mm_mask_shldv_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1 << 15);
         let c = _mm_set1_epi16(2);
@@ -3056,7 +3056,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shldv_epi16() {
+    const fn test_mm_maskz_shldv_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1 << 15);
         let c = _mm_set1_epi16(2);
@@ -3068,7 +3068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shrdv_epi64() {
+    const fn test_mm512_shrdv_epi64() {
         let a = _mm512_set1_epi64(2);
         let b = _mm512_set1_epi64(8);
         let c = _mm512_set1_epi64(1);
@@ -3078,7 +3078,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shrdv_epi64() {
+    const fn test_mm512_mask_shrdv_epi64() {
         let a = _mm512_set1_epi64(2);
         let b = _mm512_set1_epi64(8);
         let c = _mm512_set1_epi64(1);
@@ -3090,7 +3090,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shrdv_epi64() {
+    const fn test_mm512_maskz_shrdv_epi64() {
         let a = _mm512_set1_epi64(2);
         let b = _mm512_set1_epi64(8);
         let c = _mm512_set1_epi64(1);
@@ -3102,7 +3102,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shrdv_epi64() {
+    const fn test_mm256_shrdv_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(8);
         let c = _mm256_set1_epi64x(1);
@@ -3112,7 +3112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shrdv_epi64() {
+    const fn test_mm256_mask_shrdv_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(8);
         let c = _mm256_set1_epi64x(1);
@@ -3124,7 +3124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shrdv_epi64() {
+    const fn test_mm256_maskz_shrdv_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(8);
         let c = _mm256_set1_epi64x(1);
@@ -3136,7 +3136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shrdv_epi64() {
+    const fn test_mm_shrdv_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(8);
         let c = _mm_set1_epi64x(1);
@@ -3146,7 +3146,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shrdv_epi64() {
+    const fn test_mm_mask_shrdv_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(8);
         let c = _mm_set1_epi64x(1);
@@ -3158,7 +3158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shrdv_epi64() {
+    const fn test_mm_maskz_shrdv_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(8);
         let c = _mm_set1_epi64x(1);
@@ -3170,7 +3170,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shrdv_epi32() {
+    const fn test_mm512_shrdv_epi32() {
         let a = _mm512_set1_epi32(2);
         let b = _mm512_set1_epi32(8);
         let c = _mm512_set1_epi32(1);
@@ -3180,7 +3180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shrdv_epi32() {
+    const fn test_mm512_mask_shrdv_epi32() {
         let a = _mm512_set1_epi32(2);
         let b = _mm512_set1_epi32(8);
         let c = _mm512_set1_epi32(1);
@@ -3192,7 +3192,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shrdv_epi32() {
+    const fn test_mm512_maskz_shrdv_epi32() {
         let a = _mm512_set1_epi32(2);
         let b = _mm512_set1_epi32(8);
         let c = _mm512_set1_epi32(1);
@@ -3204,7 +3204,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shrdv_epi32() {
+    const fn test_mm256_shrdv_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(8);
         let c = _mm256_set1_epi32(1);
@@ -3214,7 +3214,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shrdv_epi32() {
+    const fn test_mm256_mask_shrdv_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(8);
         let c = _mm256_set1_epi32(1);
@@ -3226,7 +3226,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shrdv_epi32() {
+    const fn test_mm256_maskz_shrdv_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(8);
         let c = _mm256_set1_epi32(1);
@@ -3238,7 +3238,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shrdv_epi32() {
+    const fn test_mm_shrdv_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(8);
         let c = _mm_set1_epi32(1);
@@ -3248,7 +3248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shrdv_epi32() {
+    const fn test_mm_mask_shrdv_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(8);
         let c = _mm_set1_epi32(1);
@@ -3260,7 +3260,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shrdv_epi32() {
+    const fn test_mm_maskz_shrdv_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(8);
         let c = _mm_set1_epi32(1);
@@ -3272,7 +3272,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shrdv_epi16() {
+    const fn test_mm512_shrdv_epi16() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(8);
         let c = _mm512_set1_epi16(1);
@@ -3282,7 +3282,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shrdv_epi16() {
+    const fn test_mm512_mask_shrdv_epi16() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(8);
         let c = _mm512_set1_epi16(1);
@@ -3294,7 +3294,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shrdv_epi16() {
+    const fn test_mm512_maskz_shrdv_epi16() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(8);
         let c = _mm512_set1_epi16(1);
@@ -3306,7 +3306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shrdv_epi16() {
+    const fn test_mm256_shrdv_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(8);
         let c = _mm256_set1_epi16(1);
@@ -3316,7 +3316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shrdv_epi16() {
+    const fn test_mm256_mask_shrdv_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(8);
         let c = _mm256_set1_epi16(1);
@@ -3328,7 +3328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shrdv_epi16() {
+    const fn test_mm256_maskz_shrdv_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(8);
         let c = _mm256_set1_epi16(1);
@@ -3340,7 +3340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shrdv_epi16() {
+    const fn test_mm_shrdv_epi16() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(8);
         let c = _mm_set1_epi16(1);
@@ -3350,7 +3350,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shrdv_epi16() {
+    const fn test_mm_mask_shrdv_epi16() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(8);
         let c = _mm_set1_epi16(1);
@@ -3362,7 +3362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shrdv_epi16() {
+    const fn test_mm_maskz_shrdv_epi16() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(8);
         let c = _mm_set1_epi16(1);
@@ -3374,7 +3374,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shldi_epi64() {
+    const fn test_mm512_shldi_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(1 << 63);
         let r = _mm512_shldi_epi64::<2>(a, b);
@@ -3383,7 +3383,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shldi_epi64() {
+    const fn test_mm512_mask_shldi_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(1 << 63);
         let r = _mm512_mask_shldi_epi64::<2>(a, 0, a, b);
@@ -3394,7 +3394,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shldi_epi64() {
+    const fn test_mm512_maskz_shldi_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(1 << 63);
         let r = _mm512_maskz_shldi_epi64::<2>(0, a, b);
@@ -3405,7 +3405,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shldi_epi64() {
+    const fn test_mm256_shldi_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(1 << 63);
         let r = _mm256_shldi_epi64::<2>(a, b);
@@ -3414,7 +3414,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shldi_epi64() {
+    const fn test_mm256_mask_shldi_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(1 << 63);
         let r = _mm256_mask_shldi_epi64::<2>(a, 0, a, b);
@@ -3425,7 +3425,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shldi_epi64() {
+    const fn test_mm256_maskz_shldi_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(1 << 63);
         let r = _mm256_maskz_shldi_epi64::<2>(0, a, b);
@@ -3436,7 +3436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shldi_epi64() {
+    const fn test_mm_shldi_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(1 << 63);
         let r = _mm_shldi_epi64::<2>(a, b);
@@ -3445,7 +3445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shldi_epi64() {
+    const fn test_mm_mask_shldi_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(1 << 63);
         let r = _mm_mask_shldi_epi64::<2>(a, 0, a, b);
@@ -3456,7 +3456,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shldi_epi64() {
+    const fn test_mm_maskz_shldi_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(1 << 63);
         let r = _mm_maskz_shldi_epi64::<2>(0, a, b);
@@ -3467,7 +3467,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shldi_epi32() {
+    const fn test_mm512_shldi_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(1 << 31);
         let r = _mm512_shldi_epi32::<2>(a, b);
@@ -3476,7 +3476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shldi_epi32() {
+    const fn test_mm512_mask_shldi_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(1 << 31);
         let r = _mm512_mask_shldi_epi32::<2>(a, 0, a, b);
@@ -3487,7 +3487,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shldi_epi32() {
+    const fn test_mm512_maskz_shldi_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_set1_epi32(1 << 31);
         let r = _mm512_maskz_shldi_epi32::<2>(0, a, b);
@@ -3498,7 +3498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shldi_epi32() {
+    const fn test_mm256_shldi_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(1 << 31);
         let r = _mm256_shldi_epi32::<2>(a, b);
@@ -3507,7 +3507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shldi_epi32() {
+    const fn test_mm256_mask_shldi_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(1 << 31);
         let r = _mm256_mask_shldi_epi32::<2>(a, 0, a, b);
@@ -3518,7 +3518,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shldi_epi32() {
+    const fn test_mm256_maskz_shldi_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set1_epi32(1 << 31);
         let r = _mm256_maskz_shldi_epi32::<2>(0, a, b);
@@ -3529,7 +3529,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shldi_epi32() {
+    const fn test_mm_shldi_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(1 << 31);
         let r = _mm_shldi_epi32::<2>(a, b);
@@ -3538,7 +3538,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shldi_epi32() {
+    const fn test_mm_mask_shldi_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(1 << 31);
         let r = _mm_mask_shldi_epi32::<2>(a, 0, a, b);
@@ -3549,7 +3549,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shldi_epi32() {
+    const fn test_mm_maskz_shldi_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set1_epi32(1 << 31);
         let r = _mm_maskz_shldi_epi32::<2>(0, a, b);
@@ -3560,7 +3560,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shldi_epi16() {
+    const fn test_mm512_shldi_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1 << 15);
         let r = _mm512_shldi_epi16::<2>(a, b);
@@ -3569,7 +3569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shldi_epi16() {
+    const fn test_mm512_mask_shldi_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1 << 15);
         let r = _mm512_mask_shldi_epi16::<2>(a, 0, a, b);
@@ -3580,7 +3580,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shldi_epi16() {
+    const fn test_mm512_maskz_shldi_epi16() {
         let a = _mm512_set1_epi16(1);
         let b = _mm512_set1_epi16(1 << 15);
         let r = _mm512_maskz_shldi_epi16::<2>(0, a, b);
@@ -3591,7 +3591,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shldi_epi16() {
+    const fn test_mm256_shldi_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1 << 15);
         let r = _mm256_shldi_epi16::<2>(a, b);
@@ -3600,7 +3600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shldi_epi16() {
+    const fn test_mm256_mask_shldi_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1 << 15);
         let r = _mm256_mask_shldi_epi16::<2>(a, 0, a, b);
@@ -3611,7 +3611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shldi_epi16() {
+    const fn test_mm256_maskz_shldi_epi16() {
         let a = _mm256_set1_epi16(1);
         let b = _mm256_set1_epi16(1 << 15);
         let r = _mm256_maskz_shldi_epi16::<2>(0, a, b);
@@ -3622,7 +3622,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shldi_epi16() {
+    const fn test_mm_shldi_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1 << 15);
         let r = _mm_shldi_epi16::<2>(a, b);
@@ -3631,7 +3631,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shldi_epi16() {
+    const fn test_mm_mask_shldi_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1 << 15);
         let r = _mm_mask_shldi_epi16::<2>(a, 0, a, b);
@@ -3642,7 +3642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shldi_epi16() {
+    const fn test_mm_maskz_shldi_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(1 << 15);
         let r = _mm_maskz_shldi_epi16::<2>(0, a, b);
@@ -3653,7 +3653,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shrdi_epi64() {
+    const fn test_mm512_shrdi_epi64() {
         let a = _mm512_set1_epi64(2);
         let b = _mm512_set1_epi64(8);
         let r = _mm512_shrdi_epi64::<1>(a, b);
@@ -3662,7 +3662,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shrdi_epi64() {
+    const fn test_mm512_mask_shrdi_epi64() {
         let a = _mm512_set1_epi64(2);
         let b = _mm512_set1_epi64(8);
         let r = _mm512_mask_shrdi_epi64::<1>(a, 0, a, b);
@@ -3673,7 +3673,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shrdi_epi64() {
+    const fn test_mm512_maskz_shrdi_epi64() {
         let a = _mm512_set1_epi64(2);
         let b = _mm512_set1_epi64(8);
         let r = _mm512_maskz_shrdi_epi64::<1>(0, a, b);
@@ -3684,7 +3684,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shrdi_epi64() {
+    const fn test_mm256_shrdi_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(8);
         let r = _mm256_shrdi_epi64::<1>(a, b);
@@ -3693,7 +3693,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shrdi_epi64() {
+    const fn test_mm256_mask_shrdi_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(8);
         let r = _mm256_mask_shrdi_epi64::<1>(a, 0, a, b);
@@ -3704,7 +3704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shrdi_epi64() {
+    const fn test_mm256_maskz_shrdi_epi64() {
         let a = _mm256_set1_epi64x(2);
         let b = _mm256_set1_epi64x(8);
         let r = _mm256_maskz_shrdi_epi64::<1>(0, a, b);
@@ -3715,7 +3715,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shrdi_epi64() {
+    const fn test_mm_shrdi_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(8);
         let r = _mm_shrdi_epi64::<1>(a, b);
@@ -3724,7 +3724,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shrdi_epi64() {
+    const fn test_mm_mask_shrdi_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(8);
         let r = _mm_mask_shrdi_epi64::<1>(a, 0, a, b);
@@ -3735,7 +3735,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shrdi_epi64() {
+    const fn test_mm_maskz_shrdi_epi64() {
         let a = _mm_set1_epi64x(2);
         let b = _mm_set1_epi64x(8);
         let r = _mm_maskz_shrdi_epi64::<1>(0, a, b);
@@ -3746,7 +3746,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shrdi_epi32() {
+    const fn test_mm512_shrdi_epi32() {
         let a = _mm512_set1_epi32(2);
         let b = _mm512_set1_epi32(8);
         let r = _mm512_shrdi_epi32::<1>(a, b);
@@ -3755,7 +3755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shrdi_epi32() {
+    const fn test_mm512_mask_shrdi_epi32() {
         let a = _mm512_set1_epi32(2);
         let b = _mm512_set1_epi32(8);
         let r = _mm512_mask_shrdi_epi32::<1>(a, 0, a, b);
@@ -3766,7 +3766,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shrdi_epi32() {
+    const fn test_mm512_maskz_shrdi_epi32() {
         let a = _mm512_set1_epi32(2);
         let b = _mm512_set1_epi32(8);
         let r = _mm512_maskz_shrdi_epi32::<1>(0, a, b);
@@ -3777,7 +3777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shrdi_epi32() {
+    const fn test_mm256_shrdi_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(8);
         let r = _mm256_shrdi_epi32::<1>(a, b);
@@ -3786,7 +3786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shrdi_epi32() {
+    const fn test_mm256_mask_shrdi_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(8);
         let r = _mm256_mask_shrdi_epi32::<1>(a, 0, a, b);
@@ -3797,7 +3797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shrdi_epi32() {
+    const fn test_mm256_maskz_shrdi_epi32() {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(8);
         let r = _mm256_maskz_shrdi_epi32::<1>(0, a, b);
@@ -3808,7 +3808,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shrdi_epi32() {
+    const fn test_mm_shrdi_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(8);
         let r = _mm_shrdi_epi32::<1>(a, b);
@@ -3817,7 +3817,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shrdi_epi32() {
+    const fn test_mm_mask_shrdi_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(8);
         let r = _mm_mask_shrdi_epi32::<1>(a, 0, a, b);
@@ -3828,7 +3828,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shrdi_epi32() {
+    const fn test_mm_maskz_shrdi_epi32() {
         let a = _mm_set1_epi32(2);
         let b = _mm_set1_epi32(8);
         let r = _mm_maskz_shrdi_epi32::<1>(0, a, b);
@@ -3839,7 +3839,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_shrdi_epi16() {
+    const fn test_mm512_shrdi_epi16() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(8);
         let r = _mm512_shrdi_epi16::<1>(a, b);
@@ -3848,7 +3848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_mask_shrdi_epi16() {
+    const fn test_mm512_mask_shrdi_epi16() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(8);
         let r = _mm512_mask_shrdi_epi16::<1>(a, 0, a, b);
@@ -3859,7 +3859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2")]
-    const unsafe fn test_mm512_maskz_shrdi_epi16() {
+    const fn test_mm512_maskz_shrdi_epi16() {
         let a = _mm512_set1_epi16(2);
         let b = _mm512_set1_epi16(8);
         let r = _mm512_maskz_shrdi_epi16::<1>(0, a, b);
@@ -3870,7 +3870,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_shrdi_epi16() {
+    const fn test_mm256_shrdi_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(8);
         let r = _mm256_shrdi_epi16::<1>(a, b);
@@ -3879,7 +3879,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_mask_shrdi_epi16() {
+    const fn test_mm256_mask_shrdi_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(8);
         let r = _mm256_mask_shrdi_epi16::<1>(a, 0, a, b);
@@ -3890,7 +3890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm256_maskz_shrdi_epi16() {
+    const fn test_mm256_maskz_shrdi_epi16() {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(8);
         let r = _mm256_maskz_shrdi_epi16::<1>(0, a, b);
@@ -3901,7 +3901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_shrdi_epi16() {
+    const fn test_mm_shrdi_epi16() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(8);
         let r = _mm_shrdi_epi16::<1>(a, b);
@@ -3910,7 +3910,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_mask_shrdi_epi16() {
+    const fn test_mm_mask_shrdi_epi16() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(8);
         let r = _mm_mask_shrdi_epi16::<1>(a, 0, a, b);
@@ -3921,7 +3921,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vbmi2,avx512vl")]
-    const unsafe fn test_mm_maskz_shrdi_epi16() {
+    const fn test_mm_maskz_shrdi_epi16() {
         let a = _mm_set1_epi16(2);
         let b = _mm_set1_epi16(8);
         let r = _mm_maskz_shrdi_epi16::<1>(0, a, b);

--- a/crates/core_arch/src/x86/avx512vnni.rs
+++ b/crates/core_arch/src/x86/avx512vnni.rs
@@ -970,7 +970,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_dpwssd_epi32() {
+    fn test_mm512_dpwssd_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 16 | 1 << 0);
@@ -980,7 +980,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_mask_dpwssd_epi32() {
+    fn test_mm512_mask_dpwssd_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 16 | 1 << 0);
@@ -992,7 +992,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_maskz_dpwssd_epi32() {
+    fn test_mm512_maskz_dpwssd_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 16 | 1 << 0);
@@ -1004,7 +1004,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm256_dpwssd_avx_epi32() {
+    fn test_mm256_dpwssd_avx_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1014,7 +1014,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_dpwssd_epi32() {
+    fn test_mm256_dpwssd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1024,7 +1024,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_mask_dpwssd_epi32() {
+    fn test_mm256_mask_dpwssd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1036,7 +1036,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_maskz_dpwssd_epi32() {
+    fn test_mm256_maskz_dpwssd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm_dpwssd_avx_epi32() {
+    fn test_mm_dpwssd_avx_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1058,7 +1058,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_dpwssd_epi32() {
+    fn test_mm_dpwssd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1068,7 +1068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_mask_dpwssd_epi32() {
+    fn test_mm_mask_dpwssd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1080,7 +1080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_maskz_dpwssd_epi32() {
+    fn test_mm_maskz_dpwssd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1092,7 +1092,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_dpwssds_epi32() {
+    fn test_mm512_dpwssds_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 16 | 1 << 0);
@@ -1102,7 +1102,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_mask_dpwssds_epi32() {
+    fn test_mm512_mask_dpwssds_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 16 | 1 << 0);
@@ -1114,7 +1114,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_maskz_dpwssds_epi32() {
+    fn test_mm512_maskz_dpwssds_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 16 | 1 << 0);
@@ -1126,7 +1126,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm256_dpwssds_avx_epi32() {
+    fn test_mm256_dpwssds_avx_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1136,7 +1136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_dpwssds_epi32() {
+    fn test_mm256_dpwssds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1146,7 +1146,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_mask_dpwssds_epi32() {
+    fn test_mm256_mask_dpwssds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1158,7 +1158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_maskz_dpwssds_epi32() {
+    fn test_mm256_maskz_dpwssds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1170,7 +1170,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm_dpwssds_avx_epi32() {
+    fn test_mm_dpwssds_avx_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1180,7 +1180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_dpwssds_epi32() {
+    fn test_mm_dpwssds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1190,7 +1190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_mask_dpwssds_epi32() {
+    fn test_mm_mask_dpwssds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1202,7 +1202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_maskz_dpwssds_epi32() {
+    fn test_mm_maskz_dpwssds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1214,7 +1214,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_dpbusd_epi32() {
+    fn test_mm512_dpbusd_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1224,7 +1224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_mask_dpbusd_epi32() {
+    fn test_mm512_mask_dpbusd_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1236,7 +1236,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_maskz_dpbusd_epi32() {
+    fn test_mm512_maskz_dpbusd_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1248,7 +1248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm256_dpbusd_avx_epi32() {
+    fn test_mm256_dpbusd_avx_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1258,7 +1258,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_dpbusd_epi32() {
+    fn test_mm256_dpbusd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1268,7 +1268,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_mask_dpbusd_epi32() {
+    fn test_mm256_mask_dpbusd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1280,7 +1280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_maskz_dpbusd_epi32() {
+    fn test_mm256_maskz_dpbusd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1292,7 +1292,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm_dpbusd_avx_epi32() {
+    fn test_mm_dpbusd_avx_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1302,7 +1302,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_dpbusd_epi32() {
+    fn test_mm_dpbusd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1312,7 +1312,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_mask_dpbusd_epi32() {
+    fn test_mm_mask_dpbusd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1324,7 +1324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_maskz_dpbusd_epi32() {
+    fn test_mm_maskz_dpbusd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1336,7 +1336,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_dpbusds_epi32() {
+    fn test_mm512_dpbusds_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1346,7 +1346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_mask_dpbusds_epi32() {
+    fn test_mm512_mask_dpbusds_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1358,7 +1358,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni")]
-    unsafe fn test_mm512_maskz_dpbusds_epi32() {
+    fn test_mm512_maskz_dpbusds_epi32() {
         let src = _mm512_set1_epi32(1);
         let a = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm512_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1370,7 +1370,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm256_dpbusds_avx_epi32() {
+    fn test_mm256_dpbusds_avx_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1380,7 +1380,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_dpbusds_epi32() {
+    fn test_mm256_dpbusds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1390,7 +1390,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_mask_dpbusds_epi32() {
+    fn test_mm256_mask_dpbusds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1402,7 +1402,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm256_maskz_dpbusds_epi32() {
+    fn test_mm256_maskz_dpbusds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1414,7 +1414,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnni")]
-    unsafe fn test_mm_dpbusds_avx_epi32() {
+    fn test_mm_dpbusds_avx_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1424,7 +1424,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_dpbusds_epi32() {
+    fn test_mm_dpbusds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1434,7 +1434,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_mask_dpbusds_epi32() {
+    fn test_mm_mask_dpbusds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1446,7 +1446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vnni,avx512vl")]
-    unsafe fn test_mm_maskz_dpbusds_epi32() {
+    fn test_mm_maskz_dpbusds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1458,7 +1458,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm_dpbssd_epi32() {
+    fn test_mm_dpbssd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1468,7 +1468,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm256_dpbssd_epi32() {
+    fn test_mm256_dpbssd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1478,7 +1478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm_dpbssds_epi32() {
+    fn test_mm_dpbssds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1488,7 +1488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm256_dpbssds_epi32() {
+    fn test_mm256_dpbssds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1498,7 +1498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm_dpbsud_epi32() {
+    fn test_mm_dpbsud_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1508,7 +1508,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm256_dpbsud_epi32() {
+    fn test_mm256_dpbsud_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1518,7 +1518,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm_dpbsuds_epi32() {
+    fn test_mm_dpbsuds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1528,7 +1528,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm256_dpbsuds_epi32() {
+    fn test_mm256_dpbsuds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1538,7 +1538,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm_dpbuud_epi32() {
+    fn test_mm_dpbuud_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1548,7 +1548,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm256_dpbuud_epi32() {
+    fn test_mm256_dpbuud_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1558,7 +1558,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm_dpbuuds_epi32() {
+    fn test_mm_dpbuuds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1568,7 +1568,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint8")]
-    unsafe fn test_mm256_dpbuuds_epi32() {
+    fn test_mm256_dpbuuds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 24 | 1 << 16 | 1 << 8 | 1 << 0);
@@ -1578,7 +1578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm_dpwsud_epi32() {
+    fn test_mm_dpwsud_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1588,7 +1588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm256_dpwsud_epi32() {
+    fn test_mm256_dpwsud_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1598,7 +1598,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm_dpwsuds_epi32() {
+    fn test_mm_dpwsuds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1608,7 +1608,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm256_dpwsuds_epi32() {
+    fn test_mm256_dpwsuds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1618,7 +1618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm_dpwusd_epi32() {
+    fn test_mm_dpwusd_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1628,7 +1628,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm256_dpwusd_epi32() {
+    fn test_mm256_dpwusd_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1638,7 +1638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm_dpwusds_epi32() {
+    fn test_mm_dpwusds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1648,7 +1648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm256_dpwusds_epi32() {
+    fn test_mm256_dpwusds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1658,7 +1658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm_dpwuud_epi32() {
+    fn test_mm_dpwuud_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1668,7 +1668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm256_dpwuud_epi32() {
+    fn test_mm256_dpwuud_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);
@@ -1678,7 +1678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm_dpwuuds_epi32() {
+    fn test_mm_dpwuuds_epi32() {
         let src = _mm_set1_epi32(1);
         let a = _mm_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm_set1_epi32(1 << 16 | 1 << 0);
@@ -1688,7 +1688,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avxvnniint16")]
-    unsafe fn test_mm256_dpwuuds_epi32() {
+    fn test_mm256_dpwuuds_epi32() {
         let src = _mm256_set1_epi32(1);
         let a = _mm256_set1_epi32(1 << 16 | 1 << 0);
         let b = _mm256_set1_epi32(1 << 16 | 1 << 0);

--- a/crates/core_arch/src/x86/avx512vpopcntdq.rs
+++ b/crates/core_arch/src/x86/avx512vpopcntdq.rs
@@ -351,7 +351,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f")]
-    const unsafe fn test_mm512_popcnt_epi32() {
+    const fn test_mm512_popcnt_epi32() {
         let test_data = _mm512_set_epi32(
             0,
             1,
@@ -377,7 +377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f")]
-    const unsafe fn test_mm512_mask_popcnt_epi32() {
+    const fn test_mm512_mask_popcnt_epi32() {
         let test_data = _mm512_set_epi32(
             0,
             1,
@@ -420,7 +420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f")]
-    const unsafe fn test_mm512_maskz_popcnt_epi32() {
+    const fn test_mm512_maskz_popcnt_epi32() {
         let test_data = _mm512_set_epi32(
             0,
             1,
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f,avx512vl")]
-    const unsafe fn test_mm256_popcnt_epi32() {
+    const fn test_mm256_popcnt_epi32() {
         let test_data = _mm256_set_epi32(0, 1, -1, 2, 7, 0xFF_FE, 0x7F_FF_FF_FF, -100);
         let actual_result = _mm256_popcnt_epi32(test_data);
         let reference_result = _mm256_set_epi32(0, 1, 32, 1, 3, 15, 31, 28);
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_popcnt_epi32() {
+    const fn test_mm256_mask_popcnt_epi32() {
         let test_data = _mm256_set_epi32(0, 1, -1, 2, 7, 0xFF_FE, 0x7F_FF_FF_FF, -100);
         let mask = 0xF0;
         let actual_result = _mm256_mask_popcnt_epi32(test_data, mask, test_data);
@@ -463,7 +463,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_popcnt_epi32() {
+    const fn test_mm256_maskz_popcnt_epi32() {
         let test_data = _mm256_set_epi32(0, 1, -1, 2, 7, 0xFF_FE, 0x7F_FF_FF_FF, -100);
         let mask = 0xF0;
         let actual_result = _mm256_maskz_popcnt_epi32(mask, test_data);
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f,avx512vl")]
-    const unsafe fn test_mm_popcnt_epi32() {
+    const fn test_mm_popcnt_epi32() {
         let test_data = _mm_set_epi32(0, 1, -1, -100);
         let actual_result = _mm_popcnt_epi32(test_data);
         let reference_result = _mm_set_epi32(0, 1, 32, 28);
@@ -480,7 +480,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_popcnt_epi32() {
+    const fn test_mm_mask_popcnt_epi32() {
         let test_data = _mm_set_epi32(0, 1, -1, -100);
         let mask = 0xE;
         let actual_result = _mm_mask_popcnt_epi32(test_data, mask, test_data);
@@ -489,7 +489,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_popcnt_epi32() {
+    const fn test_mm_maskz_popcnt_epi32() {
         let test_data = _mm_set_epi32(0, 1, -1, -100);
         let mask = 0xE;
         let actual_result = _mm_maskz_popcnt_epi32(mask, test_data);
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f")]
-    const unsafe fn test_mm512_popcnt_epi64() {
+    const fn test_mm512_popcnt_epi64() {
         let test_data = _mm512_set_epi64(0, 1, -1, 2, 7, 0xFF_FE, 0x7F_FF_FF_FF_FF_FF_FF_FF, -100);
         let actual_result = _mm512_popcnt_epi64(test_data);
         let reference_result = _mm512_set_epi64(0, 1, 64, 1, 3, 15, 63, 60);
@@ -506,7 +506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f")]
-    const unsafe fn test_mm512_mask_popcnt_epi64() {
+    const fn test_mm512_mask_popcnt_epi64() {
         let test_data = _mm512_set_epi64(0, 1, -1, 2, 7, 0xFF_FE, 0x7F_FF_FF_FF_FF_FF_FF_FF, -100);
         let mask = 0xF0;
         let actual_result = _mm512_mask_popcnt_epi64(test_data, mask, test_data);
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512f")]
-    const unsafe fn test_mm512_maskz_popcnt_epi64() {
+    const fn test_mm512_maskz_popcnt_epi64() {
         let test_data = _mm512_set_epi64(0, 1, -1, 2, 7, 0xFF_FE, 0x7F_FF_FF_FF_FF_FF_FF_FF, -100);
         let mask = 0xF0;
         let actual_result = _mm512_maskz_popcnt_epi64(mask, test_data);
@@ -525,7 +525,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512vl")]
-    const unsafe fn test_mm256_popcnt_epi64() {
+    const fn test_mm256_popcnt_epi64() {
         let test_data = _mm256_set_epi64x(0, 1, -1, -100);
         let actual_result = _mm256_popcnt_epi64(test_data);
         let reference_result = _mm256_set_epi64x(0, 1, 64, 60);
@@ -533,7 +533,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512vl")]
-    const unsafe fn test_mm256_mask_popcnt_epi64() {
+    const fn test_mm256_mask_popcnt_epi64() {
         let test_data = _mm256_set_epi64x(0, 1, -1, -100);
         let mask = 0xE;
         let actual_result = _mm256_mask_popcnt_epi64(test_data, mask, test_data);
@@ -542,7 +542,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512vl")]
-    const unsafe fn test_mm256_maskz_popcnt_epi64() {
+    const fn test_mm256_maskz_popcnt_epi64() {
         let test_data = _mm256_set_epi64x(0, 1, -1, -100);
         let mask = 0xE;
         let actual_result = _mm256_maskz_popcnt_epi64(mask, test_data);
@@ -551,7 +551,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512vl")]
-    const unsafe fn test_mm_popcnt_epi64() {
+    const fn test_mm_popcnt_epi64() {
         let test_data = _mm_set_epi64x(0, 1);
         let actual_result = _mm_popcnt_epi64(test_data);
         let reference_result = _mm_set_epi64x(0, 1);
@@ -563,7 +563,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512vl")]
-    const unsafe fn test_mm_mask_popcnt_epi64() {
+    const fn test_mm_mask_popcnt_epi64() {
         let test_data = _mm_set_epi64x(0, -100);
         let mask = 0x2;
         let actual_result = _mm_mask_popcnt_epi64(test_data, mask, test_data);
@@ -577,7 +577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512vpopcntdq,avx512vl")]
-    const unsafe fn test_mm_maskz_popcnt_epi64() {
+    const fn test_mm_maskz_popcnt_epi64() {
         let test_data = _mm_set_epi64x(0, 1);
         let mask = 0x2;
         let actual_result = _mm_maskz_popcnt_epi64(mask, test_data);

--- a/crates/core_arch/src/x86/bmi1.rs
+++ b/crates/core_arch/src/x86/bmi1.rs
@@ -144,13 +144,13 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "bmi1")]
-    unsafe fn test_bextr_u32() {
+    fn test_bextr_u32() {
         let r = _bextr_u32(0b0101_0000u32, 4, 4);
         assert_eq!(r, 0b0000_0101u32);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_andn_u32() {
+    const fn test_andn_u32() {
         assert_eq!(_andn_u32(0, 0), 0);
         assert_eq!(_andn_u32(0, 1), 1);
         assert_eq!(_andn_u32(1, 0), 0);
@@ -173,32 +173,32 @@ mod tests {
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_blsi_u32() {
+    const fn test_blsi_u32() {
         assert_eq!(_blsi_u32(0b1101_0000u32), 0b0001_0000u32);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_blsmsk_u32() {
+    const fn test_blsmsk_u32() {
         let r = _blsmsk_u32(0b0011_0000u32);
         assert_eq!(r, 0b0001_1111u32);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_blsr_u32() {
+    const fn test_blsr_u32() {
         // TODO: test the behavior when the input is `0`.
         let r = _blsr_u32(0b0011_0000u32);
         assert_eq!(r, 0b0010_0000u32);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_tzcnt_u16() {
+    const fn test_tzcnt_u16() {
         assert_eq!(_tzcnt_u16(0b0000_0001u16), 0u16);
         assert_eq!(_tzcnt_u16(0b0000_0000u16), 16u16);
         assert_eq!(_tzcnt_u16(0b1001_0000u16), 4u16);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_tzcnt_u32() {
+    const fn test_tzcnt_u32() {
         assert_eq!(_tzcnt_u32(0b0000_0001u32), 0u32);
         assert_eq!(_tzcnt_u32(0b0000_0000u32), 32u32);
         assert_eq!(_tzcnt_u32(0b1001_0000u32), 4u32);

--- a/crates/core_arch/src/x86/bmi2.rs
+++ b/crates/core_arch/src/x86/bmi2.rs
@@ -84,7 +84,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "bmi2")]
-    unsafe fn test_pext_u32() {
+    fn test_pext_u32() {
         let n = 0b1011_1110_1001_0011u32;
 
         let m0 = 0b0110_0011_1000_0101u32;
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[simd_test(enable = "bmi2")]
-    unsafe fn test_pdep_u32() {
+    fn test_pdep_u32() {
         let n = 0b1011_1110_1001_0011u32;
 
         let m0 = 0b0110_0011_1000_0101u32;
@@ -112,14 +112,14 @@ mod tests {
     }
 
     #[simd_test(enable = "bmi2")]
-    unsafe fn test_bzhi_u32() {
+    fn test_bzhi_u32() {
         let n = 0b1111_0010u32;
         let s = 0b0001_0010u32;
         assert_eq!(_bzhi_u32(n, 5), s);
     }
 
     #[simd_test(enable = "bmi2")]
-    const unsafe fn test_mulx_u32() {
+    const fn test_mulx_u32() {
         let a: u32 = 4_294_967_200;
         let b: u32 = 2;
         let mut hi = 0;

--- a/crates/core_arch/src/x86/f16c.rs
+++ b/crates/core_arch/src/x86/f16c.rs
@@ -119,7 +119,7 @@ mod tests {
     const F16_EIGHT: i16 = 0x4800;
 
     #[simd_test(enable = "f16c")]
-    const unsafe fn test_mm_cvtph_ps() {
+    const fn test_mm_cvtph_ps() {
         let a = _mm_set_epi16(0, 0, 0, 0, F16_ONE, F16_TWO, F16_THREE, F16_FOUR);
         let r = _mm_cvtph_ps(a);
         let e = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[simd_test(enable = "f16c")]
-    const unsafe fn test_mm256_cvtph_ps() {
+    const fn test_mm256_cvtph_ps() {
         let a = _mm_set_epi16(
             F16_ONE, F16_TWO, F16_THREE, F16_FOUR, F16_FIVE, F16_SIX, F16_SEVEN, F16_EIGHT,
         );
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[simd_test(enable = "f16c")]
-    unsafe fn test_mm_cvtps_ph() {
+    fn test_mm_cvtps_ph() {
         let a = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtps_ph::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm_set_epi16(0, 0, 0, 0, F16_ONE, F16_TWO, F16_THREE, F16_FOUR);
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[simd_test(enable = "f16c")]
-    unsafe fn test_mm256_cvtps_ph() {
+    fn test_mm256_cvtps_ph() {
         let a = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm256_cvtps_ph::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm_set_epi16(

--- a/crates/core_arch/src/x86/fma.rs
+++ b/crates/core_arch/src/x86/fma.rs
@@ -560,7 +560,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmadd_pd() {
+    const fn test_mm_fmadd_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmadd_pd() {
+    const fn test_mm256_fmadd_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 3., 7., 2.);
         let c = _mm256_setr_pd(4., 9., 1., 7.);
@@ -578,7 +578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmadd_ps() {
+    const fn test_mm_fmadd_ps() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -587,7 +587,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmadd_ps() {
+    const fn test_mm256_fmadd_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 0., 10., -1., -2.);
         let b = _mm256_setr_ps(5., 3., 7., 2., 4., -6., 0., 14.);
         let c = _mm256_setr_ps(4., 9., 1., 7., -5., 11., -2., -3.);
@@ -596,7 +596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmadd_sd() {
+    const fn test_mm_fmadd_sd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -605,7 +605,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmadd_ss() {
+    const fn test_mm_fmadd_ss() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -614,7 +614,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmaddsub_pd() {
+    const fn test_mm_fmaddsub_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmaddsub_pd() {
+    const fn test_mm256_fmaddsub_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 3., 7., 2.);
         let c = _mm256_setr_pd(4., 9., 1., 7.);
@@ -632,7 +632,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmaddsub_ps() {
+    const fn test_mm_fmaddsub_ps() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -641,7 +641,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmaddsub_ps() {
+    const fn test_mm256_fmaddsub_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 0., 10., -1., -2.);
         let b = _mm256_setr_ps(5., 3., 7., 2., 4., -6., 0., 14.);
         let c = _mm256_setr_ps(4., 9., 1., 7., -5., 11., -2., -3.);
@@ -650,7 +650,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmsub_pd() {
+    const fn test_mm_fmsub_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -659,7 +659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmsub_pd() {
+    const fn test_mm256_fmsub_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 3., 7., 2.);
         let c = _mm256_setr_pd(4., 9., 1., 7.);
@@ -668,7 +668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmsub_ps() {
+    const fn test_mm_fmsub_ps() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -677,7 +677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmsub_ps() {
+    const fn test_mm256_fmsub_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 0., 10., -1., -2.);
         let b = _mm256_setr_ps(5., 3., 7., 2., 4., -6., 0., 14.);
         let c = _mm256_setr_ps(4., 9., 1., 7., -5., 11., -2., -3.);
@@ -686,7 +686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmsub_sd() {
+    const fn test_mm_fmsub_sd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -695,7 +695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmsub_ss() {
+    const fn test_mm_fmsub_ss() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -704,7 +704,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmsubadd_pd() {
+    const fn test_mm_fmsubadd_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -713,7 +713,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmsubadd_pd() {
+    const fn test_mm256_fmsubadd_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 3., 7., 2.);
         let c = _mm256_setr_pd(4., 9., 1., 7.);
@@ -722,7 +722,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fmsubadd_ps() {
+    const fn test_mm_fmsubadd_ps() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -731,7 +731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fmsubadd_ps() {
+    const fn test_mm256_fmsubadd_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 0., 10., -1., -2.);
         let b = _mm256_setr_ps(5., 3., 7., 2., 4., -6., 0., 14.);
         let c = _mm256_setr_ps(4., 9., 1., 7., -5., 11., -2., -3.);
@@ -740,7 +740,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmadd_pd() {
+    const fn test_mm_fnmadd_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -749,7 +749,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fnmadd_pd() {
+    const fn test_mm256_fnmadd_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 3., 7., 2.);
         let c = _mm256_setr_pd(4., 9., 1., 7.);
@@ -758,7 +758,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmadd_ps() {
+    const fn test_mm_fnmadd_ps() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -767,7 +767,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fnmadd_ps() {
+    const fn test_mm256_fnmadd_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 0., 10., -1., -2.);
         let b = _mm256_setr_ps(5., 3., 7., 2., 4., -6., 0., 14.);
         let c = _mm256_setr_ps(4., 9., 1., 7., -5., 11., -2., -3.);
@@ -776,7 +776,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmadd_sd() {
+    const fn test_mm_fnmadd_sd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -785,7 +785,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmadd_ss() {
+    const fn test_mm_fnmadd_ss() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -794,7 +794,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmsub_pd() {
+    const fn test_mm_fnmsub_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -803,7 +803,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fnmsub_pd() {
+    const fn test_mm256_fnmsub_pd() {
         let a = _mm256_setr_pd(1., 2., 3., 4.);
         let b = _mm256_setr_pd(5., 3., 7., 2.);
         let c = _mm256_setr_pd(4., 9., 1., 7.);
@@ -812,7 +812,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmsub_ps() {
+    const fn test_mm_fnmsub_ps() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);
@@ -821,7 +821,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm256_fnmsub_ps() {
+    const fn test_mm256_fnmsub_ps() {
         let a = _mm256_setr_ps(1., 2., 3., 4., 0., 10., -1., -2.);
         let b = _mm256_setr_ps(5., 3., 7., 2., 4., -6., 0., 14.);
         let c = _mm256_setr_ps(4., 9., 1., 7., -5., 11., -2., -3.);
@@ -830,7 +830,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmsub_sd() {
+    const fn test_mm_fnmsub_sd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(5., 3.);
         let c = _mm_setr_pd(4., 9.);
@@ -839,7 +839,7 @@ mod tests {
     }
 
     #[simd_test(enable = "fma")]
-    const unsafe fn test_mm_fnmsub_ss() {
+    const fn test_mm_fnmsub_ss() {
         let a = _mm_setr_ps(1., 2., 3., 4.);
         let b = _mm_setr_ps(5., 3., 7., 2.);
         let c = _mm_setr_ps(4., 9., 1., 7.);

--- a/crates/core_arch/src/x86/pclmulqdq.rs
+++ b/crates/core_arch/src/x86/pclmulqdq.rs
@@ -45,7 +45,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "pclmulqdq")]
-    unsafe fn test_mm_clmulepi64_si128() {
+    fn test_mm_clmulepi64_si128() {
         // Constants taken from https://software.intel.com/sites/default/files/managed/72/cc/clmul-wp-rev-2.02-2014-04-20.pdf
         let a = _mm_set_epi64x(0x7b5b546573745665, 0x63746f725d53475d);
         let b = _mm_set_epi64x(0x4869285368617929, 0x5b477565726f6e5d);

--- a/crates/core_arch/src/x86/sha.rs
+++ b/crates/core_arch/src/x86/sha.rs
@@ -286,7 +286,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha1msg1_epu32() {
+    fn test_mm_sha1msg1_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let expected = _mm_set_epi64x(0x98829f34f74ad457, 0xda2b1a44d0b5ad3c);
@@ -296,7 +296,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha1msg2_epu32() {
+    fn test_mm_sha1msg2_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let expected = _mm_set_epi64x(0xf714b202d863d47d, 0x90c30d946b3d3b35);
@@ -306,7 +306,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha1nexte_epu32() {
+    fn test_mm_sha1nexte_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let expected = _mm_set_epi64x(0x2589d5be923f82a4, 0x59f111f13956c25b);
@@ -316,7 +316,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha1rnds4_epu32() {
+    fn test_mm_sha1rnds4_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let expected = _mm_set_epi64x(0x32b13cd8322f5268, 0xc54420862bd9246f);
@@ -338,7 +338,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha256msg1_epu32() {
+    fn test_mm_sha256msg1_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let expected = _mm_set_epi64x(0xeb84973fd5cda67d, 0x2857b88f406b09ee);
@@ -348,7 +348,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha256msg2_epu32() {
+    fn test_mm_sha256msg2_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let expected = _mm_set_epi64x(0xb58777ce887fd851, 0x15d1ec8b73ac8450);
@@ -358,7 +358,7 @@ mod tests {
 
     #[simd_test(enable = "sha")]
     #[allow(overflowing_literals)]
-    unsafe fn test_mm_sha256rnds2_epu32() {
+    fn test_mm_sha256rnds2_epu32() {
         let a = _mm_set_epi64x(0xe9b5dba5b5c0fbcf, 0x71374491428a2f98);
         let b = _mm_set_epi64x(0xab1c5ed5923f82a4, 0x59f111f13956c25b);
         let k = _mm_set_epi64x(0, 0x12835b01d807aa98);
@@ -381,7 +381,7 @@ mod tests {
     ];
 
     #[simd_test(enable = "sha512,avx")]
-    unsafe fn test_mm256_sha512msg1_epi64() {
+    fn test_mm256_sha512msg1_epi64() {
         fn s0(word: u64) -> u64 {
             word.rotate_right(1) ^ word.rotate_right(8) ^ (word >> 7)
         }
@@ -389,8 +389,8 @@ mod tests {
         let A = &DATA_64[0..4];
         let B = &DATA_64[4..6];
 
-        let a = _mm256_loadu_si256(A.as_ptr().cast());
-        let b = _mm_loadu_si128(B.as_ptr().cast());
+        let a = unsafe { _mm256_loadu_si256(A.as_ptr().cast()) };
+        let b = unsafe { _mm_loadu_si128(B.as_ptr().cast()) };
 
         let r = _mm256_sha512msg1_epi64(a, b);
 
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sha512,avx")]
-    unsafe fn test_mm256_sha512msg2_epi64() {
+    fn test_mm256_sha512msg2_epi64() {
         fn s1(word: u64) -> u64 {
             word.rotate_right(19) ^ word.rotate_right(61) ^ (word >> 6)
         }
@@ -413,8 +413,8 @@ mod tests {
         let A = &DATA_64[0..4];
         let B = &DATA_64[4..8];
 
-        let a = _mm256_loadu_si256(A.as_ptr().cast());
-        let b = _mm256_loadu_si256(B.as_ptr().cast());
+        let a = unsafe { _mm256_loadu_si256(A.as_ptr().cast()) };
+        let b = unsafe { _mm256_loadu_si256(B.as_ptr().cast()) };
 
         let r = _mm256_sha512msg2_epi64(a, b);
 
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sha512,avx")]
-    unsafe fn test_mm256_sha512rnds2_epi64() {
+    fn test_mm256_sha512rnds2_epi64() {
         fn cap_sigma0(word: u64) -> u64 {
             word.rotate_right(28) ^ word.rotate_right(34) ^ word.rotate_right(39)
         }
@@ -452,9 +452,9 @@ mod tests {
         let B = &DATA_64[4..8];
         let K = &DATA_64[8..10];
 
-        let a = _mm256_loadu_si256(A.as_ptr().cast());
-        let b = _mm256_loadu_si256(B.as_ptr().cast());
-        let k = _mm_loadu_si128(K.as_ptr().cast());
+        let a = unsafe { _mm256_loadu_si256(A.as_ptr().cast()) };
+        let b = unsafe { _mm256_loadu_si256(B.as_ptr().cast()) };
+        let k = unsafe { _mm_loadu_si128(K.as_ptr().cast()) };
 
         let r = _mm256_sha512rnds2_epi64(a, b, k);
 
@@ -482,7 +482,7 @@ mod tests {
     ];
 
     #[simd_test(enable = "sm3,avx")]
-    unsafe fn test_mm_sm3msg1_epi32() {
+    fn test_mm_sm3msg1_epi32() {
         fn p1(x: u32) -> u32 {
             x ^ x.rotate_left(15) ^ x.rotate_left(23)
         }
@@ -490,9 +490,9 @@ mod tests {
         let B = &DATA_32[4..8];
         let C = &DATA_32[8..12];
 
-        let a = _mm_loadu_si128(A.as_ptr().cast());
-        let b = _mm_loadu_si128(B.as_ptr().cast());
-        let c = _mm_loadu_si128(C.as_ptr().cast());
+        let a = unsafe { _mm_loadu_si128(A.as_ptr().cast()) };
+        let b = unsafe { _mm_loadu_si128(B.as_ptr().cast()) };
+        let c = unsafe { _mm_loadu_si128(C.as_ptr().cast()) };
 
         let r = _mm_sm3msg1_epi32(a, b, c);
 
@@ -507,14 +507,14 @@ mod tests {
     }
 
     #[simd_test(enable = "sm3,avx")]
-    unsafe fn test_mm_sm3msg2_epi32() {
+    fn test_mm_sm3msg2_epi32() {
         let A = &DATA_32[0..4];
         let B = &DATA_32[4..8];
         let C = &DATA_32[8..12];
 
-        let a = _mm_loadu_si128(A.as_ptr().cast());
-        let b = _mm_loadu_si128(B.as_ptr().cast());
-        let c = _mm_loadu_si128(C.as_ptr().cast());
+        let a = unsafe { _mm_loadu_si128(A.as_ptr().cast()) };
+        let b = unsafe { _mm_loadu_si128(B.as_ptr().cast()) };
+        let c = unsafe { _mm_loadu_si128(C.as_ptr().cast()) };
 
         let r = _mm_sm3msg2_epi32(a, b, c);
 
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sm3,avx")]
-    unsafe fn test_mm_sm3rnds2_epi32() {
+    fn test_mm_sm3rnds2_epi32() {
         fn p0(x: u32) -> u32 {
             x ^ x.rotate_left(9) ^ x.rotate_left(17)
         }
@@ -560,9 +560,9 @@ mod tests {
         let B = &DATA_32[4..8];
         let C = &DATA_32[8..12];
 
-        let a = _mm_loadu_si128(A.as_ptr().cast());
-        let b = _mm_loadu_si128(B.as_ptr().cast());
-        let c = _mm_loadu_si128(C.as_ptr().cast());
+        let a = unsafe { _mm_loadu_si128(A.as_ptr().cast()) };
+        let b = unsafe { _mm_loadu_si128(B.as_ptr().cast()) };
+        let c = unsafe { _mm_loadu_si128(C.as_ptr().cast()) };
 
         let r = _mm_sm3rnds2_epi32::<{ ROUND as i32 }>(a, b, c);
 
@@ -641,7 +641,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sm4,avx")]
-    unsafe fn test_mm_sm4key4_epi32() {
+    fn test_mm_sm4key4_epi32() {
         fn l_key(x: u32) -> u32 {
             x ^ x.rotate_left(13) ^ x.rotate_left(23)
         }
@@ -652,8 +652,8 @@ mod tests {
         let A = &DATA_32[0..4];
         let B = &DATA_32[4..8];
 
-        let a = _mm_loadu_si128(A.as_ptr().cast());
-        let b = _mm_loadu_si128(B.as_ptr().cast());
+        let a = unsafe { _mm_loadu_si128(A.as_ptr().cast()) };
+        let b = unsafe { _mm_loadu_si128(B.as_ptr().cast()) };
 
         let r = _mm_sm4key4_epi32(a, b);
 
@@ -667,11 +667,11 @@ mod tests {
     }
 
     #[simd_test(enable = "sm4,avx")]
-    unsafe fn test_mm256_sm4key4_epi32() {
-        let a_low = _mm_loadu_si128(DATA_32.as_ptr().cast());
-        let a_high = _mm_loadu_si128(DATA_32[4..].as_ptr().cast());
-        let b_low = _mm_loadu_si128(DATA_32[8..].as_ptr().cast());
-        let b_high = _mm_loadu_si128(DATA_32[12..].as_ptr().cast());
+    fn test_mm256_sm4key4_epi32() {
+        let a_low = unsafe { _mm_loadu_si128(DATA_32.as_ptr().cast()) };
+        let a_high = unsafe { _mm_loadu_si128(DATA_32[4..].as_ptr().cast()) };
+        let b_low = unsafe { _mm_loadu_si128(DATA_32[8..].as_ptr().cast()) };
+        let b_high = unsafe { _mm_loadu_si128(DATA_32[12..].as_ptr().cast()) };
 
         let a = _mm256_set_m128i(a_high, a_low);
         let b = _mm256_set_m128i(b_high, b_low);
@@ -686,7 +686,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sm4,avx")]
-    unsafe fn test_mm_sm4rnds4_epi32() {
+    fn test_mm_sm4rnds4_epi32() {
         fn l_rnd(x: u32) -> u32 {
             x ^ x.rotate_left(2) ^ x.rotate_left(10) ^ x.rotate_left(18) ^ x.rotate_left(24)
         }
@@ -697,8 +697,8 @@ mod tests {
         let A = &DATA_32[0..4];
         let B = &DATA_32[4..8];
 
-        let a = _mm_loadu_si128(A.as_ptr().cast());
-        let b = _mm_loadu_si128(B.as_ptr().cast());
+        let a = unsafe { _mm_loadu_si128(A.as_ptr().cast()) };
+        let b = unsafe { _mm_loadu_si128(B.as_ptr().cast()) };
 
         let r = _mm_sm4rnds4_epi32(a, b);
 
@@ -712,11 +712,11 @@ mod tests {
     }
 
     #[simd_test(enable = "sm4,avx")]
-    unsafe fn test_mm256_sm4rnds4_epi32() {
-        let a_low = _mm_loadu_si128(DATA_32.as_ptr().cast());
-        let a_high = _mm_loadu_si128(DATA_32[4..].as_ptr().cast());
-        let b_low = _mm_loadu_si128(DATA_32[8..].as_ptr().cast());
-        let b_high = _mm_loadu_si128(DATA_32[12..].as_ptr().cast());
+    fn test_mm256_sm4rnds4_epi32() {
+        let a_low = unsafe { _mm_loadu_si128(DATA_32.as_ptr().cast()) };
+        let a_high = unsafe { _mm_loadu_si128(DATA_32[4..].as_ptr().cast()) };
+        let b_low = unsafe { _mm_loadu_si128(DATA_32[8..].as_ptr().cast()) };
+        let b_high = unsafe { _mm_loadu_si128(DATA_32[12..].as_ptr().cast()) };
 
         let a = _mm256_set_m128i(a_high, a_low);
         let b = _mm256_set_m128i(b_high, b_low);

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -2088,7 +2088,7 @@ mod tests {
     const NAN: f32 = f32::NAN;
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_add_ps() {
+    const fn test_mm_add_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_add_ps(a, b);
@@ -2096,7 +2096,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_add_ss() {
+    const fn test_mm_add_ss() {
         let a = _mm_set_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_set_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_add_ss(a, b);
@@ -2104,7 +2104,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_sub_ps() {
+    const fn test_mm_sub_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_sub_ps(a, b);
@@ -2112,7 +2112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_sub_ss() {
+    const fn test_mm_sub_ss() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_sub_ss(a, b);
@@ -2120,7 +2120,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_mul_ps() {
+    const fn test_mm_mul_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_mul_ps(a, b);
@@ -2128,7 +2128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_mul_ss() {
+    const fn test_mm_mul_ss() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_mul_ss(a, b);
@@ -2136,7 +2136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_div_ps() {
+    const fn test_mm_div_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 2.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.2, -5.0);
         let r = _mm_div_ps(a, b);
@@ -2144,7 +2144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_div_ss() {
+    const fn test_mm_div_ss() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_div_ss(a, b);
@@ -2152,7 +2152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_sqrt_ss() {
+    fn test_mm_sqrt_ss() {
         let a = _mm_setr_ps(4.0, 13.0, 16.0, 100.0);
         let r = _mm_sqrt_ss(a);
         let e = _mm_setr_ps(2.0, 13.0, 16.0, 100.0);
@@ -2160,7 +2160,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_sqrt_ps() {
+    fn test_mm_sqrt_ps() {
         let a = _mm_setr_ps(4.0, 13.0, 16.0, 100.0);
         let r = _mm_sqrt_ps(a);
         let e = _mm_setr_ps(2.0, 3.6055512, 4.0, 10.0);
@@ -2168,7 +2168,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_rcp_ss() {
+    fn test_mm_rcp_ss() {
         let a = _mm_setr_ps(4.0, 13.0, 16.0, 100.0);
         let r = _mm_rcp_ss(a);
         let e = _mm_setr_ps(0.24993896, 13.0, 16.0, 100.0);
@@ -2180,7 +2180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_rcp_ps() {
+    fn test_mm_rcp_ps() {
         let a = _mm_setr_ps(4.0, 13.0, 16.0, 100.0);
         let r = _mm_rcp_ps(a);
         let e = _mm_setr_ps(0.24993896, 0.0769043, 0.06248474, 0.0099983215);
@@ -2191,7 +2191,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_rsqrt_ss() {
+    fn test_mm_rsqrt_ss() {
         let a = _mm_setr_ps(4.0, 13.0, 16.0, 100.0);
         let r = _mm_rsqrt_ss(a);
         let e = _mm_setr_ps(0.49987793, 13.0, 16.0, 100.0);
@@ -2202,7 +2202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_rsqrt_ps() {
+    fn test_mm_rsqrt_ps() {
         let a = _mm_setr_ps(4.0, 13.0, 16.0, 100.0);
         let r = _mm_rsqrt_ps(a);
         let e = _mm_setr_ps(0.49987793, 0.2772827, 0.24993896, 0.099990845);
@@ -2213,7 +2213,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_min_ss() {
+    fn test_mm_min_ss() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_min_ss(a, b);
@@ -2244,7 +2244,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_max_ss() {
+    fn test_mm_max_ss() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_max_ss(a, b);
@@ -2749,7 +2749,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_comieq_ss() {
+    fn test_mm_comieq_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2770,7 +2770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_comilt_ss() {
+    fn test_mm_comilt_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2791,7 +2791,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_comile_ss() {
+    fn test_mm_comile_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2812,7 +2812,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_comigt_ss() {
+    fn test_mm_comigt_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2833,7 +2833,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_comineq_ss() {
+    fn test_mm_comineq_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2854,7 +2854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_ucomieq_ss() {
+    fn test_mm_ucomieq_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2875,7 +2875,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_ucomilt_ss() {
+    fn test_mm_ucomilt_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2896,7 +2896,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_ucomile_ss() {
+    fn test_mm_ucomile_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2917,7 +2917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_ucomigt_ss() {
+    fn test_mm_ucomigt_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2938,7 +2938,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_ucomige_ss() {
+    fn test_mm_ucomige_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2959,7 +2959,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_ucomineq_ss() {
+    fn test_mm_ucomineq_ss() {
         let aa = &[3.0f32, 12.0, 23.0, NAN];
         let bb = &[3.0f32, 47.5, 1.5, NAN];
 
@@ -2980,7 +2980,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_cvtss_si32() {
+    fn test_mm_cvtss_si32() {
         let inputs = &[42.0f32, -3.1, 4.0e10, 4.0e-20, NAN, 2147483500.1];
         let result = &[42i32, -3, i32::MIN, 0, i32::MIN, 2147483520];
         for i in 0..inputs.len() {
@@ -2996,7 +2996,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_cvttss_si32() {
+    fn test_mm_cvttss_si32() {
         let inputs = &[
             (42.0f32, 42i32),
             (-31.4, -31),
@@ -3021,7 +3021,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_cvtsi32_ss() {
+    const fn test_mm_cvtsi32_ss() {
         let a = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
 
         let r = _mm_cvtsi32_ss(a, 4555);
@@ -3042,19 +3042,19 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_cvtss_f32() {
+    const fn test_mm_cvtss_f32() {
         let a = _mm_setr_ps(312.0134, 5.0, 6.0, 7.0);
         assert_eq!(_mm_cvtss_f32(a), 312.0134);
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_set_ss() {
+    const fn test_mm_set_ss() {
         let r = _mm_set_ss(black_box(4.25));
         assert_eq_m128(r, _mm_setr_ps(4.25, 0.0, 0.0, 0.0));
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_set1_ps() {
+    const fn test_mm_set1_ps() {
         let r1 = _mm_set1_ps(black_box(4.25));
         let r2 = _mm_set_ps1(black_box(4.25));
         assert_eq!(get_m128(r1, 0), 4.25);
@@ -3068,7 +3068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_set_ps() {
+    const fn test_mm_set_ps() {
         let r = _mm_set_ps(
             black_box(1.0),
             black_box(2.0),
@@ -3082,7 +3082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_setr_ps() {
+    const fn test_mm_setr_ps() {
         let r = _mm_setr_ps(
             black_box(1.0),
             black_box(2.0),
@@ -3093,7 +3093,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_setzero_ps() {
+    const fn test_mm_setzero_ps() {
         let r = *black_box(&_mm_setzero_ps());
         assert_eq_m128(r, _mm_set1_ps(0.0));
     }
@@ -3107,7 +3107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_shuffle_ps() {
+    const fn test_mm_shuffle_ps() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
         let r = _mm_shuffle_ps::<0b00_01_01_11>(a, b);
@@ -3115,7 +3115,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_unpackhi_ps() {
+    const fn test_mm_unpackhi_ps() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
         let r = _mm_unpackhi_ps(a, b);
@@ -3123,7 +3123,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_unpacklo_ps() {
+    const fn test_mm_unpacklo_ps() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
         let r = _mm_unpacklo_ps(a, b);
@@ -3131,7 +3131,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_movehl_ps() {
+    const fn test_mm_movehl_ps() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
         let r = _mm_movehl_ps(a, b);
@@ -3139,7 +3139,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_movelh_ps() {
+    const fn test_mm_movelh_ps() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
         let r = _mm_movelh_ps(a, b);
@@ -3266,7 +3266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_move_ss() {
+    const fn test_mm_move_ss() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
 
@@ -3276,7 +3276,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_movemask_ps() {
+    const fn test_mm_movemask_ps() {
         let r = _mm_movemask_ps(_mm_setr_ps(-1.0, 5.0, -5.0, 0.0));
         assert_eq!(r, 0b0101);
 
@@ -3287,12 +3287,12 @@ mod tests {
     #[simd_test(enable = "sse")]
     // Miri cannot support this until it is clear how it fits in the Rust memory model
     #[cfg_attr(miri, ignore)]
-    unsafe fn test_mm_sfence() {
+    fn test_mm_sfence() {
         _mm_sfence();
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_MM_TRANSPOSE4_PS() {
+    const fn test_MM_TRANSPOSE4_PS() {
         let mut a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let mut b = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
         let mut c = _mm_setr_ps(9.0, 10.0, 11.0, 12.0);

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -3295,19 +3295,19 @@ mod tests {
     #[simd_test(enable = "sse2")]
     // Miri cannot support this until it is clear how it fits in the Rust memory model
     #[cfg_attr(miri, ignore)]
-    unsafe fn test_mm_lfence() {
+    fn test_mm_lfence() {
         _mm_lfence();
     }
 
     #[simd_test(enable = "sse2")]
     // Miri cannot support this until it is clear how it fits in the Rust memory model
     #[cfg_attr(miri, ignore)]
-    unsafe fn test_mm_mfence() {
+    fn test_mm_mfence() {
         _mm_mfence();
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_add_epi8() {
+    const fn test_mm_add_epi8() {
         let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let b = _mm_setr_epi8(
@@ -3322,7 +3322,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_add_epi8_overflow() {
+    fn test_mm_add_epi8_overflow() {
         let a = _mm_set1_epi8(0x7F);
         let b = _mm_set1_epi8(1);
         let r = _mm_add_epi8(a, b);
@@ -3330,7 +3330,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_add_epi16() {
+    const fn test_mm_add_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_add_epi16(a, b);
@@ -3339,7 +3339,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_add_epi32() {
+    const fn test_mm_add_epi32() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let b = _mm_setr_epi32(4, 5, 6, 7);
         let r = _mm_add_epi32(a, b);
@@ -3348,7 +3348,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_add_epi64() {
+    const fn test_mm_add_epi64() {
         let a = _mm_setr_epi64x(0, 1);
         let b = _mm_setr_epi64x(2, 3);
         let r = _mm_add_epi64(a, b);
@@ -3357,7 +3357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_adds_epi8() {
+    const fn test_mm_adds_epi8() {
         let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let b = _mm_setr_epi8(
@@ -3372,7 +3372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_adds_epi8_saturate_positive() {
+    fn test_mm_adds_epi8_saturate_positive() {
         let a = _mm_set1_epi8(0x7F);
         let b = _mm_set1_epi8(1);
         let r = _mm_adds_epi8(a, b);
@@ -3380,7 +3380,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_adds_epi8_saturate_negative() {
+    fn test_mm_adds_epi8_saturate_negative() {
         let a = _mm_set1_epi8(-0x80);
         let b = _mm_set1_epi8(-1);
         let r = _mm_adds_epi8(a, b);
@@ -3388,7 +3388,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_adds_epi16() {
+    const fn test_mm_adds_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_adds_epi16(a, b);
@@ -3397,7 +3397,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_adds_epi16_saturate_positive() {
+    fn test_mm_adds_epi16_saturate_positive() {
         let a = _mm_set1_epi16(0x7FFF);
         let b = _mm_set1_epi16(1);
         let r = _mm_adds_epi16(a, b);
@@ -3405,7 +3405,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_adds_epi16_saturate_negative() {
+    fn test_mm_adds_epi16_saturate_negative() {
         let a = _mm_set1_epi16(-0x8000);
         let b = _mm_set1_epi16(-1);
         let r = _mm_adds_epi16(a, b);
@@ -3413,7 +3413,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_adds_epu8() {
+    const fn test_mm_adds_epu8() {
         let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let b = _mm_setr_epi8(
@@ -3428,7 +3428,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_adds_epu8_saturate() {
+    fn test_mm_adds_epu8_saturate() {
         let a = _mm_set1_epi8(!0);
         let b = _mm_set1_epi8(1);
         let r = _mm_adds_epu8(a, b);
@@ -3436,7 +3436,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_adds_epu16() {
+    const fn test_mm_adds_epu16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_adds_epu16(a, b);
@@ -3445,7 +3445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_adds_epu16_saturate() {
+    fn test_mm_adds_epu16_saturate() {
         let a = _mm_set1_epi16(!0);
         let b = _mm_set1_epi16(1);
         let r = _mm_adds_epu16(a, b);
@@ -3453,21 +3453,21 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_avg_epu8() {
+    const fn test_mm_avg_epu8() {
         let (a, b) = (_mm_set1_epi8(3), _mm_set1_epi8(9));
         let r = _mm_avg_epu8(a, b);
         assert_eq_m128i(r, _mm_set1_epi8(6));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_avg_epu16() {
+    const fn test_mm_avg_epu16() {
         let (a, b) = (_mm_set1_epi16(3), _mm_set1_epi16(9));
         let r = _mm_avg_epu16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(6));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_madd_epi16() {
+    const fn test_mm_madd_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_setr_epi16(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm_madd_epi16(a, b);
@@ -3502,7 +3502,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_max_epi16() {
+    const fn test_mm_max_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(-1);
         let r = _mm_max_epi16(a, b);
@@ -3510,7 +3510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_max_epu8() {
+    const fn test_mm_max_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(!0);
         let r = _mm_max_epu8(a, b);
@@ -3518,7 +3518,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_min_epi16() {
+    const fn test_mm_min_epi16() {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(-1);
         let r = _mm_min_epi16(a, b);
@@ -3526,7 +3526,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_min_epu8() {
+    const fn test_mm_min_epu8() {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(!0);
         let r = _mm_min_epu8(a, b);
@@ -3534,28 +3534,28 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_mulhi_epi16() {
+    const fn test_mm_mulhi_epi16() {
         let (a, b) = (_mm_set1_epi16(1000), _mm_set1_epi16(-1001));
         let r = _mm_mulhi_epi16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(-16));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_mulhi_epu16() {
+    const fn test_mm_mulhi_epu16() {
         let (a, b) = (_mm_set1_epi16(1000), _mm_set1_epi16(1001));
         let r = _mm_mulhi_epu16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(15));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_mullo_epi16() {
+    const fn test_mm_mullo_epi16() {
         let (a, b) = (_mm_set1_epi16(1000), _mm_set1_epi16(-1001));
         let r = _mm_mullo_epi16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(-17960));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_mul_epu32() {
+    const fn test_mm_mul_epu32() {
         let a = _mm_setr_epi64x(1_000_000_000, 1 << 34);
         let b = _mm_setr_epi64x(1_000_000_000, 1 << 35);
         let r = _mm_mul_epu32(a, b);
@@ -3564,7 +3564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sad_epu8() {
+    fn test_mm_sad_epu8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             255u8 as i8, 254u8 as i8, 253u8 as i8, 252u8 as i8,
@@ -3579,42 +3579,42 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_sub_epi8() {
+    const fn test_mm_sub_epi8() {
         let (a, b) = (_mm_set1_epi8(5), _mm_set1_epi8(6));
         let r = _mm_sub_epi8(a, b);
         assert_eq_m128i(r, _mm_set1_epi8(-1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_sub_epi16() {
+    const fn test_mm_sub_epi16() {
         let (a, b) = (_mm_set1_epi16(5), _mm_set1_epi16(6));
         let r = _mm_sub_epi16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(-1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_sub_epi32() {
+    const fn test_mm_sub_epi32() {
         let (a, b) = (_mm_set1_epi32(5), _mm_set1_epi32(6));
         let r = _mm_sub_epi32(a, b);
         assert_eq_m128i(r, _mm_set1_epi32(-1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_sub_epi64() {
+    const fn test_mm_sub_epi64() {
         let (a, b) = (_mm_set1_epi64x(5), _mm_set1_epi64x(6));
         let r = _mm_sub_epi64(a, b);
         assert_eq_m128i(r, _mm_set1_epi64x(-1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_subs_epi8() {
+    const fn test_mm_subs_epi8() {
         let (a, b) = (_mm_set1_epi8(5), _mm_set1_epi8(2));
         let r = _mm_subs_epi8(a, b);
         assert_eq_m128i(r, _mm_set1_epi8(3));
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_subs_epi8_saturate_positive() {
+    fn test_mm_subs_epi8_saturate_positive() {
         let a = _mm_set1_epi8(0x7F);
         let b = _mm_set1_epi8(-1);
         let r = _mm_subs_epi8(a, b);
@@ -3622,7 +3622,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_subs_epi8_saturate_negative() {
+    fn test_mm_subs_epi8_saturate_negative() {
         let a = _mm_set1_epi8(-0x80);
         let b = _mm_set1_epi8(1);
         let r = _mm_subs_epi8(a, b);
@@ -3630,14 +3630,14 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_subs_epi16() {
+    const fn test_mm_subs_epi16() {
         let (a, b) = (_mm_set1_epi16(5), _mm_set1_epi16(2));
         let r = _mm_subs_epi16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(3));
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_subs_epi16_saturate_positive() {
+    fn test_mm_subs_epi16_saturate_positive() {
         let a = _mm_set1_epi16(0x7FFF);
         let b = _mm_set1_epi16(-1);
         let r = _mm_subs_epi16(a, b);
@@ -3645,7 +3645,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_subs_epi16_saturate_negative() {
+    fn test_mm_subs_epi16_saturate_negative() {
         let a = _mm_set1_epi16(-0x8000);
         let b = _mm_set1_epi16(1);
         let r = _mm_subs_epi16(a, b);
@@ -3653,14 +3653,14 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_subs_epu8() {
+    const fn test_mm_subs_epu8() {
         let (a, b) = (_mm_set1_epi8(5), _mm_set1_epi8(2));
         let r = _mm_subs_epu8(a, b);
         assert_eq_m128i(r, _mm_set1_epi8(3));
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_subs_epu8_saturate() {
+    fn test_mm_subs_epu8_saturate() {
         let a = _mm_set1_epi8(0);
         let b = _mm_set1_epi8(1);
         let r = _mm_subs_epu8(a, b);
@@ -3668,14 +3668,14 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_subs_epu16() {
+    const fn test_mm_subs_epu16() {
         let (a, b) = (_mm_set1_epi16(5), _mm_set1_epi16(2));
         let r = _mm_subs_epu16(a, b);
         assert_eq_m128i(r, _mm_set1_epi16(3));
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_subs_epu16_saturate() {
+    fn test_mm_subs_epu16_saturate() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let r = _mm_subs_epu16(a, b);
@@ -3683,7 +3683,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_slli_si128() {
+    const fn test_mm_slli_si128() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -3709,7 +3709,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_slli_epi16() {
+    const fn test_mm_slli_epi16() {
         let a = _mm_setr_epi16(0xCC, -0xCC, 0xDD, -0xDD, 0xEE, -0xEE, 0xFF, -0xFF);
         let r = _mm_slli_epi16::<4>(a);
         assert_eq_m128i(
@@ -3737,7 +3737,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_slli_epi32() {
+    const fn test_mm_slli_epi32() {
         let a = _mm_setr_epi32(0xEEEE, -0xEEEE, 0xFFFF, -0xFFFF);
         let r = _mm_slli_epi32::<4>(a);
         assert_eq_m128i(r, _mm_setr_epi32(0xEEEE0, -0xEEEE0, 0xFFFF0, -0xFFFF0));
@@ -3746,7 +3746,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sll_epi32() {
+    fn test_mm_sll_epi32() {
         let a = _mm_setr_epi32(0xEEEE, -0xEEEE, 0xFFFF, -0xFFFF);
         let r = _mm_sll_epi32(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(r, _mm_setr_epi32(0xEEEE0, -0xEEEE0, 0xFFFF0, -0xFFFF0));
@@ -3759,7 +3759,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_slli_epi64() {
+    const fn test_mm_slli_epi64() {
         let a = _mm_set_epi64x(0xFFFFFFFF, -0xFFFFFFFF);
         let r = _mm_slli_epi64::<4>(a);
         assert_eq_m128i(r, _mm_set_epi64x(0xFFFFFFFF0, -0xFFFFFFFF0));
@@ -3768,7 +3768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sll_epi64() {
+    fn test_mm_sll_epi64() {
         let a = _mm_set_epi64x(0xFFFFFFFF, -0xFFFFFFFF);
         let r = _mm_sll_epi64(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(r, _mm_set_epi64x(0xFFFFFFFF0, -0xFFFFFFFF0));
@@ -3781,7 +3781,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_srai_epi16() {
+    const fn test_mm_srai_epi16() {
         let a = _mm_setr_epi16(0xCC, -0xCC, 0xDD, -0xDD, 0xEE, -0xEE, 0xFF, -0xFF);
         let r = _mm_srai_epi16::<4>(a);
         assert_eq_m128i(
@@ -3793,7 +3793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sra_epi16() {
+    fn test_mm_sra_epi16() {
         let a = _mm_setr_epi16(0xCC, -0xCC, 0xDD, -0xDD, 0xEE, -0xEE, 0xFF, -0xFF);
         let r = _mm_sra_epi16(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(
@@ -3809,7 +3809,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_srai_epi32() {
+    const fn test_mm_srai_epi32() {
         let a = _mm_setr_epi32(0xEEEE, -0xEEEE, 0xFFFF, -0xFFFF);
         let r = _mm_srai_epi32::<4>(a);
         assert_eq_m128i(r, _mm_setr_epi32(0xEEE, -0xEEF, 0xFFF, -0x1000));
@@ -3818,7 +3818,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sra_epi32() {
+    fn test_mm_sra_epi32() {
         let a = _mm_setr_epi32(0xEEEE, -0xEEEE, 0xFFFF, -0xFFFF);
         let r = _mm_sra_epi32(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(r, _mm_setr_epi32(0xEEE, -0xEEF, 0xFFF, -0x1000));
@@ -3831,7 +3831,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_srli_si128() {
+    const fn test_mm_srli_si128() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -3860,7 +3860,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_srli_epi16() {
+    const fn test_mm_srli_epi16() {
         let a = _mm_setr_epi16(0xCC, -0xCC, 0xDD, -0xDD, 0xEE, -0xEE, 0xFF, -0xFF);
         let r = _mm_srli_epi16::<4>(a);
         assert_eq_m128i(
@@ -3872,7 +3872,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_srl_epi16() {
+    fn test_mm_srl_epi16() {
         let a = _mm_setr_epi16(0xCC, -0xCC, 0xDD, -0xDD, 0xEE, -0xEE, 0xFF, -0xFF);
         let r = _mm_srl_epi16(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(
@@ -3888,7 +3888,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_srli_epi32() {
+    const fn test_mm_srli_epi32() {
         let a = _mm_setr_epi32(0xEEEE, -0xEEEE, 0xFFFF, -0xFFFF);
         let r = _mm_srli_epi32::<4>(a);
         assert_eq_m128i(r, _mm_setr_epi32(0xEEE, 0xFFFF111, 0xFFF, 0xFFFF000));
@@ -3897,7 +3897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_srl_epi32() {
+    fn test_mm_srl_epi32() {
         let a = _mm_setr_epi32(0xEEEE, -0xEEEE, 0xFFFF, -0xFFFF);
         let r = _mm_srl_epi32(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(r, _mm_setr_epi32(0xEEE, 0xFFFF111, 0xFFF, 0xFFFF000));
@@ -3910,7 +3910,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_srli_epi64() {
+    const fn test_mm_srli_epi64() {
         let a = _mm_set_epi64x(0xFFFFFFFF, -0xFFFFFFFF);
         let r = _mm_srli_epi64::<4>(a);
         assert_eq_m128i(r, _mm_set_epi64x(0xFFFFFFF, 0xFFFFFFFF0000000));
@@ -3919,7 +3919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_srl_epi64() {
+    fn test_mm_srl_epi64() {
         let a = _mm_set_epi64x(0xFFFFFFFF, -0xFFFFFFFF);
         let r = _mm_srl_epi64(a, _mm_set_epi64x(0, 4));
         assert_eq_m128i(r, _mm_set_epi64x(0xFFFFFFF, 0xFFFFFFFF0000000));
@@ -3932,7 +3932,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_and_si128() {
+    const fn test_mm_and_si128() {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_and_si128(a, b);
@@ -3940,7 +3940,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_andnot_si128() {
+    const fn test_mm_andnot_si128() {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_andnot_si128(a, b);
@@ -3948,7 +3948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_or_si128() {
+    const fn test_mm_or_si128() {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_or_si128(a, b);
@@ -3956,7 +3956,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_xor_si128() {
+    const fn test_mm_xor_si128() {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_xor_si128(a, b);
@@ -3964,7 +3964,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmpeq_epi8() {
+    const fn test_mm_cmpeq_epi8() {
         let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let b = _mm_setr_epi8(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_cmpeq_epi8(a, b);
@@ -3978,7 +3978,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmpeq_epi16() {
+    const fn test_mm_cmpeq_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(7, 6, 2, 4, 3, 2, 1, 0);
         let r = _mm_cmpeq_epi16(a, b);
@@ -3986,7 +3986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmpeq_epi32() {
+    const fn test_mm_cmpeq_epi32() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let b = _mm_setr_epi32(3, 2, 2, 0);
         let r = _mm_cmpeq_epi32(a, b);
@@ -3994,7 +3994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmpgt_epi8() {
+    const fn test_mm_cmpgt_epi8() {
         let a = _mm_set_epi8(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let b = _mm_set1_epi8(0);
         let r = _mm_cmpgt_epi8(a, b);
@@ -4003,7 +4003,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmpgt_epi16() {
+    const fn test_mm_cmpgt_epi16() {
         let a = _mm_set_epi16(5, 0, 0, 0, 0, 0, 0, 0);
         let b = _mm_set1_epi16(0);
         let r = _mm_cmpgt_epi16(a, b);
@@ -4012,7 +4012,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmpgt_epi32() {
+    const fn test_mm_cmpgt_epi32() {
         let a = _mm_set_epi32(5, 0, 0, 0);
         let b = _mm_set1_epi32(0);
         let r = _mm_cmpgt_epi32(a, b);
@@ -4020,7 +4020,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmplt_epi8() {
+    const fn test_mm_cmplt_epi8() {
         let a = _mm_set1_epi8(0);
         let b = _mm_set_epi8(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_cmplt_epi8(a, b);
@@ -4029,7 +4029,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmplt_epi16() {
+    const fn test_mm_cmplt_epi16() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set_epi16(5, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_cmplt_epi16(a, b);
@@ -4038,7 +4038,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cmplt_epi32() {
+    const fn test_mm_cmplt_epi32() {
         let a = _mm_set1_epi32(0);
         let b = _mm_set_epi32(5, 0, 0, 0);
         let r = _mm_cmplt_epi32(a, b);
@@ -4046,21 +4046,21 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtepi32_pd() {
+    const fn test_mm_cvtepi32_pd() {
         let a = _mm_set_epi32(35, 25, 15, 5);
         let r = _mm_cvtepi32_pd(a);
         assert_eq_m128d(r, _mm_setr_pd(5.0, 15.0));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsi32_sd() {
+    const fn test_mm_cvtsi32_sd() {
         let a = _mm_set1_pd(3.5);
         let r = _mm_cvtsi32_sd(a, 5);
         assert_eq_m128d(r, _mm_setr_pd(5.0, 3.5));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtepi32_ps() {
+    const fn test_mm_cvtepi32_ps() {
         let a = _mm_setr_epi32(1, 2, 3, 4);
         let r = _mm_cvtepi32_ps(a);
         assert_eq_m128(r, _mm_setr_ps(1.0, 2.0, 3.0, 4.0));
@@ -4074,37 +4074,37 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsi32_si128() {
+    const fn test_mm_cvtsi32_si128() {
         let r = _mm_cvtsi32_si128(5);
         assert_eq_m128i(r, _mm_setr_epi32(5, 0, 0, 0));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsi128_si32() {
+    const fn test_mm_cvtsi128_si32() {
         let r = _mm_cvtsi128_si32(_mm_setr_epi32(5, 0, 0, 0));
         assert_eq!(r, 5);
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_epi64x() {
+    const fn test_mm_set_epi64x() {
         let r = _mm_set_epi64x(0, 1);
         assert_eq_m128i(r, _mm_setr_epi64x(1, 0));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_epi32() {
+    const fn test_mm_set_epi32() {
         let r = _mm_set_epi32(0, 1, 2, 3);
         assert_eq_m128i(r, _mm_setr_epi32(3, 2, 1, 0));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_epi16() {
+    const fn test_mm_set_epi16() {
         let r = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         assert_eq_m128i(r, _mm_setr_epi16(7, 6, 5, 4, 3, 2, 1, 0));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_epi8() {
+    const fn test_mm_set_epi8() {
         #[rustfmt::skip]
         let r = _mm_set_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -4118,43 +4118,43 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set1_epi64x() {
+    const fn test_mm_set1_epi64x() {
         let r = _mm_set1_epi64x(1);
         assert_eq_m128i(r, _mm_set1_epi64x(1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set1_epi32() {
+    const fn test_mm_set1_epi32() {
         let r = _mm_set1_epi32(1);
         assert_eq_m128i(r, _mm_set1_epi32(1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set1_epi16() {
+    const fn test_mm_set1_epi16() {
         let r = _mm_set1_epi16(1);
         assert_eq_m128i(r, _mm_set1_epi16(1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set1_epi8() {
+    const fn test_mm_set1_epi8() {
         let r = _mm_set1_epi8(1);
         assert_eq_m128i(r, _mm_set1_epi8(1));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_setr_epi32() {
+    const fn test_mm_setr_epi32() {
         let r = _mm_setr_epi32(0, 1, 2, 3);
         assert_eq_m128i(r, _mm_setr_epi32(0, 1, 2, 3));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_setr_epi16() {
+    const fn test_mm_setr_epi16() {
         let r = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         assert_eq_m128i(r, _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_setr_epi8() {
+    const fn test_mm_setr_epi8() {
         #[rustfmt::skip]
         let r = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -4168,7 +4168,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_setzero_si128() {
+    const fn test_mm_setzero_si128() {
         let r = _mm_setzero_si128();
         assert_eq_m128i(r, _mm_set1_epi64x(0));
     }
@@ -4261,14 +4261,14 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_move_epi64() {
+    const fn test_mm_move_epi64() {
         let a = _mm_setr_epi64x(5, 6);
         let r = _mm_move_epi64(a);
         assert_eq_m128i(r, _mm_setr_epi64x(5, 0));
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_packs_epi16() {
+    fn test_mm_packs_epi16() {
         let a = _mm_setr_epi16(0x80, -0x81, 0, 0, 0, 0, 0, 0);
         let b = _mm_setr_epi16(0, 0, 0, 0, 0, 0, -0x81, 0x80);
         let r = _mm_packs_epi16(a, b);
@@ -4282,7 +4282,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_packs_epi32() {
+    fn test_mm_packs_epi32() {
         let a = _mm_setr_epi32(0x8000, -0x8001, 0, 0);
         let b = _mm_setr_epi32(0, 0, -0x8001, 0x8000);
         let r = _mm_packs_epi32(a, b);
@@ -4293,7 +4293,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_packus_epi16() {
+    fn test_mm_packus_epi16() {
         let a = _mm_setr_epi16(0x100, -1, 0, 0, 0, 0, 0, 0);
         let b = _mm_setr_epi16(0, 0, 0, 0, 0, 0, -1, 0x100);
         let r = _mm_packus_epi16(a, b);
@@ -4304,7 +4304,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_extract_epi16() {
+    const fn test_mm_extract_epi16() {
         let a = _mm_setr_epi16(-1, 1, 2, 3, 4, 5, 6, 7);
         let r1 = _mm_extract_epi16::<0>(a);
         let r2 = _mm_extract_epi16::<3>(a);
@@ -4313,7 +4313,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_insert_epi16() {
+    const fn test_mm_insert_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_insert_epi16::<0>(a, 9);
         let e = _mm_setr_epi16(9, 1, 2, 3, 4, 5, 6, 7);
@@ -4321,7 +4321,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_movemask_epi8() {
+    const fn test_mm_movemask_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0b1000_0000u8 as i8, 0b0, 0b1000_0000u8 as i8, 0b01,
@@ -4334,7 +4334,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_shuffle_epi32() {
+    const fn test_mm_shuffle_epi32() {
         let a = _mm_setr_epi32(5, 10, 15, 20);
         let r = _mm_shuffle_epi32::<0b00_01_01_11>(a);
         let e = _mm_setr_epi32(20, 10, 10, 5);
@@ -4342,7 +4342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_shufflehi_epi16() {
+    const fn test_mm_shufflehi_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 10, 15, 20);
         let r = _mm_shufflehi_epi16::<0b00_01_01_11>(a);
         let e = _mm_setr_epi16(1, 2, 3, 4, 20, 10, 10, 5);
@@ -4350,7 +4350,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_shufflelo_epi16() {
+    const fn test_mm_shufflelo_epi16() {
         let a = _mm_setr_epi16(5, 10, 15, 20, 1, 2, 3, 4);
         let r = _mm_shufflelo_epi16::<0b00_01_01_11>(a);
         let e = _mm_setr_epi16(20, 10, 10, 5, 1, 2, 3, 4);
@@ -4358,7 +4358,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpackhi_epi8() {
+    const fn test_mm_unpackhi_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4377,7 +4377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpackhi_epi16() {
+    const fn test_mm_unpackhi_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_unpackhi_epi16(a, b);
@@ -4386,7 +4386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpackhi_epi32() {
+    const fn test_mm_unpackhi_epi32() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let b = _mm_setr_epi32(4, 5, 6, 7);
         let r = _mm_unpackhi_epi32(a, b);
@@ -4395,7 +4395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpackhi_epi64() {
+    const fn test_mm_unpackhi_epi64() {
         let a = _mm_setr_epi64x(0, 1);
         let b = _mm_setr_epi64x(2, 3);
         let r = _mm_unpackhi_epi64(a, b);
@@ -4404,7 +4404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpacklo_epi8() {
+    const fn test_mm_unpacklo_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -4424,7 +4424,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpacklo_epi16() {
+    const fn test_mm_unpacklo_epi16() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_unpacklo_epi16(a, b);
@@ -4433,7 +4433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpacklo_epi32() {
+    const fn test_mm_unpacklo_epi32() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let b = _mm_setr_epi32(4, 5, 6, 7);
         let r = _mm_unpacklo_epi32(a, b);
@@ -4442,7 +4442,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpacklo_epi64() {
+    const fn test_mm_unpacklo_epi64() {
         let a = _mm_setr_epi64x(0, 1);
         let b = _mm_setr_epi64x(2, 3);
         let r = _mm_unpacklo_epi64(a, b);
@@ -4451,7 +4451,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_add_sd() {
+    const fn test_mm_add_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_add_sd(a, b);
@@ -4459,7 +4459,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_add_pd() {
+    const fn test_mm_add_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_add_pd(a, b);
@@ -4467,7 +4467,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_div_sd() {
+    const fn test_mm_div_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_div_sd(a, b);
@@ -4475,7 +4475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_div_pd() {
+    const fn test_mm_div_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_div_pd(a, b);
@@ -4483,7 +4483,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_max_sd() {
+    fn test_mm_max_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_max_sd(a, b);
@@ -4491,7 +4491,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_max_pd() {
+    fn test_mm_max_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_max_pd(a, b);
@@ -4500,17 +4500,18 @@ mod tests {
         // Check SSE(2)-specific semantics for -0.0 handling.
         let a = _mm_setr_pd(-0.0, 0.0);
         let b = _mm_setr_pd(0.0, 0.0);
-        let r1: [u8; 16] = transmute(_mm_max_pd(a, b));
-        let r2: [u8; 16] = transmute(_mm_max_pd(b, a));
-        let a: [u8; 16] = transmute(a);
-        let b: [u8; 16] = transmute(b);
-        assert_eq!(r1, b);
-        assert_eq!(r2, a);
-        assert_ne!(a, b); // sanity check that -0.0 is actually present
+        // Cast to __m128i to compare exact bit patterns
+        let r1 = _mm_castpd_si128(_mm_max_pd(a, b));
+        let r2 = _mm_castpd_si128(_mm_max_pd(b, a));
+        let a = _mm_castpd_si128(a);
+        let b = _mm_castpd_si128(b);
+        assert_eq_m128i(r1, b);
+        assert_eq_m128i(r2, a);
+        assert_ne!(a.as_u8x16(), b.as_u8x16()); // sanity check that -0.0 is actually present
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_min_sd() {
+    fn test_mm_min_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_min_sd(a, b);
@@ -4518,7 +4519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_min_pd() {
+    fn test_mm_min_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_min_pd(a, b);
@@ -4527,17 +4528,18 @@ mod tests {
         // Check SSE(2)-specific semantics for -0.0 handling.
         let a = _mm_setr_pd(-0.0, 0.0);
         let b = _mm_setr_pd(0.0, 0.0);
-        let r1: [u8; 16] = transmute(_mm_min_pd(a, b));
-        let r2: [u8; 16] = transmute(_mm_min_pd(b, a));
-        let a: [u8; 16] = transmute(a);
-        let b: [u8; 16] = transmute(b);
-        assert_eq!(r1, b);
-        assert_eq!(r2, a);
-        assert_ne!(a, b); // sanity check that -0.0 is actually present
+        // Cast to __m128i to compare exact bit patterns
+        let r1 = _mm_castpd_si128(_mm_min_pd(a, b));
+        let r2 = _mm_castpd_si128(_mm_min_pd(b, a));
+        let a = _mm_castpd_si128(a);
+        let b = _mm_castpd_si128(b);
+        assert_eq_m128i(r1, b);
+        assert_eq_m128i(r2, a);
+        assert_ne!(a.as_u8x16(), b.as_u8x16()); // sanity check that -0.0 is actually present
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_mul_sd() {
+    const fn test_mm_mul_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_mul_sd(a, b);
@@ -4545,7 +4547,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_mul_pd() {
+    const fn test_mm_mul_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_mul_pd(a, b);
@@ -4553,7 +4555,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sqrt_sd() {
+    fn test_mm_sqrt_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_sqrt_sd(a, b);
@@ -4561,13 +4563,13 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_sqrt_pd() {
+    fn test_mm_sqrt_pd() {
         let r = _mm_sqrt_pd(_mm_setr_pd(1.0, 2.0));
         assert_eq_m128d(r, _mm_setr_pd(1.0f64.sqrt(), 2.0f64.sqrt()));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_sub_sd() {
+    const fn test_mm_sub_sd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_sub_sd(a, b);
@@ -4575,7 +4577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_sub_pd() {
+    const fn test_mm_sub_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(5.0, 10.0);
         let r = _mm_sub_pd(a, b);
@@ -4619,199 +4621,199 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpeq_sd() {
+    fn test_mm_cmpeq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpeq_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpeq_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmplt_sd() {
+    fn test_mm_cmplt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmplt_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmplt_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmple_sd() {
+    fn test_mm_cmple_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmple_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmple_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpgt_sd() {
+    fn test_mm_cmpgt_sd() {
         let (a, b) = (_mm_setr_pd(5.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpgt_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpgt_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpge_sd() {
+    fn test_mm_cmpge_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpge_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpge_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpord_sd() {
+    fn test_mm_cmpord_sd() {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpord_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpord_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpunord_sd() {
+    fn test_mm_cmpunord_sd() {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpunord_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpunord_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpneq_sd() {
+    fn test_mm_cmpneq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpneq_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpneq_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpnlt_sd() {
+    fn test_mm_cmpnlt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpnlt_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpnlt_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpnle_sd() {
+    fn test_mm_cmpnle_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpnle_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpnle_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpngt_sd() {
+    fn test_mm_cmpngt_sd() {
         let (a, b) = (_mm_setr_pd(5.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpngt_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpngt_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpnge_sd() {
+    fn test_mm_cmpnge_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 2.0f64.to_bits() as i64);
-        let r = transmute::<_, __m128i>(_mm_cmpnge_sd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpnge_sd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpeq_pd() {
+    fn test_mm_cmpeq_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 0);
-        let r = transmute::<_, __m128i>(_mm_cmpeq_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpeq_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmplt_pd() {
+    fn test_mm_cmplt_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
-        let r = transmute::<_, __m128i>(_mm_cmplt_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmplt_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmple_pd() {
+    fn test_mm_cmple_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, !0);
-        let r = transmute::<_, __m128i>(_mm_cmple_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmple_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpgt_pd() {
+    fn test_mm_cmpgt_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 0);
-        let r = transmute::<_, __m128i>(_mm_cmpgt_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpgt_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpge_pd() {
+    fn test_mm_cmpge_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 0);
-        let r = transmute::<_, __m128i>(_mm_cmpge_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpge_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpord_pd() {
+    fn test_mm_cmpord_pd() {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
-        let r = transmute::<_, __m128i>(_mm_cmpord_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpord_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpunord_pd() {
+    fn test_mm_cmpunord_pd() {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, 0);
-        let r = transmute::<_, __m128i>(_mm_cmpunord_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpunord_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpneq_pd() {
+    fn test_mm_cmpneq_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, !0);
-        let r = transmute::<_, __m128i>(_mm_cmpneq_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpneq_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpnlt_pd() {
+    fn test_mm_cmpnlt_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, 0);
-        let r = transmute::<_, __m128i>(_mm_cmpnlt_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpnlt_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpnle_pd() {
+    fn test_mm_cmpnle_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 0);
-        let r = transmute::<_, __m128i>(_mm_cmpnle_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpnle_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpngt_pd() {
+    fn test_mm_cmpngt_pd() {
         let (a, b) = (_mm_setr_pd(5.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
-        let r = transmute::<_, __m128i>(_mm_cmpngt_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpngt_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cmpnge_pd() {
+    fn test_mm_cmpnge_pd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
-        let r = transmute::<_, __m128i>(_mm_cmpnge_pd(a, b));
+        let r = _mm_castpd_si128(_mm_cmpnge_pd(a, b));
         assert_eq_m128i(r, e);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_comieq_sd() {
+    fn test_mm_comieq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_comieq_sd(a, b) != 0);
 
@@ -4820,37 +4822,37 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_comilt_sd() {
+    fn test_mm_comilt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_comilt_sd(a, b) == 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_comile_sd() {
+    fn test_mm_comile_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_comile_sd(a, b) != 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_comigt_sd() {
+    fn test_mm_comigt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_comigt_sd(a, b) == 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_comige_sd() {
+    fn test_mm_comige_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_comige_sd(a, b) != 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_comineq_sd() {
+    fn test_mm_comineq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_comineq_sd(a, b) == 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_ucomieq_sd() {
+    fn test_mm_ucomieq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_ucomieq_sd(a, b) != 0);
 
@@ -4859,37 +4861,37 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_ucomilt_sd() {
+    fn test_mm_ucomilt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_ucomilt_sd(a, b) == 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_ucomile_sd() {
+    fn test_mm_ucomile_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_ucomile_sd(a, b) != 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_ucomigt_sd() {
+    fn test_mm_ucomigt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_ucomigt_sd(a, b) == 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_ucomige_sd() {
+    fn test_mm_ucomige_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_ucomige_sd(a, b) != 0);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_ucomineq_sd() {
+    fn test_mm_ucomineq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         assert!(_mm_ucomineq_sd(a, b) == 0);
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_movemask_pd() {
+    const fn test_mm_movemask_pd() {
         let r = _mm_movemask_pd(_mm_setr_pd(-1.0, 5.0));
         assert_eq!(r, 0b01);
 
@@ -5122,7 +5124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtpd_ps() {
+    const fn test_mm_cvtpd_ps() {
         let r = _mm_cvtpd_ps(_mm_setr_pd(-1.0, 5.0));
         assert_eq_m128(r, _mm_setr_ps(-1.0, 5.0, 0.0, 0.0));
 
@@ -5137,7 +5139,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtps_pd() {
+    const fn test_mm_cvtps_pd() {
         let r = _mm_cvtps_pd(_mm_setr_ps(-1.0, 2.0, -3.0, 5.0));
         assert_eq_m128d(r, _mm_setr_pd(-1.0, 2.0));
 
@@ -5151,7 +5153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvtpd_epi32() {
+    fn test_mm_cvtpd_epi32() {
         let r = _mm_cvtpd_epi32(_mm_setr_pd(-1.0, 5.0));
         assert_eq_m128i(r, _mm_setr_epi32(-1, 5, 0, 0));
 
@@ -5169,7 +5171,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvtsd_si32() {
+    fn test_mm_cvtsd_si32() {
         let r = _mm_cvtsd_si32(_mm_setr_pd(-2.0, 5.0));
         assert_eq!(r, -2);
 
@@ -5181,7 +5183,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvtsd_ss() {
+    fn test_mm_cvtsd_ss() {
         let a = _mm_setr_ps(-1.1, -2.2, 3.3, 4.4);
         let b = _mm_setr_pd(2.0, -5.0);
 
@@ -5206,13 +5208,13 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsd_f64() {
+    const fn test_mm_cvtsd_f64() {
         let r = _mm_cvtsd_f64(_mm_setr_pd(-1.1, 2.2));
         assert_eq!(r, -1.1);
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtss_sd() {
+    const fn test_mm_cvtss_sd() {
         let a = _mm_setr_pd(-1.1, 2.2);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
 
@@ -5227,7 +5229,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvttpd_epi32() {
+    fn test_mm_cvttpd_epi32() {
         let a = _mm_setr_pd(-1.1, 2.2);
         let r = _mm_cvttpd_epi32(a);
         assert_eq_m128i(r, _mm_setr_epi32(-1, 2, 0, 0));
@@ -5238,7 +5240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvttsd_si32() {
+    fn test_mm_cvttsd_si32() {
         let a = _mm_setr_pd(-1.1, 2.2);
         let r = _mm_cvttsd_si32(a);
         assert_eq!(r, -1);
@@ -5249,7 +5251,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvttps_epi32() {
+    fn test_mm_cvttps_epi32() {
         let a = _mm_setr_ps(-1.1, 2.2, -3.3, 6.6);
         let r = _mm_cvttps_epi32(a);
         assert_eq_m128i(r, _mm_setr_epi32(-1, 2, -3, 6));
@@ -5260,37 +5262,37 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_sd() {
+    const fn test_mm_set_sd() {
         let r = _mm_set_sd(-1.0_f64);
         assert_eq_m128d(r, _mm_setr_pd(-1.0_f64, 0_f64));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set1_pd() {
+    const fn test_mm_set1_pd() {
         let r = _mm_set1_pd(-1.0_f64);
         assert_eq_m128d(r, _mm_setr_pd(-1.0_f64, -1.0_f64));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_pd1() {
+    const fn test_mm_set_pd1() {
         let r = _mm_set_pd1(-2.0_f64);
         assert_eq_m128d(r, _mm_setr_pd(-2.0_f64, -2.0_f64));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_set_pd() {
+    const fn test_mm_set_pd() {
         let r = _mm_set_pd(1.0_f64, 5.0_f64);
         assert_eq_m128d(r, _mm_setr_pd(5.0_f64, 1.0_f64));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_setr_pd() {
+    const fn test_mm_setr_pd() {
         let r = _mm_setr_pd(1.0_f64, -5.0_f64);
         assert_eq_m128d(r, _mm_setr_pd(1.0_f64, -5.0_f64));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_setzero_pd() {
+    const fn test_mm_setzero_pd() {
         let r = _mm_setzero_pd();
         assert_eq_m128d(r, _mm_setr_pd(0_f64, 0_f64));
     }
@@ -5310,7 +5312,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpackhi_pd() {
+    const fn test_mm_unpackhi_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(3.0, 4.0);
         let r = _mm_unpackhi_pd(a, b);
@@ -5318,7 +5320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_unpacklo_pd() {
+    const fn test_mm_unpacklo_pd() {
         let a = _mm_setr_pd(1.0, 2.0);
         let b = _mm_setr_pd(3.0, 4.0);
         let r = _mm_unpacklo_pd(a, b);
@@ -5326,7 +5328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_shuffle_pd() {
+    const fn test_mm_shuffle_pd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(3., 4.);
         let expected = _mm_setr_pd(1., 3.);
@@ -5335,7 +5337,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_move_sd() {
+    const fn test_mm_move_sd() {
         let a = _mm_setr_pd(1., 2.);
         let b = _mm_setr_pd(3., 4.);
         let expected = _mm_setr_pd(3., 2.);
@@ -5344,7 +5346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_castpd_ps() {
+    const fn test_mm_castpd_ps() {
         let a = _mm_set1_pd(0.);
         let expected = _mm_set1_ps(0.);
         let r = _mm_castpd_ps(a);
@@ -5352,7 +5354,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_castpd_si128() {
+    const fn test_mm_castpd_si128() {
         let a = _mm_set1_pd(0.);
         let expected = _mm_set1_epi64x(0);
         let r = _mm_castpd_si128(a);
@@ -5360,7 +5362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_castps_pd() {
+    const fn test_mm_castps_pd() {
         let a = _mm_set1_ps(0.);
         let expected = _mm_set1_pd(0.);
         let r = _mm_castps_pd(a);
@@ -5368,7 +5370,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_castps_si128() {
+    const fn test_mm_castps_si128() {
         let a = _mm_set1_ps(0.);
         let expected = _mm_set1_epi32(0);
         let r = _mm_castps_si128(a);
@@ -5376,7 +5378,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_castsi128_pd() {
+    const fn test_mm_castsi128_pd() {
         let a = _mm_set1_epi64x(0);
         let expected = _mm_set1_pd(0.);
         let r = _mm_castsi128_pd(a);
@@ -5384,7 +5386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_castsi128_ps() {
+    const fn test_mm_castsi128_ps() {
         let a = _mm_set1_epi32(0);
         let expected = _mm_set1_ps(0.);
         let r = _mm_castsi128_ps(a);

--- a/crates/core_arch/src/x86/sse3.rs
+++ b/crates/core_arch/src/x86/sse3.rs
@@ -191,7 +191,7 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_addsub_ps() {
+    const fn test_mm_addsub_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_addsub_ps(a, b);
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_addsub_pd() {
+    const fn test_mm_addsub_pd() {
         let a = _mm_setr_pd(-1.0, 5.0);
         let b = _mm_setr_pd(-100.0, 20.0);
         let r = _mm_addsub_pd(a, b);
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_hadd_pd() {
+    const fn test_mm_hadd_pd() {
         let a = _mm_setr_pd(-1.0, 5.0);
         let b = _mm_setr_pd(-100.0, 20.0);
         let r = _mm_hadd_pd(a, b);
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_hadd_ps() {
+    const fn test_mm_hadd_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_hadd_ps(a, b);
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_hsub_pd() {
+    const fn test_mm_hsub_pd() {
         let a = _mm_setr_pd(-1.0, 5.0);
         let b = _mm_setr_pd(-100.0, 20.0);
         let r = _mm_hsub_pd(a, b);
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_hsub_ps() {
+    const fn test_mm_hsub_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let b = _mm_setr_ps(-100.0, 20.0, 0.0, -5.0);
         let r = _mm_hsub_ps(a, b);
@@ -252,21 +252,21 @@ mod tests {
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_movedup_pd() {
+    const fn test_mm_movedup_pd() {
         let a = _mm_setr_pd(-1.0, 5.0);
         let r = _mm_movedup_pd(a);
         assert_eq_m128d(r, _mm_setr_pd(-1.0, -1.0));
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_movehdup_ps() {
+    const fn test_mm_movehdup_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let r = _mm_movehdup_ps(a);
         assert_eq_m128(r, _mm_setr_ps(5.0, 5.0, -10.0, -10.0));
     }
 
     #[simd_test(enable = "sse3")]
-    const unsafe fn test_mm_moveldup_ps() {
+    const fn test_mm_moveldup_ps() {
         let a = _mm_setr_ps(-1.0, 5.0, 0.0, -10.0);
         let r = _mm_moveldup_ps(a);
         assert_eq_m128(r, _mm_setr_ps(-1.0, -1.0, 0.0, 0.0));

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -1196,7 +1196,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_blendv_epi8() {
+    const fn test_mm_blendv_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -1239,7 +1239,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_blend_pd() {
+    const fn test_mm_blend_pd() {
         let a = _mm_set1_pd(0.0);
         let b = _mm_set1_pd(1.0);
         let r = _mm_blend_pd::<0b10>(a, b);
@@ -1248,7 +1248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_blend_ps() {
+    const fn test_mm_blend_ps() {
         let a = _mm_set1_ps(0.0);
         let b = _mm_set1_ps(1.0);
         let r = _mm_blend_ps::<0b1010>(a, b);
@@ -1257,7 +1257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_blend_epi16() {
+    const fn test_mm_blend_epi16() {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let r = _mm_blend_epi16::<0b1010_1100>(a, b);
@@ -1266,7 +1266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_extract_ps() {
+    const fn test_mm_extract_ps() {
         let a = _mm_setr_ps(0.0, 1.0, 2.0, 3.0);
         let r: f32 = f32::from_bits(_mm_extract_ps::<1>(a) as u32);
         assert_eq!(r, 1.0);
@@ -1275,7 +1275,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_extract_epi8() {
+    const fn test_mm_extract_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             -1, 1, 2, 3, 4, 5, 6, 7,
@@ -1288,7 +1288,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_extract_epi32() {
+    const fn test_mm_extract_epi32() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let r = _mm_extract_epi32::<1>(a);
         assert_eq!(r, 1);
@@ -1297,7 +1297,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_insert_ps() {
+    fn test_mm_insert_ps() {
         let a = _mm_set1_ps(1.0);
         let b = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_insert_ps::<0b11_00_1100>(a, b);
@@ -1313,7 +1313,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_insert_epi8() {
+    const fn test_mm_insert_epi8() {
         let a = _mm_set1_epi8(0);
         let e = _mm_setr_epi8(0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_insert_epi8::<1>(a, 32);
@@ -1324,7 +1324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_insert_epi32() {
+    const fn test_mm_insert_epi32() {
         let a = _mm_set1_epi32(0);
         let e = _mm_setr_epi32(0, 32, 0, 0);
         let r = _mm_insert_epi32::<1>(a, 32);
@@ -1335,7 +1335,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_max_epi8() {
+    const fn test_mm_max_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 4, 5, 8, 9, 12, 13, 16,
@@ -1356,7 +1356,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_max_epu16() {
+    const fn test_mm_max_epu16() {
         let a = _mm_setr_epi16(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm_setr_epi16(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm_max_epu16(a, b);
@@ -1365,7 +1365,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_max_epi32() {
+    const fn test_mm_max_epi32() {
         let a = _mm_setr_epi32(1, 4, 5, 8);
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_max_epi32(a, b);
@@ -1374,7 +1374,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_max_epu32() {
+    const fn test_mm_max_epu32() {
         let a = _mm_setr_epi32(1, 4, 5, 8);
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_max_epu32(a, b);
@@ -1383,7 +1383,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_min_epi8() {
+    const fn test_mm_min_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 4, 5, 8, 9, 12, 13, 16,
@@ -1422,7 +1422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_min_epu16() {
+    const fn test_mm_min_epu16() {
         let a = _mm_setr_epi16(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm_setr_epi16(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm_min_epu16(a, b);
@@ -1431,7 +1431,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_min_epi32() {
+    const fn test_mm_min_epi32() {
         let a = _mm_setr_epi32(1, 4, 5, 8);
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_min_epi32(a, b);
@@ -1446,7 +1446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_min_epu32() {
+    const fn test_mm_min_epu32() {
         let a = _mm_setr_epi32(1, 4, 5, 8);
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_min_epu32(a, b);
@@ -1455,7 +1455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_packus_epi32() {
+    fn test_mm_packus_epi32() {
         let a = _mm_setr_epi32(1, 2, 3, 4);
         let b = _mm_setr_epi32(-1, -2, -3, -4);
         let r = _mm_packus_epi32(a, b);
@@ -1464,7 +1464,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cmpeq_epi64() {
+    const fn test_mm_cmpeq_epi64() {
         let a = _mm_setr_epi64x(0, 1);
         let b = _mm_setr_epi64x(0, 0);
         let r = _mm_cmpeq_epi64(a, b);
@@ -1473,7 +1473,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepi8_epi16() {
+    const fn test_mm_cvtepi8_epi16() {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepi8_epi16(a);
         let e = _mm_set1_epi16(10);
@@ -1485,7 +1485,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepi8_epi32() {
+    const fn test_mm_cvtepi8_epi32() {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepi8_epi32(a);
         let e = _mm_set1_epi32(10);
@@ -1497,7 +1497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepi8_epi64() {
+    const fn test_mm_cvtepi8_epi64() {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepi8_epi64(a);
         let e = _mm_set1_epi64x(10);
@@ -1509,7 +1509,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepi16_epi32() {
+    const fn test_mm_cvtepi16_epi32() {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepi16_epi32(a);
         let e = _mm_set1_epi32(10);
@@ -1521,7 +1521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepi16_epi64() {
+    const fn test_mm_cvtepi16_epi64() {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepi16_epi64(a);
         let e = _mm_set1_epi64x(10);
@@ -1533,7 +1533,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepi32_epi64() {
+    const fn test_mm_cvtepi32_epi64() {
         let a = _mm_set1_epi32(10);
         let r = _mm_cvtepi32_epi64(a);
         let e = _mm_set1_epi64x(10);
@@ -1545,7 +1545,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepu8_epi16() {
+    const fn test_mm_cvtepu8_epi16() {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepu8_epi16(a);
         let e = _mm_set1_epi16(10);
@@ -1553,7 +1553,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepu8_epi32() {
+    const fn test_mm_cvtepu8_epi32() {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepu8_epi32(a);
         let e = _mm_set1_epi32(10);
@@ -1561,7 +1561,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepu8_epi64() {
+    const fn test_mm_cvtepu8_epi64() {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepu8_epi64(a);
         let e = _mm_set1_epi64x(10);
@@ -1569,7 +1569,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepu16_epi32() {
+    const fn test_mm_cvtepu16_epi32() {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepu16_epi32(a);
         let e = _mm_set1_epi32(10);
@@ -1577,7 +1577,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepu16_epi64() {
+    const fn test_mm_cvtepu16_epi64() {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepu16_epi64(a);
         let e = _mm_set1_epi64x(10);
@@ -1585,7 +1585,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_cvtepu32_epi64() {
+    const fn test_mm_cvtepu32_epi64() {
         let a = _mm_set1_epi32(10);
         let r = _mm_cvtepu32_epi64(a);
         let e = _mm_set1_epi64x(10);
@@ -1593,7 +1593,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_dp_pd() {
+    fn test_mm_dp_pd() {
         let a = _mm_setr_pd(2.0, 3.0);
         let b = _mm_setr_pd(1.0, 4.0);
         let e = _mm_setr_pd(14.0, 0.0);
@@ -1601,7 +1601,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_dp_ps() {
+    fn test_mm_dp_ps() {
         let a = _mm_setr_ps(2.0, 3.0, 1.0, 10.0);
         let b = _mm_setr_ps(1.0, 4.0, 0.5, 10.0);
         let e = _mm_setr_ps(14.5, 0.0, 14.5, 0.0);
@@ -1609,7 +1609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_floor_pd() {
+    const fn test_mm_floor_pd() {
         let a = _mm_setr_pd(2.5, 4.5);
         let r = _mm_floor_pd(a);
         let e = _mm_setr_pd(2.0, 4.0);
@@ -1617,7 +1617,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_floor_ps() {
+    const fn test_mm_floor_ps() {
         let a = _mm_setr_ps(2.5, 4.5, 8.5, 16.5);
         let r = _mm_floor_ps(a);
         let e = _mm_setr_ps(2.0, 4.0, 8.0, 16.0);
@@ -1625,7 +1625,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_floor_sd() {
+    fn test_mm_floor_sd() {
         let a = _mm_setr_pd(2.5, 4.5);
         let b = _mm_setr_pd(-1.5, -3.5);
         let r = _mm_floor_sd(a, b);
@@ -1634,7 +1634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_floor_ss() {
+    fn test_mm_floor_ss() {
         let a = _mm_setr_ps(2.5, 4.5, 8.5, 16.5);
         let b = _mm_setr_ps(-1.5, -3.5, -7.5, -15.5);
         let r = _mm_floor_ss(a, b);
@@ -1643,7 +1643,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_ceil_pd() {
+    const fn test_mm_ceil_pd() {
         let a = _mm_setr_pd(1.5, 3.5);
         let r = _mm_ceil_pd(a);
         let e = _mm_setr_pd(2.0, 4.0);
@@ -1651,7 +1651,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_ceil_ps() {
+    const fn test_mm_ceil_ps() {
         let a = _mm_setr_ps(1.5, 3.5, 7.5, 15.5);
         let r = _mm_ceil_ps(a);
         let e = _mm_setr_ps(2.0, 4.0, 8.0, 16.0);
@@ -1659,7 +1659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_ceil_sd() {
+    fn test_mm_ceil_sd() {
         let a = _mm_setr_pd(1.5, 3.5);
         let b = _mm_setr_pd(-2.5, -4.5);
         let r = _mm_ceil_sd(a, b);
@@ -1668,7 +1668,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_ceil_ss() {
+    fn test_mm_ceil_ss() {
         let a = _mm_setr_ps(1.5, 3.5, 7.5, 15.5);
         let b = _mm_setr_ps(-2.5, -4.5, -8.5, -16.5);
         let r = _mm_ceil_ss(a, b);
@@ -1677,7 +1677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_round_pd() {
+    fn test_mm_round_pd() {
         let a = _mm_setr_pd(1.25, 3.75);
         let r = _mm_round_pd::<_MM_FROUND_TO_NEAREST_INT>(a);
         let e = _mm_setr_pd(1.0, 4.0);
@@ -1685,7 +1685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_round_ps() {
+    fn test_mm_round_ps() {
         let a = _mm_setr_ps(2.25, 4.75, -1.75, -4.25);
         let r = _mm_round_ps::<_MM_FROUND_TO_ZERO>(a);
         let e = _mm_setr_ps(2.0, 4.0, -1.0, -4.0);
@@ -1693,7 +1693,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_round_sd() {
+    fn test_mm_round_sd() {
         let a = _mm_setr_pd(1.5, 3.5);
         let b = _mm_setr_pd(-2.5, -4.5);
         let r = _mm_round_sd::<_MM_FROUND_TO_NEAREST_INT>(a, b);
@@ -1720,7 +1720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_round_ss() {
+    fn test_mm_round_ss() {
         let a = _mm_setr_ps(1.5, 3.5, 7.5, 15.5);
         let b = _mm_setr_ps(-1.75, -4.5, -8.5, -16.5);
         let r = _mm_round_ss::<_MM_FROUND_TO_NEAREST_INT>(a, b);
@@ -1747,7 +1747,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_minpos_epu16_1() {
+    fn test_mm_minpos_epu16_1() {
         let a = _mm_setr_epi16(23, 18, 44, 97, 50, 13, 67, 66);
         let r = _mm_minpos_epu16(a);
         let e = _mm_setr_epi16(13, 5, 0, 0, 0, 0, 0, 0);
@@ -1755,7 +1755,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_minpos_epu16_2() {
+    fn test_mm_minpos_epu16_2() {
         let a = _mm_setr_epi16(0, 18, 44, 97, 50, 13, 67, 66);
         let r = _mm_minpos_epu16(a);
         let e = _mm_setr_epi16(0, 0, 0, 0, 0, 0, 0, 0);
@@ -1763,7 +1763,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_minpos_epu16_3() {
+    fn test_mm_minpos_epu16_3() {
         // Case where the minimum value is repeated
         let a = _mm_setr_epi16(23, 18, 44, 97, 50, 13, 67, 13);
         let r = _mm_minpos_epu16(a);
@@ -1772,7 +1772,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_mul_epi32() {
+    const fn test_mm_mul_epi32() {
         {
             let a = _mm_setr_epi32(1, 1, 1, 1);
             let b = _mm_setr_epi32(1, 2, 3, 4);
@@ -1793,7 +1793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_mullo_epi32() {
+    const fn test_mm_mullo_epi32() {
         {
             let a = _mm_setr_epi32(1, 1, 1, 1);
             let b = _mm_setr_epi32(1, 2, 3, 4);
@@ -1814,7 +1814,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_minpos_epu16() {
+    fn test_mm_minpos_epu16() {
         let a = _mm_setr_epi16(8, 7, 6, 5, 4, 1, 2, 3);
         let r = _mm_minpos_epu16(a);
         let e = _mm_setr_epi16(1, 5, 0, 0, 0, 0, 0, 0);
@@ -1822,7 +1822,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_mpsadbw_epu8() {
+    fn test_mm_mpsadbw_epu8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             0, 1, 2, 3, 4, 5, 6, 7,
@@ -1851,7 +1851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_testz_si128() {
+    const fn test_mm_testz_si128() {
         let a = _mm_set1_epi8(1);
         let mask = _mm_set1_epi8(0);
         let r = _mm_testz_si128(a, mask);
@@ -1867,7 +1867,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_testc_si128() {
+    const fn test_mm_testc_si128() {
         let a = _mm_set1_epi8(-1);
         let mask = _mm_set1_epi8(0);
         let r = _mm_testc_si128(a, mask);
@@ -1883,7 +1883,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_testnzc_si128() {
+    fn test_mm_testnzc_si128() {
         let a = _mm_set1_epi8(0);
         let mask = _mm_set1_epi8(1);
         let r = _mm_testnzc_si128(a, mask);
@@ -1903,7 +1903,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_test_all_zeros() {
+    const fn test_mm_test_all_zeros() {
         let a = _mm_set1_epi8(1);
         let mask = _mm_set1_epi8(0);
         let r = _mm_test_all_zeros(a, mask);
@@ -1919,7 +1919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_test_all_ones() {
+    const fn test_mm_test_all_ones() {
         let a = _mm_set1_epi8(-1);
         let r = _mm_test_all_ones(a);
         assert_eq!(r, 1);
@@ -1929,7 +1929,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    unsafe fn test_mm_test_mix_ones_zeros() {
+    fn test_mm_test_mix_ones_zeros() {
         let a = _mm_set1_epi8(0);
         let mask = _mm_set1_epi8(1);
         let r = _mm_test_mix_ones_zeros(a, mask);

--- a/crates/core_arch/src/x86/sse42.rs
+++ b/crates/core_arch/src/x86/sse42.rs
@@ -619,18 +619,17 @@ mod tests {
     // Currently one cannot `load` a &[u8] that is less than 16
     // in length. This makes loading strings less than 16 in length
     // a bit difficult. Rather than `load` and mutate the __m128i,
-    // it is easier to memcpy the given string to a local slice with
-    // length 16 and `load` the local slice.
-    #[target_feature(enable = "sse4.2")]
-    unsafe fn str_to_m128i(s: &[u8]) -> __m128i {
+    // it is easier to memcpy the given string to a zero-padded
+    // 16-byte array and transmute it to `__m128i`.
+    fn str_to_m128i(s: &[u8]) -> __m128i {
         assert!(s.len() <= 16);
-        let slice = &mut [0u8; 16];
-        ptr::copy_nonoverlapping(s.as_ptr(), slice.as_mut_ptr(), s.len());
-        _mm_loadu_si128(slice.as_ptr() as *const _)
+        let mut array = [0u8; 16];
+        array[..s.len()].copy_from_slice(s);
+        unsafe { transmute(array) }
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistrm() {
+    fn test_mm_cmpistrm() {
         let a = str_to_m128i(b"Hello! Good-Bye!");
         let b = str_to_m128i(b"hello! good-bye!");
         let i = _mm_cmpistrm::<_SIDD_UNIT_MASK>(a, b);
@@ -643,7 +642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistri() {
+    fn test_mm_cmpistri() {
         let a = str_to_m128i(b"Hello");
         let b = str_to_m128i(b"   Hello        ");
         let i = _mm_cmpistri::<_SIDD_CMP_EQUAL_ORDERED>(a, b);
@@ -651,7 +650,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistrz() {
+    fn test_mm_cmpistrz() {
         let a = str_to_m128i(b"");
         let b = str_to_m128i(b"Hello");
         let i = _mm_cmpistrz::<_SIDD_CMP_EQUAL_ORDERED>(a, b);
@@ -659,7 +658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistrc() {
+    fn test_mm_cmpistrc() {
         let a = str_to_m128i(b"                ");
         let b = str_to_m128i(b"       !        ");
         let i = _mm_cmpistrc::<_SIDD_UNIT_MASK>(a, b);
@@ -667,7 +666,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistrs() {
+    fn test_mm_cmpistrs() {
         let a = str_to_m128i(b"Hello");
         let b = str_to_m128i(b"");
         let i = _mm_cmpistrs::<_SIDD_CMP_EQUAL_ORDERED>(a, b);
@@ -675,7 +674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistro() {
+    fn test_mm_cmpistro() {
         #[rustfmt::skip]
         let a_bytes = _mm_setr_epi8(
             0x00, 0x47, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c,
@@ -693,7 +692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpistra() {
+    fn test_mm_cmpistra() {
         let a = str_to_m128i(b"");
         let b = str_to_m128i(b"Hello!!!!!!!!!!!");
         let i = _mm_cmpistra::<_SIDD_UNIT_MASK>(a, b);
@@ -701,7 +700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestrm() {
+    fn test_mm_cmpestrm() {
         let a = str_to_m128i(b"Hello!");
         let b = str_to_m128i(b"Hello.");
         let i = _mm_cmpestrm::<_SIDD_UNIT_MASK>(a, 5, b, 5);
@@ -714,7 +713,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestri() {
+    fn test_mm_cmpestri() {
         let a = str_to_m128i(b"bar - garbage");
         let b = str_to_m128i(b"foobar");
         let i = _mm_cmpestri::<_SIDD_CMP_EQUAL_ORDERED>(a, 3, b, 6);
@@ -722,7 +721,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestrz() {
+    fn test_mm_cmpestrz() {
         let a = str_to_m128i(b"");
         let b = str_to_m128i(b"Hello");
         let i = _mm_cmpestrz::<_SIDD_CMP_EQUAL_ORDERED>(a, 16, b, 6);
@@ -730,7 +729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestrc() {
+    fn test_mm_cmpestrc() {
         let va = str_to_m128i(b"!!!!!!!!");
         let vb = str_to_m128i(b"        ");
         let i = _mm_cmpestrc::<_SIDD_UNIT_MASK>(va, 7, vb, 7);
@@ -738,7 +737,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestrs() {
+    fn test_mm_cmpestrs() {
         #[rustfmt::skip]
         let a_bytes = _mm_setr_epi8(
             0x00, 0x48, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c,
@@ -751,7 +750,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestro() {
+    fn test_mm_cmpestro() {
         let a = str_to_m128i(b"Hello");
         let b = str_to_m128i(b"World");
         let i = _mm_cmpestro::<_SIDD_UBYTE_OPS>(a, 5, b, 5);
@@ -759,7 +758,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_cmpestra() {
+    fn test_mm_cmpestra() {
         let a = str_to_m128i(b"Cannot match a");
         let b = str_to_m128i(b"Null after 14");
         let i = _mm_cmpestra::<{ _SIDD_CMP_EQUAL_EACH | _SIDD_UNIT_MASK }>(a, 14, b, 16);
@@ -767,7 +766,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_crc32_u8() {
+    fn test_mm_crc32_u8() {
         let crc = 0x2aa1e72b;
         let v = 0x2a;
         let i = _mm_crc32_u8(crc, v);
@@ -775,7 +774,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_crc32_u16() {
+    fn test_mm_crc32_u16() {
         let crc = 0x8ecec3b5;
         let v = 0x22b;
         let i = _mm_crc32_u16(crc, v);
@@ -783,7 +782,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_crc32_u32() {
+    fn test_mm_crc32_u32() {
         let crc = 0xae2912c8;
         let v = 0x845fed;
         let i = _mm_crc32_u32(crc, v);
@@ -791,7 +790,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.2")]
-    const unsafe fn test_mm_cmpgt_epi64() {
+    const fn test_mm_cmpgt_epi64() {
         let a = _mm_setr_epi64x(0, 0x2a);
         let b = _mm_set1_epi64x(0x00);
         let i = _mm_cmpgt_epi64(a, b);

--- a/crates/core_arch/src/x86/sse4a.rs
+++ b/crates/core_arch/src/x86/sse4a.rs
@@ -151,7 +151,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse4a")]
-    unsafe fn test_mm_extract_si64() {
+    fn test_mm_extract_si64() {
         let b = 0b0110_0000_0000_i64;
         //        ^^^^ bit range extracted
         let x = _mm_setr_epi64x(b, 0);
@@ -164,7 +164,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4a")]
-    unsafe fn test_mm_extracti_si64() {
+    fn test_mm_extracti_si64() {
         let a = _mm_setr_epi64x(0x0123456789abcdef, 0);
         let r = _mm_extracti_si64::<8, 8>(a);
         let e = _mm_setr_epi64x(0xcd, 0);
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4a")]
-    unsafe fn test_mm_insert_si64() {
+    fn test_mm_insert_si64() {
         let i = 0b0110_i64;
         //        ^^^^ bit range inserted
         let z = 0b1010_1010_1010i64;
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4a")]
-    unsafe fn test_mm_inserti_si64() {
+    fn test_mm_inserti_si64() {
         let a = _mm_setr_epi64x(0x0123456789abcdef, 0);
         let b = _mm_setr_epi64x(0x0011223344556677, 0);
         let r = _mm_inserti_si64::<8, 8>(a, b);

--- a/crates/core_arch/src/x86/ssse3.rs
+++ b/crates/core_arch/src/x86/ssse3.rs
@@ -367,25 +367,25 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_abs_epi8() {
+    const fn test_mm_abs_epi8() {
         let r = _mm_abs_epi8(_mm_set1_epi8(-5));
         assert_eq_m128i(r, _mm_set1_epi8(5));
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_abs_epi16() {
+    const fn test_mm_abs_epi16() {
         let r = _mm_abs_epi16(_mm_set1_epi16(-5));
         assert_eq_m128i(r, _mm_set1_epi16(5));
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_abs_epi32() {
+    const fn test_mm_abs_epi32() {
         let r = _mm_abs_epi32(_mm_set1_epi32(-5));
         assert_eq_m128i(r, _mm_set1_epi32(5));
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_shuffle_epi8() {
+    fn test_mm_shuffle_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_alignr_epi8() {
+    const fn test_mm_alignr_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -449,7 +449,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_hadd_epi16() {
+    const fn test_mm_hadd_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_setr_epi16(4, 128, 4, 3, 24, 12, 6, 19);
         let expected = _mm_setr_epi16(3, 7, 11, 15, 132, 7, 36, 25);
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_hadds_epi16() {
+    fn test_mm_hadds_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_setr_epi16(4, 128, 4, 3, 32767, 1, -32768, -1);
         let expected = _mm_setr_epi16(3, 7, 11, 15, 132, 7, 32767, -32768);
@@ -499,7 +499,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_hadd_epi32() {
+    const fn test_mm_hadd_epi32() {
         let a = _mm_setr_epi32(1, 2, 3, 4);
         let b = _mm_setr_epi32(4, 128, 4, 3);
         let expected = _mm_setr_epi32(3, 7, 132, 7);
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_hsub_epi16() {
+    const fn test_mm_hsub_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_setr_epi16(4, 128, 4, 3, 24, 12, 6, 19);
         let expected = _mm_setr_epi16(-1, -1, -1, -1, -124, 1, 12, -13);
@@ -540,7 +540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_hsubs_epi16() {
+    fn test_mm_hsubs_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_setr_epi16(4, 128, 4, 3, 32767, -1, -32768, 1);
         let expected = _mm_setr_epi16(-1, -1, -1, -1, -124, 1, 32767, -32768);
@@ -565,7 +565,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    const unsafe fn test_mm_hsub_epi32() {
+    const fn test_mm_hsub_epi32() {
         let a = _mm_setr_epi32(1, 2, 3, 4);
         let b = _mm_setr_epi32(4, 128, 4, 3);
         let expected = _mm_setr_epi32(-1, -1, -124, 1);
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_maddubs_epi16() {
+    fn test_mm_maddubs_epi16() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_mulhrs_epi16() {
+    fn test_mm_mulhrs_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm_setr_epi16(4, 128, 4, 3, 32767, -1, -32768, 1);
         let expected = _mm_setr_epi16(0, 0, 0, 0, 5, 0, -7, 0);
@@ -637,7 +637,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_sign_epi8() {
+    fn test_mm_sign_epi8() {
         #[rustfmt::skip]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,
@@ -658,7 +658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_sign_epi16() {
+    fn test_mm_sign_epi16() {
         let a = _mm_setr_epi16(1, 2, 3, 4, -5, -6, 7, 8);
         let b = _mm_setr_epi16(4, 128, 0, 3, 1, -1, -2, 1);
         let expected = _mm_setr_epi16(1, 2, 0, 4, -5, 6, -7, 8);
@@ -667,7 +667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "ssse3")]
-    unsafe fn test_mm_sign_epi32() {
+    fn test_mm_sign_epi32() {
         let a = _mm_setr_epi32(-1, 2, 3, 4);
         let b = _mm_setr_epi32(1, -1, 1, 0);
         let expected = _mm_setr_epi32(-1, -2, 3, 0);

--- a/crates/core_arch/src/x86/tbm.rs
+++ b/crates/core_arch/src/x86/tbm.rs
@@ -154,18 +154,18 @@ mod tests {
     use crate::core_arch::x86::*;
 
     #[simd_test(enable = "tbm")]
-    unsafe fn test_bextri_u32() {
+    fn test_bextri_u32() {
         assert_eq!(_bextri_u32::<0x0404>(0b0101_0000u32), 0b0000_0101u32);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcfill_u32() {
+    const fn test_blcfill_u32() {
         assert_eq!(_blcfill_u32(0b0101_0111u32), 0b0101_0000u32);
         assert_eq!(_blcfill_u32(0b1111_1111u32), 0u32);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blci_u32() {
+    const fn test_blci_u32() {
         assert_eq!(
             _blci_u32(0b0101_0000u32),
             0b1111_1111_1111_1111_1111_1111_1111_1110u32
@@ -177,25 +177,25 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcic_u32() {
+    const fn test_blcic_u32() {
         assert_eq!(_blcic_u32(0b0101_0001u32), 0b0000_0010u32);
         assert_eq!(_blcic_u32(0b1111_1111u32), 0b1_0000_0000u32);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcmsk_u32() {
+    const fn test_blcmsk_u32() {
         assert_eq!(_blcmsk_u32(0b0101_0001u32), 0b0000_0011u32);
         assert_eq!(_blcmsk_u32(0b1111_1111u32), 0b1_1111_1111u32);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcs_u32() {
+    const fn test_blcs_u32() {
         assert_eq!(_blcs_u32(0b0101_0001u32), 0b0101_0011u32);
         assert_eq!(_blcs_u32(0b1111_1111u32), 0b1_1111_1111u32);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blsfill_u32() {
+    const fn test_blsfill_u32() {
         assert_eq!(_blsfill_u32(0b0101_0100u32), 0b0101_0111u32);
         assert_eq!(
             _blsfill_u32(0u32),
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blsic_u32() {
+    const fn test_blsic_u32() {
         assert_eq!(
             _blsic_u32(0b0101_0100u32),
             0b1111_1111_1111_1111_1111_1111_1111_1011u32
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_t1mskc_u32() {
+    const fn test_t1mskc_u32() {
         assert_eq!(
             _t1mskc_u32(0b0101_0111u32),
             0b1111_1111_1111_1111_1111_1111_1111_1000u32
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_tzmsk_u32() {
+    const fn test_tzmsk_u32() {
         assert_eq!(_tzmsk_u32(0b0101_1000u32), 0b0000_0111u32);
         assert_eq!(_tzmsk_u32(0b0101_1001u32), 0b0000_0000u32);
     }

--- a/crates/core_arch/src/x86/test.rs
+++ b/crates/core_arch/src/x86/test.rs
@@ -1,225 +1,122 @@
 //! Utilities used in testing the x86 intrinsics
 
 use crate::core_arch::assert_eq_const as assert_eq;
+use crate::core_arch::simd::*;
 use crate::core_arch::x86::*;
 use std::mem::transmute;
 
 #[track_caller]
-#[target_feature(enable = "sse2")]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(crate) const unsafe fn assert_eq_m128i(a: __m128i, b: __m128i) {
-    assert_eq!(transmute::<_, [u64; 2]>(a), transmute::<_, [u64; 2]>(b))
-}
-
-#[track_caller]
-#[target_feature(enable = "avx")]
-#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(crate) const unsafe fn assert_eq_m256i(a: __m256i, b: __m256i) {
-    assert_eq!(transmute::<_, [u64; 4]>(a), transmute::<_, [u64; 4]>(b))
+pub(crate) const fn assert_eq_m128i(a: __m128i, b: __m128i) {
+    assert_eq!(a.as_u32x4(), b.as_u32x4());
 }
 
 #[track_caller]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(crate) const unsafe fn assert_eq_m512i(a: __m512i, b: __m512i) {
-    assert_eq!(transmute::<_, [i32; 16]>(a), transmute::<_, [i32; 16]>(b))
+pub(crate) const fn assert_eq_m128(a: __m128, b: __m128) {
+    assert_eq!(a.as_f32x4(), b.as_f32x4());
 }
 
-macro_rules! make_ct_rt {
-    ($(
-        $( #[$meta:meta] )*
-        $vis:vis unsafe fn $name:ident ($($param:ident : $type:ty),* $(,)?) {
-            ct: $ct:expr;
-            rt: $rt:expr;
-        }
-    )*) => {$(
-        $( #[$meta] )*
-        #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-        $vis const unsafe fn $name ($($param : $type),*) {
-            #[inline(always)]
-            #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-            const fn ct($($param : $type),*) {
-                $ct
-            }
-            #[inline(always)]
-            fn rt($($param : $type),*) {
-                $rt
-            }
-
-            $crate::intrinsics::const_eval_select(($($param),*), ct, rt)
-        }
-    )*}
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m128d(a: __m128d, b: __m128d) {
+    assert_eq!(a.as_f64x2(), b.as_f64x2());
 }
 
-make_ct_rt! {
-    // SAFETY: we can use simple float equality because when this should only be used in const
-    // context where Intel peculiarities don't appear
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m128h(a: __m128h, b: __m128h) {
+    assert_eq!(a.as_f16x8(), b.as_f16x8());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "sse2")]
-    pub unsafe fn assert_eq_m128d(a: __m128d, b: __m128d) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f64; 2]>(a), transmute::<_, [f64; 2]>(b))
-        };
-        rt: unsafe {
-            if _mm_movemask_pd(_mm_cmpeq_pd(a, b)) != 0b11 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m256i(a: __m256i, b: __m256i) {
+    assert_eq!(a.as_u32x8(), b.as_u32x8());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "sse")]
-    pub unsafe fn assert_eq_m128(a: __m128, b: __m128) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f32; 4]>(a), transmute::<_, [f32; 4]>(b))
-        };
-        rt: unsafe {
-            let r = _mm_cmpeq_ps(a, b);
-            if _mm_movemask_ps(r) != 0b1111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m256(a: __m256, b: __m256) {
+    assert_eq!(a.as_f32x8(), b.as_f32x8());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "avx512fp16,avx512vl")]
-    pub unsafe fn assert_eq_m128h(a: __m128h, b: __m128h) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f16; 8]>(a), transmute::<_, [f16; 8]>(b))
-        };
-        rt: unsafe {
-            let r = _mm_cmp_ph_mask::<_CMP_EQ_OQ>(a, b);
-            if r != 0b1111_1111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m256d(a: __m256d, b: __m256d) {
+    assert_eq!(a.as_f64x4(), b.as_f64x4());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "avx")]
-    pub unsafe fn assert_eq_m256d(a: __m256d, b: __m256d) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f64; 4]>(a), transmute::<_, [f64; 4]>(b))
-        };
-        rt: unsafe {
-            let cmp = _mm256_cmp_pd::<_CMP_EQ_OQ>(a, b);
-            if _mm256_movemask_pd(cmp) != 0b1111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m256h(a: __m256h, b: __m256h) {
+    assert_eq!(a.as_f16x16(), b.as_f16x16());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "avx")]
-    pub unsafe fn assert_eq_m256(a: __m256, b: __m256) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f32; 8]>(a), transmute::<_, [f32; 8]>(b))
-        };
-        rt: unsafe {
-            let cmp = _mm256_cmp_ps::<_CMP_EQ_OQ>(a, b);
-            if _mm256_movemask_ps(cmp) != 0b11111111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m512i(a: __m512i, b: __m512i) {
+    assert_eq!(a.as_i64x8(), b.as_i64x8());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "avx512fp16,avx512vl")]
-    pub unsafe fn assert_eq_m256h(a: __m256h, b: __m256h) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f16; 16]>(a), transmute::<_, [f16; 16]>(b))
-        };
-        rt: unsafe {
-            let r = _mm256_cmp_ph_mask::<_CMP_EQ_OQ>(a, b);
-            if r != 0b11111111_11111111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m512(a: __m512, b: __m512) {
+    assert_eq!(a.as_f32x16(), b.as_f32x16());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "avx512f")]
-    pub unsafe fn assert_eq_m512d(a: __m512d, b: __m512d) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f64; 8]>(a), transmute::<_, [f64; 8]>(b))
-        };
-        rt: unsafe {
-            let cmp = _mm512_cmp_pd_mask::<_CMP_EQ_OQ>(a, b);
-            if cmp != 0b11111111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m512d(a: __m512d, b: __m512d) {
+    assert_eq!(a.as_f64x8(), b.as_f64x8());
+}
 
-    #[track_caller]
-    #[target_feature(enable = "avx512f")]
-    pub unsafe fn assert_eq_m512(a: __m512, b: __m512) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f32; 16]>(a), transmute::<_, [f32; 16]>(b))
-        };
-        rt: unsafe {
-            let cmp = _mm512_cmp_ps_mask::<_CMP_EQ_OQ>(a, b);
-            if cmp != 0b11111111_11111111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
-
-    #[track_caller]
-    #[target_feature(enable = "avx512fp16")]
-    pub unsafe fn assert_eq_m512h(a: __m512h, b: __m512h) {
-        ct: unsafe {
-            assert_eq!(transmute::<_, [f16; 32]>(a), transmute::<_, [f16; 32]>(b))
-        };
-        rt: unsafe {
-            let r = _mm512_cmp_ph_mask::<_CMP_EQ_OQ>(a, b);
-            if r != 0b11111111_11111111_11111111_11111111 {
-                panic!("{:?} != {:?}", a, b);
-            }
-        };
-    }
+#[track_caller]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+pub(crate) const fn assert_eq_m512h(a: __m512h, b: __m512h) {
+    assert_eq!(a.as_f16x32(), b.as_f16x32());
 }
 
 #[target_feature(enable = "sse2")]
-pub(crate) const unsafe fn get_m128d(a: __m128d, idx: usize) -> f64 {
-    transmute::<_, [f64; 2]>(a)[idx]
+pub(crate) const fn get_m128d(a: __m128d, idx: usize) -> f64 {
+    a.as_f64x2().extract(idx)
 }
 
 #[target_feature(enable = "sse")]
-pub(crate) const unsafe fn get_m128(a: __m128, idx: usize) -> f32 {
-    transmute::<_, [f32; 4]>(a)[idx]
+pub(crate) const fn get_m128(a: __m128, idx: usize) -> f32 {
+    a.as_f32x4().extract(idx)
 }
 
 #[target_feature(enable = "avx")]
-pub(crate) const unsafe fn get_m256d(a: __m256d, idx: usize) -> f64 {
-    transmute::<_, [f64; 4]>(a)[idx]
+pub(crate) const fn get_m256d(a: __m256d, idx: usize) -> f64 {
+    a.as_f64x4().extract(idx)
 }
 
 #[target_feature(enable = "avx")]
-pub(crate) const unsafe fn get_m256(a: __m256, idx: usize) -> f32 {
-    transmute::<_, [f32; 8]>(a)[idx]
+pub(crate) const fn get_m256(a: __m256, idx: usize) -> f32 {
+    a.as_f32x8().extract(idx)
 }
 
 #[target_feature(enable = "avx512f")]
-pub(crate) const unsafe fn get_m512(a: __m512, idx: usize) -> f32 {
-    transmute::<_, [f32; 16]>(a)[idx]
+pub(crate) const fn get_m512(a: __m512, idx: usize) -> f32 {
+    a.as_f32x16().extract(idx)
 }
 
 #[target_feature(enable = "avx512f")]
-pub(crate) const unsafe fn get_m512d(a: __m512d, idx: usize) -> f64 {
-    transmute::<_, [f64; 8]>(a)[idx]
+pub(crate) const fn get_m512d(a: __m512d, idx: usize) -> f64 {
+    a.as_f64x8().extract(idx)
 }
 
 #[target_feature(enable = "avx512f")]
-pub(crate) const unsafe fn get_m512i(a: __m512i, idx: usize) -> i64 {
-    transmute::<_, [i64; 8]>(a)[idx]
+pub(crate) const fn get_m512i(a: __m512i, idx: usize) -> i64 {
+    a.as_i64x8().extract(idx)
 }
 
 // not actually an intrinsic but useful in various tests as we ported from
 // `i64x2::new` which is backwards from `_mm_set_epi64x`
 #[target_feature(enable = "sse2")]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub const unsafe fn _mm_setr_epi64x(a: i64, b: i64) -> __m128i {
+pub const fn _mm_setr_epi64x(a: i64, b: i64) -> __m128i {
     _mm_set_epi64x(b, a)
 }
 
@@ -232,17 +129,17 @@ mod x86_polyfill {
 
     #[rustc_legacy_const_generics(2)]
     #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-    pub const unsafe fn _mm_insert_epi64<const INDEX: i32>(a: __m128i, val: i64) -> __m128i {
+    pub const fn _mm_insert_epi64<const INDEX: i32>(a: __m128i, val: i64) -> __m128i {
         static_assert_uimm_bits!(INDEX, 1);
-        transmute(simd_insert!(a.as_i64x2(), INDEX as u32, val))
+        unsafe { transmute(simd_insert!(a.as_i64x2(), INDEX as u32, val)) }
     }
 
     #[target_feature(enable = "avx2")]
     #[rustc_legacy_const_generics(2)]
     #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-    pub const unsafe fn _mm256_insert_epi64<const INDEX: i32>(a: __m256i, val: i64) -> __m256i {
+    pub const fn _mm256_insert_epi64<const INDEX: i32>(a: __m256i, val: i64) -> __m256i {
         static_assert_uimm_bits!(INDEX, 2);
-        transmute(simd_insert!(a.as_i64x4(), INDEX as u32, val))
+        unsafe { transmute(simd_insert!(a.as_i64x4(), INDEX as u32, val)) }
     }
 }
 

--- a/crates/core_arch/src/x86/vaes.rs
+++ b/crates/core_arch/src/x86/vaes.rs
@@ -146,9 +146,9 @@ mod tests {
     // ideally we'd be using quickcheck here instead
 
     #[target_feature(enable = "avx2")]
-    unsafe fn helper_for_256_vaes(
-        linear: unsafe fn(__m128i, __m128i) -> __m128i,
-        vectorized: unsafe fn(__m256i, __m256i) -> __m256i,
+    fn helper_for_256_vaes(
+        linear: fn(__m128i, __m128i) -> __m128i,
+        vectorized: fn(__m256i, __m256i) -> __m256i,
     ) {
         let a = _mm256_set_epi64x(
             0xDCB4DB3657BF0B7D,
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[target_feature(enable = "sse2")]
-    unsafe fn setup_state_key<T>(broadcast: unsafe fn(__m128i) -> T) -> (T, T) {
+    fn setup_state_key<T>(broadcast: fn(__m128i) -> T) -> (T, T) {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
         let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
         let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
@@ -186,17 +186,17 @@ mod tests {
     }
 
     #[target_feature(enable = "avx2")]
-    unsafe fn setup_state_key_256() -> (__m256i, __m256i) {
+    fn setup_state_key_256() -> (__m256i, __m256i) {
         setup_state_key(_mm256_broadcastsi128_si256)
     }
 
     #[target_feature(enable = "avx512f")]
-    unsafe fn setup_state_key_512() -> (__m512i, __m512i) {
+    fn setup_state_key_512() -> (__m512i, __m512i) {
         setup_state_key(_mm512_broadcast_i32x4)
     }
 
     #[simd_test(enable = "vaes,avx512vl")]
-    unsafe fn test_mm256_aesdec_epi128() {
+    fn test_mm256_aesdec_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
         let (a, k) = setup_state_key_256();
         let e = _mm_set_epi64x(0x044e4f5176fec48f, 0xb57ecfa381da39ee);
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512vl")]
-    unsafe fn test_mm256_aesdeclast_epi128() {
+    fn test_mm256_aesdeclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714178.aspx.
         let (a, k) = setup_state_key_256();
         let e = _mm_set_epi64x(0x36cad57d9072bf9e, 0xf210dd981fa4a493);
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512vl")]
-    unsafe fn test_mm256_aesenc_epi128() {
+    fn test_mm256_aesenc_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664810.aspx.
         // they are repeated appropriately
         let (a, k) = setup_state_key_256();
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512vl")]
-    unsafe fn test_mm256_aesenclast_epi128() {
+    fn test_mm256_aesenclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714136.aspx.
         let (a, k) = setup_state_key_256();
         let e = _mm_set_epi64x(0xb6dd7df25d7ab320, 0x4b04f98cf4c860f8);
@@ -245,9 +245,9 @@ mod tests {
     }
 
     #[target_feature(enable = "avx512f")]
-    unsafe fn helper_for_512_vaes(
-        linear: unsafe fn(__m128i, __m128i) -> __m128i,
-        vectorized: unsafe fn(__m512i, __m512i) -> __m512i,
+    fn helper_for_512_vaes(
+        linear: fn(__m128i, __m128i) -> __m128i,
+        vectorized: fn(__m512i, __m512i) -> __m512i,
     ) {
         let a = _mm512_set_epi64(
             0xDCB4DB3657BF0B7D,
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesdec_epi128() {
+    fn test_mm512_aesdec_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
         let (a, k) = setup_state_key_512();
         let e = _mm_set_epi64x(0x044e4f5176fec48f, 0xb57ecfa381da39ee);
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesdeclast_epi128() {
+    fn test_mm512_aesdeclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714178.aspx.
         let (a, k) = setup_state_key_512();
         let e = _mm_set_epi64x(0x36cad57d9072bf9e, 0xf210dd981fa4a493);
@@ -315,7 +315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesenc_epi128() {
+    fn test_mm512_aesenc_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc664810.aspx.
         let (a, k) = setup_state_key_512();
         let e = _mm_set_epi64x(0x16ab0e57dfc442ed, 0x28e4ee1884504333);
@@ -327,7 +327,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesenclast_epi128() {
+    fn test_mm512_aesenclast_epi128() {
         // Constants taken from https://msdn.microsoft.com/en-us/library/cc714136.aspx.
         let (a, k) = setup_state_key_512();
         let e = _mm_set_epi64x(0xb6dd7df25d7ab320, 0x4b04f98cf4c860f8);

--- a/crates/core_arch/src/x86/vpclmulqdq.rs
+++ b/crates/core_arch/src/x86/vpclmulqdq.rs
@@ -124,9 +124,9 @@ mod tests {
     // this function tests one of the possible 4 instances
     // with different inputs across lanes
     #[target_feature(enable = "vpclmulqdq,avx512f")]
-    unsafe fn verify_512_helper(
-        linear: unsafe fn(__m128i, __m128i) -> __m128i,
-        vectorized: unsafe fn(__m512i, __m512i) -> __m512i,
+    fn verify_512_helper(
+        linear: fn(__m128i, __m128i) -> __m128i,
+        vectorized: fn(__m512i, __m512i) -> __m512i,
     ) {
         let a = _mm512_set_epi64(
             0xDCB4DB3657BF0B7D,
@@ -165,9 +165,9 @@ mod tests {
     // this function tests one of the possible 4 instances
     // with different inputs across lanes for the VL version
     #[target_feature(enable = "vpclmulqdq,avx512vl")]
-    unsafe fn verify_256_helper(
-        linear: unsafe fn(__m128i, __m128i) -> __m128i,
-        vectorized: unsafe fn(__m256i, __m256i) -> __m256i,
+    fn verify_256_helper(
+        linear: fn(__m128i, __m128i) -> __m128i,
+        vectorized: fn(__m256i, __m256i) -> __m256i,
     ) {
         let a = _mm512_set_epi64(
             0xDCB4DB3657BF0B7D,
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vpclmulqdq,avx512f")]
-    unsafe fn test_mm512_clmulepi64_epi128() {
+    fn test_mm512_clmulepi64_epi128() {
         verify_kat_pclmul!(
             _mm512_broadcast_i32x4,
             _mm512_clmulepi64_epi128,
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "vpclmulqdq,avx512vl")]
-    unsafe fn test_mm256_clmulepi64_epi128() {
+    fn test_mm256_clmulepi64_epi128() {
         verify_kat_pclmul!(
             _mm256_broadcastsi128_si256,
             _mm256_clmulepi64_epi128,

--- a/crates/core_arch/src/x86_64/abm.rs
+++ b/crates/core_arch/src/x86_64/abm.rs
@@ -54,12 +54,12 @@ mod tests {
     use crate::core_arch::arch::x86_64::*;
 
     #[simd_test(enable = "lzcnt")]
-    const unsafe fn test_lzcnt_u64() {
+    const fn test_lzcnt_u64() {
         assert_eq!(_lzcnt_u64(0b0101_1010), 57);
     }
 
     #[simd_test(enable = "popcnt")]
-    const unsafe fn test_popcnt64() {
+    const fn test_popcnt64() {
         assert_eq!(_popcnt64(0b0101_1010), 4);
     }
 }

--- a/crates/core_arch/src/x86_64/avx.rs
+++ b/crates/core_arch/src/x86_64/avx.rs
@@ -52,7 +52,7 @@ mod tests {
     use crate::core_arch::arch::x86_64::*;
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_insert_epi64() {
+    const fn test_mm256_insert_epi64() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_insert_epi64::<3>(a, 0);
         let e = _mm256_setr_epi64x(1, 2, 3, 0);
@@ -60,7 +60,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    const unsafe fn test_mm256_extract_epi64() {
+    const fn test_mm256_extract_epi64() {
         let a = _mm256_setr_epi64x(0, 1, 2, 3);
         let r = _mm256_extract_epi64::<3>(a);
         assert_eq!(r, 3);

--- a/crates/core_arch/src/x86_64/avx512bw.rs
+++ b/crates/core_arch/src/x86_64/avx512bw.rs
@@ -31,7 +31,7 @@ mod tests {
     use crate::core_arch::{x86::*, x86_64::*};
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_cvtmask64_u64() {
+    const fn test_cvtmask64_u64() {
         let a: __mmask64 = 0b11001100_00110011_01100110_10011001;
         let r = _cvtmask64_u64(a);
         let e: u64 = 0b11001100_00110011_01100110_10011001;
@@ -39,7 +39,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512bw")]
-    const unsafe fn test_cvtu64_mask64() {
+    const fn test_cvtu64_mask64() {
         let a: u64 = 0b11001100_00110011_01100110_10011001;
         let r = _cvtu64_mask64(a);
         let e: __mmask64 = 0b11001100_00110011_01100110_10011001;

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -567,7 +567,7 @@ mod tests {
     use crate::hint::black_box;
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_abs_epi64() {
+    const fn test_mm512_abs_epi64() {
         let a = _mm512_set_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let r = _mm512_abs_epi64(a);
         let e = _mm512_set_epi64(0, 1, 1, i64::MAX, i64::MAX.wrapping_add(1), 100, 100, 32);
@@ -575,7 +575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_abs_epi64() {
+    const fn test_mm512_mask_abs_epi64() {
         let a = _mm512_set_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let r = _mm512_mask_abs_epi64(a, 0, a);
         assert_eq_m512i(r, a);
@@ -585,7 +585,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_abs_epi64() {
+    const fn test_mm512_maskz_abs_epi64() {
         let a = _mm512_set_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let r = _mm512_maskz_abs_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -595,7 +595,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_abs_epi64() {
+    const fn test_mm256_abs_epi64() {
         let a = _mm256_set_epi64x(i64::MAX, i64::MIN, 100, -100);
         let r = _mm256_abs_epi64(a);
         let e = _mm256_set_epi64x(i64::MAX, i64::MAX.wrapping_add(1), 100, 100);
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_abs_epi64() {
+    const fn test_mm256_mask_abs_epi64() {
         let a = _mm256_set_epi64x(i64::MAX, i64::MIN, 100, -100);
         let r = _mm256_mask_abs_epi64(a, 0, a);
         assert_eq_m256i(r, a);
@@ -613,7 +613,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_abs_epi64() {
+    const fn test_mm256_maskz_abs_epi64() {
         let a = _mm256_set_epi64x(i64::MAX, i64::MIN, 100, -100);
         let r = _mm256_maskz_abs_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_abs_epi64() {
+    const fn test_mm_abs_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let r = _mm_abs_epi64(a);
         let e = _mm_set_epi64x(i64::MAX, i64::MAX.wrapping_add(1));
@@ -635,7 +635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_abs_epi64() {
+    const fn test_mm_mask_abs_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let r = _mm_mask_abs_epi64(a, 0, a);
         assert_eq_m128i(r, a);
@@ -649,7 +649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_abs_epi64() {
+    const fn test_mm_maskz_abs_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let r = _mm_maskz_abs_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -663,7 +663,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_abs_pd() {
+    const fn test_mm512_abs_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let r = _mm512_abs_pd(a);
         let e = _mm512_setr_pd(0., 1., 1., f64::MAX, f64::MAX, 100., 100., 32.);
@@ -671,7 +671,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_abs_pd() {
+    const fn test_mm512_mask_abs_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let r = _mm512_mask_abs_pd(a, 0, a);
         assert_eq_m512d(r, a);
@@ -681,7 +681,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mov_epi64() {
+    const fn test_mm512_mask_mov_epi64() {
         let src = _mm512_set1_epi64(1);
         let a = _mm512_set1_epi64(2);
         let r = _mm512_mask_mov_epi64(src, 0, a);
@@ -691,7 +691,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mov_epi64() {
+    const fn test_mm512_maskz_mov_epi64() {
         let a = _mm512_set1_epi64(2);
         let r = _mm512_maskz_mov_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -700,7 +700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mov_epi64() {
+    const fn test_mm256_mask_mov_epi64() {
         let src = _mm256_set1_epi64x(1);
         let a = _mm256_set1_epi64x(2);
         let r = _mm256_mask_mov_epi64(src, 0, a);
@@ -710,7 +710,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mov_epi64() {
+    const fn test_mm256_maskz_mov_epi64() {
         let a = _mm256_set1_epi64x(2);
         let r = _mm256_maskz_mov_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -719,7 +719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mov_epi64() {
+    const fn test_mm_mask_mov_epi64() {
         let src = _mm_set1_epi64x(1);
         let a = _mm_set1_epi64x(2);
         let r = _mm_mask_mov_epi64(src, 0, a);
@@ -729,7 +729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mov_epi64() {
+    const fn test_mm_maskz_mov_epi64() {
         let a = _mm_set1_epi64x(2);
         let r = _mm_maskz_mov_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -738,7 +738,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mov_pd() {
+    const fn test_mm512_mask_mov_pd() {
         let src = _mm512_set1_pd(1.);
         let a = _mm512_set1_pd(2.);
         let r = _mm512_mask_mov_pd(src, 0, a);
@@ -748,7 +748,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mov_pd() {
+    const fn test_mm512_maskz_mov_pd() {
         let a = _mm512_set1_pd(2.);
         let r = _mm512_maskz_mov_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -757,7 +757,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mov_pd() {
+    const fn test_mm256_mask_mov_pd() {
         let src = _mm256_set1_pd(1.);
         let a = _mm256_set1_pd(2.);
         let r = _mm256_mask_mov_pd(src, 0, a);
@@ -767,7 +767,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mov_pd() {
+    const fn test_mm256_maskz_mov_pd() {
         let a = _mm256_set1_pd(2.);
         let r = _mm256_maskz_mov_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -776,7 +776,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mov_pd() {
+    const fn test_mm_mask_mov_pd() {
         let src = _mm_set1_pd(1.);
         let a = _mm_set1_pd(2.);
         let r = _mm_mask_mov_pd(src, 0, a);
@@ -786,7 +786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mov_pd() {
+    const fn test_mm_maskz_mov_pd() {
         let a = _mm_set1_pd(2.);
         let r = _mm_maskz_mov_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -795,7 +795,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_add_epi64() {
+    const fn test_mm512_add_epi64() {
         let a = _mm512_setr_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let b = _mm512_set1_epi64(1);
         let r = _mm512_add_epi64(a, b);
@@ -804,7 +804,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_add_epi64() {
+    const fn test_mm512_mask_add_epi64() {
         let a = _mm512_setr_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let b = _mm512_set1_epi64(1);
         let r = _mm512_mask_add_epi64(a, 0, a, b);
@@ -815,7 +815,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_add_epi64() {
+    const fn test_mm512_maskz_add_epi64() {
         let a = _mm512_setr_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let b = _mm512_set1_epi64(1);
         let r = _mm512_maskz_add_epi64(0, a, b);
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_add_epi64() {
+    const fn test_mm256_mask_add_epi64() {
         let a = _mm256_set_epi64x(1, -1, i64::MAX, i64::MIN);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_mask_add_epi64(a, 0, a, b);
@@ -837,7 +837,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_epi64() {
+    const fn test_mm256_maskz_add_epi64() {
         let a = _mm256_set_epi64x(1, -1, i64::MAX, i64::MIN);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_maskz_add_epi64(0, a, b);
@@ -848,7 +848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_add_epi64() {
+    const fn test_mm_mask_add_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let b = _mm_set1_epi64x(1);
         let r = _mm_mask_add_epi64(a, 0, a, b);
@@ -859,7 +859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_add_epi64() {
+    const fn test_mm_maskz_add_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let b = _mm_set1_epi64x(1);
         let r = _mm_maskz_add_epi64(0, a, b);
@@ -870,7 +870,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_add_pd() {
+    const fn test_mm512_add_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_add_pd(a, b);
@@ -879,7 +879,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_add_pd() {
+    const fn test_mm512_mask_add_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_mask_add_pd(a, 0, a, b);
@@ -890,7 +890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_add_pd() {
+    const fn test_mm512_maskz_add_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_maskz_add_pd(0, a, b);
@@ -901,7 +901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_add_pd() {
+    const fn test_mm256_mask_add_pd() {
         let a = _mm256_set_pd(1., -1., f64::MAX, f64::MIN);
         let b = _mm256_set1_pd(1.);
         let r = _mm256_mask_add_pd(a, 0, a, b);
@@ -912,7 +912,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_add_pd() {
+    const fn test_mm256_maskz_add_pd() {
         let a = _mm256_set_pd(1., -1., f64::MAX, f64::MIN);
         let b = _mm256_set1_pd(1.);
         let r = _mm256_maskz_add_pd(0, a, b);
@@ -923,7 +923,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_add_pd() {
+    const fn test_mm_mask_add_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set1_pd(1.);
         let r = _mm_mask_add_pd(a, 0, a, b);
@@ -934,7 +934,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_add_pd() {
+    const fn test_mm_maskz_add_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set1_pd(1.);
         let r = _mm_maskz_add_pd(0, a, b);
@@ -945,7 +945,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_sub_epi64() {
+    const fn test_mm512_sub_epi64() {
         let a = _mm512_setr_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let b = _mm512_set1_epi64(1);
         let r = _mm512_sub_epi64(a, b);
@@ -954,7 +954,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_sub_epi64() {
+    const fn test_mm512_mask_sub_epi64() {
         let a = _mm512_setr_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let b = _mm512_set1_epi64(1);
         let r = _mm512_mask_sub_epi64(a, 0, a, b);
@@ -965,7 +965,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_sub_epi64() {
+    const fn test_mm512_maskz_sub_epi64() {
         let a = _mm512_setr_epi64(0, 1, -1, i64::MAX, i64::MIN, 100, -100, -32);
         let b = _mm512_set1_epi64(1);
         let r = _mm512_maskz_sub_epi64(0, a, b);
@@ -976,7 +976,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_epi64() {
+    const fn test_mm256_mask_sub_epi64() {
         let a = _mm256_set_epi64x(1, -1, i64::MAX, i64::MIN);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_mask_sub_epi64(a, 0, a, b);
@@ -987,7 +987,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_epi64() {
+    const fn test_mm256_maskz_sub_epi64() {
         let a = _mm256_set_epi64x(1, -1, i64::MAX, i64::MIN);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_maskz_sub_epi64(0, a, b);
@@ -998,7 +998,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_sub_epi64() {
+    const fn test_mm_mask_sub_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let b = _mm_set1_epi64x(1);
         let r = _mm_mask_sub_epi64(a, 0, a, b);
@@ -1009,7 +1009,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_epi64() {
+    const fn test_mm_maskz_sub_epi64() {
         let a = _mm_set_epi64x(i64::MAX, i64::MIN);
         let b = _mm_set1_epi64x(1);
         let r = _mm_maskz_sub_epi64(0, a, b);
@@ -1020,7 +1020,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_sub_pd() {
+    const fn test_mm512_sub_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_sub_pd(a, b);
@@ -1029,7 +1029,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_sub_pd() {
+    const fn test_mm512_mask_sub_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_mask_sub_pd(a, 0, a, b);
@@ -1040,7 +1040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_sub_pd() {
+    const fn test_mm512_maskz_sub_pd() {
         let a = _mm512_setr_pd(0., 1., -1., f64::MAX, f64::MIN, 100., -100., -32.);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_maskz_sub_pd(0, a, b);
@@ -1051,7 +1051,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_sub_pd() {
+    const fn test_mm256_mask_sub_pd() {
         let a = _mm256_set_pd(1., -1., f64::MAX, f64::MIN);
         let b = _mm256_set1_pd(1.);
         let r = _mm256_mask_sub_pd(a, 0, a, b);
@@ -1062,7 +1062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_sub_pd() {
+    const fn test_mm256_maskz_sub_pd() {
         let a = _mm256_set_pd(1., -1., f64::MAX, f64::MIN);
         let b = _mm256_set1_pd(1.);
         let r = _mm256_maskz_sub_pd(0, a, b);
@@ -1073,7 +1073,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_sub_pd() {
+    const fn test_mm_mask_sub_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set1_pd(1.);
         let r = _mm_mask_sub_pd(a, 0, a, b);
@@ -1084,7 +1084,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_sub_pd() {
+    const fn test_mm_maskz_sub_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set1_pd(1.);
         let r = _mm_maskz_sub_pd(0, a, b);
@@ -1095,7 +1095,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mul_epi32() {
+    const fn test_mm512_mul_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mul_epi32(a, b);
@@ -1104,7 +1104,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mul_epi32() {
+    const fn test_mm512_mask_mul_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_mul_epi32(a, 0, a, b);
@@ -1119,7 +1119,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mul_epi32() {
+    const fn test_mm512_maskz_mul_epi32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_mul_epi32(0, a, b);
@@ -1130,7 +1130,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mul_epi32() {
+    const fn test_mm256_mask_mul_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_mask_mul_epi32(a, 0, a, b);
@@ -1141,7 +1141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mul_epi32() {
+    const fn test_mm256_maskz_mul_epi32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_mul_epi32(0, a, b);
@@ -1152,7 +1152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mul_epi32() {
+    const fn test_mm_mask_mul_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_mask_mul_epi32(a, 0, a, b);
@@ -1163,7 +1163,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mul_epi32() {
+    const fn test_mm_maskz_mul_epi32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_maskz_mul_epi32(0, a, b);
@@ -1174,7 +1174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mul_epu32() {
+    const fn test_mm512_mul_epu32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mul_epu32(a, b);
@@ -1183,7 +1183,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mul_epu32() {
+    const fn test_mm512_mask_mul_epu32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_mask_mul_epu32(a, 0, a, b);
@@ -1198,7 +1198,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mul_epu32() {
+    const fn test_mm512_maskz_mul_epu32() {
         let a = _mm512_set1_epi32(1);
         let b = _mm512_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm512_maskz_mul_epu32(0, a, b);
@@ -1209,7 +1209,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mul_epu32() {
+    const fn test_mm256_mask_mul_epu32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_mask_mul_epu32(a, 0, a, b);
@@ -1220,7 +1220,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mul_epu32() {
+    const fn test_mm256_maskz_mul_epu32() {
         let a = _mm256_set1_epi32(1);
         let b = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_maskz_mul_epu32(0, a, b);
@@ -1231,7 +1231,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mul_epu32() {
+    const fn test_mm_mask_mul_epu32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_mask_mul_epu32(a, 0, a, b);
@@ -1242,7 +1242,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mul_epu32() {
+    const fn test_mm_maskz_mul_epu32() {
         let a = _mm_set1_epi32(1);
         let b = _mm_set_epi32(1, 2, 3, 4);
         let r = _mm_maskz_mul_epu32(0, a, b);
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mullox_epi64() {
+    const fn test_mm512_mullox_epi64() {
         let a = _mm512_setr_epi64(0, 1, i64::MAX, i64::MIN, i64::MAX, 100, -100, -32);
         let b = _mm512_set1_epi64(2);
         let r = _mm512_mullox_epi64(a, b);
@@ -1262,7 +1262,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mullox_epi64() {
+    const fn test_mm512_mask_mullox_epi64() {
         let a = _mm512_setr_epi64(0, 1, i64::MAX, i64::MIN, i64::MAX, 100, -100, -32);
         let b = _mm512_set1_epi64(2);
         let r = _mm512_mask_mullox_epi64(a, 0, a, b);
@@ -1273,7 +1273,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mul_pd() {
+    const fn test_mm512_mul_pd() {
         let a = _mm512_setr_pd(0., 1., f64::MAX, f64::MIN, f64::MAX, f64::MIN, -100., -32.);
         let b = _mm512_set1_pd(2.);
         let r = _mm512_mul_pd(a, b);
@@ -1286,7 +1286,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_mul_pd() {
+    const fn test_mm512_mask_mul_pd() {
         let a = _mm512_setr_pd(0., 1., f64::MAX, f64::MIN, f64::MAX, f64::MIN, -100., -32.);
         let b = _mm512_set1_pd(2.);
         let r = _mm512_mask_mul_pd(a, 0, a, b);
@@ -1301,7 +1301,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_mul_pd() {
+    const fn test_mm512_maskz_mul_pd() {
         let a = _mm512_setr_pd(0., 1., f64::MAX, f64::MIN, f64::MAX, f64::MIN, -100., -32.);
         let b = _mm512_set1_pd(2.);
         let r = _mm512_maskz_mul_pd(0, a, b);
@@ -1312,7 +1312,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_mul_pd() {
+    const fn test_mm256_mask_mul_pd() {
         let a = _mm256_set_pd(0., 1., f64::MAX, f64::MIN);
         let b = _mm256_set1_pd(2.);
         let r = _mm256_mask_mul_pd(a, 0, a, b);
@@ -1323,7 +1323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_mul_pd() {
+    const fn test_mm256_maskz_mul_pd() {
         let a = _mm256_set_pd(0., 1., f64::MAX, f64::MIN);
         let b = _mm256_set1_pd(2.);
         let r = _mm256_maskz_mul_pd(0, a, b);
@@ -1334,7 +1334,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_mul_pd() {
+    const fn test_mm_mask_mul_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set1_pd(2.);
         let r = _mm_mask_mul_pd(a, 0, a, b);
@@ -1345,7 +1345,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_mul_pd() {
+    const fn test_mm_maskz_mul_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set1_pd(2.);
         let r = _mm_maskz_mul_pd(0, a, b);
@@ -1356,7 +1356,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_div_pd() {
+    const fn test_mm512_div_pd() {
         let a = _mm512_setr_pd(0., 1., f64::MAX, f64::MIN, f64::MAX, f64::MIN, -100., -32.);
         let b = _mm512_setr_pd(2., 2., 0., 0., 0., 0., 2., 2.);
         let r = _mm512_div_pd(a, b);
@@ -1369,7 +1369,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_div_pd() {
+    const fn test_mm512_mask_div_pd() {
         let a = _mm512_setr_pd(0., 1., f64::MAX, f64::MIN, f64::MAX, f64::MIN, -100., -32.);
         let b = _mm512_setr_pd(2., 2., 0., 0., 0., 0., 2., 2.);
         let r = _mm512_mask_div_pd(a, 0, a, b);
@@ -1384,7 +1384,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_div_pd() {
+    const fn test_mm512_maskz_div_pd() {
         let a = _mm512_setr_pd(0., 1., f64::MAX, f64::MIN, f64::MAX, f64::MIN, -100., -32.);
         let b = _mm512_setr_pd(2., 2., 0., 0., 0., 0., 2., 2.);
         let r = _mm512_maskz_div_pd(0, a, b);
@@ -1395,7 +1395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_div_pd() {
+    const fn test_mm256_mask_div_pd() {
         let a = _mm256_set_pd(0., 1., f64::MAX, f64::MIN);
         let b = _mm256_set_pd(2., 2., 0., 0.);
         let r = _mm256_mask_div_pd(a, 0, a, b);
@@ -1406,7 +1406,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_div_pd() {
+    const fn test_mm256_maskz_div_pd() {
         let a = _mm256_set_pd(0., 1., f64::MAX, f64::MIN);
         let b = _mm256_set_pd(2., 2., 0., 0.);
         let r = _mm256_maskz_div_pd(0, a, b);
@@ -1417,7 +1417,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_div_pd() {
+    const fn test_mm_mask_div_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set_pd(0., 0.);
         let r = _mm_mask_div_pd(a, 0, a, b);
@@ -1428,7 +1428,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_div_pd() {
+    const fn test_mm_maskz_div_pd() {
         let a = _mm_set_pd(f64::MAX, f64::MIN);
         let b = _mm_set_pd(0., 0.);
         let r = _mm_maskz_div_pd(0, a, b);
@@ -1439,7 +1439,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_max_epi64() {
+    const fn test_mm512_max_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_max_epi64(a, b);
@@ -1448,7 +1448,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_max_epi64() {
+    const fn test_mm512_mask_max_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_max_epi64(a, 0, a, b);
@@ -1459,7 +1459,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_max_epi64() {
+    const fn test_mm512_maskz_max_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_max_epi64(0, a, b);
@@ -1470,7 +1470,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_max_epi64() {
+    const fn test_mm256_max_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_max_epi64(a, b);
@@ -1479,7 +1479,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epi64() {
+    const fn test_mm256_mask_max_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_mask_max_epi64(a, 0, a, b);
@@ -1490,7 +1490,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epi64() {
+    const fn test_mm256_maskz_max_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_maskz_max_epi64(0, a, b);
@@ -1501,7 +1501,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_max_epi64() {
+    const fn test_mm_max_epi64() {
         let a = _mm_set_epi64x(2, 3);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_max_epi64(a, b);
@@ -1510,7 +1510,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_max_epi64() {
+    const fn test_mm_mask_max_epi64() {
         let a = _mm_set_epi64x(2, 3);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_mask_max_epi64(a, 0, a, b);
@@ -1521,7 +1521,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epi64() {
+    const fn test_mm_maskz_max_epi64() {
         let a = _mm_set_epi64x(2, 3);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_maskz_max_epi64(0, a, b);
@@ -1532,7 +1532,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_max_pd() {
+    fn test_mm512_max_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_max_pd(a, b);
@@ -1541,7 +1541,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_max_pd() {
+    fn test_mm512_mask_max_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_mask_max_pd(a, 0, a, b);
@@ -1552,7 +1552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_max_pd() {
+    fn test_mm512_maskz_max_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_maskz_max_pd(0, a, b);
@@ -1563,7 +1563,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_max_pd() {
+    fn test_mm256_mask_max_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let b = _mm256_set_pd(3., 2., 1., 0.);
         let r = _mm256_mask_max_pd(a, 0, a, b);
@@ -1574,7 +1574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_max_pd() {
+    fn test_mm256_maskz_max_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let b = _mm256_set_pd(3., 2., 1., 0.);
         let r = _mm256_maskz_max_pd(0, a, b);
@@ -1585,7 +1585,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_max_pd() {
+    fn test_mm_mask_max_pd() {
         let a = _mm_set_pd(2., 3.);
         let b = _mm_set_pd(3., 2.);
         let r = _mm_mask_max_pd(a, 0, a, b);
@@ -1596,7 +1596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_max_pd() {
+    fn test_mm_maskz_max_pd() {
         let a = _mm_set_pd(2., 3.);
         let b = _mm_set_pd(3., 2.);
         let r = _mm_maskz_max_pd(0, a, b);
@@ -1607,7 +1607,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_max_epu64() {
+    const fn test_mm512_max_epu64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_max_epu64(a, b);
@@ -1616,7 +1616,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_max_epu64() {
+    const fn test_mm512_mask_max_epu64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_max_epu64(a, 0, a, b);
@@ -1627,7 +1627,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_max_epu64() {
+    const fn test_mm512_maskz_max_epu64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_max_epu64(0, a, b);
@@ -1638,7 +1638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_max_epu64() {
+    const fn test_mm256_max_epu64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_max_epu64(a, b);
@@ -1647,7 +1647,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_max_epu64() {
+    const fn test_mm256_mask_max_epu64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_mask_max_epu64(a, 0, a, b);
@@ -1658,7 +1658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_max_epu64() {
+    const fn test_mm256_maskz_max_epu64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_maskz_max_epu64(0, a, b);
@@ -1669,7 +1669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_max_epu64() {
+    const fn test_mm_max_epu64() {
         let a = _mm_set_epi64x(2, 3);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_max_epu64(a, b);
@@ -1678,7 +1678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_max_epu64() {
+    const fn test_mm_mask_max_epu64() {
         let a = _mm_set_epi64x(2, 3);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_mask_max_epu64(a, 0, a, b);
@@ -1689,7 +1689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_max_epu64() {
+    const fn test_mm_maskz_max_epu64() {
         let a = _mm_set_epi64x(2, 3);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_maskz_max_epu64(0, a, b);
@@ -1700,7 +1700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_min_epi64() {
+    const fn test_mm512_min_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_min_epi64(a, b);
@@ -1709,7 +1709,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_min_epi64() {
+    const fn test_mm512_mask_min_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_min_epi64(a, 0, a, b);
@@ -1720,7 +1720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_min_epi64() {
+    const fn test_mm512_maskz_min_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_min_epi64(0, a, b);
@@ -1731,7 +1731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_min_epi64() {
+    const fn test_mm256_min_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_min_epi64(a, b);
@@ -1740,7 +1740,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epi64() {
+    const fn test_mm256_mask_min_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_mask_min_epi64(a, 0, a, b);
@@ -1751,7 +1751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epi64() {
+    const fn test_mm256_maskz_min_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_maskz_min_epi64(0, a, b);
@@ -1762,7 +1762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_min_epi64() {
+    const fn test_mm_min_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_min_epi64(a, b);
@@ -1776,7 +1776,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_min_epi64() {
+    const fn test_mm_mask_min_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_mask_min_epi64(a, 0, a, b);
@@ -1787,7 +1787,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epi64() {
+    const fn test_mm_maskz_min_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(3, 2);
         let r = _mm_maskz_min_epi64(0, a, b);
@@ -1798,7 +1798,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_min_pd() {
+    fn test_mm512_min_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_min_pd(a, b);
@@ -1807,7 +1807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_min_pd() {
+    fn test_mm512_mask_min_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_mask_min_pd(a, 0, a, b);
@@ -1818,7 +1818,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_min_pd() {
+    fn test_mm512_maskz_min_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_maskz_min_pd(0, a, b);
@@ -1829,7 +1829,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_min_pd() {
+    fn test_mm256_mask_min_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let b = _mm256_set_pd(3., 2., 1., 0.);
         let r = _mm256_mask_min_pd(a, 0, a, b);
@@ -1840,7 +1840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_min_pd() {
+    fn test_mm256_maskz_min_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let b = _mm256_set_pd(3., 2., 1., 0.);
         let r = _mm256_maskz_min_pd(0, a, b);
@@ -1851,7 +1851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_min_pd() {
+    fn test_mm_mask_min_pd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(1., 0.);
         let r = _mm_mask_min_pd(a, 0, a, b);
@@ -1862,7 +1862,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_min_pd() {
+    fn test_mm_maskz_min_pd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set_pd(1., 0.);
         let r = _mm_maskz_min_pd(0, a, b);
@@ -1873,7 +1873,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_min_epu64() {
+    const fn test_mm512_min_epu64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_min_epu64(a, b);
@@ -1882,7 +1882,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_min_epu64() {
+    const fn test_mm512_mask_min_epu64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_mask_min_epu64(a, 0, a, b);
@@ -1893,7 +1893,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_min_epu64() {
+    const fn test_mm512_maskz_min_epu64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm512_maskz_min_epu64(0, a, b);
@@ -1904,7 +1904,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_min_epu64() {
+    const fn test_mm256_min_epu64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_min_epu64(a, b);
@@ -1913,7 +1913,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_min_epu64() {
+    const fn test_mm256_mask_min_epu64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_mask_min_epu64(a, 0, a, b);
@@ -1924,7 +1924,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_min_epu64() {
+    const fn test_mm256_maskz_min_epu64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_maskz_min_epu64(0, a, b);
@@ -1935,7 +1935,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_min_epu64() {
+    const fn test_mm_min_epu64() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(1, 0);
         let r = _mm_min_epu64(a, b);
@@ -1944,7 +1944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_min_epu64() {
+    const fn test_mm_mask_min_epu64() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(1, 0);
         let r = _mm_mask_min_epu64(a, 0, a, b);
@@ -1955,7 +1955,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_min_epu64() {
+    const fn test_mm_maskz_min_epu64() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(1, 0);
         let r = _mm_maskz_min_epu64(0, a, b);
@@ -1966,7 +1966,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sqrt_pd() {
+    fn test_mm512_sqrt_pd() {
         let a = _mm512_setr_pd(0., 1., 4., 9., 16., 25., 36., 49.);
         let r = _mm512_sqrt_pd(a);
         let e = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
@@ -1974,7 +1974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sqrt_pd() {
+    fn test_mm512_mask_sqrt_pd() {
         let a = _mm512_setr_pd(0., 1., 4., 9., 16., 25., 36., 49.);
         let r = _mm512_mask_sqrt_pd(a, 0, a);
         assert_eq_m512d(r, a);
@@ -1984,7 +1984,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sqrt_pd() {
+    fn test_mm512_maskz_sqrt_pd() {
         let a = _mm512_setr_pd(0., 1., 4., 9., 16., 25., 36., 49.);
         let r = _mm512_maskz_sqrt_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -1994,7 +1994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_sqrt_pd() {
+    fn test_mm256_mask_sqrt_pd() {
         let a = _mm256_set_pd(0., 1., 4., 9.);
         let r = _mm256_mask_sqrt_pd(a, 0, a);
         assert_eq_m256d(r, a);
@@ -2004,7 +2004,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_sqrt_pd() {
+    fn test_mm256_maskz_sqrt_pd() {
         let a = _mm256_set_pd(0., 1., 4., 9.);
         let r = _mm256_maskz_sqrt_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -2014,7 +2014,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_sqrt_pd() {
+    fn test_mm_mask_sqrt_pd() {
         let a = _mm_set_pd(0., 1.);
         let r = _mm_mask_sqrt_pd(a, 0, a);
         assert_eq_m128d(r, a);
@@ -2024,7 +2024,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_sqrt_pd() {
+    fn test_mm_maskz_sqrt_pd() {
         let a = _mm_set_pd(0., 1.);
         let r = _mm_maskz_sqrt_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -2034,7 +2034,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmadd_pd() {
+    const fn test_mm512_fmadd_pd() {
         let a = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
@@ -2044,7 +2044,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmadd_pd() {
+    const fn test_mm512_mask_fmadd_pd() {
         let a = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
@@ -2056,7 +2056,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmadd_pd() {
+    const fn test_mm512_maskz_fmadd_pd() {
         let a = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
@@ -2068,7 +2068,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmadd_pd() {
+    const fn test_mm512_mask3_fmadd_pd() {
         let a = _mm512_setr_pd(1., 1., 1., 1., 1., 1., 1., 1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 2., 2., 2., 2.);
@@ -2080,7 +2080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmadd_pd() {
+    const fn test_mm256_mask_fmadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2092,7 +2092,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmadd_pd() {
+    const fn test_mm256_maskz_fmadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2104,7 +2104,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmadd_pd() {
+    const fn test_mm256_mask3_fmadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2116,7 +2116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmadd_pd() {
+    const fn test_mm_mask_fmadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2128,7 +2128,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmadd_pd() {
+    const fn test_mm_maskz_fmadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2140,7 +2140,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmadd_pd() {
+    const fn test_mm_mask3_fmadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2152,7 +2152,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmsub_pd() {
+    const fn test_mm512_fmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2162,7 +2162,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmsub_pd() {
+    const fn test_mm512_mask_fmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2174,7 +2174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmsub_pd() {
+    const fn test_mm512_maskz_fmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2186,7 +2186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmsub_pd() {
+    const fn test_mm512_mask3_fmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 2., 2., 2., 2.);
@@ -2198,7 +2198,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmsub_pd() {
+    const fn test_mm256_mask_fmsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2210,7 +2210,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmsub_pd() {
+    const fn test_mm256_maskz_fmsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2222,7 +2222,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmsub_pd() {
+    const fn test_mm256_mask3_fmsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2234,7 +2234,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmsub_pd() {
+    const fn test_mm_mask_fmsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2246,7 +2246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsub_pd() {
+    const fn test_mm_maskz_fmsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2258,7 +2258,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsub_pd() {
+    const fn test_mm_mask3_fmsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2270,7 +2270,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmaddsub_pd() {
+    const fn test_mm512_fmaddsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2280,7 +2280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmaddsub_pd() {
+    const fn test_mm512_mask_fmaddsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2292,7 +2292,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmaddsub_pd() {
+    const fn test_mm512_maskz_fmaddsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2304,7 +2304,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmaddsub_pd() {
+    const fn test_mm512_mask3_fmaddsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 2., 2., 2., 2.);
@@ -2316,7 +2316,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmaddsub_pd() {
+    const fn test_mm256_mask_fmaddsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2328,7 +2328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmaddsub_pd() {
+    const fn test_mm256_maskz_fmaddsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2340,7 +2340,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmaddsub_pd() {
+    const fn test_mm256_mask3_fmaddsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2352,7 +2352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmaddsub_pd() {
+    const fn test_mm_mask_fmaddsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2364,7 +2364,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmaddsub_pd() {
+    const fn test_mm_maskz_fmaddsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2376,7 +2376,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmaddsub_pd() {
+    const fn test_mm_mask3_fmaddsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2388,7 +2388,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fmsubadd_pd() {
+    const fn test_mm512_fmsubadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2398,7 +2398,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fmsubadd_pd() {
+    const fn test_mm512_mask_fmsubadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2410,7 +2410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fmsubadd_pd() {
+    const fn test_mm512_maskz_fmsubadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2422,7 +2422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fmsubadd_pd() {
+    const fn test_mm512_mask3_fmsubadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 2., 2., 2., 2.);
@@ -2434,7 +2434,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fmsubadd_pd() {
+    const fn test_mm256_mask_fmsubadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2446,7 +2446,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fmsubadd_pd() {
+    const fn test_mm256_maskz_fmsubadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2458,7 +2458,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fmsubadd_pd() {
+    const fn test_mm256_mask3_fmsubadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2470,7 +2470,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fmsubadd_pd() {
+    const fn test_mm_mask_fmsubadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2482,7 +2482,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fmsubadd_pd() {
+    const fn test_mm_maskz_fmsubadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2494,7 +2494,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fmsubadd_pd() {
+    const fn test_mm_mask3_fmsubadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2506,7 +2506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fnmadd_pd() {
+    const fn test_mm512_fnmadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2516,7 +2516,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fnmadd_pd() {
+    const fn test_mm512_mask_fnmadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2528,7 +2528,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fnmadd_pd() {
+    const fn test_mm512_maskz_fnmadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2540,7 +2540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fnmadd_pd() {
+    const fn test_mm512_mask3_fnmadd_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 2., 2., 2., 2.);
@@ -2552,7 +2552,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fnmadd_pd() {
+    const fn test_mm256_mask_fnmadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2564,7 +2564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fnmadd_pd() {
+    const fn test_mm256_maskz_fnmadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2576,7 +2576,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fnmadd_pd() {
+    const fn test_mm256_mask3_fnmadd_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2588,7 +2588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fnmadd_pd() {
+    const fn test_mm_mask_fnmadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2600,7 +2600,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmadd_pd() {
+    const fn test_mm_maskz_fnmadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2612,7 +2612,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmadd_pd() {
+    const fn test_mm_mask3_fnmadd_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2624,7 +2624,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_fnmsub_pd() {
+    const fn test_mm512_fnmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2634,7 +2634,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_fnmsub_pd() {
+    const fn test_mm512_mask_fnmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2646,7 +2646,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_fnmsub_pd() {
+    const fn test_mm512_maskz_fnmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_set1_pd(1.);
@@ -2658,7 +2658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask3_fnmsub_pd() {
+    const fn test_mm512_mask3_fnmsub_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let c = _mm512_setr_pd(1., 1., 1., 1., 2., 2., 2., 2.);
@@ -2670,7 +2670,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_fnmsub_pd() {
+    const fn test_mm256_mask_fnmsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2682,7 +2682,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_fnmsub_pd() {
+    const fn test_mm256_maskz_fnmsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2694,7 +2694,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask3_fnmsub_pd() {
+    const fn test_mm256_mask3_fnmsub_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set_pd(0., 1., 2., 3.);
         let c = _mm256_set1_pd(1.);
@@ -2706,7 +2706,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_fnmsub_pd() {
+    const fn test_mm_mask_fnmsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2718,7 +2718,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_fnmsub_pd() {
+    const fn test_mm_maskz_fnmsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2730,7 +2730,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask3_fnmsub_pd() {
+    const fn test_mm_mask3_fnmsub_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set_pd(0., 1.);
         let c = _mm_set1_pd(1.);
@@ -2742,7 +2742,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_rcp14_pd() {
+    fn test_mm512_rcp14_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_rcp14_pd(a);
         let e = _mm512_set1_pd(0.3333320617675781);
@@ -2750,7 +2750,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_rcp14_pd() {
+    fn test_mm512_mask_rcp14_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_mask_rcp14_pd(a, 0, a);
         assert_eq_m512d(r, a);
@@ -2764,7 +2764,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_rcp14_pd() {
+    fn test_mm512_maskz_rcp14_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_maskz_rcp14_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -2778,7 +2778,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_rcp14_pd() {
+    fn test_mm256_rcp14_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_rcp14_pd(a);
         let e = _mm256_set1_pd(0.3333320617675781);
@@ -2786,7 +2786,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_rcp14_pd() {
+    fn test_mm256_mask_rcp14_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_mask_rcp14_pd(a, 0, a);
         assert_eq_m256d(r, a);
@@ -2796,7 +2796,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_rcp14_pd() {
+    fn test_mm256_maskz_rcp14_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_maskz_rcp14_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -2806,7 +2806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_rcp14_pd() {
+    fn test_mm_rcp14_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_rcp14_pd(a);
         let e = _mm_set1_pd(0.3333320617675781);
@@ -2814,7 +2814,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_rcp14_pd() {
+    fn test_mm_mask_rcp14_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_mask_rcp14_pd(a, 0, a);
         assert_eq_m128d(r, a);
@@ -2824,7 +2824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_rcp14_pd() {
+    fn test_mm_maskz_rcp14_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_maskz_rcp14_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -2834,7 +2834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_rsqrt14_pd() {
+    fn test_mm512_rsqrt14_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_rsqrt14_pd(a);
         let e = _mm512_set1_pd(0.5773391723632813);
@@ -2842,7 +2842,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_rsqrt14_pd() {
+    fn test_mm512_mask_rsqrt14_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_mask_rsqrt14_pd(a, 0, a);
         assert_eq_m512d(r, a);
@@ -2856,7 +2856,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_rsqrt14_pd() {
+    fn test_mm512_maskz_rsqrt14_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_maskz_rsqrt14_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -2870,7 +2870,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_rsqrt14_pd() {
+    fn test_mm256_rsqrt14_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_rsqrt14_pd(a);
         let e = _mm256_set1_pd(0.5773391723632813);
@@ -2878,7 +2878,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_rsqrt14_pd() {
+    fn test_mm256_mask_rsqrt14_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_mask_rsqrt14_pd(a, 0, a);
         assert_eq_m256d(r, a);
@@ -2888,7 +2888,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_rsqrt14_pd() {
+    fn test_mm256_maskz_rsqrt14_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_maskz_rsqrt14_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -2898,7 +2898,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_rsqrt14_pd() {
+    fn test_mm_rsqrt14_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_rsqrt14_pd(a);
         let e = _mm_set1_pd(0.5773391723632813);
@@ -2906,7 +2906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_rsqrt14_pd() {
+    fn test_mm_mask_rsqrt14_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_mask_rsqrt14_pd(a, 0, a);
         assert_eq_m128d(r, a);
@@ -2916,7 +2916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_rsqrt14_pd() {
+    fn test_mm_maskz_rsqrt14_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_maskz_rsqrt14_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -2926,7 +2926,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getexp_pd() {
+    fn test_mm512_getexp_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_getexp_pd(a);
         let e = _mm512_set1_pd(1.);
@@ -2934,7 +2934,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getexp_pd() {
+    fn test_mm512_mask_getexp_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_mask_getexp_pd(a, 0, a);
         assert_eq_m512d(r, a);
@@ -2944,7 +2944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getexp_pd() {
+    fn test_mm512_maskz_getexp_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_maskz_getexp_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -2954,7 +2954,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_getexp_pd() {
+    fn test_mm256_getexp_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_getexp_pd(a);
         let e = _mm256_set1_pd(1.);
@@ -2962,7 +2962,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_getexp_pd() {
+    fn test_mm256_mask_getexp_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_mask_getexp_pd(a, 0, a);
         assert_eq_m256d(r, a);
@@ -2972,7 +2972,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_getexp_pd() {
+    fn test_mm256_maskz_getexp_pd() {
         let a = _mm256_set1_pd(3.);
         let r = _mm256_maskz_getexp_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -2982,7 +2982,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_getexp_pd() {
+    fn test_mm_getexp_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_getexp_pd(a);
         let e = _mm_set1_pd(1.);
@@ -2990,7 +2990,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_getexp_pd() {
+    fn test_mm_mask_getexp_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_mask_getexp_pd(a, 0, a);
         assert_eq_m128d(r, a);
@@ -3000,7 +3000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_getexp_pd() {
+    fn test_mm_maskz_getexp_pd() {
         let a = _mm_set1_pd(3.);
         let r = _mm_maskz_getexp_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -3010,7 +3010,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_roundscale_pd() {
+    fn test_mm512_roundscale_pd() {
         let a = _mm512_set1_pd(1.1);
         let r = _mm512_roundscale_pd::<0b00_00_00_00>(a);
         let e = _mm512_set1_pd(1.0);
@@ -3018,7 +3018,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_roundscale_pd() {
+    fn test_mm512_mask_roundscale_pd() {
         let a = _mm512_set1_pd(1.1);
         let r = _mm512_mask_roundscale_pd::<0b00_00_00_00>(a, 0, a);
         let e = _mm512_set1_pd(1.1);
@@ -3029,7 +3029,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_roundscale_pd() {
+    fn test_mm512_maskz_roundscale_pd() {
         let a = _mm512_set1_pd(1.1);
         let r = _mm512_maskz_roundscale_pd::<0b00_00_00_00>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -3039,7 +3039,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_roundscale_pd() {
+    fn test_mm256_roundscale_pd() {
         let a = _mm256_set1_pd(1.1);
         let r = _mm256_roundscale_pd::<0b00_00_00_00>(a);
         let e = _mm256_set1_pd(1.0);
@@ -3047,7 +3047,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_roundscale_pd() {
+    fn test_mm256_mask_roundscale_pd() {
         let a = _mm256_set1_pd(1.1);
         let r = _mm256_mask_roundscale_pd::<0b00_00_00_00>(a, 0, a);
         assert_eq_m256d(r, a);
@@ -3057,7 +3057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_roundscale_pd() {
+    fn test_mm256_maskz_roundscale_pd() {
         let a = _mm256_set1_pd(1.1);
         let r = _mm256_maskz_roundscale_pd::<0b00_00_00_00>(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -3067,7 +3067,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_roundscale_pd() {
+    fn test_mm_roundscale_pd() {
         let a = _mm_set1_pd(1.1);
         let r = _mm_roundscale_pd::<0b00_00_00_00>(a);
         let e = _mm_set1_pd(1.0);
@@ -3075,7 +3075,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_roundscale_pd() {
+    fn test_mm_mask_roundscale_pd() {
         let a = _mm_set1_pd(1.1);
         let r = _mm_mask_roundscale_pd::<0b00_00_00_00>(a, 0, a);
         let e = _mm_set1_pd(1.1);
@@ -3086,7 +3086,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_roundscale_pd() {
+    fn test_mm_maskz_roundscale_pd() {
         let a = _mm_set1_pd(1.1);
         let r = _mm_maskz_roundscale_pd::<0b00_00_00_00>(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -3096,7 +3096,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_scalef_pd() {
+    fn test_mm512_scalef_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_scalef_pd(a, b);
@@ -3105,7 +3105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_scalef_pd() {
+    fn test_mm512_mask_scalef_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_mask_scalef_pd(a, 0, a, b);
@@ -3116,7 +3116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_scalef_pd() {
+    fn test_mm512_maskz_scalef_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_maskz_scalef_pd(0, a, b);
@@ -3127,7 +3127,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_scalef_pd() {
+    fn test_mm256_scalef_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set1_pd(3.);
         let r = _mm256_scalef_pd(a, b);
@@ -3136,7 +3136,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_scalef_pd() {
+    fn test_mm256_mask_scalef_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set1_pd(3.);
         let r = _mm256_mask_scalef_pd(a, 0, a, b);
@@ -3147,7 +3147,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_scalef_pd() {
+    fn test_mm256_maskz_scalef_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set1_pd(3.);
         let r = _mm256_maskz_scalef_pd(0, a, b);
@@ -3158,7 +3158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_scalef_pd() {
+    fn test_mm_scalef_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_scalef_pd(a, b);
@@ -3167,7 +3167,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_scalef_pd() {
+    fn test_mm_mask_scalef_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_mask_scalef_pd(a, 0, a, b);
@@ -3178,7 +3178,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_scalef_pd() {
+    fn test_mm_maskz_scalef_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(3.);
         let r = _mm_maskz_scalef_pd(0, a, b);
@@ -3189,7 +3189,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fixupimm_pd() {
+    fn test_mm512_fixupimm_pd() {
         let a = _mm512_set1_pd(f64::NAN);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
@@ -3199,7 +3199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fixupimm_pd() {
+    fn test_mm512_mask_fixupimm_pd() {
         let a = _mm512_set_pd(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 1., 1., 1., 1.);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
@@ -3209,7 +3209,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fixupimm_pd() {
+    fn test_mm512_maskz_fixupimm_pd() {
         let a = _mm512_set_pd(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 1., 1., 1., 1.);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
@@ -3219,7 +3219,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_fixupimm_pd() {
+    fn test_mm256_fixupimm_pd() {
         let a = _mm256_set1_pd(f64::NAN);
         let b = _mm256_set1_pd(f64::MAX);
         let c = _mm256_set1_epi64x(i32::MAX as i64);
@@ -3229,7 +3229,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_fixupimm_pd() {
+    fn test_mm256_mask_fixupimm_pd() {
         let a = _mm256_set1_pd(f64::NAN);
         let b = _mm256_set1_pd(f64::MAX);
         let c = _mm256_set1_epi64x(i32::MAX as i64);
@@ -3239,7 +3239,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_fixupimm_pd() {
+    fn test_mm256_maskz_fixupimm_pd() {
         let a = _mm256_set1_pd(f64::NAN);
         let b = _mm256_set1_pd(f64::MAX);
         let c = _mm256_set1_epi64x(i32::MAX as i64);
@@ -3249,7 +3249,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_fixupimm_pd() {
+    fn test_mm_fixupimm_pd() {
         let a = _mm_set1_pd(f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -3259,7 +3259,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_fixupimm_pd() {
+    fn test_mm_mask_fixupimm_pd() {
         let a = _mm_set1_pd(f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -3269,7 +3269,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_fixupimm_pd() {
+    fn test_mm_maskz_fixupimm_pd() {
         let a = _mm_set1_pd(f64::NAN);
         let b = _mm_set1_pd(f64::MAX);
         let c = _mm_set1_epi64x(i32::MAX as i64);
@@ -3279,7 +3279,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_ternarylogic_epi64() {
+    fn test_mm512_ternarylogic_epi64() {
         let a = _mm512_set1_epi64(1 << 2);
         let b = _mm512_set1_epi64(1 << 1);
         let c = _mm512_set1_epi64(1 << 0);
@@ -3289,7 +3289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_ternarylogic_epi64() {
+    fn test_mm512_mask_ternarylogic_epi64() {
         let src = _mm512_set1_epi64(1 << 2);
         let a = _mm512_set1_epi64(1 << 1);
         let b = _mm512_set1_epi64(1 << 0);
@@ -3301,7 +3301,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_ternarylogic_epi64() {
+    fn test_mm512_maskz_ternarylogic_epi64() {
         let a = _mm512_set1_epi64(1 << 2);
         let b = _mm512_set1_epi64(1 << 1);
         let c = _mm512_set1_epi64(1 << 0);
@@ -3313,7 +3313,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_ternarylogic_epi64() {
+    fn test_mm256_ternarylogic_epi64() {
         let a = _mm256_set1_epi64x(1 << 2);
         let b = _mm256_set1_epi64x(1 << 1);
         let c = _mm256_set1_epi64x(1 << 0);
@@ -3323,7 +3323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_ternarylogic_epi64() {
+    fn test_mm256_mask_ternarylogic_epi64() {
         let src = _mm256_set1_epi64x(1 << 2);
         let a = _mm256_set1_epi64x(1 << 1);
         let b = _mm256_set1_epi64x(1 << 0);
@@ -3335,7 +3335,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_ternarylogic_epi64() {
+    fn test_mm256_maskz_ternarylogic_epi64() {
         let a = _mm256_set1_epi64x(1 << 2);
         let b = _mm256_set1_epi64x(1 << 1);
         let c = _mm256_set1_epi64x(1 << 0);
@@ -3347,7 +3347,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_ternarylogic_epi64() {
+    fn test_mm_ternarylogic_epi64() {
         let a = _mm_set1_epi64x(1 << 2);
         let b = _mm_set1_epi64x(1 << 1);
         let c = _mm_set1_epi64x(1 << 0);
@@ -3357,7 +3357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_ternarylogic_epi64() {
+    fn test_mm_mask_ternarylogic_epi64() {
         let src = _mm_set1_epi64x(1 << 2);
         let a = _mm_set1_epi64x(1 << 1);
         let b = _mm_set1_epi64x(1 << 0);
@@ -3369,7 +3369,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_ternarylogic_epi64() {
+    fn test_mm_maskz_ternarylogic_epi64() {
         let a = _mm_set1_epi64x(1 << 2);
         let b = _mm_set1_epi64x(1 << 1);
         let c = _mm_set1_epi64x(1 << 0);
@@ -3381,7 +3381,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getmant_pd() {
+    fn test_mm512_getmant_pd() {
         let a = _mm512_set1_pd(10.);
         let r = _mm512_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a);
         let e = _mm512_set1_pd(1.25);
@@ -3389,7 +3389,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getmant_pd() {
+    fn test_mm512_mask_getmant_pd() {
         let a = _mm512_set1_pd(10.);
         let r = _mm512_mask_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a);
         assert_eq_m512d(r, a);
@@ -3399,7 +3399,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getmant_pd() {
+    fn test_mm512_maskz_getmant_pd() {
         let a = _mm512_set1_pd(10.);
         let r = _mm512_maskz_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -3409,7 +3409,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_getmant_pd() {
+    fn test_mm256_getmant_pd() {
         let a = _mm256_set1_pd(10.);
         let r = _mm256_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a);
         let e = _mm256_set1_pd(1.25);
@@ -3417,7 +3417,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_getmant_pd() {
+    fn test_mm256_mask_getmant_pd() {
         let a = _mm256_set1_pd(10.);
         let r = _mm256_mask_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a);
         assert_eq_m256d(r, a);
@@ -3427,7 +3427,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_getmant_pd() {
+    fn test_mm256_maskz_getmant_pd() {
         let a = _mm256_set1_pd(10.);
         let r = _mm256_maskz_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -3437,7 +3437,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_getmant_pd() {
+    fn test_mm_getmant_pd() {
         let a = _mm_set1_pd(10.);
         let r = _mm_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a);
         let e = _mm_set1_pd(1.25);
@@ -3445,7 +3445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_getmant_pd() {
+    fn test_mm_mask_getmant_pd() {
         let a = _mm_set1_pd(10.);
         let r = _mm_mask_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(a, 0, a);
         assert_eq_m128d(r, a);
@@ -3455,7 +3455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_getmant_pd() {
+    fn test_mm_maskz_getmant_pd() {
         let a = _mm_set1_pd(10.);
         let r = _mm_maskz_getmant_pd::<_MM_MANT_NORM_1_2, _MM_MANT_SIGN_SRC>(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -3465,7 +3465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtps_pd() {
+    fn test_mm512_cvtps_pd() {
         let a = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvtps_pd(a);
         let e = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
@@ -3473,7 +3473,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtps_pd() {
+    fn test_mm512_mask_cvtps_pd() {
         let a = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm512_set1_pd(0.);
         let r = _mm512_mask_cvtps_pd(src, 0, a);
@@ -3484,7 +3484,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtps_pd() {
+    fn test_mm512_maskz_cvtps_pd() {
         let a = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvtps_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -3494,7 +3494,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtpslo_pd() {
+    fn test_mm512_cvtpslo_pd() {
         let v2 = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 100., 100., 100., 100., 100., 100., 100., 100.,
         );
@@ -3504,7 +3504,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtpslo_pd() {
+    fn test_mm512_mask_cvtpslo_pd() {
         let v2 = _mm512_setr_ps(
             0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5, 100., 100., 100., 100., 100., 100., 100., 100.,
         );
@@ -3517,7 +3517,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtpd_ps() {
+    fn test_mm512_cvtpd_ps() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvtpd_ps(a);
         let e = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
@@ -3525,7 +3525,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtpd_ps() {
+    fn test_mm512_mask_cvtpd_ps() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_ps(0.);
         let r = _mm512_mask_cvtpd_ps(src, 0, a);
@@ -3536,7 +3536,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtpd_ps() {
+    fn test_mm512_maskz_cvtpd_ps() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvtpd_ps(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -3546,7 +3546,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpd_ps() {
+    fn test_mm256_mask_cvtpd_ps() {
         let a = _mm256_set_pd(4., -5.5, 6., -7.5);
         let src = _mm_set1_ps(0.);
         let r = _mm256_mask_cvtpd_ps(src, 0, a);
@@ -3557,7 +3557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpd_ps() {
+    fn test_mm256_maskz_cvtpd_ps() {
         let a = _mm256_set_pd(4., -5.5, 6., -7.5);
         let r = _mm256_maskz_cvtpd_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -3567,7 +3567,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtpd_ps() {
+    fn test_mm_mask_cvtpd_ps() {
         let a = _mm_set_pd(6., -7.5);
         let src = _mm_set1_ps(0.);
         let r = _mm_mask_cvtpd_ps(src, 0, a);
@@ -3578,7 +3578,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpd_ps() {
+    fn test_mm_maskz_cvtpd_ps() {
         let a = _mm_set_pd(6., -7.5);
         let r = _mm_maskz_cvtpd_ps(0, a);
         assert_eq_m128(r, _mm_setzero_ps());
@@ -3588,7 +3588,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtpd_epi32() {
+    fn test_mm512_cvtpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvtpd_epi32(a);
         let e = _mm256_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8);
@@ -3596,7 +3596,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtpd_epi32() {
+    fn test_mm512_mask_cvtpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvtpd_epi32(src, 0, a);
@@ -3607,7 +3607,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtpd_epi32() {
+    fn test_mm512_maskz_cvtpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvtpd_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -3617,7 +3617,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpd_epi32() {
+    fn test_mm256_mask_cvtpd_epi32() {
         let a = _mm256_set_pd(4., -5.5, 6., -7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm256_mask_cvtpd_epi32(src, 0, a);
@@ -3628,7 +3628,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpd_epi32() {
+    fn test_mm256_maskz_cvtpd_epi32() {
         let a = _mm256_set_pd(4., -5.5, 6., -7.5);
         let r = _mm256_maskz_cvtpd_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3638,7 +3638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtpd_epi32() {
+    fn test_mm_mask_cvtpd_epi32() {
         let a = _mm_set_pd(6., -7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtpd_epi32(src, 0, a);
@@ -3649,7 +3649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpd_epi32() {
+    fn test_mm_maskz_cvtpd_epi32() {
         let a = _mm_set_pd(6., -7.5);
         let r = _mm_maskz_cvtpd_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3659,7 +3659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtpd_epu32() {
+    fn test_mm512_cvtpd_epu32() {
         let a = _mm512_setr_pd(0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5);
         let r = _mm512_cvtpd_epu32(a);
         let e = _mm256_setr_epi32(0, 2, 2, 4, 4, 6, 6, 8);
@@ -3667,7 +3667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtpd_epu32() {
+    fn test_mm512_mask_cvtpd_epu32() {
         let a = _mm512_setr_pd(0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvtpd_epu32(src, 0, a);
@@ -3678,7 +3678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtpd_epu32() {
+    fn test_mm512_maskz_cvtpd_epu32() {
         let a = _mm512_setr_pd(0., 1.5, 2., 3.5, 4., 5.5, 6., 7.5);
         let r = _mm512_maskz_cvtpd_epu32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -3688,7 +3688,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtpd_epu32() {
+    fn test_mm256_cvtpd_epu32() {
         let a = _mm256_set_pd(4., 5.5, 6., 7.5);
         let r = _mm256_cvtpd_epu32(a);
         let e = _mm_set_epi32(4, 6, 6, 8);
@@ -3696,7 +3696,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtpd_epu32() {
+    fn test_mm256_mask_cvtpd_epu32() {
         let a = _mm256_set_pd(4., 5.5, 6., 7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm256_mask_cvtpd_epu32(src, 0, a);
@@ -3707,7 +3707,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtpd_epu32() {
+    fn test_mm256_maskz_cvtpd_epu32() {
         let a = _mm256_set_pd(4., 5.5, 6., 7.5);
         let r = _mm256_maskz_cvtpd_epu32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3717,7 +3717,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtpd_epu32() {
+    fn test_mm_cvtpd_epu32() {
         let a = _mm_set_pd(6., 7.5);
         let r = _mm_cvtpd_epu32(a);
         let e = _mm_set_epi32(0, 0, 6, 8);
@@ -3725,7 +3725,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtpd_epu32() {
+    fn test_mm_mask_cvtpd_epu32() {
         let a = _mm_set_pd(6., 7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtpd_epu32(src, 0, a);
@@ -3736,7 +3736,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtpd_epu32() {
+    fn test_mm_maskz_cvtpd_epu32() {
         let a = _mm_set_pd(6., 7.5);
         let r = _mm_maskz_cvtpd_epu32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3746,7 +3746,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtpd_pslo() {
+    fn test_mm512_cvtpd_pslo() {
         let v2 = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvtpd_pslo(v2);
         let e = _mm512_setr_ps(
@@ -3756,7 +3756,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtpd_pslo() {
+    fn test_mm512_mask_cvtpd_pslo() {
         let v2 = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm512_set1_ps(0.);
         let r = _mm512_mask_cvtpd_pslo(src, 0, v2);
@@ -3769,7 +3769,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi8_epi64() {
+    const fn test_mm512_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi8_epi64(a);
         let e = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
@@ -3777,7 +3777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi8_epi64() {
+    const fn test_mm512_mask_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi64(-1);
         let r = _mm512_mask_cvtepi8_epi64(src, 0, a);
@@ -3788,7 +3788,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi8_epi64() {
+    const fn test_mm512_maskz_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi8_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -3798,7 +3798,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi8_epi64() {
+    const fn test_mm256_mask_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi64x(-1);
         let r = _mm256_mask_cvtepi8_epi64(src, 0, a);
@@ -3809,7 +3809,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi8_epi64() {
+    const fn test_mm256_maskz_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepi8_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -3819,7 +3819,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi8_epi64() {
+    const fn test_mm_mask_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi64x(-1);
         let r = _mm_mask_cvtepi8_epi64(src, 0, a);
@@ -3830,7 +3830,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi8_epi64() {
+    const fn test_mm_maskz_cvtepi8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepi8_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3840,7 +3840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu8_epi64() {
+    const fn test_mm512_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu8_epi64(a);
         let e = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
@@ -3848,7 +3848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu8_epi64() {
+    const fn test_mm512_mask_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi64(-1);
         let r = _mm512_mask_cvtepu8_epi64(src, 0, a);
@@ -3859,7 +3859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu8_epi64() {
+    const fn test_mm512_maskz_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu8_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -3869,7 +3869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu8_epi64() {
+    const fn test_mm256_mask_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi64x(-1);
         let r = _mm256_mask_cvtepu8_epi64(src, 0, a);
@@ -3880,7 +3880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu8_epi64() {
+    const fn test_mm256_maskz_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepu8_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -3890,7 +3890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu8_epi64() {
+    const fn test_mm_mask_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi64x(-1);
         let r = _mm_mask_cvtepu8_epi64(src, 0, a);
@@ -3901,7 +3901,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu8_epi64() {
+    const fn test_mm_maskz_cvtepu8_epi64() {
         let a = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepu8_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3911,7 +3911,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi16_epi64() {
+    const fn test_mm512_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi16_epi64(a);
         let e = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
@@ -3919,7 +3919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi16_epi64() {
+    const fn test_mm512_mask_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi64(-1);
         let r = _mm512_mask_cvtepi16_epi64(src, 0, a);
@@ -3930,7 +3930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi16_epi64() {
+    const fn test_mm512_maskz_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi16_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -3940,7 +3940,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi16_epi64() {
+    const fn test_mm256_mask_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi64x(-1);
         let r = _mm256_mask_cvtepi16_epi64(src, 0, a);
@@ -3951,7 +3951,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi16_epi64() {
+    const fn test_mm256_maskz_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepi16_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -3961,7 +3961,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi16_epi64() {
+    const fn test_mm_mask_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi64x(-1);
         let r = _mm_mask_cvtepi16_epi64(src, 0, a);
@@ -3972,7 +3972,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi16_epi64() {
+    const fn test_mm_maskz_cvtepi16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepi16_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -3982,7 +3982,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu16_epi64() {
+    const fn test_mm512_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu16_epi64(a);
         let e = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
@@ -3990,7 +3990,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu16_epi64() {
+    const fn test_mm512_mask_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi64(-1);
         let r = _mm512_mask_cvtepu16_epi64(src, 0, a);
@@ -4001,7 +4001,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu16_epi64() {
+    const fn test_mm512_maskz_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu16_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -4011,7 +4011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu16_epi64() {
+    const fn test_mm256_mask_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi64x(-1);
         let r = _mm256_mask_cvtepu16_epi64(src, 0, a);
@@ -4022,7 +4022,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu16_epi64() {
+    const fn test_mm256_maskz_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_maskz_cvtepu16_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -4032,7 +4032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu16_epi64() {
+    const fn test_mm_mask_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi64x(-1);
         let r = _mm_mask_cvtepu16_epi64(src, 0, a);
@@ -4043,7 +4043,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu16_epi64() {
+    const fn test_mm_maskz_cvtepu16_epi64() {
         let a = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_maskz_cvtepu16_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4053,7 +4053,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi32_epi64() {
+    const fn test_mm512_cvtepi32_epi64() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi32_epi64(a);
         let e = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
@@ -4061,7 +4061,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi32_epi64() {
+    const fn test_mm512_mask_cvtepi32_epi64() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi64(-1);
         let r = _mm512_mask_cvtepi32_epi64(src, 0, a);
@@ -4072,7 +4072,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi32_epi64() {
+    const fn test_mm512_maskz_cvtepi32_epi64() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi32_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -4082,7 +4082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi32_epi64() {
+    const fn test_mm256_mask_cvtepi32_epi64() {
         let a = _mm_set_epi32(8, 9, 10, 11);
         let src = _mm256_set1_epi64x(-1);
         let r = _mm256_mask_cvtepi32_epi64(src, 0, a);
@@ -4093,7 +4093,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi32_epi64() {
+    const fn test_mm256_maskz_cvtepi32_epi64() {
         let a = _mm_set_epi32(8, 9, 10, 11);
         let r = _mm256_maskz_cvtepi32_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -4103,7 +4103,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi32_epi64() {
+    const fn test_mm_mask_cvtepi32_epi64() {
         let a = _mm_set_epi32(8, 9, 10, 11);
         let src = _mm_set1_epi64x(0);
         let r = _mm_mask_cvtepi32_epi64(src, 0, a);
@@ -4114,7 +4114,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi32_epi64() {
+    const fn test_mm_maskz_cvtepi32_epi64() {
         let a = _mm_set_epi32(8, 9, 10, 11);
         let r = _mm_maskz_cvtepi32_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4124,7 +4124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu32_epi64() {
+    const fn test_mm512_cvtepu32_epi64() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu32_epi64(a);
         let e = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
@@ -4132,7 +4132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu32_epi64() {
+    const fn test_mm512_mask_cvtepu32_epi64() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_epi64(-1);
         let r = _mm512_mask_cvtepu32_epi64(src, 0, a);
@@ -4143,7 +4143,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu32_epi64() {
+    const fn test_mm512_maskz_cvtepu32_epi64() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu32_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -4153,7 +4153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu32_epi64() {
+    const fn test_mm256_mask_cvtepu32_epi64() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let src = _mm256_set1_epi64x(-1);
         let r = _mm256_mask_cvtepu32_epi64(src, 0, a);
@@ -4164,7 +4164,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu32_epi64() {
+    const fn test_mm256_maskz_cvtepu32_epi64() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm256_maskz_cvtepu32_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -4174,7 +4174,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu32_epi64() {
+    const fn test_mm_mask_cvtepu32_epi64() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let src = _mm_set1_epi64x(-1);
         let r = _mm_mask_cvtepu32_epi64(src, 0, a);
@@ -4185,7 +4185,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu32_epi64() {
+    const fn test_mm_maskz_cvtepu32_epi64() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm_maskz_cvtepu32_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4195,7 +4195,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi32_pd() {
+    const fn test_mm512_cvtepi32_pd() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi32_pd(a);
         let e = _mm512_set_pd(8., 9., 10., 11., 12., 13., 14., 15.);
@@ -4203,7 +4203,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi32_pd() {
+    const fn test_mm512_mask_cvtepi32_pd() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_pd(-1.);
         let r = _mm512_mask_cvtepi32_pd(src, 0, a);
@@ -4214,7 +4214,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi32_pd() {
+    const fn test_mm512_maskz_cvtepi32_pd() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi32_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -4224,7 +4224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi32_pd() {
+    const fn test_mm256_mask_cvtepi32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let src = _mm256_set1_pd(-1.);
         let r = _mm256_mask_cvtepi32_pd(src, 0, a);
@@ -4235,7 +4235,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi32_pd() {
+    const fn test_mm256_maskz_cvtepi32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm256_maskz_cvtepi32_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -4245,7 +4245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepi32_pd() {
+    const fn test_mm_mask_cvtepi32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let src = _mm_set1_pd(-1.);
         let r = _mm_mask_cvtepi32_pd(src, 0, a);
@@ -4256,7 +4256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepi32_pd() {
+    const fn test_mm_maskz_cvtepi32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm_maskz_cvtepi32_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -4266,7 +4266,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu32_pd() {
+    const fn test_mm512_cvtepu32_pd() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu32_pd(a);
         let e = _mm512_set_pd(8., 9., 10., 11., 12., 13., 14., 15.);
@@ -4274,7 +4274,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu32_pd() {
+    const fn test_mm512_mask_cvtepu32_pd() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_pd(-1.);
         let r = _mm512_mask_cvtepu32_pd(src, 0, a);
@@ -4285,7 +4285,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepu32_pd() {
+    const fn test_mm512_maskz_cvtepu32_pd() {
         let a = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepu32_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -4295,7 +4295,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cvtepu32_pd() {
+    const fn test_mm256_cvtepu32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm256_cvtepu32_pd(a);
         let e = _mm256_set_pd(12., 13., 14., 15.);
@@ -4303,7 +4303,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepu32_pd() {
+    const fn test_mm256_mask_cvtepu32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let src = _mm256_set1_pd(-1.);
         let r = _mm256_mask_cvtepu32_pd(src, 0, a);
@@ -4314,7 +4314,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepu32_pd() {
+    const fn test_mm256_maskz_cvtepu32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm256_maskz_cvtepu32_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -4324,7 +4324,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cvtepu32_pd() {
+    const fn test_mm_cvtepu32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm_cvtepu32_pd(a);
         let e = _mm_set_pd(14., 15.);
@@ -4332,7 +4332,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cvtepu32_pd() {
+    const fn test_mm_mask_cvtepu32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let src = _mm_set1_pd(-1.);
         let r = _mm_mask_cvtepu32_pd(src, 0, a);
@@ -4343,7 +4343,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_cvtepu32_pd() {
+    const fn test_mm_maskz_cvtepu32_pd() {
         let a = _mm_set_epi32(12, 13, 14, 15);
         let r = _mm_maskz_cvtepu32_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -4353,7 +4353,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi32lo_pd() {
+    const fn test_mm512_cvtepi32lo_pd() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi32lo_pd(a);
         let e = _mm512_set_pd(8., 9., 10., 11., 12., 13., 14., 15.);
@@ -4361,7 +4361,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi32lo_pd() {
+    const fn test_mm512_mask_cvtepi32lo_pd() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_pd(-1.);
         let r = _mm512_mask_cvtepi32lo_pd(src, 0, a);
@@ -4372,7 +4372,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepu32lo_pd() {
+    const fn test_mm512_cvtepu32lo_pd() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepu32lo_pd(a);
         let e = _mm512_set_pd(8., 9., 10., 11., 12., 13., 14., 15.);
@@ -4380,7 +4380,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepu32lo_pd() {
+    const fn test_mm512_mask_cvtepu32lo_pd() {
         let a = _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm512_set1_pd(-1.);
         let r = _mm512_mask_cvtepu32lo_pd(src, 0, a);
@@ -4391,7 +4391,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi64_epi32() {
+    const fn test_mm512_cvtepi64_epi32() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi64_epi32(a);
         let e = _mm256_set_epi32(8, 9, 10, 11, 12, 13, 14, 15);
@@ -4399,7 +4399,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi64_epi32() {
+    const fn test_mm512_mask_cvtepi64_epi32() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm256_set1_epi32(-1);
         let r = _mm512_mask_cvtepi64_epi32(src, 0, a);
@@ -4410,7 +4410,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi64_epi32() {
+    const fn test_mm512_maskz_cvtepi64_epi32() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi64_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -4420,7 +4420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cvtepi64_epi32() {
+    const fn test_mm256_cvtepi64_epi32() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_cvtepi64_epi32(a);
         let e = _mm_set_epi32(1, 2, 3, 4);
@@ -4428,7 +4428,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cvtepi64_epi32() {
+    const fn test_mm256_mask_cvtepi64_epi32() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let src = _mm_set1_epi32(0);
         let r = _mm256_mask_cvtepi64_epi32(src, 0, a);
@@ -4439,7 +4439,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_cvtepi64_epi32() {
+    const fn test_mm256_maskz_cvtepi64_epi32() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let r = _mm256_maskz_cvtepi64_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4449,7 +4449,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtepi64_epi32() {
+    fn test_mm_cvtepi64_epi32() {
         let a = _mm_set_epi64x(3, 4);
         let r = _mm_cvtepi64_epi32(a);
         let e = _mm_set_epi32(0, 0, 3, 4);
@@ -4457,7 +4457,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi64_epi32() {
+    fn test_mm_mask_cvtepi64_epi32() {
         let a = _mm_set_epi64x(3, 4);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtepi64_epi32(src, 0, a);
@@ -4468,7 +4468,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi64_epi32() {
+    fn test_mm_maskz_cvtepi64_epi32() {
         let a = _mm_set_epi64x(3, 4);
         let r = _mm_maskz_cvtepi64_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4478,7 +4478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cvtepi64_epi16() {
+    const fn test_mm512_cvtepi64_epi16() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi64_epi16(a);
         let e = _mm_set_epi16(8, 9, 10, 11, 12, 13, 14, 15);
@@ -4486,7 +4486,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cvtepi64_epi16() {
+    const fn test_mm512_mask_cvtepi64_epi16() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set1_epi16(-1);
         let r = _mm512_mask_cvtepi64_epi16(src, 0, a);
@@ -4497,7 +4497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_cvtepi64_epi16() {
+    const fn test_mm512_maskz_cvtepi64_epi16() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4507,7 +4507,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtepi64_epi16() {
+    fn test_mm256_cvtepi64_epi16() {
         let a = _mm256_set_epi64x(12, 13, 14, 15);
         let r = _mm256_cvtepi64_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 12, 13, 14, 15);
@@ -4515,7 +4515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi64_epi16() {
+    fn test_mm256_mask_cvtepi64_epi16() {
         let a = _mm256_set_epi64x(12, 13, 14, 15);
         let src = _mm_set1_epi16(0);
         let r = _mm256_mask_cvtepi64_epi16(src, 0, a);
@@ -4526,7 +4526,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi64_epi16() {
+    fn test_mm256_maskz_cvtepi64_epi16() {
         let a = _mm256_set_epi64x(12, 13, 14, 15);
         let r = _mm256_maskz_cvtepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4536,7 +4536,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtepi64_epi16() {
+    fn test_mm_cvtepi64_epi16() {
         let a = _mm_set_epi64x(14, 15);
         let r = _mm_cvtepi64_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 0, 0, 14, 15);
@@ -4544,7 +4544,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi64_epi16() {
+    fn test_mm_mask_cvtepi64_epi16() {
         let a = _mm_set_epi64x(14, 15);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtepi64_epi16(src, 0, a);
@@ -4555,7 +4555,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi64_epi16() {
+    fn test_mm_maskz_cvtepi64_epi16() {
         let a = _mm_set_epi64x(14, 15);
         let r = _mm_maskz_cvtepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4565,7 +4565,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtepi64_epi8() {
+    fn test_mm512_cvtepi64_epi8() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_cvtepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -4573,7 +4573,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtepi64_epi8() {
+    fn test_mm512_mask_cvtepi64_epi8() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let src = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1);
         let r = _mm512_mask_cvtepi64_epi8(src, 0, a);
@@ -4584,7 +4584,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtepi64_epi8() {
+    fn test_mm512_maskz_cvtepi64_epi8() {
         let a = _mm512_set_epi64(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm512_maskz_cvtepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4594,7 +4594,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtepi64_epi8() {
+    fn test_mm256_cvtepi64_epi8() {
         let a = _mm256_set_epi64x(12, 13, 14, 15);
         let r = _mm256_cvtepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 13, 14, 15);
@@ -4602,7 +4602,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtepi64_epi8() {
+    fn test_mm256_mask_cvtepi64_epi8() {
         let a = _mm256_set_epi64x(12, 13, 14, 15);
         let src = _mm_set1_epi8(0);
         let r = _mm256_mask_cvtepi64_epi8(src, 0, a);
@@ -4613,7 +4613,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtepi64_epi8() {
+    fn test_mm256_maskz_cvtepi64_epi8() {
         let a = _mm256_set_epi64x(12, 13, 14, 15);
         let r = _mm256_maskz_cvtepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4623,7 +4623,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtepi64_epi8() {
+    fn test_mm_cvtepi64_epi8() {
         let a = _mm_set_epi64x(14, 15);
         let r = _mm_cvtepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 14, 15);
@@ -4631,7 +4631,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtepi64_epi8() {
+    fn test_mm_mask_cvtepi64_epi8() {
         let a = _mm_set_epi64x(14, 15);
         let src = _mm_set1_epi8(0);
         let r = _mm_mask_cvtepi64_epi8(src, 0, a);
@@ -4642,7 +4642,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtepi64_epi8() {
+    fn test_mm_maskz_cvtepi64_epi8() {
         let a = _mm_set_epi64x(14, 15);
         let r = _mm_maskz_cvtepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4652,7 +4652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtsepi64_epi32() {
+    fn test_mm512_cvtsepi64_epi32() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let r = _mm512_cvtsepi64_epi32(a);
         let e = _mm256_set_epi32(0, 1, 2, 3, 4, 5, i32::MIN, i32::MAX);
@@ -4660,7 +4660,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtsepi64_epi32() {
+    fn test_mm512_mask_cvtsepi64_epi32() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let src = _mm256_set1_epi32(-1);
         let r = _mm512_mask_cvtsepi64_epi32(src, 0, a);
@@ -4671,7 +4671,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtsepi64_epi32() {
+    fn test_mm512_maskz_cvtsepi64_epi32() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let r = _mm512_maskz_cvtsepi64_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -4681,7 +4681,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtsepi64_epi32() {
+    fn test_mm256_cvtsepi64_epi32() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let r = _mm256_cvtsepi64_epi32(a);
         let e = _mm_set_epi32(4, 5, i32::MIN, i32::MAX);
@@ -4689,7 +4689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtsepi64_epi32() {
+    fn test_mm256_mask_cvtsepi64_epi32() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let src = _mm_set1_epi32(-1);
         let r = _mm256_mask_cvtsepi64_epi32(src, 0, a);
@@ -4700,7 +4700,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtsepi64_epi32() {
+    fn test_mm256_maskz_cvtsepi64_epi32() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let r = _mm256_maskz_cvtsepi64_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4710,7 +4710,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtsepi64_epi32() {
+    fn test_mm_cvtsepi64_epi32() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let r = _mm_cvtsepi64_epi32(a);
         let e = _mm_set_epi32(0, 0, i32::MIN, i32::MAX);
@@ -4718,7 +4718,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtsepi64_epi32() {
+    fn test_mm_mask_cvtsepi64_epi32() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtsepi64_epi32(src, 0, a);
@@ -4729,7 +4729,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsepi64_epi32() {
+    fn test_mm_maskz_cvtsepi64_epi32() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let r = _mm_maskz_cvtsepi64_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4739,7 +4739,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtsepi64_epi16() {
+    fn test_mm512_cvtsepi64_epi16() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let r = _mm512_cvtsepi64_epi16(a);
         let e = _mm_set_epi16(0, 1, 2, 3, 4, 5, i16::MIN, i16::MAX);
@@ -4747,7 +4747,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtsepi64_epi16() {
+    fn test_mm512_mask_cvtsepi64_epi16() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let src = _mm_set1_epi16(-1);
         let r = _mm512_mask_cvtsepi64_epi16(src, 0, a);
@@ -4758,7 +4758,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtsepi64_epi16() {
+    fn test_mm512_maskz_cvtsepi64_epi16() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let r = _mm512_maskz_cvtsepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4768,7 +4768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtsepi64_epi16() {
+    fn test_mm256_cvtsepi64_epi16() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let r = _mm256_cvtsepi64_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 4, 5, i16::MIN, i16::MAX);
@@ -4776,7 +4776,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtsepi64_epi16() {
+    fn test_mm256_mask_cvtsepi64_epi16() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let src = _mm_set1_epi16(0);
         let r = _mm256_mask_cvtsepi64_epi16(src, 0, a);
@@ -4787,7 +4787,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtsepi64_epi16() {
+    fn test_mm256_maskz_cvtsepi64_epi16() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let r = _mm256_maskz_cvtsepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4797,7 +4797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtsepi64_epi16() {
+    fn test_mm_cvtsepi64_epi16() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let r = _mm_cvtsepi64_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 0, 0, i16::MIN, i16::MAX);
@@ -4805,7 +4805,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtsepi64_epi16() {
+    fn test_mm_mask_cvtsepi64_epi16() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtsepi64_epi16(src, 0, a);
@@ -4816,7 +4816,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsepi64_epi16() {
+    fn test_mm_maskz_cvtsepi64_epi16() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let r = _mm_maskz_cvtsepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4826,7 +4826,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtsepi64_epi8() {
+    fn test_mm512_cvtsepi64_epi8() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let r = _mm512_cvtsepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, i8::MIN, i8::MAX);
@@ -4834,7 +4834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtsepi64_epi8() {
+    fn test_mm512_mask_cvtsepi64_epi8() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let src = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1);
         let r = _mm512_mask_cvtsepi64_epi8(src, 0, a);
@@ -4851,7 +4851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtsepi64_epi8() {
+    fn test_mm512_maskz_cvtsepi64_epi8() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MAX);
         let r = _mm512_maskz_cvtsepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4861,7 +4861,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtsepi64_epi8() {
+    fn test_mm256_cvtsepi64_epi8() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let r = _mm256_cvtsepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, i8::MIN, i8::MAX);
@@ -4869,7 +4869,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtsepi64_epi8() {
+    fn test_mm256_mask_cvtsepi64_epi8() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let src = _mm_set1_epi8(0);
         let r = _mm256_mask_cvtsepi64_epi8(src, 0, a);
@@ -4880,7 +4880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtsepi64_epi8() {
+    fn test_mm256_maskz_cvtsepi64_epi8() {
         let a = _mm256_set_epi64x(4, 5, i64::MIN, i64::MAX);
         let r = _mm256_maskz_cvtsepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4890,7 +4890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtsepi64_epi8() {
+    fn test_mm_cvtsepi64_epi8() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let r = _mm_cvtsepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i8::MIN, i8::MAX);
@@ -4898,7 +4898,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtsepi64_epi8() {
+    fn test_mm_mask_cvtsepi64_epi8() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let src = _mm_set1_epi8(0);
         let r = _mm_mask_cvtsepi64_epi8(src, 0, a);
@@ -4909,7 +4909,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtsepi64_epi8() {
+    fn test_mm_maskz_cvtsepi64_epi8() {
         let a = _mm_set_epi64x(i64::MIN, i64::MAX);
         let r = _mm_maskz_cvtsepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4919,7 +4919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtusepi64_epi32() {
+    fn test_mm512_cvtusepi64_epi32() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let r = _mm512_cvtusepi64_epi32(a);
         let e = _mm256_set_epi32(0, 1, 2, 3, 4, 5, -1, -1);
@@ -4927,7 +4927,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtusepi64_epi32() {
+    fn test_mm512_mask_cvtusepi64_epi32() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let src = _mm256_set1_epi32(-1);
         let r = _mm512_mask_cvtusepi64_epi32(src, 0, a);
@@ -4938,7 +4938,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtusepi64_epi32() {
+    fn test_mm512_maskz_cvtusepi64_epi32() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let r = _mm512_maskz_cvtusepi64_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -4948,7 +4948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtusepi64_epi32() {
+    fn test_mm256_cvtusepi64_epi32() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let r = _mm256_cvtusepi64_epi32(a);
         let e = _mm_set_epi32(4, 5, 6, u32::MAX as i32);
@@ -4956,7 +4956,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtusepi64_epi32() {
+    fn test_mm256_mask_cvtusepi64_epi32() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let src = _mm_set1_epi32(0);
         let r = _mm256_mask_cvtusepi64_epi32(src, 0, a);
@@ -4967,7 +4967,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtusepi64_epi32() {
+    fn test_mm256_maskz_cvtusepi64_epi32() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let r = _mm256_maskz_cvtusepi64_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -4977,7 +4977,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtusepi64_epi32() {
+    fn test_mm_cvtusepi64_epi32() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let r = _mm_cvtusepi64_epi32(a);
         let e = _mm_set_epi32(0, 0, 6, u32::MAX as i32);
@@ -4985,7 +4985,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtusepi64_epi32() {
+    fn test_mm_mask_cvtusepi64_epi32() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvtusepi64_epi32(src, 0, a);
@@ -4996,7 +4996,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtusepi64_epi32() {
+    fn test_mm_maskz_cvtusepi64_epi32() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let r = _mm_maskz_cvtusepi64_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5006,7 +5006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtusepi64_epi16() {
+    fn test_mm512_cvtusepi64_epi16() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let r = _mm512_cvtusepi64_epi16(a);
         let e = _mm_set_epi16(0, 1, 2, 3, 4, 5, -1, -1);
@@ -5014,7 +5014,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtusepi64_epi16() {
+    fn test_mm512_mask_cvtusepi64_epi16() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let src = _mm_set1_epi16(-1);
         let r = _mm512_mask_cvtusepi64_epi16(src, 0, a);
@@ -5025,7 +5025,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtusepi64_epi16() {
+    fn test_mm512_maskz_cvtusepi64_epi16() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let r = _mm512_maskz_cvtusepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5035,7 +5035,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtusepi64_epi16() {
+    fn test_mm256_cvtusepi64_epi16() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let r = _mm256_cvtusepi64_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 4, 5, 6, u16::MAX as i16);
@@ -5043,7 +5043,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtusepi64_epi16() {
+    fn test_mm256_mask_cvtusepi64_epi16() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let src = _mm_set1_epi16(0);
         let r = _mm256_mask_cvtusepi64_epi16(src, 0, a);
@@ -5054,7 +5054,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtusepi64_epi16() {
+    fn test_mm256_maskz_cvtusepi64_epi16() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let r = _mm256_maskz_cvtusepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5064,7 +5064,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtusepi64_epi16() {
+    fn test_mm_cvtusepi64_epi16() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let r = _mm_cvtusepi64_epi16(a);
         let e = _mm_set_epi16(0, 0, 0, 0, 0, 0, 6, u16::MAX as i16);
@@ -5072,7 +5072,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtusepi64_epi16() {
+    fn test_mm_mask_cvtusepi64_epi16() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let src = _mm_set1_epi16(0);
         let r = _mm_mask_cvtusepi64_epi16(src, 0, a);
@@ -5083,7 +5083,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtusepi64_epi16() {
+    fn test_mm_maskz_cvtusepi64_epi16() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let r = _mm_maskz_cvtusepi64_epi16(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5093,7 +5093,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtusepi64_epi8() {
+    fn test_mm512_cvtusepi64_epi8() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let r = _mm512_cvtusepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, -1, -1);
@@ -5101,7 +5101,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtusepi64_epi8() {
+    fn test_mm512_mask_cvtusepi64_epi8() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let src = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1);
         let r = _mm512_mask_cvtusepi64_epi8(src, 0, a);
@@ -5112,7 +5112,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtusepi64_epi8() {
+    fn test_mm512_maskz_cvtusepi64_epi8() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, i64::MIN, i64::MIN);
         let r = _mm512_maskz_cvtusepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5122,7 +5122,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvtusepi64_epi8() {
+    fn test_mm256_cvtusepi64_epi8() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let r = _mm256_cvtusepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, 6, u8::MAX as i8);
@@ -5130,7 +5130,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvtusepi64_epi8() {
+    fn test_mm256_mask_cvtusepi64_epi8() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let src = _mm_set1_epi8(0);
         let r = _mm256_mask_cvtusepi64_epi8(src, 0, a);
@@ -5141,7 +5141,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvtusepi64_epi8() {
+    fn test_mm256_maskz_cvtusepi64_epi8() {
         let a = _mm256_set_epi64x(4, 5, 6, i64::MAX);
         let r = _mm256_maskz_cvtusepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5151,7 +5151,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvtusepi64_epi8() {
+    fn test_mm_cvtusepi64_epi8() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let r = _mm_cvtusepi64_epi8(a);
         let e = _mm_set_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, u8::MAX as i8);
@@ -5159,7 +5159,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvtusepi64_epi8() {
+    fn test_mm_mask_cvtusepi64_epi8() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let src = _mm_set1_epi8(0);
         let r = _mm_mask_cvtusepi64_epi8(src, 0, a);
@@ -5170,7 +5170,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvtusepi64_epi8() {
+    fn test_mm_maskz_cvtusepi64_epi8() {
         let a = _mm_set_epi64x(6, i64::MAX);
         let r = _mm_maskz_cvtusepi64_epi8(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5180,7 +5180,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtt_roundpd_epi32() {
+    fn test_mm512_cvtt_roundpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvtt_roundpd_epi32::<_MM_FROUND_NO_EXC>(a);
         let e = _mm256_setr_epi32(0, -1, 2, -3, 4, -5, 6, -7);
@@ -5188,7 +5188,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtt_roundpd_epi32() {
+    fn test_mm512_mask_cvtt_roundpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvtt_roundpd_epi32::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -5199,7 +5199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtt_roundpd_epi32() {
+    fn test_mm512_maskz_cvtt_roundpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvtt_roundpd_epi32::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -5209,7 +5209,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvtt_roundpd_epu32() {
+    fn test_mm512_cvtt_roundpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvtt_roundpd_epu32::<_MM_FROUND_NO_EXC>(a);
         let e = _mm256_setr_epi32(0, -1, 2, -1, 4, -1, 6, -1);
@@ -5217,7 +5217,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvtt_roundpd_epu32() {
+    fn test_mm512_mask_cvtt_roundpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvtt_roundpd_epu32::<_MM_FROUND_NO_EXC>(src, 0, a);
@@ -5228,7 +5228,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvtt_roundpd_epu32() {
+    fn test_mm512_maskz_cvtt_roundpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvtt_roundpd_epu32::<_MM_FROUND_NO_EXC>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -5238,7 +5238,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvttpd_epi32() {
+    fn test_mm512_cvttpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvttpd_epi32(a);
         let e = _mm256_setr_epi32(0, -1, 2, -3, 4, -5, 6, -7);
@@ -5246,7 +5246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvttpd_epi32() {
+    fn test_mm512_mask_cvttpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvttpd_epi32(src, 0, a);
@@ -5257,7 +5257,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvttpd_epi32() {
+    fn test_mm512_maskz_cvttpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvttpd_epi32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -5267,7 +5267,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvttpd_epi32() {
+    fn test_mm256_mask_cvttpd_epi32() {
         let a = _mm256_setr_pd(4., -5.5, 6., -7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm256_mask_cvttpd_epi32(src, 0, a);
@@ -5278,7 +5278,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttpd_epi32() {
+    fn test_mm256_maskz_cvttpd_epi32() {
         let a = _mm256_setr_pd(4., -5.5, 6., -7.5);
         let r = _mm256_maskz_cvttpd_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5288,7 +5288,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvttpd_epi32() {
+    fn test_mm_mask_cvttpd_epi32() {
         let a = _mm_set_pd(6., -7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvttpd_epi32(src, 0, a);
@@ -5299,7 +5299,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvttpd_epi32() {
+    fn test_mm_maskz_cvttpd_epi32() {
         let a = _mm_set_pd(6., -7.5);
         let r = _mm_maskz_cvttpd_epi32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5309,7 +5309,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvttpd_epu32() {
+    fn test_mm512_cvttpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvttpd_epu32(a);
         let e = _mm256_setr_epi32(0, -1, 2, -1, 4, -1, 6, -1);
@@ -5317,7 +5317,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvttpd_epu32() {
+    fn test_mm512_mask_cvttpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvttpd_epu32(src, 0, a);
@@ -5328,7 +5328,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvttpd_epu32() {
+    fn test_mm512_maskz_cvttpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvttpd_epu32(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -5338,7 +5338,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cvttpd_epu32() {
+    fn test_mm256_cvttpd_epu32() {
         let a = _mm256_set_pd(4., 5.5, 6., 7.5);
         let r = _mm256_cvttpd_epu32(a);
         let e = _mm_set_epi32(4, 5, 6, 7);
@@ -5346,7 +5346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cvttpd_epu32() {
+    fn test_mm256_mask_cvttpd_epu32() {
         let a = _mm256_set_pd(4., 5.5, 6., 7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm256_mask_cvttpd_epu32(src, 0, a);
@@ -5357,7 +5357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_cvttpd_epu32() {
+    fn test_mm256_maskz_cvttpd_epu32() {
         let a = _mm256_set_pd(4., 5.5, 6., 7.5);
         let r = _mm256_maskz_cvttpd_epu32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5367,7 +5367,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cvttpd_epu32() {
+    fn test_mm_cvttpd_epu32() {
         let a = _mm_set_pd(6., 7.5);
         let r = _mm_cvttpd_epu32(a);
         let e = _mm_set_epi32(0, 0, 6, 7);
@@ -5375,7 +5375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cvttpd_epu32() {
+    fn test_mm_mask_cvttpd_epu32() {
         let a = _mm_set_pd(6., 7.5);
         let src = _mm_set1_epi32(0);
         let r = _mm_mask_cvttpd_epu32(src, 0, a);
@@ -5386,7 +5386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_cvttpd_epu32() {
+    fn test_mm_maskz_cvttpd_epu32() {
         let a = _mm_set_pd(6., 7.5);
         let r = _mm_maskz_cvttpd_epu32(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -5396,7 +5396,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_add_round_pd() {
+    fn test_mm512_add_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(-1.);
         let r = _mm512_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -5408,7 +5408,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_add_round_pd() {
+    fn test_mm512_mask_add_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(-1.);
         let r = _mm512_mask_add_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -5423,7 +5423,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_add_round_pd() {
+    fn test_mm512_maskz_add_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(-1.);
         let r =
@@ -5437,7 +5437,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sub_round_pd() {
+    fn test_mm512_sub_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_sub_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -5449,7 +5449,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sub_round_pd() {
+    fn test_mm512_mask_sub_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let r = _mm512_mask_sub_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -5464,7 +5464,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sub_round_pd() {
+    fn test_mm512_maskz_sub_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let r =
@@ -5478,7 +5478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mul_round_pd() {
+    fn test_mm512_mul_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.);
         let b = _mm512_set1_pd(0.1);
         let r = _mm512_mul_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -5499,7 +5499,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_mul_round_pd() {
+    fn test_mm512_mask_mul_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.);
         let b = _mm512_set1_pd(0.1);
         let r = _mm512_mask_mul_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -5523,7 +5523,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_mul_round_pd() {
+    fn test_mm512_maskz_mul_round_pd() {
         let a = _mm512_setr_pd(8., 9.5, 10., 11.5, 12., 13.5, 14., 0.);
         let b = _mm512_set1_pd(0.1);
         let r =
@@ -5546,7 +5546,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_div_round_pd() {
+    fn test_mm512_div_round_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_div_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -5558,7 +5558,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_div_round_pd() {
+    fn test_mm512_mask_div_round_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_mask_div_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -5582,7 +5582,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_div_round_pd() {
+    fn test_mm512_maskz_div_round_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r =
@@ -5605,7 +5605,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sqrt_round_pd() {
+    fn test_mm512_sqrt_round_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_sqrt_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         let e = _mm512_set1_pd(1.7320508075688772);
@@ -5616,7 +5616,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sqrt_round_pd() {
+    fn test_mm512_mask_sqrt_round_pd() {
         let a = _mm512_set1_pd(3.);
         let r =
             _mm512_mask_sqrt_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, 0, a);
@@ -5638,7 +5638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sqrt_round_pd() {
+    fn test_mm512_maskz_sqrt_round_pd() {
         let a = _mm512_set1_pd(3.);
         let r =
             _mm512_maskz_sqrt_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(0, a);
@@ -5660,7 +5660,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmadd_round_pd() {
+    fn test_mm512_fmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5673,7 +5673,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmadd_round_pd() {
+    fn test_mm512_mask_fmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5698,7 +5698,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmadd_round_pd() {
+    fn test_mm512_maskz_fmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5714,7 +5714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmadd_round_pd() {
+    fn test_mm512_mask3_fmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5730,7 +5730,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmsub_round_pd() {
+    fn test_mm512_fmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -5743,7 +5743,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmsub_round_pd() {
+    fn test_mm512_mask_fmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -5768,7 +5768,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmsub_round_pd() {
+    fn test_mm512_maskz_fmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -5784,7 +5784,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmsub_round_pd() {
+    fn test_mm512_mask3_fmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -5800,7 +5800,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmaddsub_round_pd() {
+    fn test_mm512_fmaddsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5823,7 +5823,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmaddsub_round_pd() {
+    fn test_mm512_mask_fmaddsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5848,7 +5848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmaddsub_round_pd() {
+    fn test_mm512_maskz_fmaddsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5864,7 +5864,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmaddsub_round_pd() {
+    fn test_mm512_mask3_fmaddsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5880,7 +5880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fmsubadd_round_pd() {
+    fn test_mm512_fmsubadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5903,7 +5903,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fmsubadd_round_pd() {
+    fn test_mm512_mask_fmsubadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5928,7 +5928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fmsubadd_round_pd() {
+    fn test_mm512_maskz_fmsubadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5944,7 +5944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fmsubadd_round_pd() {
+    fn test_mm512_mask3_fmsubadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -5960,7 +5960,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fnmadd_round_pd() {
+    fn test_mm512_fnmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -5974,7 +5974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fnmadd_round_pd() {
+    fn test_mm512_mask_fnmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -5999,7 +5999,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fnmadd_round_pd() {
+    fn test_mm512_maskz_fnmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -6015,7 +6015,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fnmadd_round_pd() {
+    fn test_mm512_mask3_fnmadd_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(1.);
@@ -6031,7 +6031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fnmsub_round_pd() {
+    fn test_mm512_fnmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -6045,7 +6045,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fnmsub_round_pd() {
+    fn test_mm512_mask_fnmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -6070,7 +6070,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fnmsub_round_pd() {
+    fn test_mm512_maskz_fnmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -6086,7 +6086,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask3_fnmsub_round_pd() {
+    fn test_mm512_mask3_fnmsub_round_pd() {
         let a = _mm512_set1_pd(0.000000000000000007);
         let b = _mm512_set1_pd(1.);
         let c = _mm512_set1_pd(-1.);
@@ -6102,7 +6102,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_max_round_pd() {
+    fn test_mm512_max_round_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_max_round_pd::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -6111,7 +6111,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_max_round_pd() {
+    fn test_mm512_mask_max_round_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_mask_max_round_pd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -6122,7 +6122,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_max_round_pd() {
+    fn test_mm512_maskz_max_round_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_maskz_max_round_pd::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -6133,7 +6133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_min_round_pd() {
+    fn test_mm512_min_round_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_min_round_pd::<_MM_FROUND_CUR_DIRECTION>(a, b);
@@ -6142,7 +6142,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_min_round_pd() {
+    fn test_mm512_mask_min_round_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_mask_min_round_pd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a, b);
@@ -6153,7 +6153,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_min_round_pd() {
+    fn test_mm512_maskz_min_round_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_setr_pd(7., 6., 5., 4., 3., 2., 1., 0.);
         let r = _mm512_maskz_min_round_pd::<_MM_FROUND_CUR_DIRECTION>(0, a, b);
@@ -6164,7 +6164,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getexp_round_pd() {
+    fn test_mm512_getexp_round_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_getexp_round_pd::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm512_set1_pd(1.);
@@ -6172,7 +6172,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getexp_round_pd() {
+    fn test_mm512_mask_getexp_round_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_mask_getexp_round_pd::<_MM_FROUND_CUR_DIRECTION>(a, 0, a);
         assert_eq_m512d(r, a);
@@ -6182,7 +6182,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getexp_round_pd() {
+    fn test_mm512_maskz_getexp_round_pd() {
         let a = _mm512_set1_pd(3.);
         let r = _mm512_maskz_getexp_round_pd::<_MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -6192,7 +6192,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_roundscale_round_pd() {
+    fn test_mm512_roundscale_round_pd() {
         let a = _mm512_set1_pd(1.1);
         let r = _mm512_roundscale_round_pd::<0, _MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm512_set1_pd(1.0);
@@ -6200,7 +6200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_roundscale_round_pd() {
+    fn test_mm512_mask_roundscale_round_pd() {
         let a = _mm512_set1_pd(1.1);
         let r = _mm512_mask_roundscale_round_pd::<0, _MM_FROUND_CUR_DIRECTION>(a, 0, a);
         let e = _mm512_set1_pd(1.1);
@@ -6211,7 +6211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_roundscale_round_pd() {
+    fn test_mm512_maskz_roundscale_round_pd() {
         let a = _mm512_set1_pd(1.1);
         let r = _mm512_maskz_roundscale_round_pd::<0, _MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -6221,7 +6221,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_scalef_round_pd() {
+    fn test_mm512_scalef_round_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_scalef_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, b);
@@ -6230,7 +6230,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_scalef_round_pd() {
+    fn test_mm512_mask_scalef_round_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_mask_scalef_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -6245,7 +6245,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_scalef_round_pd() {
+    fn test_mm512_maskz_scalef_round_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(3.);
         let r = _mm512_maskz_scalef_round_pd::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(
@@ -6260,7 +6260,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_fixupimm_round_pd() {
+    fn test_mm512_fixupimm_round_pd() {
         let a = _mm512_set1_pd(f64::NAN);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
@@ -6270,7 +6270,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_fixupimm_round_pd() {
+    fn test_mm512_mask_fixupimm_round_pd() {
         let a = _mm512_set_pd(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 1., 1., 1., 1.);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
@@ -6280,7 +6280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_fixupimm_round_pd() {
+    fn test_mm512_maskz_fixupimm_round_pd() {
         let a = _mm512_set_pd(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 1., 1., 1., 1.);
         let b = _mm512_set1_pd(f64::MAX);
         let c = _mm512_set1_epi64(i32::MAX as i64);
@@ -6290,7 +6290,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_getmant_round_pd() {
+    fn test_mm512_getmant_round_pd() {
         let a = _mm512_set1_pd(10.);
         let r = _mm512_getmant_round_pd::<
             _MM_MANT_NORM_1_2,
@@ -6302,7 +6302,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_getmant_round_pd() {
+    fn test_mm512_mask_getmant_round_pd() {
         let a = _mm512_set1_pd(10.);
         let r = _mm512_mask_getmant_round_pd::<
             _MM_MANT_NORM_1_2,
@@ -6320,7 +6320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_getmant_round_pd() {
+    fn test_mm512_maskz_getmant_round_pd() {
         let a = _mm512_set1_pd(10.);
         let r = _mm512_maskz_getmant_round_pd::<
             _MM_MANT_NORM_1_2,
@@ -6338,7 +6338,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundps_pd() {
+    fn test_mm512_cvt_roundps_pd() {
         let a = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvt_roundps_pd::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
@@ -6346,7 +6346,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundps_pd() {
+    fn test_mm512_mask_cvt_roundps_pd() {
         let a = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm512_set1_pd(0.);
         let r = _mm512_mask_cvt_roundps_pd::<_MM_FROUND_CUR_DIRECTION>(src, 0, a);
@@ -6357,7 +6357,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundps_pd() {
+    fn test_mm512_maskz_cvt_roundps_pd() {
         let a = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvt_roundps_pd::<_MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -6367,7 +6367,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundpd_ps() {
+    fn test_mm512_cvt_roundpd_ps() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvt_roundpd_ps::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm256_setr_ps(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
@@ -6375,7 +6375,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundpd_ps() {
+    fn test_mm512_mask_cvt_roundpd_ps() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_ps(0.);
         let r = _mm512_mask_cvt_roundpd_ps::<_MM_FROUND_CUR_DIRECTION>(src, 0, a);
@@ -6386,7 +6386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundpd_ps() {
+    fn test_mm512_maskz_cvt_roundpd_ps() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvt_roundpd_ps::<_MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m256(r, _mm256_setzero_ps());
@@ -6396,7 +6396,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundpd_epi32() {
+    fn test_mm512_cvt_roundpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvt_roundpd_epi32::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm256_setr_epi32(0, -2, 2, -4, 4, -6, 6, -8);
@@ -6404,7 +6404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundpd_epi32() {
+    fn test_mm512_mask_cvt_roundpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvt_roundpd_epi32::<_MM_FROUND_CUR_DIRECTION>(src, 0, a);
@@ -6415,7 +6415,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundpd_epi32() {
+    fn test_mm512_maskz_cvt_roundpd_epi32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvt_roundpd_epi32::<_MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -6425,7 +6425,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cvt_roundpd_epu32() {
+    fn test_mm512_cvt_roundpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_cvt_roundpd_epu32::<_MM_FROUND_CUR_DIRECTION>(a);
         let e = _mm256_setr_epi32(0, -1, 2, -1, 4, -1, 6, -1);
@@ -6433,7 +6433,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cvt_roundpd_epu32() {
+    fn test_mm512_mask_cvt_roundpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let src = _mm256_set1_epi32(0);
         let r = _mm512_mask_cvt_roundpd_epu32::<_MM_FROUND_CUR_DIRECTION>(src, 0, a);
@@ -6444,7 +6444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_cvt_roundpd_epu32() {
+    fn test_mm512_maskz_cvt_roundpd_epu32() {
         let a = _mm512_setr_pd(0., -1.5, 2., -3.5, 4., -5.5, 6., -7.5);
         let r = _mm512_maskz_cvt_roundpd_epu32::<_MM_FROUND_CUR_DIRECTION>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -6454,48 +6454,48 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setzero_pd() {
+    const fn test_mm512_setzero_pd() {
         assert_eq_m512d(_mm512_setzero_pd(), _mm512_set1_pd(0.));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set1_epi64() {
+    const fn test_mm512_set1_epi64() {
         let r = _mm512_set_epi64(2, 2, 2, 2, 2, 2, 2, 2);
         assert_eq_m512i(r, _mm512_set1_epi64(2));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set1_pd() {
+    const fn test_mm512_set1_pd() {
         let expected = _mm512_set_pd(2., 2., 2., 2., 2., 2., 2., 2.);
         assert_eq_m512d(expected, _mm512_set1_pd(2.));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set4_epi64() {
+    const fn test_mm512_set4_epi64() {
         let r = _mm512_set_epi64(4, 3, 2, 1, 4, 3, 2, 1);
         assert_eq_m512i(r, _mm512_set4_epi64(4, 3, 2, 1));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set4_pd() {
+    const fn test_mm512_set4_pd() {
         let r = _mm512_set_pd(4., 3., 2., 1., 4., 3., 2., 1.);
         assert_eq_m512d(r, _mm512_set4_pd(4., 3., 2., 1.));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr4_epi64() {
+    const fn test_mm512_setr4_epi64() {
         let r = _mm512_set_epi64(4, 3, 2, 1, 4, 3, 2, 1);
         assert_eq_m512i(r, _mm512_setr4_epi64(1, 2, 3, 4));
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr4_pd() {
+    const fn test_mm512_setr4_pd() {
         let r = _mm512_set_pd(4., 3., 2., 1., 4., 3., 2., 1.);
         assert_eq_m512d(r, _mm512_setr4_pd(1., 2., 3., 4.));
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmplt_pd_mask() {
+    fn test_mm512_cmplt_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6504,7 +6504,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmplt_pd_mask() {
+    fn test_mm512_mask_cmplt_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6514,7 +6514,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpnlt_pd_mask() {
+    fn test_mm512_cmpnlt_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6522,7 +6522,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpnlt_pd_mask() {
+    fn test_mm512_mask_cmpnlt_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6531,7 +6531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmple_pd_mask() {
+    fn test_mm512_cmple_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6539,7 +6539,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmple_pd_mask() {
+    fn test_mm512_mask_cmple_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6548,7 +6548,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpnle_pd_mask() {
+    fn test_mm512_cmpnle_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6557,7 +6557,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpnle_pd_mask() {
+    fn test_mm512_mask_cmpnle_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., f64::MAX, f64::NAN, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6567,7 +6567,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpeq_pd_mask() {
+    fn test_mm512_cmpeq_pd_mask() {
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, f64::NAN, -100.);
         let b = _mm512_set_pd(0., 1., 13., 42., f64::MAX, f64::MIN, f64::NAN, -100.);
         let m = _mm512_cmpeq_pd_mask(b, a);
@@ -6575,7 +6575,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpeq_pd_mask() {
+    fn test_mm512_mask_cmpeq_pd_mask() {
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, f64::NAN, -100.);
         let b = _mm512_set_pd(0., 1., 13., 42., f64::MAX, f64::MIN, f64::NAN, -100.);
         let mask = 0b01111010;
@@ -6584,7 +6584,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpneq_pd_mask() {
+    fn test_mm512_cmpneq_pd_mask() {
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, f64::NAN, -100.);
         let b = _mm512_set_pd(0., 1., 13., 42., f64::MAX, f64::MIN, f64::NAN, -100.);
         let m = _mm512_cmpneq_pd_mask(b, a);
@@ -6592,7 +6592,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpneq_pd_mask() {
+    fn test_mm512_mask_cmpneq_pd_mask() {
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, f64::NAN, -100.);
         let b = _mm512_set_pd(0., 1., 13., 42., f64::MAX, f64::MIN, f64::NAN, -100.);
         let mask = 0b01111010;
@@ -6601,7 +6601,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmp_pd_mask() {
+    fn test_mm512_cmp_pd_mask() {
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
         let m = _mm512_cmp_pd_mask::<_CMP_LT_OQ>(a, b);
@@ -6609,7 +6609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmp_pd_mask() {
+    fn test_mm512_mask_cmp_pd_mask() {
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
         let mask = 0b01100110;
@@ -6618,7 +6618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_cmp_pd_mask() {
+    fn test_mm256_cmp_pd_mask() {
         let a = _mm256_set_pd(0., 1., -1., 13.);
         let b = _mm256_set1_pd(1.);
         let m = _mm256_cmp_pd_mask::<_CMP_LT_OQ>(a, b);
@@ -6626,7 +6626,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_cmp_pd_mask() {
+    fn test_mm256_mask_cmp_pd_mask() {
         let a = _mm256_set_pd(0., 1., -1., 13.);
         let b = _mm256_set1_pd(1.);
         let mask = 0b11111111;
@@ -6635,7 +6635,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_cmp_pd_mask() {
+    fn test_mm_cmp_pd_mask() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set1_pd(1.);
         let m = _mm_cmp_pd_mask::<_CMP_LT_OQ>(a, b);
@@ -6643,7 +6643,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_cmp_pd_mask() {
+    fn test_mm_mask_cmp_pd_mask() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set1_pd(1.);
         let mask = 0b11111111;
@@ -6652,7 +6652,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmp_round_pd_mask() {
+    fn test_mm512_cmp_round_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6661,7 +6661,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmp_round_pd_mask() {
+    fn test_mm512_mask_cmp_round_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(0., 1., -1., 13., f64::MAX, f64::MIN, 100., -100.);
         let b = _mm512_set1_pd(-1.);
@@ -6671,7 +6671,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpord_pd_mask() {
+    fn test_mm512_cmpord_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(f64::NAN, f64::MAX, f64::NAN, f64::MIN, f64::NAN, -1., f64::NAN, 0.);
         #[rustfmt::skip]
@@ -6681,7 +6681,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpord_pd_mask() {
+    fn test_mm512_mask_cmpord_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(f64::NAN, f64::MAX, f64::NAN, f64::MIN, f64::NAN, -1., f64::NAN, 0.);
         #[rustfmt::skip]
@@ -6692,7 +6692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_cmpunord_pd_mask() {
+    fn test_mm512_cmpunord_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(f64::NAN, f64::MAX, f64::NAN, f64::MIN, f64::NAN, -1., f64::NAN, 0.);
         #[rustfmt::skip]
@@ -6703,7 +6703,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_cmpunord_pd_mask() {
+    fn test_mm512_mask_cmpunord_pd_mask() {
         #[rustfmt::skip]
         let a = _mm512_set_pd(f64::NAN, f64::MAX, f64::NAN, f64::MIN, f64::NAN, -1., f64::NAN, 0.);
         #[rustfmt::skip]
@@ -6714,7 +6714,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmplt_epu64_mask() {
+    const fn test_mm512_cmplt_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let m = _mm512_cmplt_epu64_mask(a, b);
@@ -6722,7 +6722,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmplt_epu64_mask() {
+    const fn test_mm512_mask_cmplt_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01111010;
@@ -6731,7 +6731,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epu64_mask() {
+    const fn test_mm256_cmplt_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, 100);
         let b = _mm256_set1_epi64x(2);
         let r = _mm256_cmplt_epu64_mask(a, b);
@@ -6739,7 +6739,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epu64_mask() {
+    const fn test_mm256_mask_cmplt_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, 100);
         let b = _mm256_set1_epi64x(2);
         let mask = 0b11111111;
@@ -6748,7 +6748,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmplt_epu64_mask() {
+    const fn test_mm_cmplt_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(2);
         let r = _mm_cmplt_epu64_mask(a, b);
@@ -6756,7 +6756,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epu64_mask() {
+    const fn test_mm_mask_cmplt_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(2);
         let mask = 0b11111111;
@@ -6765,7 +6765,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpgt_epu64_mask() {
+    const fn test_mm512_cmpgt_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let m = _mm512_cmpgt_epu64_mask(b, a);
@@ -6773,7 +6773,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpgt_epu64_mask() {
+    const fn test_mm512_mask_cmpgt_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01111010;
@@ -6782,7 +6782,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epu64_mask() {
+    const fn test_mm256_cmpgt_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_cmpgt_epu64_mask(a, b);
@@ -6790,7 +6790,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epu64_mask() {
+    const fn test_mm256_mask_cmpgt_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let b = _mm256_set1_epi64x(1);
         let mask = 0b11111111;
@@ -6799,7 +6799,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epu64_mask() {
+    const fn test_mm_cmpgt_epu64_mask() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set1_epi64x(1);
         let r = _mm_cmpgt_epu64_mask(a, b);
@@ -6807,7 +6807,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epu64_mask() {
+    const fn test_mm_mask_cmpgt_epu64_mask() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set1_epi64x(1);
         let mask = 0b11111111;
@@ -6816,7 +6816,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmple_epu64_mask() {
+    const fn test_mm512_cmple_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         assert_eq!(
@@ -6826,7 +6826,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmple_epu64_mask() {
+    const fn test_mm512_mask_cmple_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01111010;
@@ -6834,7 +6834,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmple_epu64_mask() {
+    const fn test_mm256_cmple_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, 1);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_cmple_epu64_mask(a, b);
@@ -6842,7 +6842,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epu64_mask() {
+    const fn test_mm256_mask_cmple_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, 1);
         let b = _mm256_set1_epi64x(1);
         let mask = 0b11111111;
@@ -6851,7 +6851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmple_epu64_mask() {
+    const fn test_mm_cmple_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let r = _mm_cmple_epu64_mask(a, b);
@@ -6859,7 +6859,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epu64_mask() {
+    const fn test_mm_mask_cmple_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let mask = 0b11111111;
@@ -6868,7 +6868,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpge_epu64_mask() {
+    const fn test_mm512_cmpge_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         assert_eq!(
@@ -6878,7 +6878,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpge_epu64_mask() {
+    const fn test_mm512_mask_cmpge_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b11111111;
@@ -6887,7 +6887,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epu64_mask() {
+    const fn test_mm256_cmpge_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, u64::MAX as i64);
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_cmpge_epu64_mask(a, b);
@@ -6895,7 +6895,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epu64_mask() {
+    const fn test_mm256_mask_cmpge_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, 2, u64::MAX as i64);
         let b = _mm256_set1_epi64x(1);
         let mask = 0b11111111;
@@ -6904,7 +6904,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpge_epu64_mask() {
+    const fn test_mm_cmpge_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let r = _mm_cmpge_epu64_mask(a, b);
@@ -6912,7 +6912,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epu64_mask() {
+    const fn test_mm_mask_cmpge_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let mask = 0b11111111;
@@ -6921,7 +6921,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpeq_epu64_mask() {
+    const fn test_mm512_cmpeq_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let m = _mm512_cmpeq_epu64_mask(b, a);
@@ -6929,7 +6929,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpeq_epu64_mask() {
+    const fn test_mm512_mask_cmpeq_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let mask = 0b01111010;
@@ -6938,7 +6938,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epu64_mask() {
+    const fn test_mm256_cmpeq_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, u64::MAX as i64);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let m = _mm256_cmpeq_epu64_mask(b, a);
@@ -6946,7 +6946,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epu64_mask() {
+    const fn test_mm256_mask_cmpeq_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, u64::MAX as i64);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -6955,7 +6955,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epu64_mask() {
+    const fn test_mm_cmpeq_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(0, 1);
         let m = _mm_cmpeq_epu64_mask(b, a);
@@ -6963,7 +6963,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epu64_mask() {
+    const fn test_mm_mask_cmpeq_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(0, 1);
         let mask = 0b11111111;
@@ -6972,7 +6972,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpneq_epu64_mask() {
+    const fn test_mm512_cmpneq_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let m = _mm512_cmpneq_epu64_mask(b, a);
@@ -6980,7 +6980,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpneq_epu64_mask() {
+    const fn test_mm512_mask_cmpneq_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, -100, 100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let mask = 0b01111010;
@@ -6989,7 +6989,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epu64_mask() {
+    const fn test_mm256_cmpneq_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, u64::MAX as i64);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let r = _mm256_cmpneq_epu64_mask(b, a);
@@ -6997,7 +6997,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epu64_mask() {
+    const fn test_mm256_mask_cmpneq_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, u64::MAX as i64);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -7006,7 +7006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epu64_mask() {
+    const fn test_mm_cmpneq_epu64_mask() {
         let a = _mm_set_epi64x(-1, u64::MAX as i64);
         let b = _mm_set_epi64x(13, 42);
         let r = _mm_cmpneq_epu64_mask(b, a);
@@ -7014,7 +7014,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epu64_mask() {
+    const fn test_mm_mask_cmpneq_epu64_mask() {
         let a = _mm_set_epi64x(-1, u64::MAX as i64);
         let b = _mm_set_epi64x(13, 42);
         let mask = 0b11111111;
@@ -7023,7 +7023,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmp_epu64_mask() {
+    const fn test_mm512_cmp_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let m = _mm512_cmp_epu64_mask::<_MM_CMPINT_LT>(a, b);
@@ -7031,7 +7031,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmp_epu64_mask() {
+    const fn test_mm512_mask_cmp_epu64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01111010;
@@ -7040,7 +7040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmp_epu64_mask() {
+    const fn test_mm256_cmp_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 100);
         let b = _mm256_set1_epi64x(1);
         let m = _mm256_cmp_epu64_mask::<_MM_CMPINT_LT>(a, b);
@@ -7048,7 +7048,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epu64_mask() {
+    const fn test_mm256_mask_cmp_epu64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 100);
         let b = _mm256_set1_epi64x(1);
         let mask = 0b11111111;
@@ -7057,7 +7057,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmp_epu64_mask() {
+    const fn test_mm_cmp_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let m = _mm_cmp_epu64_mask::<_MM_CMPINT_LT>(a, b);
@@ -7065,7 +7065,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epu64_mask() {
+    const fn test_mm_mask_cmp_epu64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let mask = 0b11111111;
@@ -7074,7 +7074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmplt_epi64_mask() {
+    const fn test_mm512_cmplt_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let m = _mm512_cmplt_epi64_mask(a, b);
@@ -7082,7 +7082,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmplt_epi64_mask() {
+    const fn test_mm512_mask_cmplt_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01100110;
@@ -7091,7 +7091,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmplt_epi64_mask() {
+    const fn test_mm256_cmplt_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, -13);
         let b = _mm256_set1_epi64x(-1);
         let r = _mm256_cmplt_epi64_mask(a, b);
@@ -7099,7 +7099,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmplt_epi64_mask() {
+    const fn test_mm256_mask_cmplt_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, -13);
         let b = _mm256_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7108,7 +7108,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmplt_epi64_mask() {
+    const fn test_mm_cmplt_epi64_mask() {
         let a = _mm_set_epi64x(-1, -13);
         let b = _mm_set1_epi64x(-1);
         let r = _mm_cmplt_epi64_mask(a, b);
@@ -7116,7 +7116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmplt_epi64_mask() {
+    const fn test_mm_mask_cmplt_epi64_mask() {
         let a = _mm_set_epi64x(-1, -13);
         let b = _mm_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7125,7 +7125,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpgt_epi64_mask() {
+    const fn test_mm512_cmpgt_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let m = _mm512_cmpgt_epi64_mask(b, a);
@@ -7133,7 +7133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpgt_epi64_mask() {
+    const fn test_mm512_mask_cmpgt_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01100110;
@@ -7142,7 +7142,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpgt_epi64_mask() {
+    const fn test_mm256_cmpgt_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set1_epi64x(-1);
         let r = _mm256_cmpgt_epi64_mask(a, b);
@@ -7150,7 +7150,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpgt_epi64_mask() {
+    const fn test_mm256_mask_cmpgt_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7159,7 +7159,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpgt_epi64_mask() {
+    const fn test_mm_cmpgt_epi64_mask() {
         let a = _mm_set_epi64x(0, -1);
         let b = _mm_set1_epi64x(-1);
         let r = _mm_cmpgt_epi64_mask(a, b);
@@ -7167,7 +7167,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpgt_epi64_mask() {
+    const fn test_mm_mask_cmpgt_epi64_mask() {
         let a = _mm_set_epi64x(0, -1);
         let b = _mm_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7176,7 +7176,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmple_epi64_mask() {
+    const fn test_mm512_cmple_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         assert_eq!(
@@ -7186,7 +7186,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmple_epi64_mask() {
+    const fn test_mm512_mask_cmple_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01111010;
@@ -7194,7 +7194,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmple_epi64_mask() {
+    const fn test_mm256_cmple_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, i64::MAX);
         let b = _mm256_set1_epi64x(-1);
         let r = _mm256_cmple_epi64_mask(a, b);
@@ -7202,7 +7202,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmple_epi64_mask() {
+    const fn test_mm256_mask_cmple_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, i64::MAX);
         let b = _mm256_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7211,7 +7211,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmple_epi64_mask() {
+    const fn test_mm_cmple_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let r = _mm_cmple_epi64_mask(a, b);
@@ -7219,7 +7219,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmple_epi64_mask() {
+    const fn test_mm_mask_cmple_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let mask = 0b11111111;
@@ -7228,7 +7228,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpge_epi64_mask() {
+    const fn test_mm512_cmpge_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         assert_eq!(
@@ -7238,7 +7238,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpge_epi64_mask() {
+    const fn test_mm512_mask_cmpge_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, u64::MAX as i64, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b11111111;
@@ -7247,7 +7247,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpge_epi64_mask() {
+    const fn test_mm256_cmpge_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, i64::MAX);
         let b = _mm256_set1_epi64x(-1);
         let r = _mm256_cmpge_epi64_mask(a, b);
@@ -7255,7 +7255,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpge_epi64_mask() {
+    const fn test_mm256_mask_cmpge_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, i64::MAX);
         let b = _mm256_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7264,7 +7264,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpge_epi64_mask() {
+    const fn test_mm_cmpge_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(-1);
         let r = _mm_cmpge_epi64_mask(a, b);
@@ -7272,7 +7272,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpge_epi64_mask() {
+    const fn test_mm_mask_cmpge_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(-1);
         let mask = 0b11111111;
@@ -7281,7 +7281,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpeq_epi64_mask() {
+    const fn test_mm512_cmpeq_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let m = _mm512_cmpeq_epi64_mask(b, a);
@@ -7289,7 +7289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpeq_epi64_mask() {
+    const fn test_mm512_mask_cmpeq_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let mask = 0b01111010;
@@ -7298,7 +7298,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpeq_epi64_mask() {
+    const fn test_mm256_cmpeq_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let m = _mm256_cmpeq_epi64_mask(b, a);
@@ -7306,7 +7306,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpeq_epi64_mask() {
+    const fn test_mm256_mask_cmpeq_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -7315,7 +7315,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpeq_epi64_mask() {
+    const fn test_mm_cmpeq_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(0, 1);
         let m = _mm_cmpeq_epi64_mask(b, a);
@@ -7323,7 +7323,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpeq_epi64_mask() {
+    const fn test_mm_mask_cmpeq_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set_epi64x(0, 1);
         let mask = 0b11111111;
@@ -7332,19 +7332,19 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_set_epi64() {
+    const fn test_mm512_set_epi64() {
         let r = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         assert_eq_m512i(r, _mm512_set_epi64(7, 6, 5, 4, 3, 2, 1, 0))
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_setr_epi64() {
+    const fn test_mm512_setr_epi64() {
         let r = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         assert_eq_m512i(r, _mm512_setr_epi64(7, 6, 5, 4, 3, 2, 1, 0))
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmpneq_epi64_mask() {
+    const fn test_mm512_cmpneq_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let m = _mm512_cmpneq_epi64_mask(b, a);
@@ -7352,7 +7352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmpneq_epi64_mask() {
+    const fn test_mm512_mask_cmpneq_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, -100, 100);
         let b = _mm512_set_epi64(0, 1, 13, 42, i64::MAX, i64::MIN, 100, -100);
         let mask = 0b01111010;
@@ -7361,7 +7361,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmpneq_epi64_mask() {
+    const fn test_mm256_cmpneq_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let r = _mm256_cmpneq_epi64_mask(b, a);
@@ -7369,7 +7369,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmpneq_epi64_mask() {
+    const fn test_mm256_mask_cmpneq_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set_epi64x(0, 1, 13, 42);
         let mask = 0b11111111;
@@ -7378,7 +7378,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmpneq_epi64_mask() {
+    const fn test_mm_cmpneq_epi64_mask() {
         let a = _mm_set_epi64x(-1, 13);
         let b = _mm_set_epi64x(13, 42);
         let r = _mm_cmpneq_epi64_mask(b, a);
@@ -7386,7 +7386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmpneq_epi64_mask() {
+    const fn test_mm_mask_cmpneq_epi64_mask() {
         let a = _mm_set_epi64x(-1, 13);
         let b = _mm_set_epi64x(13, 42);
         let mask = 0b11111111;
@@ -7395,7 +7395,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_cmp_epi64_mask() {
+    const fn test_mm512_cmp_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let m = _mm512_cmp_epi64_mask::<_MM_CMPINT_LT>(a, b);
@@ -7403,7 +7403,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_cmp_epi64_mask() {
+    const fn test_mm512_mask_cmp_epi64_mask() {
         let a = _mm512_set_epi64(0, 1, -1, 13, i64::MAX, i64::MIN, 100, -100);
         let b = _mm512_set1_epi64(-1);
         let mask = 0b01100110;
@@ -7412,7 +7412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_cmp_epi64_mask() {
+    const fn test_mm256_cmp_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set1_epi64x(1);
         let m = _mm256_cmp_epi64_mask::<_MM_CMPINT_LT>(a, b);
@@ -7420,7 +7420,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_cmp_epi64_mask() {
+    const fn test_mm256_mask_cmp_epi64_mask() {
         let a = _mm256_set_epi64x(0, 1, -1, 13);
         let b = _mm256_set1_epi64x(1);
         let mask = 0b11111111;
@@ -7429,7 +7429,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_cmp_epi64_mask() {
+    const fn test_mm_cmp_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let m = _mm_cmp_epi64_mask::<_MM_CMPINT_LT>(a, b);
@@ -7437,7 +7437,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_cmp_epi64_mask() {
+    const fn test_mm_mask_cmp_epi64_mask() {
         let a = _mm_set_epi64x(0, 1);
         let b = _mm_set1_epi64x(1);
         let mask = 0b11111111;
@@ -8318,7 +8318,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_rol_epi64() {
+    const fn test_mm512_rol_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 63, 1 << 32, 1 << 32, 1 << 32,
@@ -8334,7 +8334,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_rol_epi64() {
+    const fn test_mm512_mask_rol_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 63, 1 << 32, 1 << 32, 1 << 32,
@@ -8352,7 +8352,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_rol_epi64() {
+    const fn test_mm512_maskz_rol_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8366,7 +8366,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_rol_epi64() {
+    const fn test_mm256_rol_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_rol_epi64::<1>(a);
         let e = _mm256_set_epi64x(1 << 0, 1 << 33, 1 << 33, 1 << 33);
@@ -8374,7 +8374,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_rol_epi64() {
+    const fn test_mm256_mask_rol_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_mask_rol_epi64::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -8384,7 +8384,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_rol_epi64() {
+    const fn test_mm256_maskz_rol_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_maskz_rol_epi64::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -8394,7 +8394,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_rol_epi64() {
+    const fn test_mm_rol_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let r = _mm_rol_epi64::<1>(a);
         let e = _mm_set_epi64x(1 << 0, 1 << 33);
@@ -8402,7 +8402,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_rol_epi64() {
+    const fn test_mm_mask_rol_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let r = _mm_mask_rol_epi64::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -8412,7 +8412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_rol_epi64() {
+    const fn test_mm_maskz_rol_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let r = _mm_maskz_rol_epi64::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -8422,7 +8422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_ror_epi64() {
+    const fn test_mm512_ror_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 0,  1 << 32, 1 << 32, 1 << 32,
@@ -8438,7 +8438,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_ror_epi64() {
+    const fn test_mm512_mask_ror_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 0,  1 << 32, 1 << 32, 1 << 32,
@@ -8456,7 +8456,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_ror_epi64() {
+    const fn test_mm512_maskz_ror_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8470,7 +8470,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_ror_epi64() {
+    const fn test_mm256_ror_epi64() {
         let a = _mm256_set_epi64x(1 << 0, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_ror_epi64::<1>(a);
         let e = _mm256_set_epi64x(1 << 63, 1 << 31, 1 << 31, 1 << 31);
@@ -8478,7 +8478,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_ror_epi64() {
+    const fn test_mm256_mask_ror_epi64() {
         let a = _mm256_set_epi64x(1 << 0, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_mask_ror_epi64::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -8488,7 +8488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_ror_epi64() {
+    const fn test_mm256_maskz_ror_epi64() {
         let a = _mm256_set_epi64x(1 << 0, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_maskz_ror_epi64::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -8498,7 +8498,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_ror_epi64() {
+    const fn test_mm_ror_epi64() {
         let a = _mm_set_epi64x(1 << 0, 1 << 32);
         let r = _mm_ror_epi64::<1>(a);
         let e = _mm_set_epi64x(1 << 63, 1 << 31);
@@ -8506,7 +8506,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_ror_epi64() {
+    const fn test_mm_mask_ror_epi64() {
         let a = _mm_set_epi64x(1 << 0, 1 << 32);
         let r = _mm_mask_ror_epi64::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -8516,7 +8516,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_ror_epi64() {
+    const fn test_mm_maskz_ror_epi64() {
         let a = _mm_set_epi64x(1 << 0, 1 << 32);
         let r = _mm_maskz_ror_epi64::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -8526,7 +8526,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_slli_epi64() {
+    const fn test_mm512_slli_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 63, 1 << 32, 1 << 32, 1 << 32,
@@ -8542,7 +8542,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_slli_epi64() {
+    const fn test_mm512_mask_slli_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 63, 1 << 32, 1 << 32, 1 << 32,
@@ -8560,7 +8560,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_slli_epi64() {
+    const fn test_mm512_maskz_slli_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8574,7 +8574,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_slli_epi64() {
+    const fn test_mm256_mask_slli_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_mask_slli_epi64::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -8584,7 +8584,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_slli_epi64() {
+    const fn test_mm256_maskz_slli_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let r = _mm256_maskz_slli_epi64::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -8594,7 +8594,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_slli_epi64() {
+    const fn test_mm_mask_slli_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let r = _mm_mask_slli_epi64::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -8604,7 +8604,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_slli_epi64() {
+    const fn test_mm_maskz_slli_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let r = _mm_maskz_slli_epi64::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -8614,7 +8614,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srli_epi64() {
+    const fn test_mm512_srli_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 0, 1 << 32, 1 << 32, 1 << 32,
@@ -8630,7 +8630,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srli_epi64() {
+    const fn test_mm512_mask_srli_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 0, 1 << 32, 1 << 32, 1 << 32,
@@ -8648,7 +8648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srli_epi64() {
+    const fn test_mm512_maskz_srli_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8662,7 +8662,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srli_epi64() {
+    const fn test_mm256_mask_srli_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let r = _mm256_mask_srli_epi64::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -8672,7 +8672,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srli_epi64() {
+    const fn test_mm256_maskz_srli_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let r = _mm256_maskz_srli_epi64::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -8682,7 +8682,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srli_epi64() {
+    const fn test_mm_mask_srli_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let r = _mm_mask_srli_epi64::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -8692,7 +8692,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srli_epi64() {
+    const fn test_mm_maskz_srli_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let r = _mm_maskz_srli_epi64::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -8702,7 +8702,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_rolv_epi64() {
+    const fn test_mm512_rolv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 63, 1 << 32, 1 << 32,
@@ -8719,7 +8719,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_rolv_epi64() {
+    const fn test_mm512_mask_rolv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 63, 1 << 32, 1 << 32,
@@ -8738,7 +8738,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_rolv_epi64() {
+    const fn test_mm512_maskz_rolv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8753,7 +8753,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_rolv_epi64() {
+    const fn test_mm256_rolv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 63, 1 << 32, 1 << 32);
         let b = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_rolv_epi64(a, b);
@@ -8762,7 +8762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_rolv_epi64() {
+    const fn test_mm256_mask_rolv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 63, 1 << 32, 1 << 32);
         let b = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_mask_rolv_epi64(a, 0, a, b);
@@ -8773,7 +8773,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_rolv_epi64() {
+    const fn test_mm256_maskz_rolv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 63, 1 << 32, 1 << 32);
         let b = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_maskz_rolv_epi64(0, a, b);
@@ -8784,7 +8784,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_rolv_epi64() {
+    const fn test_mm_rolv_epi64() {
         let a = _mm_set_epi64x(1 << 32, 1 << 63);
         let b = _mm_set_epi64x(0, 1);
         let r = _mm_rolv_epi64(a, b);
@@ -8793,7 +8793,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_rolv_epi64() {
+    const fn test_mm_mask_rolv_epi64() {
         let a = _mm_set_epi64x(1 << 32, 1 << 63);
         let b = _mm_set_epi64x(0, 1);
         let r = _mm_mask_rolv_epi64(a, 0, a, b);
@@ -8804,7 +8804,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_rolv_epi64() {
+    const fn test_mm_maskz_rolv_epi64() {
         let a = _mm_set_epi64x(1 << 32, 1 << 63);
         let b = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_rolv_epi64(0, a, b);
@@ -8815,7 +8815,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_rorv_epi64() {
+    const fn test_mm512_rorv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 0, 1 << 32, 1 << 32,
@@ -8832,7 +8832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_rorv_epi64() {
+    const fn test_mm512_mask_rorv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 0, 1 << 32, 1 << 32,
@@ -8851,7 +8851,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_rorv_epi64() {
+    const fn test_mm512_maskz_rorv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8866,7 +8866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_rorv_epi64() {
+    const fn test_mm256_rorv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 0, 1 << 32, 1 << 32);
         let b = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_rorv_epi64(a, b);
@@ -8875,7 +8875,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_rorv_epi64() {
+    const fn test_mm256_mask_rorv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 0, 1 << 32, 1 << 32);
         let b = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_mask_rorv_epi64(a, 0, a, b);
@@ -8886,7 +8886,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_rorv_epi64() {
+    const fn test_mm256_maskz_rorv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 0, 1 << 32, 1 << 32);
         let b = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_maskz_rorv_epi64(0, a, b);
@@ -8897,7 +8897,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_rorv_epi64() {
+    const fn test_mm_rorv_epi64() {
         let a = _mm_set_epi64x(1 << 32, 1 << 0);
         let b = _mm_set_epi64x(0, 1);
         let r = _mm_rorv_epi64(a, b);
@@ -8906,7 +8906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_rorv_epi64() {
+    const fn test_mm_mask_rorv_epi64() {
         let a = _mm_set_epi64x(1 << 32, 1 << 0);
         let b = _mm_set_epi64x(0, 1);
         let r = _mm_mask_rorv_epi64(a, 0, a, b);
@@ -8917,7 +8917,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_rorv_epi64() {
+    const fn test_mm_maskz_rorv_epi64() {
         let a = _mm_set_epi64x(1 << 32, 1 << 0);
         let b = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_rorv_epi64(0, a, b);
@@ -8928,7 +8928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_sllv_epi64() {
+    const fn test_mm512_sllv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 63, 1 << 32, 1 << 32,
@@ -8945,7 +8945,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_sllv_epi64() {
+    const fn test_mm512_mask_sllv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 63, 1 << 32,
@@ -8964,7 +8964,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_sllv_epi64() {
+    const fn test_mm512_maskz_sllv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -8979,7 +8979,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_sllv_epi64() {
+    const fn test_mm256_mask_sllv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 32, 1 << 63, 1 << 32);
         let count = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_mask_sllv_epi64(a, 0, a, count);
@@ -8990,7 +8990,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_sllv_epi64() {
+    const fn test_mm256_maskz_sllv_epi64() {
         let a = _mm256_set_epi64x(1 << 32, 1 << 32, 1 << 63, 1 << 32);
         let count = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_maskz_sllv_epi64(0, a, count);
@@ -9001,7 +9001,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_sllv_epi64() {
+    const fn test_mm_mask_sllv_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let count = _mm_set_epi64x(2, 3);
         let r = _mm_mask_sllv_epi64(a, 0, a, count);
@@ -9012,7 +9012,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_sllv_epi64() {
+    const fn test_mm_maskz_sllv_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let count = _mm_set_epi64x(2, 3);
         let r = _mm_maskz_sllv_epi64(0, a, count);
@@ -9023,7 +9023,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srlv_epi64() {
+    const fn test_mm512_srlv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 0, 1 << 32, 1 << 32,
@@ -9040,7 +9040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srlv_epi64() {
+    const fn test_mm512_mask_srlv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 0, 1 << 32, 1 << 32,
@@ -9059,7 +9059,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srlv_epi64() {
+    const fn test_mm512_maskz_srlv_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -9074,7 +9074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srlv_epi64() {
+    const fn test_mm256_mask_srlv_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_mask_srlv_epi64(a, 0, a, count);
@@ -9085,7 +9085,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srlv_epi64() {
+    const fn test_mm256_maskz_srlv_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_maskz_srlv_epi64(0, a, count);
@@ -9096,7 +9096,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srlv_epi64() {
+    const fn test_mm_mask_srlv_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set1_epi64x(1);
         let r = _mm_mask_srlv_epi64(a, 0, a, count);
@@ -9107,7 +9107,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srlv_epi64() {
+    const fn test_mm_maskz_srlv_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set1_epi64x(1);
         let r = _mm_maskz_srlv_epi64(0, a, count);
@@ -9118,7 +9118,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sll_epi64() {
+    fn test_mm512_sll_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 63, 1 << 32, 1 << 32, 1 << 32,
@@ -9138,7 +9138,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sll_epi64() {
+    fn test_mm512_mask_sll_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 63, 1 << 32, 1 << 32, 1 << 32,
@@ -9157,7 +9157,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sll_epi64() {
+    fn test_mm512_maskz_sll_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -9172,7 +9172,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_sll_epi64() {
+    fn test_mm256_mask_sll_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_mask_sll_epi64(a, 0, a, count);
@@ -9183,7 +9183,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_sll_epi64() {
+    fn test_mm256_maskz_sll_epi64() {
         let a = _mm256_set_epi64x(1 << 63, 1 << 32, 1 << 32, 1 << 32);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_maskz_sll_epi64(0, a, count);
@@ -9194,7 +9194,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_sll_epi64() {
+    fn test_mm_mask_sll_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_mask_sll_epi64(a, 0, a, count);
@@ -9205,7 +9205,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_sll_epi64() {
+    fn test_mm_maskz_sll_epi64() {
         let a = _mm_set_epi64x(1 << 63, 1 << 32);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_sll_epi64(0, a, count);
@@ -9216,7 +9216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_srl_epi64() {
+    fn test_mm512_srl_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 0, 1 << 32, 1 << 32, 1 << 32,
@@ -9233,7 +9233,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_srl_epi64() {
+    fn test_mm512_mask_srl_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 0, 1 << 32, 1 << 32, 1 << 32,
@@ -9252,7 +9252,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_srl_epi64() {
+    fn test_mm512_maskz_srl_epi64() {
         #[rustfmt::skip]
         let a = _mm512_set_epi64(
             1 << 32, 1 << 32, 1 << 32, 1 << 32,
@@ -9267,7 +9267,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_srl_epi64() {
+    fn test_mm256_mask_srl_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_mask_srl_epi64(a, 0, a, count);
@@ -9278,7 +9278,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_srl_epi64() {
+    fn test_mm256_maskz_srl_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_maskz_srl_epi64(0, a, count);
@@ -9289,7 +9289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_srl_epi64() {
+    fn test_mm_mask_srl_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_mask_srl_epi64(a, 0, a, count);
@@ -9300,7 +9300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_srl_epi64() {
+    fn test_mm_maskz_srl_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_srl_epi64(0, a, count);
@@ -9311,7 +9311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_sra_epi64() {
+    fn test_mm512_sra_epi64() {
         let a = _mm512_set_epi64(1, -8, 0, 0, 0, 0, 15, -16);
         let count = _mm_set_epi64x(0, 2);
         let r = _mm512_sra_epi64(a, count);
@@ -9320,7 +9320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_sra_epi64() {
+    fn test_mm512_mask_sra_epi64() {
         let a = _mm512_set_epi64(1, -8, 0, 0, 0, 0, 15, -16);
         let count = _mm_set_epi64x(0, 2);
         let r = _mm512_mask_sra_epi64(a, 0, a, count);
@@ -9331,7 +9331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_sra_epi64() {
+    fn test_mm512_maskz_sra_epi64() {
         let a = _mm512_set_epi64(1, -8, 0, 0, 0, 0, 15, -16);
         let count = _mm_set_epi64x(0, 2);
         let r = _mm512_maskz_sra_epi64(0, a, count);
@@ -9342,7 +9342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_sra_epi64() {
+    fn test_mm256_sra_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_sra_epi64(a, count);
@@ -9351,7 +9351,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_sra_epi64() {
+    fn test_mm256_mask_sra_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_mask_sra_epi64(a, 0, a, count);
@@ -9362,7 +9362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_sra_epi64() {
+    fn test_mm256_maskz_sra_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm256_maskz_sra_epi64(0, a, count);
@@ -9373,7 +9373,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_sra_epi64() {
+    fn test_mm_sra_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_sra_epi64(a, count);
@@ -9382,7 +9382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_sra_epi64() {
+    fn test_mm_mask_sra_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_mask_sra_epi64(a, 0, a, count);
@@ -9393,7 +9393,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_sra_epi64() {
+    fn test_mm_maskz_sra_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_sra_epi64(0, a, count);
@@ -9404,7 +9404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srav_epi64() {
+    const fn test_mm512_srav_epi64() {
         let a = _mm512_set_epi64(1, -8, 0, 0, 0, 0, 15, -16);
         let count = _mm512_set_epi64(2, 2, 0, 0, 0, 0, 2, 1);
         let r = _mm512_srav_epi64(a, count);
@@ -9413,7 +9413,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srav_epi64() {
+    const fn test_mm512_mask_srav_epi64() {
         let a = _mm512_set_epi64(1, -8, 0, 0, 0, 0, 15, -16);
         let count = _mm512_set_epi64(2, 2, 0, 0, 0, 0, 2, 1);
         let r = _mm512_mask_srav_epi64(a, 0, a, count);
@@ -9424,7 +9424,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srav_epi64() {
+    const fn test_mm512_maskz_srav_epi64() {
         let a = _mm512_set_epi64(1, -8, 0, 0, 0, 0, 15, -16);
         let count = _mm512_set_epi64(2, 2, 0, 0, 0, 0, 2, 1);
         let r = _mm512_maskz_srav_epi64(0, a, count);
@@ -9435,7 +9435,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_srav_epi64() {
+    const fn test_mm256_srav_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_srav_epi64(a, count);
@@ -9444,7 +9444,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srav_epi64() {
+    const fn test_mm256_mask_srav_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_mask_srav_epi64(a, 0, a, count);
@@ -9455,7 +9455,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srav_epi64() {
+    const fn test_mm256_maskz_srav_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_maskz_srav_epi64(0, a, count);
@@ -9466,7 +9466,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_srav_epi64() {
+    const fn test_mm_srav_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set1_epi64x(1);
         let r = _mm_srav_epi64(a, count);
@@ -9475,7 +9475,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srav_epi64() {
+    const fn test_mm_mask_srav_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set1_epi64x(1);
         let r = _mm_mask_srav_epi64(a, 0, a, count);
@@ -9486,7 +9486,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srav_epi64() {
+    const fn test_mm_maskz_srav_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let count = _mm_set1_epi64x(1);
         let r = _mm_maskz_srav_epi64(0, a, count);
@@ -9497,7 +9497,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_srai_epi64() {
+    const fn test_mm512_srai_epi64() {
         let a = _mm512_set_epi64(1, -4, 15, 0, 0, 0, 0, -16);
         let r = _mm512_srai_epi64::<2>(a);
         let e = _mm512_set_epi64(0, -1, 3, 0, 0, 0, 0, -4);
@@ -9505,7 +9505,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_srai_epi64() {
+    const fn test_mm512_mask_srai_epi64() {
         let a = _mm512_set_epi64(1, -4, 15, 0, 0, 0, 0, -16);
         let r = _mm512_mask_srai_epi64::<2>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -9515,7 +9515,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_srai_epi64() {
+    const fn test_mm512_maskz_srai_epi64() {
         let a = _mm512_set_epi64(1, -4, 15, 0, 0, 0, 0, -16);
         let r = _mm512_maskz_srai_epi64::<2>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -9525,7 +9525,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_srai_epi64() {
+    const fn test_mm256_srai_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let r = _mm256_srai_epi64::<1>(a);
         let e = _mm256_set_epi64x(1 << 4, 0, 0, 0);
@@ -9533,7 +9533,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_srai_epi64() {
+    const fn test_mm256_mask_srai_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let r = _mm256_mask_srai_epi64::<1>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -9543,7 +9543,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_srai_epi64() {
+    const fn test_mm256_maskz_srai_epi64() {
         let a = _mm256_set_epi64x(1 << 5, 0, 0, 0);
         let r = _mm256_maskz_srai_epi64::<1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -9553,7 +9553,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_srai_epi64() {
+    const fn test_mm_srai_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let r = _mm_srai_epi64::<1>(a);
         let e = _mm_set_epi64x(1 << 4, 0);
@@ -9561,7 +9561,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_srai_epi64() {
+    const fn test_mm_mask_srai_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let r = _mm_mask_srai_epi64::<1>(a, 0, a);
         assert_eq_m128i(r, a);
@@ -9571,7 +9571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_srai_epi64() {
+    const fn test_mm_maskz_srai_epi64() {
         let a = _mm_set_epi64x(1 << 5, 0);
         let r = _mm_maskz_srai_epi64::<1>(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -9581,7 +9581,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_permute_pd() {
+    const fn test_mm512_permute_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_permute_pd::<0b11_11_11_11>(a);
         let e = _mm512_setr_pd(1., 1., 3., 3., 5., 5., 7., 7.);
@@ -9589,7 +9589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_permute_pd() {
+    const fn test_mm512_mask_permute_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_mask_permute_pd::<0b11_11_11_11>(a, 0, a);
         assert_eq_m512d(r, a);
@@ -9599,7 +9599,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_permute_pd() {
+    const fn test_mm512_maskz_permute_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_maskz_permute_pd::<0b11_11_11_11>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -9609,7 +9609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_permute_pd() {
+    const fn test_mm256_mask_permute_pd() {
         let a = _mm256_set_pd(3., 2., 1., 0.);
         let r = _mm256_mask_permute_pd::<0b11_11>(a, 0, a);
         assert_eq_m256d(r, a);
@@ -9619,7 +9619,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_permute_pd() {
+    const fn test_mm256_maskz_permute_pd() {
         let a = _mm256_set_pd(3., 2., 1., 0.);
         let r = _mm256_maskz_permute_pd::<0b11_11>(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -9629,7 +9629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_permute_pd() {
+    const fn test_mm_mask_permute_pd() {
         let a = _mm_set_pd(1., 0.);
         let r = _mm_mask_permute_pd::<0b11>(a, 0, a);
         assert_eq_m128d(r, a);
@@ -9639,7 +9639,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_permute_pd() {
+    const fn test_mm_maskz_permute_pd() {
         let a = _mm_set_pd(1., 0.);
         let r = _mm_maskz_permute_pd::<0b11>(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -9649,7 +9649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_permutex_epi64() {
+    const fn test_mm512_permutex_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_permutex_epi64::<0b11_11_11_11>(a);
         let e = _mm512_setr_epi64(3, 3, 3, 3, 7, 7, 7, 7);
@@ -9657,7 +9657,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_permutex_epi64() {
+    const fn test_mm512_mask_permutex_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_mask_permutex_epi64::<0b11_11_11_11>(a, 0, a);
         assert_eq_m512i(r, a);
@@ -9667,7 +9667,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_permutex_epi64() {
+    const fn test_mm512_maskz_permutex_epi64() {
         let a = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_maskz_permutex_epi64::<0b11_11_11_11>(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -9677,7 +9677,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_permutex_epi64() {
+    const fn test_mm256_permutex_epi64() {
         let a = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_permutex_epi64::<0b11_11_11_11>(a);
         let e = _mm256_set_epi64x(3, 3, 3, 3);
@@ -9685,7 +9685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_permutex_epi64() {
+    const fn test_mm256_mask_permutex_epi64() {
         let a = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_mask_permutex_epi64::<0b11_11_11_11>(a, 0, a);
         assert_eq_m256i(r, a);
@@ -9695,7 +9695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_permutex_epi64() {
+    const fn test_mm256_maskz_permutex_epi64() {
         let a = _mm256_set_epi64x(3, 2, 1, 0);
         let r = _mm256_maskz_permutex_epi64::<0b11_11_11_11>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -9705,7 +9705,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_permutex_pd() {
+    const fn test_mm512_permutex_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_permutex_pd::<0b11_11_11_11>(a);
         let e = _mm512_setr_pd(3., 3., 3., 3., 7., 7., 7., 7.);
@@ -9713,7 +9713,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_permutex_pd() {
+    const fn test_mm512_mask_permutex_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_mask_permutex_pd::<0b11_11_11_11>(a, 0, a);
         assert_eq_m512d(r, a);
@@ -9723,7 +9723,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_permutex_pd() {
+    const fn test_mm512_maskz_permutex_pd() {
         let a = _mm512_setr_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_maskz_permutex_pd::<0b11_11_11_11>(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -9733,7 +9733,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_permutex_pd() {
+    const fn test_mm256_permutex_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_permutex_pd::<0b11_11_11_11>(a);
         let e = _mm256_set_pd(0., 0., 0., 0.);
@@ -9741,7 +9741,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_permutex_pd() {
+    const fn test_mm256_mask_permutex_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_mask_permutex_pd::<0b11_11_11_11>(a, 0, a);
         assert_eq_m256d(r, a);
@@ -9751,7 +9751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_permutex_pd() {
+    const fn test_mm256_maskz_permutex_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_maskz_permutex_pd::<0b11_11_11_11>(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -9761,7 +9761,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutevar_pd() {
+    fn test_mm512_permutevar_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_set1_epi64(0b1);
         let r = _mm512_permutevar_pd(a, b);
@@ -9770,7 +9770,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutevar_pd() {
+    fn test_mm512_mask_permutevar_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_set1_epi64(0b1);
         let r = _mm512_mask_permutevar_pd(a, 0, a, b);
@@ -9781,7 +9781,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutevar_pd() {
+    fn test_mm512_maskz_permutevar_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let b = _mm512_set1_epi64(0b1);
         let r = _mm512_maskz_permutevar_pd(0, a, b);
@@ -9792,7 +9792,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutevar_pd() {
+    fn test_mm256_mask_permutevar_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let b = _mm256_set1_epi64x(0b1);
         let r = _mm256_mask_permutevar_pd(a, 0, a, b);
@@ -9803,7 +9803,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutevar_pd() {
+    fn test_mm256_maskz_permutevar_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let b = _mm256_set1_epi64x(0b1);
         let r = _mm256_maskz_permutevar_pd(0, a, b);
@@ -9814,7 +9814,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_permutevar_pd() {
+    fn test_mm_mask_permutevar_pd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set1_epi64x(0b1);
         let r = _mm_mask_permutevar_pd(a, 0, a, b);
@@ -9825,7 +9825,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_permutevar_pd() {
+    fn test_mm_maskz_permutevar_pd() {
         let a = _mm_set_pd(0., 1.);
         let b = _mm_set1_epi64x(0b1);
         let r = _mm_maskz_permutevar_pd(0, a, b);
@@ -9836,7 +9836,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutexvar_epi64() {
+    fn test_mm512_permutexvar_epi64() {
         let idx = _mm512_set1_epi64(1);
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_permutexvar_epi64(idx, a);
@@ -9845,7 +9845,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutexvar_epi64() {
+    fn test_mm512_mask_permutexvar_epi64() {
         let idx = _mm512_set1_epi64(1);
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_mask_permutexvar_epi64(a, 0, idx, a);
@@ -9856,7 +9856,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutexvar_epi64() {
+    fn test_mm512_maskz_permutexvar_epi64() {
         let idx = _mm512_set1_epi64(1);
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_maskz_permutexvar_epi64(0, idx, a);
@@ -9867,7 +9867,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutexvar_epi64() {
+    fn test_mm256_permutexvar_epi64() {
         let idx = _mm256_set1_epi64x(1);
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_permutexvar_epi64(idx, a);
@@ -9876,7 +9876,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutexvar_epi64() {
+    fn test_mm256_mask_permutexvar_epi64() {
         let idx = _mm256_set1_epi64x(1);
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_mask_permutexvar_epi64(a, 0, idx, a);
@@ -9887,7 +9887,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutexvar_epi64() {
+    fn test_mm256_maskz_permutexvar_epi64() {
         let idx = _mm256_set1_epi64x(1);
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_maskz_permutexvar_epi64(0, idx, a);
@@ -9898,7 +9898,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutexvar_pd() {
+    fn test_mm512_permutexvar_pd() {
         let idx = _mm512_set1_epi64(1);
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_permutexvar_pd(idx, a);
@@ -9907,7 +9907,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutexvar_pd() {
+    fn test_mm512_mask_permutexvar_pd() {
         let idx = _mm512_set1_epi64(1);
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_mask_permutexvar_pd(a, 0, idx, a);
@@ -9918,7 +9918,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutexvar_pd() {
+    fn test_mm512_maskz_permutexvar_pd() {
         let idx = _mm512_set1_epi64(1);
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_maskz_permutexvar_pd(0, idx, a);
@@ -9929,7 +9929,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutexvar_pd() {
+    fn test_mm256_permutexvar_pd() {
         let idx = _mm256_set1_epi64x(1);
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_permutexvar_pd(idx, a);
@@ -9938,7 +9938,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutexvar_pd() {
+    fn test_mm256_mask_permutexvar_pd() {
         let idx = _mm256_set1_epi64x(1);
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_mask_permutexvar_pd(a, 0, idx, a);
@@ -9949,7 +9949,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutexvar_pd() {
+    fn test_mm256_maskz_permutexvar_pd() {
         let idx = _mm256_set1_epi64x(1);
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_maskz_permutexvar_pd(0, idx, a);
@@ -9960,7 +9960,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutex2var_epi64() {
+    fn test_mm512_permutex2var_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_epi64(100);
@@ -9970,7 +9970,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutex2var_epi64() {
+    fn test_mm512_mask_permutex2var_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_epi64(100);
@@ -9982,7 +9982,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutex2var_epi64() {
+    fn test_mm512_maskz_permutex2var_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_epi64(100);
@@ -9994,7 +9994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask2_permutex2var_epi64() {
+    fn test_mm512_mask2_permutex2var_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let idx = _mm512_set_epi64(1000, 1 << 3, 2000, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_epi64(100);
@@ -10006,7 +10006,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutex2var_epi64() {
+    fn test_mm256_permutex2var_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_epi64x(100);
@@ -10016,7 +10016,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutex2var_epi64() {
+    fn test_mm256_mask_permutex2var_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_epi64x(100);
@@ -10028,7 +10028,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutex2var_epi64() {
+    fn test_mm256_maskz_permutex2var_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_epi64x(100);
@@ -10040,7 +10040,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask2_permutex2var_epi64() {
+    fn test_mm256_mask2_permutex2var_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_epi64x(100);
@@ -10052,7 +10052,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_permutex2var_epi64() {
+    fn test_mm_permutex2var_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_epi64x(100);
@@ -10062,7 +10062,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_permutex2var_epi64() {
+    fn test_mm_mask_permutex2var_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_epi64x(100);
@@ -10074,7 +10074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_permutex2var_epi64() {
+    fn test_mm_maskz_permutex2var_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_epi64x(100);
@@ -10086,7 +10086,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask2_permutex2var_epi64() {
+    fn test_mm_mask2_permutex2var_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_epi64x(100);
@@ -10098,7 +10098,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_permutex2var_pd() {
+    fn test_mm512_permutex2var_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_pd(100.);
@@ -10108,7 +10108,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_permutex2var_pd() {
+    fn test_mm512_mask_permutex2var_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_pd(100.);
@@ -10120,7 +10120,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_permutex2var_pd() {
+    fn test_mm512_maskz_permutex2var_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_pd(100.);
@@ -10132,7 +10132,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask2_permutex2var_pd() {
+    fn test_mm512_mask2_permutex2var_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let idx = _mm512_set_epi64(1, 1 << 3, 2, 1 << 3, 3, 1 << 3, 4, 1 << 3);
         let b = _mm512_set1_pd(100.);
@@ -10144,7 +10144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_permutex2var_pd() {
+    fn test_mm256_permutex2var_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_pd(100.);
@@ -10154,7 +10154,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_permutex2var_pd() {
+    fn test_mm256_mask_permutex2var_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_pd(100.);
@@ -10166,7 +10166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_permutex2var_pd() {
+    fn test_mm256_maskz_permutex2var_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_pd(100.);
@@ -10178,7 +10178,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask2_permutex2var_pd() {
+    fn test_mm256_mask2_permutex2var_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let idx = _mm256_set_epi64x(1, 1 << 2, 2, 1 << 2);
         let b = _mm256_set1_pd(100.);
@@ -10190,7 +10190,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_permutex2var_pd() {
+    fn test_mm_permutex2var_pd() {
         let a = _mm_set_pd(0., 1.);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_pd(100.);
@@ -10200,7 +10200,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_permutex2var_pd() {
+    fn test_mm_mask_permutex2var_pd() {
         let a = _mm_set_pd(0., 1.);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_pd(100.);
@@ -10212,7 +10212,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_permutex2var_pd() {
+    fn test_mm_maskz_permutex2var_pd() {
         let a = _mm_set_pd(0., 1.);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_pd(100.);
@@ -10224,7 +10224,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask2_permutex2var_pd() {
+    fn test_mm_mask2_permutex2var_pd() {
         let a = _mm_set_pd(0., 1.);
         let idx = _mm_set_epi64x(1, 1 << 1);
         let b = _mm_set1_pd(100.);
@@ -10236,7 +10236,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_pd() {
+    const fn test_mm256_mask_shuffle_pd() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
         let r = _mm256_mask_shuffle_pd::<0b11_11_11_11>(a, 0, a, b);
@@ -10247,7 +10247,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_pd() {
+    const fn test_mm256_maskz_shuffle_pd() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
         let r = _mm256_maskz_shuffle_pd::<0b11_11_11_11>(0, a, b);
@@ -10258,7 +10258,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_shuffle_pd() {
+    const fn test_mm_mask_shuffle_pd() {
         let a = _mm_set_pd(1., 4.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_mask_shuffle_pd::<0b11_11_11_11>(a, 0, a, b);
@@ -10269,7 +10269,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_shuffle_pd() {
+    const fn test_mm_maskz_shuffle_pd() {
         let a = _mm_set_pd(1., 4.);
         let b = _mm_set_pd(2., 3.);
         let r = _mm_maskz_shuffle_pd::<0b11_11_11_11>(0, a, b);
@@ -10280,7 +10280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_i64x2() {
+    const fn test_mm512_shuffle_i64x2() {
         let a = _mm512_setr_epi64(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm512_setr_epi64(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm512_shuffle_i64x2::<0b00_00_00_00>(a, b);
@@ -10289,7 +10289,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_i64x2() {
+    const fn test_mm512_mask_shuffle_i64x2() {
         let a = _mm512_setr_epi64(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm512_setr_epi64(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm512_mask_shuffle_i64x2::<0b00_00_00_00>(a, 0, a, b);
@@ -10300,7 +10300,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_i64x2() {
+    const fn test_mm512_maskz_shuffle_i64x2() {
         let a = _mm512_setr_epi64(1, 4, 5, 8, 9, 12, 13, 16);
         let b = _mm512_setr_epi64(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm512_maskz_shuffle_i64x2::<0b00_00_00_00>(0, a, b);
@@ -10311,7 +10311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_shuffle_i64x2() {
+    const fn test_mm256_shuffle_i64x2() {
         let a = _mm256_set_epi64x(1, 4, 5, 8);
         let b = _mm256_set_epi64x(2, 3, 6, 7);
         let r = _mm256_shuffle_i64x2::<0b00>(a, b);
@@ -10320,7 +10320,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_i64x2() {
+    const fn test_mm256_mask_shuffle_i64x2() {
         let a = _mm256_set_epi64x(1, 4, 5, 8);
         let b = _mm256_set_epi64x(2, 3, 6, 7);
         let r = _mm256_mask_shuffle_i64x2::<0b00>(a, 0, a, b);
@@ -10331,7 +10331,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_i64x2() {
+    const fn test_mm256_maskz_shuffle_i64x2() {
         let a = _mm256_set_epi64x(1, 4, 5, 8);
         let b = _mm256_set_epi64x(2, 3, 6, 7);
         let r = _mm256_maskz_shuffle_i64x2::<0b00>(0, a, b);
@@ -10342,7 +10342,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_shuffle_f64x2() {
+    const fn test_mm512_shuffle_f64x2() {
         let a = _mm512_setr_pd(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm512_setr_pd(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm512_shuffle_f64x2::<0b00_00_00_00>(a, b);
@@ -10351,7 +10351,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_shuffle_f64x2() {
+    const fn test_mm512_mask_shuffle_f64x2() {
         let a = _mm512_setr_pd(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm512_setr_pd(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm512_mask_shuffle_f64x2::<0b00_00_00_00>(a, 0, a, b);
@@ -10362,7 +10362,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_shuffle_f64x2() {
+    const fn test_mm512_maskz_shuffle_f64x2() {
         let a = _mm512_setr_pd(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm512_setr_pd(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm512_maskz_shuffle_f64x2::<0b00_00_00_00>(0, a, b);
@@ -10373,7 +10373,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_shuffle_f64x2() {
+    const fn test_mm256_shuffle_f64x2() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
         let r = _mm256_shuffle_f64x2::<0b00>(a, b);
@@ -10382,7 +10382,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_shuffle_f64x2() {
+    const fn test_mm256_mask_shuffle_f64x2() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
         let r = _mm256_mask_shuffle_f64x2::<0b00>(a, 0, a, b);
@@ -10393,7 +10393,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_shuffle_f64x2() {
+    const fn test_mm256_maskz_shuffle_f64x2() {
         let a = _mm256_set_pd(1., 4., 5., 8.);
         let b = _mm256_set_pd(2., 3., 6., 7.);
         let r = _mm256_maskz_shuffle_f64x2::<0b00>(0, a, b);
@@ -10404,7 +10404,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_movedup_pd() {
+    const fn test_mm512_movedup_pd() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_movedup_pd(a);
         let e = _mm512_setr_pd(1., 1., 3., 3., 5., 5., 7., 7.);
@@ -10412,7 +10412,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_movedup_pd() {
+    const fn test_mm512_mask_movedup_pd() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_mask_movedup_pd(a, 0, a);
         assert_eq_m512d(r, a);
@@ -10422,7 +10422,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_movedup_pd() {
+    const fn test_mm512_maskz_movedup_pd() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_movedup_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -10432,7 +10432,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_movedup_pd() {
+    const fn test_mm256_mask_movedup_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_mask_movedup_pd(a, 0, a);
         assert_eq_m256d(r, a);
@@ -10442,7 +10442,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_movedup_pd() {
+    const fn test_mm256_maskz_movedup_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let r = _mm256_maskz_movedup_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -10452,7 +10452,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_movedup_pd() {
+    const fn test_mm_mask_movedup_pd() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_mask_movedup_pd(a, 0, a);
         assert_eq_m128d(r, a);
@@ -10462,7 +10462,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_movedup_pd() {
+    const fn test_mm_maskz_movedup_pd() {
         let a = _mm_set_pd(1., 2.);
         let r = _mm_maskz_movedup_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -10472,7 +10472,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_inserti64x4() {
+    const fn test_mm512_inserti64x4() {
         let a = _mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_setr_epi64x(17, 18, 19, 20);
         let r = _mm512_inserti64x4::<1>(a, b);
@@ -10481,7 +10481,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_inserti64x4() {
+    const fn test_mm512_mask_inserti64x4() {
         let a = _mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_setr_epi64x(17, 18, 19, 20);
         let r = _mm512_mask_inserti64x4::<1>(a, 0, a, b);
@@ -10492,7 +10492,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_inserti64x4() {
+    const fn test_mm512_maskz_inserti64x4() {
         let a = _mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm256_setr_epi64x(17, 18, 19, 20);
         let r = _mm512_maskz_inserti64x4::<1>(0, a, b);
@@ -10503,7 +10503,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_insertf64x4() {
+    const fn test_mm512_insertf64x4() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_pd(17., 18., 19., 20.);
         let r = _mm512_insertf64x4::<1>(a, b);
@@ -10512,7 +10512,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_insertf64x4() {
+    const fn test_mm512_mask_insertf64x4() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_pd(17., 18., 19., 20.);
         let r = _mm512_mask_insertf64x4::<1>(a, 0, a, b);
@@ -10523,7 +10523,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_insertf64x4() {
+    const fn test_mm512_maskz_insertf64x4() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm256_setr_pd(17., 18., 19., 20.);
         let r = _mm512_maskz_insertf64x4::<1>(0, a, b);
@@ -10534,21 +10534,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castpd128_pd512() {
+    const fn test_mm512_castpd128_pd512() {
         let a = _mm_setr_pd(17., 18.);
         let r = _mm512_castpd128_pd512(a);
         assert_eq_m128d(_mm512_castpd512_pd128(r), a);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castpd256_pd512() {
+    const fn test_mm512_castpd256_pd512() {
         let a = _mm256_setr_pd(17., 18., 19., 20.);
         let r = _mm512_castpd256_pd512(a);
         assert_eq_m256d(_mm512_castpd512_pd256(r), a);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_zextpd128_pd512() {
+    const fn test_mm512_zextpd128_pd512() {
         let a = _mm_setr_pd(17., 18.);
         let r = _mm512_zextpd128_pd512(a);
         let e = _mm512_setr_pd(17., 18., 0., 0., 0., 0., 0., 0.);
@@ -10556,7 +10556,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_zextpd256_pd512() {
+    const fn test_mm512_zextpd256_pd512() {
         let a = _mm256_setr_pd(17., 18., 19., 20.);
         let r = _mm512_zextpd256_pd512(a);
         let e = _mm512_setr_pd(17., 18., 19., 20., 0., 0., 0., 0.);
@@ -10564,7 +10564,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castpd512_pd128() {
+    const fn test_mm512_castpd512_pd128() {
         let a = _mm512_setr_pd(17., 18., -1., -1., -1., -1., -1., -1.);
         let r = _mm512_castpd512_pd128(a);
         let e = _mm_setr_pd(17., 18.);
@@ -10572,7 +10572,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castpd512_pd256() {
+    const fn test_mm512_castpd512_pd256() {
         let a = _mm512_setr_pd(17., 18., 19., 20., -1., -1., -1., -1.);
         let r = _mm512_castpd512_pd256(a);
         let e = _mm256_setr_pd(17., 18., 19., 20.);
@@ -10580,7 +10580,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castpd_ps() {
+    const fn test_mm512_castpd_ps() {
         let a = _mm512_set1_pd(1.);
         let r = _mm512_castpd_ps(a);
         let e = _mm512_set_ps(
@@ -10591,7 +10591,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castpd_si512() {
+    const fn test_mm512_castpd_si512() {
         let a = _mm512_set1_pd(1.);
         let r = _mm512_castpd_si512(a);
         let e = _mm512_set_epi32(
@@ -10602,21 +10602,21 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castsi128_si512() {
+    const fn test_mm512_castsi128_si512() {
         let a = _mm_setr_epi64x(17, 18);
         let r = _mm512_castsi128_si512(a);
         assert_eq_m128i(_mm512_castsi512_si128(r), a);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castsi256_si512() {
+    const fn test_mm512_castsi256_si512() {
         let a = _mm256_setr_epi64x(17, 18, 19, 20);
         let r = _mm512_castsi256_si512(a);
         assert_eq_m256i(_mm512_castsi512_si256(r), a);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_zextsi128_si512() {
+    const fn test_mm512_zextsi128_si512() {
         let a = _mm_setr_epi64x(17, 18);
         let r = _mm512_zextsi128_si512(a);
         let e = _mm512_setr_epi64(17, 18, 0, 0, 0, 0, 0, 0);
@@ -10624,7 +10624,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_zextsi256_si512() {
+    const fn test_mm512_zextsi256_si512() {
         let a = _mm256_setr_epi64x(17, 18, 19, 20);
         let r = _mm512_zextsi256_si512(a);
         let e = _mm512_setr_epi64(17, 18, 19, 20, 0, 0, 0, 0);
@@ -10632,7 +10632,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castsi512_si128() {
+    const fn test_mm512_castsi512_si128() {
         let a = _mm512_setr_epi64(17, 18, -1, -1, -1, -1, -1, -1);
         let r = _mm512_castsi512_si128(a);
         let e = _mm_setr_epi64x(17, 18);
@@ -10640,7 +10640,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castsi512_si256() {
+    const fn test_mm512_castsi512_si256() {
         let a = _mm512_setr_epi64(17, 18, 19, 20, -1, -1, -1, -1);
         let r = _mm512_castsi512_si256(a);
         let e = _mm256_setr_epi64x(17, 18, 19, 20);
@@ -10648,7 +10648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castsi512_ps() {
+    const fn test_mm512_castsi512_ps() {
         let a = _mm512_set1_epi64(1 << 62);
         let r = _mm512_castsi512_ps(a);
         let e = _mm512_set_ps(
@@ -10658,7 +10658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_castsi512_pd() {
+    const fn test_mm512_castsi512_pd() {
         let a = _mm512_set1_epi64(1 << 62);
         let r = _mm512_castsi512_pd(a);
         let e = _mm512_set_pd(2., 2., 2., 2., 2., 2., 2., 2.);
@@ -10666,7 +10666,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcastq_epi64() {
+    const fn test_mm512_broadcastq_epi64() {
         let a = _mm_setr_epi64x(17, 18);
         let r = _mm512_broadcastq_epi64(a);
         let e = _mm512_set1_epi64(17);
@@ -10674,7 +10674,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcastq_epi64() {
+    const fn test_mm512_mask_broadcastq_epi64() {
         let src = _mm512_set1_epi64(18);
         let a = _mm_setr_epi64x(17, 18);
         let r = _mm512_mask_broadcastq_epi64(src, 0, a);
@@ -10685,7 +10685,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcastq_epi64() {
+    const fn test_mm512_maskz_broadcastq_epi64() {
         let a = _mm_setr_epi64x(17, 18);
         let r = _mm512_maskz_broadcastq_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -10695,7 +10695,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcastq_epi64() {
+    const fn test_mm256_mask_broadcastq_epi64() {
         let src = _mm256_set1_epi64x(18);
         let a = _mm_set_epi64x(17, 18);
         let r = _mm256_mask_broadcastq_epi64(src, 0, a);
@@ -10706,7 +10706,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcastq_epi64() {
+    const fn test_mm256_maskz_broadcastq_epi64() {
         let a = _mm_set_epi64x(17, 18);
         let r = _mm256_maskz_broadcastq_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -10716,7 +10716,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_broadcastq_epi64() {
+    const fn test_mm_mask_broadcastq_epi64() {
         let src = _mm_set1_epi64x(18);
         let a = _mm_set_epi64x(17, 18);
         let r = _mm_mask_broadcastq_epi64(src, 0, a);
@@ -10727,7 +10727,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_broadcastq_epi64() {
+    const fn test_mm_maskz_broadcastq_epi64() {
         let a = _mm_set_epi64x(17, 18);
         let r = _mm_maskz_broadcastq_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -10737,7 +10737,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcastsd_pd() {
+    const fn test_mm512_broadcastsd_pd() {
         let a = _mm_set_pd(17., 18.);
         let r = _mm512_broadcastsd_pd(a);
         let e = _mm512_set1_pd(18.);
@@ -10745,7 +10745,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcastsd_pd() {
+    const fn test_mm512_mask_broadcastsd_pd() {
         let src = _mm512_set1_pd(18.);
         let a = _mm_set_pd(17., 18.);
         let r = _mm512_mask_broadcastsd_pd(src, 0, a);
@@ -10756,7 +10756,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcastsd_pd() {
+    const fn test_mm512_maskz_broadcastsd_pd() {
         let a = _mm_set_pd(17., 18.);
         let r = _mm512_maskz_broadcastsd_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -10766,7 +10766,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_broadcastsd_pd() {
+    const fn test_mm256_mask_broadcastsd_pd() {
         let src = _mm256_set1_pd(18.);
         let a = _mm_set_pd(17., 18.);
         let r = _mm256_mask_broadcastsd_pd(src, 0, a);
@@ -10777,7 +10777,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_broadcastsd_pd() {
+    const fn test_mm256_maskz_broadcastsd_pd() {
         let a = _mm_set_pd(17., 18.);
         let r = _mm256_maskz_broadcastsd_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -10787,7 +10787,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcast_i64x4() {
+    const fn test_mm512_broadcast_i64x4() {
         let a = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm512_broadcast_i64x4(a);
         let e = _mm512_set_epi64(17, 18, 19, 20, 17, 18, 19, 20);
@@ -10795,7 +10795,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcast_i64x4() {
+    const fn test_mm512_mask_broadcast_i64x4() {
         let src = _mm512_set1_epi64(18);
         let a = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm512_mask_broadcast_i64x4(src, 0, a);
@@ -10806,7 +10806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcast_i64x4() {
+    const fn test_mm512_maskz_broadcast_i64x4() {
         let a = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm512_maskz_broadcast_i64x4(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -10816,7 +10816,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_broadcast_f64x4() {
+    const fn test_mm512_broadcast_f64x4() {
         let a = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm512_broadcast_f64x4(a);
         let e = _mm512_set_pd(17., 18., 19., 20., 17., 18., 19., 20.);
@@ -10824,7 +10824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_broadcast_f64x4() {
+    const fn test_mm512_mask_broadcast_f64x4() {
         let src = _mm512_set1_pd(18.);
         let a = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm512_mask_broadcast_f64x4(src, 0, a);
@@ -10835,7 +10835,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_broadcast_f64x4() {
+    const fn test_mm512_maskz_broadcast_f64x4() {
         let a = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm512_maskz_broadcast_f64x4(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -10845,7 +10845,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_blend_epi64() {
+    const fn test_mm512_mask_blend_epi64() {
         let a = _mm512_set1_epi64(1);
         let b = _mm512_set1_epi64(2);
         let r = _mm512_mask_blend_epi64(0b11110000, a, b);
@@ -10854,7 +10854,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_epi64() {
+    const fn test_mm256_mask_blend_epi64() {
         let a = _mm256_set1_epi64x(1);
         let b = _mm256_set1_epi64x(2);
         let r = _mm256_mask_blend_epi64(0b00001111, a, b);
@@ -10863,7 +10863,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_blend_epi64() {
+    const fn test_mm_mask_blend_epi64() {
         let a = _mm_set1_epi64x(1);
         let b = _mm_set1_epi64x(2);
         let r = _mm_mask_blend_epi64(0b00000011, a, b);
@@ -10872,7 +10872,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_blend_pd() {
+    const fn test_mm512_mask_blend_pd() {
         let a = _mm512_set1_pd(1.);
         let b = _mm512_set1_pd(2.);
         let r = _mm512_mask_blend_pd(0b11110000, a, b);
@@ -10881,7 +10881,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_blend_pd() {
+    const fn test_mm256_mask_blend_pd() {
         let a = _mm256_set1_pd(1.);
         let b = _mm256_set1_pd(2.);
         let r = _mm256_mask_blend_pd(0b00001111, a, b);
@@ -10890,7 +10890,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_blend_pd() {
+    const fn test_mm_mask_blend_pd() {
         let a = _mm_set1_pd(1.);
         let b = _mm_set1_pd(2.);
         let r = _mm_mask_blend_pd(0b00000011, a, b);
@@ -10899,7 +10899,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpackhi_epi64() {
+    const fn test_mm512_unpackhi_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_unpackhi_epi64(a, b);
@@ -10908,7 +10908,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpackhi_epi64() {
+    const fn test_mm512_mask_unpackhi_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_mask_unpackhi_epi64(a, 0, a, b);
@@ -10919,7 +10919,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpackhi_epi64() {
+    const fn test_mm512_maskz_unpackhi_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_maskz_unpackhi_epi64(0, a, b);
@@ -10930,7 +10930,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpackhi_epi64() {
+    const fn test_mm256_mask_unpackhi_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm256_mask_unpackhi_epi64(a, 0, a, b);
@@ -10941,7 +10941,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpackhi_epi64() {
+    const fn test_mm256_maskz_unpackhi_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm256_maskz_unpackhi_epi64(0, a, b);
@@ -10952,7 +10952,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpackhi_epi64() {
+    const fn test_mm_mask_unpackhi_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(17, 18);
         let r = _mm_mask_unpackhi_epi64(a, 0, a, b);
@@ -10963,7 +10963,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpackhi_epi64() {
+    const fn test_mm_maskz_unpackhi_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(17, 18);
         let r = _mm_maskz_unpackhi_epi64(0, a, b);
@@ -10974,7 +10974,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpackhi_pd() {
+    const fn test_mm512_unpackhi_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_unpackhi_pd(a, b);
@@ -10983,7 +10983,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpackhi_pd() {
+    const fn test_mm512_mask_unpackhi_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_mask_unpackhi_pd(a, 0, a, b);
@@ -10994,7 +10994,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpackhi_pd() {
+    const fn test_mm512_maskz_unpackhi_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_maskz_unpackhi_pd(0, a, b);
@@ -11005,7 +11005,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpackhi_pd() {
+    const fn test_mm256_mask_unpackhi_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm256_mask_unpackhi_pd(a, 0, a, b);
@@ -11016,7 +11016,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpackhi_pd() {
+    const fn test_mm256_maskz_unpackhi_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm256_maskz_unpackhi_pd(0, a, b);
@@ -11027,7 +11027,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpackhi_pd() {
+    const fn test_mm_mask_unpackhi_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(17., 18.);
         let r = _mm_mask_unpackhi_pd(a, 0, a, b);
@@ -11038,7 +11038,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpackhi_pd() {
+    const fn test_mm_maskz_unpackhi_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(17., 18.);
         let r = _mm_maskz_unpackhi_pd(0, a, b);
@@ -11049,7 +11049,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpacklo_epi64() {
+    const fn test_mm512_unpacklo_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_unpacklo_epi64(a, b);
@@ -11058,7 +11058,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpacklo_epi64() {
+    const fn test_mm512_mask_unpacklo_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_mask_unpacklo_epi64(a, 0, a, b);
@@ -11069,7 +11069,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpacklo_epi64() {
+    const fn test_mm512_maskz_unpacklo_epi64() {
         let a = _mm512_set_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let b = _mm512_set_epi64(17, 18, 19, 20, 21, 22, 23, 24);
         let r = _mm512_maskz_unpacklo_epi64(0, a, b);
@@ -11080,7 +11080,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpacklo_epi64() {
+    const fn test_mm256_mask_unpacklo_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm256_mask_unpacklo_epi64(a, 0, a, b);
@@ -11091,7 +11091,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpacklo_epi64() {
+    const fn test_mm256_maskz_unpacklo_epi64() {
         let a = _mm256_set_epi64x(1, 2, 3, 4);
         let b = _mm256_set_epi64x(17, 18, 19, 20);
         let r = _mm256_maskz_unpacklo_epi64(0, a, b);
@@ -11102,7 +11102,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpacklo_epi64() {
+    const fn test_mm_mask_unpacklo_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(17, 18);
         let r = _mm_mask_unpacklo_epi64(a, 0, a, b);
@@ -11113,7 +11113,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpacklo_epi64() {
+    const fn test_mm_maskz_unpacklo_epi64() {
         let a = _mm_set_epi64x(1, 2);
         let b = _mm_set_epi64x(17, 18);
         let r = _mm_maskz_unpacklo_epi64(0, a, b);
@@ -11124,7 +11124,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_unpacklo_pd() {
+    const fn test_mm512_unpacklo_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_unpacklo_pd(a, b);
@@ -11133,7 +11133,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_unpacklo_pd() {
+    const fn test_mm512_mask_unpacklo_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_mask_unpacklo_pd(a, 0, a, b);
@@ -11144,7 +11144,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_unpacklo_pd() {
+    const fn test_mm512_maskz_unpacklo_pd() {
         let a = _mm512_set_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let b = _mm512_set_pd(17., 18., 19., 20., 21., 22., 23., 24.);
         let r = _mm512_maskz_unpacklo_pd(0, a, b);
@@ -11155,7 +11155,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_unpacklo_pd() {
+    const fn test_mm256_mask_unpacklo_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm256_mask_unpacklo_pd(a, 0, a, b);
@@ -11166,7 +11166,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_unpacklo_pd() {
+    const fn test_mm256_maskz_unpacklo_pd() {
         let a = _mm256_set_pd(1., 2., 3., 4.);
         let b = _mm256_set_pd(17., 18., 19., 20.);
         let r = _mm256_maskz_unpacklo_pd(0, a, b);
@@ -11177,7 +11177,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_unpacklo_pd() {
+    const fn test_mm_mask_unpacklo_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(17., 18.);
         let r = _mm_mask_unpacklo_pd(a, 0, a, b);
@@ -11188,7 +11188,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_unpacklo_pd() {
+    const fn test_mm_maskz_unpacklo_pd() {
         let a = _mm_set_pd(1., 2.);
         let b = _mm_set_pd(17., 18.);
         let r = _mm_maskz_unpacklo_pd(0, a, b);
@@ -11199,7 +11199,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_alignr_epi64() {
+    const fn test_mm512_alignr_epi64() {
         let a = _mm512_set_epi64(8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm512_set_epi64(16, 15, 14, 13, 12, 11, 10, 9);
         let r = _mm512_alignr_epi64::<0>(a, b);
@@ -11212,7 +11212,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_alignr_epi64() {
+    const fn test_mm512_mask_alignr_epi64() {
         let a = _mm512_set_epi64(8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm512_set_epi64(16, 15, 14, 13, 12, 11, 10, 9);
         let r = _mm512_mask_alignr_epi64::<1>(a, 0, a, b);
@@ -11223,7 +11223,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_alignr_epi64() {
+    const fn test_mm512_maskz_alignr_epi64() {
         let a = _mm512_set_epi64(8, 7, 6, 5, 4, 3, 2, 1);
         let b = _mm512_set_epi64(16, 15, 14, 13, 12, 11, 10, 9);
         let r = _mm512_maskz_alignr_epi64::<1>(0, a, b);
@@ -11234,7 +11234,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_alignr_epi64() {
+    const fn test_mm256_alignr_epi64() {
         let a = _mm256_set_epi64x(4, 3, 2, 1);
         let b = _mm256_set_epi64x(8, 7, 6, 5);
         let r = _mm256_alignr_epi64::<0>(a, b);
@@ -11249,7 +11249,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_alignr_epi64() {
+    const fn test_mm256_mask_alignr_epi64() {
         let a = _mm256_set_epi64x(4, 3, 2, 1);
         let b = _mm256_set_epi64x(8, 7, 6, 5);
         let r = _mm256_mask_alignr_epi64::<1>(a, 0, a, b);
@@ -11260,7 +11260,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_alignr_epi64() {
+    const fn test_mm256_maskz_alignr_epi64() {
         let a = _mm256_set_epi64x(4, 3, 2, 1);
         let b = _mm256_set_epi64x(8, 7, 6, 5);
         let r = _mm256_maskz_alignr_epi64::<1>(0, a, b);
@@ -11271,7 +11271,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_alignr_epi64() {
+    const fn test_mm_alignr_epi64() {
         let a = _mm_set_epi64x(2, 1);
         let b = _mm_set_epi64x(4, 3);
         let r = _mm_alignr_epi64::<0>(a, b);
@@ -11280,7 +11280,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_alignr_epi64() {
+    const fn test_mm_mask_alignr_epi64() {
         let a = _mm_set_epi64x(2, 1);
         let b = _mm_set_epi64x(4, 3);
         let r = _mm_mask_alignr_epi64::<1>(a, 0, a, b);
@@ -11291,7 +11291,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_alignr_epi64() {
+    const fn test_mm_maskz_alignr_epi64() {
         let a = _mm_set_epi64x(2, 1);
         let b = _mm_set_epi64x(4, 3);
         let r = _mm_maskz_alignr_epi64::<1>(0, a, b);
@@ -11302,7 +11302,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_and_epi64() {
+    const fn test_mm512_and_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_and_epi64(a, b);
@@ -11311,7 +11311,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_and_epi64() {
+    const fn test_mm512_mask_and_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_mask_and_epi64(a, 0, a, b);
@@ -11322,7 +11322,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_and_epi64() {
+    const fn test_mm512_maskz_and_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_maskz_and_epi64(0, a, b);
@@ -11333,7 +11333,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_and_epi64() {
+    const fn test_mm256_mask_and_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 0);
         let r = _mm256_mask_and_epi64(a, 0, a, b);
@@ -11344,7 +11344,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_and_epi64() {
+    const fn test_mm256_maskz_and_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 0);
         let r = _mm256_maskz_and_epi64(0, a, b);
@@ -11355,7 +11355,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_and_epi64() {
+    const fn test_mm_mask_and_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 0);
         let r = _mm_mask_and_epi64(a, 0, a, b);
@@ -11366,7 +11366,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_and_epi64() {
+    const fn test_mm_maskz_and_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 0);
         let r = _mm_maskz_and_epi64(0, a, b);
@@ -11377,7 +11377,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_and_si512() {
+    const fn test_mm512_and_si512() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_and_epi64(a, b);
@@ -11386,7 +11386,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_or_epi64() {
+    const fn test_mm512_or_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_or_epi64(a, b);
@@ -11399,7 +11399,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_or_epi64() {
+    const fn test_mm512_mask_or_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_mask_or_epi64(a, 0, a, b);
@@ -11414,7 +11414,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_or_epi64() {
+    const fn test_mm512_maskz_or_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_maskz_or_epi64(0, a, b);
@@ -11425,7 +11425,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_or_epi64() {
+    const fn test_mm256_or_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 13);
         let r = _mm256_or_epi64(a, b);
@@ -11434,7 +11434,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_or_epi64() {
+    const fn test_mm256_mask_or_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 13);
         let r = _mm256_mask_or_epi64(a, 0, a, b);
@@ -11445,7 +11445,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_or_epi64() {
+    const fn test_mm256_maskz_or_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 13);
         let r = _mm256_maskz_or_epi64(0, a, b);
@@ -11456,7 +11456,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_or_epi64() {
+    const fn test_mm_or_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 13);
         let r = _mm_or_epi64(a, b);
@@ -11465,7 +11465,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_or_epi64() {
+    const fn test_mm_mask_or_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 13);
         let r = _mm_mask_or_epi64(a, 0, a, b);
@@ -11476,7 +11476,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_or_epi64() {
+    const fn test_mm_maskz_or_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 13);
         let r = _mm_maskz_or_epi64(0, a, b);
@@ -11487,7 +11487,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_or_si512() {
+    const fn test_mm512_or_si512() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_or_epi64(a, b);
@@ -11500,7 +11500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_xor_epi64() {
+    const fn test_mm512_xor_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_xor_epi64(a, b);
@@ -11509,7 +11509,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_xor_epi64() {
+    const fn test_mm512_mask_xor_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_mask_xor_epi64(a, 0, a, b);
@@ -11520,7 +11520,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_xor_epi64() {
+    const fn test_mm512_maskz_xor_epi64() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_maskz_xor_epi64(0, a, b);
@@ -11531,7 +11531,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_xor_epi64() {
+    const fn test_mm256_xor_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 13);
         let r = _mm256_xor_epi64(a, b);
@@ -11540,7 +11540,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_xor_epi64() {
+    const fn test_mm256_mask_xor_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 13);
         let r = _mm256_mask_xor_epi64(a, 0, a, b);
@@ -11551,7 +11551,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_xor_epi64() {
+    const fn test_mm256_maskz_xor_epi64() {
         let a = _mm256_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm256_set1_epi64x(1 << 13);
         let r = _mm256_maskz_xor_epi64(0, a, b);
@@ -11562,7 +11562,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_xor_epi64() {
+    const fn test_mm_xor_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 13);
         let r = _mm_xor_epi64(a, b);
@@ -11571,7 +11571,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_xor_epi64() {
+    const fn test_mm_mask_xor_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 13);
         let r = _mm_mask_xor_epi64(a, 0, a, b);
@@ -11582,7 +11582,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_xor_epi64() {
+    const fn test_mm_maskz_xor_epi64() {
         let a = _mm_set1_epi64x(1 << 0 | 1 << 15);
         let b = _mm_set1_epi64x(1 << 13);
         let r = _mm_maskz_xor_epi64(0, a, b);
@@ -11593,7 +11593,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_xor_si512() {
+    const fn test_mm512_xor_si512() {
         let a = _mm512_set_epi64(1 << 0 | 1 << 15, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let b = _mm512_set_epi64(1 << 13, 0, 0, 0, 0, 0, 0, 1 << 1 | 1 << 2 | 1 << 3);
         let r = _mm512_xor_epi64(a, b);
@@ -11602,7 +11602,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_andnot_epi64() {
+    const fn test_mm512_andnot_epi64() {
         let a = _mm512_set1_epi64(0);
         let b = _mm512_set1_epi64(1 << 3 | 1 << 4);
         let r = _mm512_andnot_epi64(a, b);
@@ -11611,7 +11611,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_andnot_epi64() {
+    const fn test_mm512_mask_andnot_epi64() {
         let a = _mm512_set1_epi64(1 << 1 | 1 << 2);
         let b = _mm512_set1_epi64(1 << 3 | 1 << 4);
         let r = _mm512_mask_andnot_epi64(a, 0, a, b);
@@ -11622,7 +11622,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_andnot_epi64() {
+    const fn test_mm512_maskz_andnot_epi64() {
         let a = _mm512_set1_epi64(1 << 1 | 1 << 2);
         let b = _mm512_set1_epi64(1 << 3 | 1 << 4);
         let r = _mm512_maskz_andnot_epi64(0, a, b);
@@ -11637,7 +11637,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_andnot_epi64() {
+    const fn test_mm256_mask_andnot_epi64() {
         let a = _mm256_set1_epi64x(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi64x(1 << 3 | 1 << 4);
         let r = _mm256_mask_andnot_epi64(a, 0, a, b);
@@ -11648,7 +11648,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_andnot_epi64() {
+    const fn test_mm256_maskz_andnot_epi64() {
         let a = _mm256_set1_epi64x(1 << 1 | 1 << 2);
         let b = _mm256_set1_epi64x(1 << 3 | 1 << 4);
         let r = _mm256_maskz_andnot_epi64(0, a, b);
@@ -11659,7 +11659,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_andnot_epi64() {
+    const fn test_mm_mask_andnot_epi64() {
         let a = _mm_set1_epi64x(1 << 1 | 1 << 2);
         let b = _mm_set1_epi64x(1 << 3 | 1 << 4);
         let r = _mm_mask_andnot_epi64(a, 0, a, b);
@@ -11670,7 +11670,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_andnot_epi64() {
+    const fn test_mm_maskz_andnot_epi64() {
         let a = _mm_set1_epi64x(1 << 1 | 1 << 2);
         let b = _mm_set1_epi64x(1 << 3 | 1 << 4);
         let r = _mm_maskz_andnot_epi64(0, a, b);
@@ -11681,7 +11681,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_andnot_si512() {
+    const fn test_mm512_andnot_si512() {
         let a = _mm512_set1_epi64(0);
         let b = _mm512_set1_epi64(1 << 3 | 1 << 4);
         let r = _mm512_andnot_si512(a, b);
@@ -11690,175 +11690,175 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_add_epi64() {
+    const fn test_mm512_reduce_add_epi64() {
         let a = _mm512_set1_epi64(1);
         let e: i64 = _mm512_reduce_add_epi64(a);
         assert_eq!(8, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_add_epi64() {
+    const fn test_mm512_mask_reduce_add_epi64() {
         let a = _mm512_set1_epi64(1);
         let e: i64 = _mm512_mask_reduce_add_epi64(0b11110000, a);
         assert_eq!(4, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_add_pd() {
+    const fn test_mm512_reduce_add_pd() {
         let a = _mm512_set1_pd(1.);
         let e: f64 = _mm512_reduce_add_pd(a);
         assert_eq!(8., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_add_pd() {
+    const fn test_mm512_mask_reduce_add_pd() {
         let a = _mm512_set1_pd(1.);
         let e: f64 = _mm512_mask_reduce_add_pd(0b11110000, a);
         assert_eq!(4., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_mul_epi64() {
+    const fn test_mm512_reduce_mul_epi64() {
         let a = _mm512_set1_epi64(2);
         let e: i64 = _mm512_reduce_mul_epi64(a);
         assert_eq!(256, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_mul_epi64() {
+    const fn test_mm512_mask_reduce_mul_epi64() {
         let a = _mm512_set1_epi64(2);
         let e: i64 = _mm512_mask_reduce_mul_epi64(0b11110000, a);
         assert_eq!(16, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_mul_pd() {
+    const fn test_mm512_reduce_mul_pd() {
         let a = _mm512_set1_pd(2.);
         let e: f64 = _mm512_reduce_mul_pd(a);
         assert_eq!(256., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_mul_pd() {
+    const fn test_mm512_mask_reduce_mul_pd() {
         let a = _mm512_set1_pd(2.);
         let e: f64 = _mm512_mask_reduce_mul_pd(0b11110000, a);
         assert_eq!(16., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_max_epi64() {
+    const fn test_mm512_reduce_max_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i64 = _mm512_reduce_max_epi64(a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_max_epi64() {
+    const fn test_mm512_mask_reduce_max_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i64 = _mm512_mask_reduce_max_epi64(0b11110000, a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_max_epu64() {
+    const fn test_mm512_reduce_max_epu64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u64 = _mm512_reduce_max_epu64(a);
         assert_eq!(7, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_max_epu64() {
+    const fn test_mm512_mask_reduce_max_epu64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u64 = _mm512_mask_reduce_max_epu64(0b11110000, a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_reduce_max_pd() {
+    fn test_mm512_reduce_max_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let e: f64 = _mm512_reduce_max_pd(a);
         assert_eq!(7., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_reduce_max_pd() {
+    fn test_mm512_mask_reduce_max_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let e: f64 = _mm512_mask_reduce_max_pd(0b11110000, a);
         assert_eq!(3., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_min_epi64() {
+    const fn test_mm512_reduce_min_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i64 = _mm512_reduce_min_epi64(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_min_epi64() {
+    const fn test_mm512_mask_reduce_min_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: i64 = _mm512_mask_reduce_min_epi64(0b11110000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_min_epu64() {
+    const fn test_mm512_reduce_min_epu64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u64 = _mm512_reduce_min_epu64(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_min_epu64() {
+    const fn test_mm512_mask_reduce_min_epu64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let e: u64 = _mm512_mask_reduce_min_epu64(0b11110000, a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_reduce_min_pd() {
+    fn test_mm512_reduce_min_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let e: f64 = _mm512_reduce_min_pd(a);
         assert_eq!(0., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_reduce_min_pd() {
+    fn test_mm512_mask_reduce_min_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let e: f64 = _mm512_mask_reduce_min_pd(0b11110000, a);
         assert_eq!(0., e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_and_epi64() {
+    const fn test_mm512_reduce_and_epi64() {
         let a = _mm512_set_epi64(1, 1, 1, 1, 2, 2, 2, 2);
         let e: i64 = _mm512_reduce_and_epi64(a);
         assert_eq!(0, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_and_epi64() {
+    const fn test_mm512_mask_reduce_and_epi64() {
         let a = _mm512_set_epi64(1, 1, 1, 1, 2, 2, 2, 2);
         let e: i64 = _mm512_mask_reduce_and_epi64(0b11110000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_reduce_or_epi64() {
+    const fn test_mm512_reduce_or_epi64() {
         let a = _mm512_set_epi64(1, 1, 1, 1, 2, 2, 2, 2);
         let e: i64 = _mm512_reduce_or_epi64(a);
         assert_eq!(3, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_reduce_or_epi64() {
+    const fn test_mm512_mask_reduce_or_epi64() {
         let a = _mm512_set_epi64(1, 1, 1, 1, 2, 2, 2, 2);
         let e: i64 = _mm512_mask_reduce_or_epi64(0b11110000, a);
         assert_eq!(1, e);
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_extractf64x4_pd() {
+    const fn test_mm512_extractf64x4_pd() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_extractf64x4_pd::<1>(a);
         let e = _mm256_setr_pd(5., 6., 7., 8.);
@@ -11866,7 +11866,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_extractf64x4_pd() {
+    const fn test_mm512_mask_extractf64x4_pd() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let src = _mm256_set1_pd(100.);
         let r = _mm512_mask_extractf64x4_pd::<1>(src, 0, a);
@@ -11877,7 +11877,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_extractf64x4_pd() {
+    const fn test_mm512_maskz_extractf64x4_pd() {
         let a = _mm512_setr_pd(1., 2., 3., 4., 5., 6., 7., 8.);
         let r = _mm512_maskz_extractf64x4_pd::<1>(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -11887,7 +11887,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_extracti64x4_epi64() {
+    const fn test_mm512_extracti64x4_epi64() {
         let a = _mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_extracti64x4_epi64::<0x1>(a);
         let e = _mm256_setr_epi64x(5, 6, 7, 8);
@@ -11895,7 +11895,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_extracti64x4_epi64() {
+    const fn test_mm512_mask_extracti64x4_epi64() {
         let a = _mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let src = _mm256_set1_epi64x(100);
         let r = _mm512_mask_extracti64x4_epi64::<0x1>(src, 0, a);
@@ -11906,7 +11906,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_extracti64x4_epi64() {
+    const fn test_mm512_maskz_extracti64x4_epi64() {
         let a = _mm512_setr_epi64(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm512_maskz_extracti64x4_epi64::<0x1>(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -11916,7 +11916,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_compress_epi64() {
+    fn test_mm512_mask_compress_epi64() {
         let src = _mm512_set1_epi64(200);
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_mask_compress_epi64(src, 0, a);
@@ -11927,7 +11927,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_compress_epi64() {
+    fn test_mm512_maskz_compress_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_maskz_compress_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -11937,7 +11937,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_compress_epi64() {
+    fn test_mm256_mask_compress_epi64() {
         let src = _mm256_set1_epi64x(200);
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_mask_compress_epi64(src, 0, a);
@@ -11948,7 +11948,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_compress_epi64() {
+    fn test_mm256_maskz_compress_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_maskz_compress_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -11958,7 +11958,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_compress_epi64() {
+    fn test_mm_mask_compress_epi64() {
         let src = _mm_set1_epi64x(200);
         let a = _mm_set_epi64x(0, 1);
         let r = _mm_mask_compress_epi64(src, 0, a);
@@ -11969,7 +11969,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_compress_epi64() {
+    fn test_mm_maskz_compress_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_compress_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -11979,7 +11979,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_compress_pd() {
+    fn test_mm512_mask_compress_pd() {
         let src = _mm512_set1_pd(200.);
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_mask_compress_pd(src, 0, a);
@@ -11990,7 +11990,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_compress_pd() {
+    fn test_mm512_maskz_compress_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_maskz_compress_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -12000,7 +12000,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_compress_pd() {
+    fn test_mm256_mask_compress_pd() {
         let src = _mm256_set1_pd(200.);
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_mask_compress_pd(src, 0, a);
@@ -12011,7 +12011,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_compress_pd() {
+    fn test_mm256_maskz_compress_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_maskz_compress_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -12021,7 +12021,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_compress_pd() {
+    fn test_mm_mask_compress_pd() {
         let src = _mm_set1_pd(200.);
         let a = _mm_set_pd(0., 1.);
         let r = _mm_mask_compress_pd(src, 0, a);
@@ -12032,7 +12032,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_compress_pd() {
+    fn test_mm_maskz_compress_pd() {
         let a = _mm_set_pd(0., 1.);
         let r = _mm_maskz_compress_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -12042,7 +12042,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_expand_epi64() {
+    fn test_mm512_mask_expand_epi64() {
         let src = _mm512_set1_epi64(200);
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_mask_expand_epi64(src, 0, a);
@@ -12053,7 +12053,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_expand_epi64() {
+    fn test_mm512_maskz_expand_epi64() {
         let a = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm512_maskz_expand_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -12063,7 +12063,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_expand_epi64() {
+    fn test_mm256_mask_expand_epi64() {
         let src = _mm256_set1_epi64x(200);
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_mask_expand_epi64(src, 0, a);
@@ -12074,7 +12074,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_expand_epi64() {
+    fn test_mm256_maskz_expand_epi64() {
         let a = _mm256_set_epi64x(0, 1, 2, 3);
         let r = _mm256_maskz_expand_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -12084,7 +12084,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_expand_epi64() {
+    fn test_mm_mask_expand_epi64() {
         let src = _mm_set1_epi64x(200);
         let a = _mm_set_epi64x(0, 1);
         let r = _mm_mask_expand_epi64(src, 0, a);
@@ -12095,7 +12095,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_expand_epi64() {
+    fn test_mm_maskz_expand_epi64() {
         let a = _mm_set_epi64x(0, 1);
         let r = _mm_maskz_expand_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -12105,7 +12105,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_mask_expand_pd() {
+    fn test_mm512_mask_expand_pd() {
         let src = _mm512_set1_pd(200.);
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_mask_expand_pd(src, 0, a);
@@ -12116,7 +12116,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm512_maskz_expand_pd() {
+    fn test_mm512_maskz_expand_pd() {
         let a = _mm512_set_pd(0., 1., 2., 3., 4., 5., 6., 7.);
         let r = _mm512_maskz_expand_pd(0, a);
         assert_eq_m512d(r, _mm512_setzero_pd());
@@ -12126,7 +12126,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_mask_expand_pd() {
+    fn test_mm256_mask_expand_pd() {
         let src = _mm256_set1_pd(200.);
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_mask_expand_pd(src, 0, a);
@@ -12137,7 +12137,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm256_maskz_expand_pd() {
+    fn test_mm256_maskz_expand_pd() {
         let a = _mm256_set_pd(0., 1., 2., 3.);
         let r = _mm256_maskz_expand_pd(0, a);
         assert_eq_m256d(r, _mm256_setzero_pd());
@@ -12147,7 +12147,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_mask_expand_pd() {
+    fn test_mm_mask_expand_pd() {
         let src = _mm_set1_pd(200.);
         let a = _mm_set_pd(0., 1.);
         let r = _mm_mask_expand_pd(src, 0, a);
@@ -12158,7 +12158,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    unsafe fn test_mm_maskz_expand_pd() {
+    fn test_mm_maskz_expand_pd() {
         let a = _mm_set_pd(0., 1.);
         let r = _mm_maskz_expand_pd(0, a);
         assert_eq_m128d(r, _mm_setzero_pd());
@@ -12589,7 +12589,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_test_epi64_mask() {
+    const fn test_mm512_test_epi64_mask() {
         let a = _mm512_set1_epi64(1 << 0);
         let b = _mm512_set1_epi64(1 << 0 | 1 << 1);
         let r = _mm512_test_epi64_mask(a, b);
@@ -12598,7 +12598,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_test_epi64_mask() {
+    const fn test_mm512_mask_test_epi64_mask() {
         let a = _mm512_set1_epi64(1 << 0);
         let b = _mm512_set1_epi64(1 << 0 | 1 << 1);
         let r = _mm512_mask_test_epi64_mask(0, a, b);
@@ -12609,7 +12609,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_test_epi64_mask() {
+    const fn test_mm256_test_epi64_mask() {
         let a = _mm256_set1_epi64x(1 << 0);
         let b = _mm256_set1_epi64x(1 << 0 | 1 << 1);
         let r = _mm256_test_epi64_mask(a, b);
@@ -12618,7 +12618,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_test_epi64_mask() {
+    const fn test_mm256_mask_test_epi64_mask() {
         let a = _mm256_set1_epi64x(1 << 0);
         let b = _mm256_set1_epi64x(1 << 0 | 1 << 1);
         let r = _mm256_mask_test_epi64_mask(0, a, b);
@@ -12629,7 +12629,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_test_epi64_mask() {
+    const fn test_mm_test_epi64_mask() {
         let a = _mm_set1_epi64x(1 << 0);
         let b = _mm_set1_epi64x(1 << 0 | 1 << 1);
         let r = _mm_test_epi64_mask(a, b);
@@ -12638,7 +12638,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_test_epi64_mask() {
+    const fn test_mm_mask_test_epi64_mask() {
         let a = _mm_set1_epi64x(1 << 0);
         let b = _mm_set1_epi64x(1 << 0 | 1 << 1);
         let r = _mm_mask_test_epi64_mask(0, a, b);
@@ -12649,7 +12649,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_testn_epi64_mask() {
+    const fn test_mm512_testn_epi64_mask() {
         let a = _mm512_set1_epi64(1 << 0);
         let b = _mm512_set1_epi64(1 << 0 | 1 << 1);
         let r = _mm512_testn_epi64_mask(a, b);
@@ -12658,7 +12658,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_testn_epi64_mask() {
+    const fn test_mm512_mask_testn_epi64_mask() {
         let a = _mm512_set1_epi64(1 << 0);
         let b = _mm512_set1_epi64(1 << 1);
         let r = _mm512_mask_testn_epi64_mask(0, a, b);
@@ -12669,7 +12669,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_testn_epi64_mask() {
+    const fn test_mm256_testn_epi64_mask() {
         let a = _mm256_set1_epi64x(1 << 0);
         let b = _mm256_set1_epi64x(1 << 1);
         let r = _mm256_testn_epi64_mask(a, b);
@@ -12678,7 +12678,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_testn_epi64_mask() {
+    const fn test_mm256_mask_testn_epi64_mask() {
         let a = _mm256_set1_epi64x(1 << 0);
         let b = _mm256_set1_epi64x(1 << 1);
         let r = _mm256_mask_testn_epi64_mask(0, a, b);
@@ -12689,7 +12689,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_testn_epi64_mask() {
+    const fn test_mm_testn_epi64_mask() {
         let a = _mm_set1_epi64x(1 << 0);
         let b = _mm_set1_epi64x(1 << 1);
         let r = _mm_testn_epi64_mask(a, b);
@@ -12698,7 +12698,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_testn_epi64_mask() {
+    const fn test_mm_mask_testn_epi64_mask() {
         let a = _mm_set1_epi64x(1 << 0);
         let b = _mm_set1_epi64x(1 << 1);
         let r = _mm_mask_testn_epi64_mask(0, a, b);
@@ -12709,7 +12709,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_mask_set1_epi64() {
+    const fn test_mm512_mask_set1_epi64() {
         let src = _mm512_set1_epi64(2);
         let a: i64 = 11;
         let r = _mm512_mask_set1_epi64(src, 0, a);
@@ -12720,7 +12720,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm512_maskz_set1_epi64() {
+    const fn test_mm512_maskz_set1_epi64() {
         let a: i64 = 11;
         let r = _mm512_maskz_set1_epi64(0, a);
         assert_eq_m512i(r, _mm512_setzero_si512());
@@ -12730,7 +12730,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_mask_set1_epi64() {
+    const fn test_mm256_mask_set1_epi64() {
         let src = _mm256_set1_epi64x(2);
         let a: i64 = 11;
         let r = _mm256_mask_set1_epi64(src, 0, a);
@@ -12741,7 +12741,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm256_maskz_set1_epi64() {
+    const fn test_mm256_maskz_set1_epi64() {
         let a: i64 = 11;
         let r = _mm256_maskz_set1_epi64(0, a);
         assert_eq_m256i(r, _mm256_setzero_si256());
@@ -12751,7 +12751,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_mask_set1_epi64() {
+    const fn test_mm_mask_set1_epi64() {
         let src = _mm_set1_epi64x(2);
         let a: i64 = 11;
         let r = _mm_mask_set1_epi64(src, 0, a);
@@ -12762,7 +12762,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f,avx512vl")]
-    const unsafe fn test_mm_maskz_set1_epi64() {
+    const fn test_mm_maskz_set1_epi64() {
         let a: i64 = 11;
         let r = _mm_maskz_set1_epi64(0, a);
         assert_eq_m128i(r, _mm_setzero_si128());
@@ -12772,7 +12772,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtsd_i64() {
+    fn test_mm_cvtsd_i64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtsd_i64(a);
         let e: i64 = -2;
@@ -12780,7 +12780,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtss_i64() {
+    fn test_mm_cvtss_i64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtss_i64(a);
         let e: i64 = -2;
@@ -12788,7 +12788,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundi64_ss() {
+    fn test_mm_cvt_roundi64_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: i64 = 9;
         let r = _mm_cvt_roundi64_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -12797,7 +12797,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsi64_ss() {
+    fn test_mm_cvt_roundsi64_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: i64 = 9;
         let r = _mm_cvt_roundsi64_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -12806,7 +12806,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvti64_ss() {
+    const fn test_mm_cvti64_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: i64 = 9;
         let r = _mm_cvti64_ss(a, b);
@@ -12815,7 +12815,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvti64_sd() {
+    const fn test_mm_cvti64_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: i64 = 9;
         let r = _mm_cvti64_sd(a, b);
@@ -12824,7 +12824,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_si64() {
+    fn test_mm_cvt_roundsd_si64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvt_roundsd_si64::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i64 = -1;
@@ -12832,7 +12832,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_i64() {
+    fn test_mm_cvt_roundsd_i64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvt_roundsd_i64::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i64 = -1;
@@ -12840,7 +12840,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsd_u64() {
+    fn test_mm_cvt_roundsd_u64() {
         let a = _mm_set_pd(1., f64::MAX);
         let r = _mm_cvt_roundsd_u64::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: u64 = u64::MAX;
@@ -12848,7 +12848,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtsd_u64() {
+    fn test_mm_cvtsd_u64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtsd_u64(a);
         let e: u64 = u64::MAX;
@@ -12856,7 +12856,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_i64() {
+    fn test_mm_cvt_roundss_i64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_i64::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i64 = -1;
@@ -12864,7 +12864,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_si64() {
+    fn test_mm_cvt_roundss_si64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_si64::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: i64 = -1;
@@ -12872,7 +12872,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundss_u64() {
+    fn test_mm_cvt_roundss_u64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvt_roundss_u64::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a);
         let e: u64 = u64::MAX;
@@ -12880,7 +12880,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtss_u64() {
+    fn test_mm_cvtss_u64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtss_u64(a);
         let e: u64 = u64::MAX;
@@ -12888,7 +12888,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttsd_i64() {
+    fn test_mm_cvttsd_i64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvttsd_i64(a);
         let e: i64 = -1;
@@ -12896,7 +12896,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundsd_i64() {
+    fn test_mm_cvtt_roundsd_i64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtt_roundsd_i64::<_MM_FROUND_NO_EXC>(a);
         let e: i64 = -1;
@@ -12904,7 +12904,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundsd_si64() {
+    fn test_mm_cvtt_roundsd_si64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtt_roundsd_si64::<_MM_FROUND_NO_EXC>(a);
         let e: i64 = -1;
@@ -12912,7 +12912,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundsd_u64() {
+    fn test_mm_cvtt_roundsd_u64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvtt_roundsd_u64::<_MM_FROUND_NO_EXC>(a);
         let e: u64 = u64::MAX;
@@ -12920,7 +12920,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttsd_u64() {
+    fn test_mm_cvttsd_u64() {
         let a = _mm_set_pd(1., -1.5);
         let r = _mm_cvttsd_u64(a);
         let e: u64 = u64::MAX;
@@ -12928,7 +12928,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttss_i64() {
+    fn test_mm_cvttss_i64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvttss_i64(a);
         let e: i64 = -1;
@@ -12936,7 +12936,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundss_i64() {
+    fn test_mm_cvtt_roundss_i64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtt_roundss_i64::<_MM_FROUND_NO_EXC>(a);
         let e: i64 = -1;
@@ -12944,7 +12944,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundss_si64() {
+    fn test_mm_cvtt_roundss_si64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtt_roundss_si64::<_MM_FROUND_NO_EXC>(a);
         let e: i64 = -1;
@@ -12952,7 +12952,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvtt_roundss_u64() {
+    fn test_mm_cvtt_roundss_u64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvtt_roundss_u64::<_MM_FROUND_NO_EXC>(a);
         let e: u64 = u64::MAX;
@@ -12960,7 +12960,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvttss_u64() {
+    fn test_mm_cvttss_u64() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let r = _mm_cvttss_u64(a);
         let e: u64 = u64::MAX;
@@ -12968,7 +12968,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvtu64_ss() {
+    const fn test_mm_cvtu64_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: u64 = 9;
         let r = _mm_cvtu64_ss(a, b);
@@ -12977,7 +12977,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    const unsafe fn test_mm_cvtu64_sd() {
+    const fn test_mm_cvtu64_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: u64 = 9;
         let r = _mm_cvtu64_sd(a, b);
@@ -12986,7 +12986,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundu64_ss() {
+    fn test_mm_cvt_roundu64_ss() {
         let a = _mm_set_ps(0., -0.5, 1., -1.5);
         let b: u64 = 9;
         let r = _mm_cvt_roundu64_ss::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -12995,7 +12995,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundu64_sd() {
+    fn test_mm_cvt_roundu64_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: u64 = 9;
         let r = _mm_cvt_roundu64_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -13004,7 +13004,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundi64_sd() {
+    fn test_mm_cvt_roundi64_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: i64 = 9;
         let r = _mm_cvt_roundi64_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);
@@ -13013,7 +13013,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    unsafe fn test_mm_cvt_roundsi64_sd() {
+    fn test_mm_cvt_roundsi64_sd() {
         let a = _mm_set_pd(1., -1.5);
         let b: i64 = 9;
         let r = _mm_cvt_roundsi64_sd::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a, b);

--- a/crates/core_arch/src/x86_64/avx512fp16.rs
+++ b/crates/core_arch/src/x86_64/avx512fp16.rs
@@ -232,7 +232,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvti64_sh() {
+    fn test_mm_cvti64_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvti64_sh(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvt_roundi64_sh() {
+    fn test_mm_cvt_roundi64_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundi64_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvtu64_sh() {
+    fn test_mm_cvtu64_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtu64_sh(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
-    unsafe fn test_mm_cvt_roundu64_sh() {
+    fn test_mm_cvt_roundu64_sh() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundu64_sh::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a, 10);
         let e = _mm_setr_ph(10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
@@ -264,56 +264,56 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtsh_i64() {
+    fn test_mm_cvtsh_i64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtsh_i64(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvt_roundsh_i64() {
+    fn test_mm_cvt_roundsh_i64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundsh_i64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtsh_u64() {
+    fn test_mm_cvtsh_u64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtsh_u64(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvt_roundsh_u64() {
+    fn test_mm_cvt_roundsh_u64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvt_roundsh_u64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvttsh_i64() {
+    fn test_mm_cvttsh_i64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttsh_i64(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtt_roundsh_i64() {
+    fn test_mm_cvtt_roundsh_i64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtt_roundsh_i64::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvttsh_u64() {
+    fn test_mm_cvttsh_u64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvttsh_u64(a);
         assert_eq!(r, 1);
     }
 
     #[simd_test(enable = "avx512fp16")]
-    unsafe fn test_mm_cvtt_roundsh_u64() {
+    fn test_mm_cvtt_roundsh_u64() {
         let a = _mm_setr_ph(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
         let r = _mm_cvtt_roundsh_u64::<_MM_FROUND_NO_EXC>(a);
         assert_eq!(r, 1);

--- a/crates/core_arch/src/x86_64/bmi.rs
+++ b/crates/core_arch/src/x86_64/bmi.rs
@@ -135,13 +135,13 @@ mod tests {
     use crate::core_arch::{x86::*, x86_64::*};
 
     #[simd_test(enable = "bmi1")]
-    unsafe fn test_bextr_u64() {
+    fn test_bextr_u64() {
         let r = _bextr_u64(0b0101_0000u64, 4, 4);
         assert_eq!(r, 0b0000_0101u64);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_andn_u64() {
+    const fn test_andn_u64() {
         assert_eq!(_andn_u64(0, 0), 0);
         assert_eq!(_andn_u64(0, 1), 1);
         assert_eq!(_andn_u64(1, 0), 0);
@@ -164,25 +164,25 @@ mod tests {
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_blsi_u64() {
+    const fn test_blsi_u64() {
         assert_eq!(_blsi_u64(0b1101_0000u64), 0b0001_0000u64);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_blsmsk_u64() {
+    const fn test_blsmsk_u64() {
         let r = _blsmsk_u64(0b0011_0000u64);
         assert_eq!(r, 0b0001_1111u64);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_blsr_u64() {
+    const fn test_blsr_u64() {
         // TODO: test the behavior when the input is `0`.
         let r = _blsr_u64(0b0011_0000u64);
         assert_eq!(r, 0b0010_0000u64);
     }
 
     #[simd_test(enable = "bmi1")]
-    const unsafe fn test_tzcnt_u64() {
+    const fn test_tzcnt_u64() {
         assert_eq!(_tzcnt_u64(0b0000_0001u64), 0u64);
         assert_eq!(_tzcnt_u64(0b0000_0000u64), 64u64);
         assert_eq!(_tzcnt_u64(0b1001_0000u64), 4u64);

--- a/crates/core_arch/src/x86_64/bmi2.rs
+++ b/crates/core_arch/src/x86_64/bmi2.rs
@@ -86,7 +86,7 @@ mod tests {
     use crate::core_arch::x86_64::*;
 
     #[simd_test(enable = "bmi2")]
-    unsafe fn test_pext_u64() {
+    fn test_pext_u64() {
         let n = 0b1011_1110_1001_0011u64;
 
         let m0 = 0b0110_0011_1000_0101u64;
@@ -100,7 +100,7 @@ mod tests {
     }
 
     #[simd_test(enable = "bmi2")]
-    unsafe fn test_pdep_u64() {
+    fn test_pdep_u64() {
         let n = 0b1011_1110_1001_0011u64;
 
         let m0 = 0b0110_0011_1000_0101u64;
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[simd_test(enable = "bmi2")]
-    unsafe fn test_bzhi_u64() {
+    fn test_bzhi_u64() {
         let n = 0b1111_0010u64;
         let s = 0b0001_0010u64;
         assert_eq!(_bzhi_u64(n, 5), s);
@@ -122,7 +122,7 @@ mod tests {
 
     #[simd_test(enable = "bmi2")]
     #[rustfmt::skip]
-const     unsafe fn test_mulx_u64() {
+    const fn test_mulx_u64() {
         let a: u64 = 9_223_372_036_854_775_800;
         let b: u64 = 100;
         let mut hi = 0;

--- a/crates/core_arch/src/x86_64/sse.rs
+++ b/crates/core_arch/src/x86_64/sse.rs
@@ -74,7 +74,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_cvtss_si64() {
+    fn test_mm_cvtss_si64() {
         let inputs = &[
             (42.0f32, 42i64),
             (-31.4, -31),
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    unsafe fn test_mm_cvttss_si64() {
+    fn test_mm_cvttss_si64() {
         let inputs = &[
             (42.0f32, 42i64),
             (-31.4, -31),
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse")]
-    const unsafe fn test_mm_cvtsi64_ss() {
+    const fn test_mm_cvtsi64_ss() {
         let a = _mm_setr_ps(5.0, 6.0, 7.0, 8.0);
 
         let r = _mm_cvtsi64_ss(a, 4555);

--- a/crates/core_arch/src/x86_64/sse2.rs
+++ b/crates/core_arch/src/x86_64/sse2.rs
@@ -172,7 +172,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvtsd_si64() {
+    fn test_mm_cvtsd_si64() {
         let r = _mm_cvtsd_si64(_mm_setr_pd(-2.0, 5.0));
         assert_eq!(r, -2_i64);
 
@@ -181,20 +181,20 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvtsd_si64x() {
+    fn test_mm_cvtsd_si64x() {
         let r = _mm_cvtsd_si64x(_mm_setr_pd(f64::NAN, f64::NAN));
         assert_eq!(r, i64::MIN);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvttsd_si64() {
+    fn test_mm_cvttsd_si64() {
         let a = _mm_setr_pd(-1.1, 2.2);
         let r = _mm_cvttsd_si64(a);
         assert_eq!(r, -1_i64);
     }
 
     #[simd_test(enable = "sse2")]
-    unsafe fn test_mm_cvttsd_si64x() {
+    fn test_mm_cvttsd_si64x() {
         let a = _mm_setr_pd(f64::NEG_INFINITY, f64::NAN);
         let r = _mm_cvttsd_si64x(a);
         assert_eq!(r, i64::MIN);
@@ -213,19 +213,19 @@ mod tests {
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsi64_si128() {
+    const fn test_mm_cvtsi64_si128() {
         let r = _mm_cvtsi64_si128(5);
         assert_eq_m128i(r, _mm_setr_epi64x(5, 0));
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsi128_si64() {
+    const fn test_mm_cvtsi128_si64() {
         let r = _mm_cvtsi128_si64(_mm_setr_epi64x(5, 0));
         assert_eq!(r, 5);
     }
 
     #[simd_test(enable = "sse2")]
-    const unsafe fn test_mm_cvtsi64_sd() {
+    const fn test_mm_cvtsi64_sd() {
         let a = _mm_set1_pd(3.5);
         let r = _mm_cvtsi64_sd(a, 5);
         assert_eq_m128d(r, _mm_setr_pd(5.0, 3.5));

--- a/crates/core_arch/src/x86_64/sse41.rs
+++ b/crates/core_arch/src/x86_64/sse41.rs
@@ -41,7 +41,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_extract_epi64() {
+    const fn test_mm_extract_epi64() {
         let a = _mm_setr_epi64x(0, 1);
         let r = _mm_extract_epi64::<1>(a);
         assert_eq!(r, 1);
@@ -50,7 +50,7 @@ mod tests {
     }
 
     #[simd_test(enable = "sse4.1")]
-    const unsafe fn test_mm_insert_epi64() {
+    const fn test_mm_insert_epi64() {
         let a = _mm_set1_epi64x(0);
         let e = _mm_setr_epi64x(0, 32);
         let r = _mm_insert_epi64::<1>(a, 32);

--- a/crates/core_arch/src/x86_64/sse42.rs
+++ b/crates/core_arch/src/x86_64/sse42.rs
@@ -28,7 +28,7 @@ mod tests {
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "sse4.2")]
-    unsafe fn test_mm_crc32_u64() {
+    fn test_mm_crc32_u64() {
         let crc = 0x7819dccd3e824;
         let v = 0x2a22b845fed;
         let i = _mm_crc32_u64(crc, v);

--- a/crates/core_arch/src/x86_64/tbm.rs
+++ b/crates/core_arch/src/x86_64/tbm.rs
@@ -154,18 +154,18 @@ mod tests {
     use crate::core_arch::x86_64::*;
 
     #[simd_test(enable = "tbm")]
-    unsafe fn test_bextri_u64() {
+    fn test_bextri_u64() {
         assert_eq!(_bextri_u64::<0x0404>(0b0101_0000u64), 0b0000_0101u64);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcfill_u64() {
+    const fn test_blcfill_u64() {
         assert_eq!(_blcfill_u64(0b0101_0111u64), 0b0101_0000u64);
         assert_eq!(_blcfill_u64(0b1111_1111u64), 0u64);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blci_u64() {
+    const fn test_blci_u64() {
         assert_eq!(
             _blci_u64(0b0101_0000u64),
             0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1110u64
@@ -177,25 +177,25 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcic_u64() {
+    const fn test_blcic_u64() {
         assert_eq!(_blcic_u64(0b0101_0001u64), 0b0000_0010u64);
         assert_eq!(_blcic_u64(0b1111_1111u64), 0b1_0000_0000u64);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcmsk_u64() {
+    const fn test_blcmsk_u64() {
         assert_eq!(_blcmsk_u64(0b0101_0001u64), 0b0000_0011u64);
         assert_eq!(_blcmsk_u64(0b1111_1111u64), 0b1_1111_1111u64);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blcs_u64() {
+    const fn test_blcs_u64() {
         assert_eq!(_blcs_u64(0b0101_0001u64), 0b0101_0011u64);
         assert_eq!(_blcs_u64(0b1111_1111u64), 0b1_1111_1111u64);
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blsfill_u64() {
+    const fn test_blsfill_u64() {
         assert_eq!(_blsfill_u64(0b0101_0100u64), 0b0101_0111u64);
         assert_eq!(
             _blsfill_u64(0u64),
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_blsic_u64() {
+    const fn test_blsic_u64() {
         assert_eq!(
             _blsic_u64(0b0101_0100u64),
             0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1011u64
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_t1mskc_u64() {
+    const fn test_t1mskc_u64() {
         assert_eq!(
             _t1mskc_u64(0b0101_0111u64),
             0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000u64
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[simd_test(enable = "tbm")]
-    const unsafe fn test_tzmsk_u64() {
+    const fn test_tzmsk_u64() {
         assert_eq!(_tzmsk_u64(0b0101_1000u64), 0b0000_0111u64);
         assert_eq!(_tzmsk_u64(0b0101_1001u64), 0b0000_0000u64);
     }


### PR DESCRIPTION
Some test utility functions (e.g., `assert_eq_m128`) have been refactored so they are not unsafe. Many test functions (`test_mm_*`) do not call any unsafe function (besides needing target features) anymore, so they do not need to be `unsafe fn`.