### PR TITLE
remove overflowing `f16` literal

### DIFF
--- a/crates/core_arch/src/x86/avx512fp16.rs
+++ b/crates/core_arch/src/x86/avx512fp16.rs
@@ -23993,16 +23993,16 @@ mod tests {
 
     #[simd_test(enable = "avx512fp16,avx512vl")]
     const fn test_mm256_reduce_mul_ph() {
-        let a = _mm256_set1_ph(2.0);
+        let a = _mm256_set1_ph(1.1);
         let r = _mm256_reduce_mul_ph(a);
-        assert_eq!(r, 65536.0);
+        assert_eq!(r, 1.1f32.powi(16) as f16);
     }
 
     #[simd_test(enable = "avx512fp16")]
     const fn test_mm512_reduce_mul_ph() {
-        let a = _mm512_set1_ph(2.0);
+        let a = _mm512_set1_ph(1.1);
         let r = _mm512_reduce_mul_ph(a);
-        assert_eq!(r, 16777216.0);
+        assert_eq!(r, 1.1f32.powi(32) as f16);
     }
 
     #[simd_test(enable = "avx512fp16,avx512vl")]


### PR DESCRIPTION
r? @sayantn 

The lint for overflowing `f16` literals was recently enabled. This causes errors when running std with miri, see [#miri > Miri test-libstd Failure (2026-01) @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Miri.20test-libstd.20Failure.20.282026-01.29/near/570520551)

```
  22.397776   error: literal out of range for `f16`
  0.000065        --> src/x86/avx512fp16.rs:23998:23
  0.000014         |
  0.000009   23998 |         assert_eq!(r, 65536.0);
  0.000009         |                       ^^^^^^^
  0.000008         |
  0.000008         = note: the literal `65536.0` does not fit into the type `f16` and will be converted to `f16::INFINITY`
  0.000007         = note: `#[deny(overflowing_literals)]` on by default
  0.000008
  0.000010   error: literal out of range for `f16`
  0.000009        --> src/x86/avx512fp16.rs:24005:23
  0.000008         |
  0.000008   24005 |         assert_eq!(r, 16777216.0);
  0.000007         |                       ^^^^^^^^^^
  0.000008         |
  0.000007         = note: the literal `16777216.0` does not fit into the type `f16` and will be converted to `f16::INFINITY`
```

