### PR TITLE
Change `repr(packed)` struct to `repr(C, packed)`

### DIFF
--- a/crates/core_arch/src/x86_64/amx.rs
+++ b/crates/core_arch/src/x86_64/amx.rs
@@ -510,7 +510,7 @@ mod tests {
     use syscalls::{Sysno, syscall};
 
     #[allow(non_camel_case_types)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     #[derive(Copy, Clone, Default, Debug, PartialEq)]
     struct __tilecfg {
         /// 0 `or` 1


### PR DESCRIPTION
`repr(packed)` structs do not have a well-defined layout