### PR TITLE
test `vmulh_lane_f16` in intrinsic test

### DIFF
--- a/crates/intrinsic-test/missing_aarch64.txt
+++ b/crates/intrinsic-test/missing_aarch64.txt
@@ -59,6 +59,3 @@ vluti4q_laneq_u8
 
 # Broken in Clang
 vcvth_s16_f16
-# FIXME: Broken output due to missing f16 printing support in Rust, see git blame for this line
-vmulh_lane_f16
-vmulh_laneq_f16

--- a/crates/intrinsic-test/missing_aarch64_be.txt
+++ b/crates/intrinsic-test/missing_aarch64_be.txt
@@ -100,6 +100,3 @@ vluti4q_laneq_u8
 
 # Broken in Clang
 vcvth_s16_f16
-# FIXME: Broken output due to missing f16 printing support in Rust
-vmulh_lane_f16
-vmulh_laneq_f16


### PR DESCRIPTION
They seem to work locally