### PR TITLE
remove `impl Neg` on s390x/powerpc vector types

### DIFF
--- a/crates/core_arch/src/powerpc/macros.rs
+++ b/crates/core_arch/src/powerpc/macros.rs
@@ -274,20 +274,6 @@ macro_rules! t_b {
     };
 }
 
-macro_rules! impl_neg {
-    ($s: ident : $zero: expr) => {
-        #[unstable(feature = "stdarch_powerpc", issue = "111145")]
-        impl crate::ops::Neg for s_t_l!($s) {
-            type Output = s_t_l!($s);
-            #[inline]
-            fn neg(self) -> Self::Output {
-                unsafe { simd_neg(self) }
-            }
-        }
-    };
-}
-
-pub(crate) use impl_neg;
 pub(crate) use impl_vec_trait;
 pub(crate) use s_t_l;
 pub(crate) use t_b;

--- a/crates/core_arch/src/s390x/macros.rs
+++ b/crates/core_arch/src/s390x/macros.rs
@@ -431,20 +431,6 @@ macro_rules! t_b {
     };
 }
 
-macro_rules! impl_neg {
-    ($s: ident : $zero: expr) => {
-        #[unstable(feature = "stdarch_s390x", issue = "135681")]
-        impl crate::ops::Neg for s_t_l!($s) {
-            type Output = s_t_l!($s);
-            #[inline]
-            fn neg(self) -> Self::Output {
-                unsafe { simd_neg(self) }
-            }
-        }
-    };
-}
-
-pub(crate) use impl_neg;
 pub(crate) use impl_vec_trait;
 pub(crate) use l_t_t;
 pub(crate) use s_t_l;


### PR DESCRIPTION
For other targets we don't have such instances. We specifically decided against implementing arithmetic operators on these low-level vector types. The `impl` has been replaced by a `vec_neg` function.

Over on https://www.ibm.com/docs/en/zos/2.4.0?topic=functions-defining-vector-built-in-from-operators it is suggested to define `vec_neg`. We already implement the other `define`s on that page, so this seems like a logical extension. 

On s390x `vec_neg` is also implemented for unsigned integer vector types https://godbolt.org/z/ddadsrn3q. `vec_neg` is not implemented for the `bool` types, see https://godbolt.org/z/TdKr7enhb).

On powerpc `vec_neg` is also implemented for the unsigned integer _and_ bool vector types https://godbolt.org/z/faMbx45K3.

I plan to propose stabilization of the s390x vector types in the near future.