### PR TITLE
ci: use `macos-15-intel` runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,9 +101,9 @@ jobs:
 
         # macOS targets
         - tuple: x86_64-apple-darwin
-          os: macos-15-large
+          os: macos-15-intel
         - tuple: x86_64-apple-ios-macabi
-          os: macos-15-large
+          os: macos-15-intel
         - tuple: aarch64-apple-darwin
           os: macos-15
         - tuple: aarch64-apple-ios-macabi


### PR DESCRIPTION
seems unnecessary to use `macos-15-large` just for x86_64 support

> Larger runners are not eligible for the use of included minutes on private repositories. For both private and public repositories, when larger runners are in use, they will always be billed at the per-minute rate.

https://docs.github.com/en/actions/concepts/runners/larger-runners#billing
