### PR TITLE
disable s390x vector intrinsics if softfloat is enabled

### DIFF
--- a/crates/core_arch/src/s390x/mod.rs
+++ b/crates/core_arch/src/s390x/mod.rs
@@ -2,6 +2,11 @@
 
 pub(crate) mod macros;
 
+/// the float and vector registers overlap therefore we cannot use any vector
+/// extensions if softfloat is enabled.
+
+#[cfg(not(target_abi = "softfloat"))]
 mod vector;
+#[cfg(not(target_abi = "softfloat"))]
 #[unstable(feature = "stdarch_s390x", issue = "130869")]
 pub use self::vector::*;


### PR DESCRIPTION
we will add an explicit incompatibility of softfloat and vector feature in rutsc s390x-unknown-none-softfloat target specification. Therefore we need to disable vector intrinsics here to be able to compile core for this target.

=> https://github.com/rust-lang/rust/pull/151154