### PR TITLE
s390x: add f64 tests for vec_min

### DIFF
--- a/crates/core_arch/src/s390x/vector.rs
+++ b/crates/core_arch/src/s390x/vector.rs
@@ -7491,17 +7491,28 @@ mod tests {
         [0, !0, !0, !0]
     }
 
-    // f32 is the tricky case for max/min as that needs a fallback on z13
-    test_vec_2! { test_vec_max, vec_max, f32x4, f32x4 -> f32x4,
+    test_vec_2! { test_vec_max_f32, vec_max, f32x4, f32x4 -> f32x4,
         [1.0,   f32::NAN, f32::INFINITY, 2.0],
         [-10.0, -10.0,    5.0,           f32::NAN],
         [1.0,   -10.0,    f32::INFINITY, 2.0]
     }
 
-    test_vec_2! { test_vec_min, vec_min, f32x4, f32x4 -> f32x4,
+    test_vec_2! { test_vec_min_f32, vec_min, f32x4, f32x4 -> f32x4,
         [1.0,   f32::NAN, f32::INFINITY, 2.0],
         [-10.0, -10.0,    5.0,           f32::NAN],
         [-10.0, -10.0,    5.0,           2.0]
+    }
+
+    test_vec_2! { test_vec_max_f64, vec_max, f64x2, f64x2 -> f64x2,
+        [f64::NAN, 2.0],
+        [-10.0,    f64::NAN],
+        [-10.0,    2.0]
+    }
+
+    test_vec_2! { test_vec_min_f64, vec_min, f64x2, f64x2 -> f64x2,
+        [f64::NAN, 2.0],
+        [-10.0,    f64::NAN],
+        [-10.0,    2.0]
     }
 
     #[simd_test(enable = "vector")]


### PR DESCRIPTION
Apparently I was [wrong](https://github.com/rust-lang/stdarch/pull/2058#discussion_r2919656602) about f32 being the hard case and the actual hard case is f64. Let's just test both of them.