### PR TITLE
use `simd_extract_dyn` for `extract`

### DIFF
--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -4740,7 +4740,7 @@ mod tests {
         for off in 0..16 {
             let val: u8x16 = transmute(vec_xl(0, (pat.as_ptr() as *const u8).offset(off)));
             for i in 0..16 {
-                let v = val.extract(i);
+                let v = val.extract_dyn(i);
                 assert_eq!(off as usize + i, v as usize);
             }
         }
@@ -4795,7 +4795,7 @@ mod tests {
         )];
         for off in 0..16 {
             let v: u8x16 = transmute(vec_lde(off, pat.as_ptr() as *const u8));
-            assert_eq!(off as u8, v.extract(off as _));
+            assert_eq!(off as u8, v.extract_dyn(off as _));
         }
     }
 
@@ -4804,7 +4804,7 @@ mod tests {
         let pat = [u16x8::new(0, 1, 2, 3, 4, 5, 6, 7)];
         for off in 0..8 {
             let v: u16x8 = transmute(vec_lde(off * 2, pat.as_ptr() as *const u16));
-            assert_eq!(off as u16, v.extract(off as _));
+            assert_eq!(off as u16, v.extract_dyn(off as _));
         }
     }
 
@@ -4813,7 +4813,7 @@ mod tests {
         let pat = [u32x4::new(0, 1, 2, 3)];
         for off in 0..4 {
             let v: u32x4 = transmute(vec_lde(off * 4, pat.as_ptr() as *const u32));
-            assert_eq!(off as u32, v.extract(off as _));
+            assert_eq!(off as u32, v.extract_dyn(off as _));
         }
     }
 

--- a/crates/core_arch/src/simd.rs
+++ b/crates/core_arch/src/simd.rs
@@ -60,13 +60,14 @@ impl<T: SimdElement, const N: usize> Simd<T, N> {
         unsafe { simd_shuffle!(one, one, [0; N]) }
     }
 
-    /// Extract the element at position `index`.
-    /// `index` is not a constant so this is not efficient!
-    /// Use for testing only.
-    // FIXME: Workaround rust@60637
-    #[inline(always)]
-    pub(crate) const fn extract(&self, index: usize) -> T {
-        self.as_array()[index]
+    /// Extract the element at position `index`. Note that `index` is not a constant so this
+    /// operation is not efficient on most platforms. Use for testing only.
+    #[inline]
+    #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+    pub(crate) const fn extract_dyn(&self, index: usize) -> T {
+        assert!(index < N);
+        // SAFETY: self is a vector, T its element type.
+        unsafe { crate::intrinsics::simd::simd_extract_dyn(*self, index as u32) }
     }
 
     #[inline]

--- a/crates/core_arch/src/x86/test.rs
+++ b/crates/core_arch/src/x86/test.rs
@@ -78,38 +78,45 @@ pub(crate) const fn assert_eq_m512h(a: __m512h, b: __m512h) {
 }
 
 #[target_feature(enable = "sse2")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m128d(a: __m128d, idx: usize) -> f64 {
-    a.as_f64x2().extract(idx)
+    a.as_f64x2().extract_dyn(idx)
 }
 
 #[target_feature(enable = "sse")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m128(a: __m128, idx: usize) -> f32 {
-    a.as_f32x4().extract(idx)
+    a.as_f32x4().extract_dyn(idx)
 }
 
 #[target_feature(enable = "avx")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m256d(a: __m256d, idx: usize) -> f64 {
-    a.as_f64x4().extract(idx)
+    a.as_f64x4().extract_dyn(idx)
 }
 
 #[target_feature(enable = "avx")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m256(a: __m256, idx: usize) -> f32 {
-    a.as_f32x8().extract(idx)
+    a.as_f32x8().extract_dyn(idx)
 }
 
 #[target_feature(enable = "avx512f")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m512(a: __m512, idx: usize) -> f32 {
-    a.as_f32x16().extract(idx)
+    a.as_f32x16().extract_dyn(idx)
 }
 
 #[target_feature(enable = "avx512f")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m512d(a: __m512d, idx: usize) -> f64 {
-    a.as_f64x8().extract(idx)
+    a.as_f64x8().extract_dyn(idx)
 }
 
 #[target_feature(enable = "avx512f")]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 pub(crate) const fn get_m512i(a: __m512i, idx: usize) -> i64 {
-    a.as_i64x8().extract(idx)
+    a.as_i64x8().extract_dyn(idx)
 }
 
 // not actually an intrinsic but useful in various tests as we ported from


### PR DESCRIPTION
blocked on https://github.com/rust-lang/rust/pull/151453

Seems nicer to make the `dyn` part explicit, and also this does generate slightly better code for some targets.