### PR TITLE
Stabilize `__jcvt`

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -49,7 +49,7 @@ pub fn __crc32d(crc: u32, data: u64) -> u32 {
 #[inline]
 #[target_feature(enable = "jsconv")]
 #[cfg_attr(test, assert_instr(fjcvtzs))]
-#[unstable(feature = "stdarch_aarch64_jscvt", issue = "147555")]
+#[stable(feature = "stdarch_aarch64_jscvt", since = "CURRENT_RUSTC_VERSION")]
 pub fn __jcvt(a: f64) -> i32 {
     unsafe extern "unadjusted" {
         #[cfg_attr(

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -63,8 +63,8 @@ neon-unstable-f16: &neon-unstable-f16
 neon-unstable-feat-lut: &neon-unstable-feat-lut
   FnCall: [unstable, ['feature = "stdarch_neon_feat_lut"', 'issue = "138050"']]
 
-aarch64-unstable-jscvt: &aarch64-unstable-jscvt
-  FnCall: [unstable, ['feature = "stdarch_aarch64_jscvt"', 'issue = "147555"']]
+aarch64-stable-jscvt: &aarch64-stable-jscvt
+  FnCall: [stable, ['feature = "stdarch_aarch64_jscvt"', 'since = "CURRENT_RUSTC_VERSION"']]
 
 # #[cfg(target_endian = "little")]
 little-endian: &little-endian
@@ -14275,7 +14275,7 @@ intrinsics:
     attr:
       - FnCall: [target_feature, ['enable = "jsconv"']]
       - FnCall: [cfg_attr, [test, { FnCall: [assert_instr, ["fjcvtzs"]] }]]
-      - *aarch64-unstable-jscvt
+      - *aarch64-stable-jscvt
     safety: safe
     types:
       - f64


### PR DESCRIPTION
implementation: https://github.com/rust-lang/stdarch/pull/1938
tracking issue: https://github.com/rust-lang/rust/issues/147555

I think we should stabilize this intrinsic. The `jsconv` feature itself has been stable since `1.60.0`. The intrinsic works as expected in ruffle, see https://github.com/ruffle-rs/ruffle/pull/22138#issuecomment-3743856346.

# API surface

The `stdarch_aarch64_jscvt` feature contains one function:

> Floating-point JavaScript convert to signed fixed-point, rounding toward zero

```rust
#[target_feature(enable = "jsconv")]
pub fn __jcvt(a: f64) -> i32;
```

