### PR TITLE
hexagon: Add scalar DSP intrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert-instr-macro"
@@ -84,15 +84,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -106,9 +106,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -140,15 +140,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core_arch"
@@ -185,9 +185,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -195,11 +195,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -209,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -232,9 +231,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -255,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "env_filter",
  "log",
@@ -274,12 +273,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -300,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -375,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -430,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "leb128fmt"
@@ -442,9 +435,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linked-hash-map"
@@ -534,25 +527,25 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
- "env_logger 0.11.9",
+ "env_logger 0.11.10",
  "log",
  "rand 0.10.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -571,7 +564,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -645,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-demangle"
@@ -672,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -733,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -743,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -802,6 +795,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stdarch-gen-hexagon-scalar"
+version = "0.1.0"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "stdarch-gen-loongarch"
 version = "0.1.0"
 dependencies = [
@@ -849,9 +849,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -962,7 +962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser 0.244.0",
 ]
@@ -974,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -986,7 +986,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -1053,7 +1053,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -1084,7 +1084,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -1103,7 +1103,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -1130,18 +1130,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/core_arch/src/hexagon/mod.rs
+++ b/crates/core_arch/src/hexagon/mod.rs
@@ -1,12 +1,17 @@
 //! Hexagon architecture intrinsics
 //!
 //! This module contains intrinsics for the Qualcomm Hexagon DSP architecture,
-//! including the Hexagon Vector Extensions (HVX).
+//! including scalar operations and the Hexagon Vector Extensions (HVX).
+//!
+//! ## Scalar Intrinsics
+//!
+//! The [`scalar`] module provides intrinsics for scalar DSP operations including
+//! arithmetic, multiply, shift, saturate, compare, and floating-point operations.
+//!
+//! ## HVX Vector Intrinsics
 //!
 //! HVX is a wide SIMD architecture designed for high-performance signal processing,
 //! machine learning, and image processing workloads.
-//!
-//! ## Vector Length Modes
 //!
 //! HVX supports two vector length modes:
 //! - 64-byte mode (512-bit vectors): Use the [`v64`] module
@@ -19,6 +24,10 @@
 //!
 //! Note that HVX v66 and later default to 128-byte mode, while earlier versions
 //! (v60-v65) default to 64-byte mode.
+
+/// Scalar intrinsics for Hexagon DSP operations
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub mod scalar;
 
 /// HVX intrinsics for 64-byte vector mode (512-bit vectors)
 #[unstable(feature = "stdarch_hexagon", issue = "151523")]

--- a/crates/core_arch/src/hexagon/scalar.rs
+++ b/crates/core_arch/src/hexagon/scalar.rs
@@ -1,0 +1,12181 @@
+//! Hexagon scalar intrinsics
+//!
+//! This module provides intrinsics for scalar (non-HVX) Hexagon DSP operations,
+//! including arithmetic, multiply, shift, saturate, compare, and floating-point
+//! operations.
+//!
+//! [Hexagon V68 Programmer's Reference Manual](https://docs.qualcomm.com/doc/80-N2040-45)
+//!
+//! ## Naming Convention
+//!
+//! Function names preserve the original Q6 naming case because the convention
+//! uses case to distinguish register types:
+//! - `P` (uppercase) = 64-bit register pair (`Word64`)
+//! - `p` (lowercase) = predicate register (`Byte`)
+//!
+//! For example, `Q6_P_and_PP` operates on 64-bit pairs while `Q6_p_and_pp`
+//! operates on predicate registers.
+//!
+//! ## Architecture Versions
+//!
+//! Most scalar intrinsics are available on all Hexagon architectures.
+//! Some intrinsics require specific architecture versions (v60, v62, v65,
+//! v66, v67, v68, or v67+audio) and carry
+//! `#[target_feature(enable = "v68")]` (or the appropriate version).
+//! Enable these with `-C target-feature=+v68` or by setting the target CPU
+//! via `-C target-cpu=hexagonv68`.
+//!
+//! Each version includes all features from previous versions.
+
+#![allow(non_snake_case)]
+
+#[cfg(test)]
+use stdarch_test::assert_instr;
+
+// LLVM intrinsic declarations for Hexagon scalar operations
+#[allow(improper_ctypes)]
+unsafe extern "unadjusted" {
+    #[link_name = "llvm.hexagon.A2.abs"]
+    fn hexagon_A2_abs(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.absp"]
+    fn hexagon_A2_absp(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.abssat"]
+    fn hexagon_A2_abssat(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.add"]
+    fn hexagon_A2_add(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.hh"]
+    fn hexagon_A2_addh_h16_hh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.hl"]
+    fn hexagon_A2_addh_h16_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.lh"]
+    fn hexagon_A2_addh_h16_lh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.ll"]
+    fn hexagon_A2_addh_h16_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.sat.hh"]
+    fn hexagon_A2_addh_h16_sat_hh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.sat.hl"]
+    fn hexagon_A2_addh_h16_sat_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.sat.lh"]
+    fn hexagon_A2_addh_h16_sat_lh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.h16.sat.ll"]
+    fn hexagon_A2_addh_h16_sat_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.l16.hl"]
+    fn hexagon_A2_addh_l16_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.l16.ll"]
+    fn hexagon_A2_addh_l16_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.l16.sat.hl"]
+    fn hexagon_A2_addh_l16_sat_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addh.l16.sat.ll"]
+    fn hexagon_A2_addh_l16_sat_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addi"]
+    fn hexagon_A2_addi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addp"]
+    fn hexagon_A2_addp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.addpsat"]
+    fn hexagon_A2_addpsat(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.addsat"]
+    fn hexagon_A2_addsat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.addsp"]
+    fn hexagon_A2_addsp(_: i32, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.and"]
+    fn hexagon_A2_and(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.andir"]
+    fn hexagon_A2_andir(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.andp"]
+    fn hexagon_A2_andp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.aslh"]
+    fn hexagon_A2_aslh(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.asrh"]
+    fn hexagon_A2_asrh(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.combine.hh"]
+    fn hexagon_A2_combine_hh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.combine.hl"]
+    fn hexagon_A2_combine_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.combine.lh"]
+    fn hexagon_A2_combine_lh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.combine.ll"]
+    fn hexagon_A2_combine_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.combineii"]
+    fn hexagon_A2_combineii(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A2.combinew"]
+    fn hexagon_A2_combinew(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A2.max"]
+    fn hexagon_A2_max(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.maxp"]
+    fn hexagon_A2_maxp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.maxu"]
+    fn hexagon_A2_maxu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.maxup"]
+    fn hexagon_A2_maxup(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.min"]
+    fn hexagon_A2_min(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.minp"]
+    fn hexagon_A2_minp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.minu"]
+    fn hexagon_A2_minu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.minup"]
+    fn hexagon_A2_minup(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.neg"]
+    fn hexagon_A2_neg(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.negp"]
+    fn hexagon_A2_negp(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.negsat"]
+    fn hexagon_A2_negsat(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.not"]
+    fn hexagon_A2_not(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.notp"]
+    fn hexagon_A2_notp(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.or"]
+    fn hexagon_A2_or(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.orir"]
+    fn hexagon_A2_orir(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.orp"]
+    fn hexagon_A2_orp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.roundsat"]
+    fn hexagon_A2_roundsat(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.sat"]
+    fn hexagon_A2_sat(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.satb"]
+    fn hexagon_A2_satb(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.sath"]
+    fn hexagon_A2_sath(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.satub"]
+    fn hexagon_A2_satub(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.satuh"]
+    fn hexagon_A2_satuh(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.sub"]
+    fn hexagon_A2_sub(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.hh"]
+    fn hexagon_A2_subh_h16_hh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.hl"]
+    fn hexagon_A2_subh_h16_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.lh"]
+    fn hexagon_A2_subh_h16_lh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.ll"]
+    fn hexagon_A2_subh_h16_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.sat.hh"]
+    fn hexagon_A2_subh_h16_sat_hh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.sat.hl"]
+    fn hexagon_A2_subh_h16_sat_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.sat.lh"]
+    fn hexagon_A2_subh_h16_sat_lh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.h16.sat.ll"]
+    fn hexagon_A2_subh_h16_sat_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.l16.hl"]
+    fn hexagon_A2_subh_l16_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.l16.ll"]
+    fn hexagon_A2_subh_l16_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.l16.sat.hl"]
+    fn hexagon_A2_subh_l16_sat_hl(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subh.l16.sat.ll"]
+    fn hexagon_A2_subh_l16_sat_ll(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subp"]
+    fn hexagon_A2_subp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.subri"]
+    fn hexagon_A2_subri(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.subsat"]
+    fn hexagon_A2_subsat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svaddh"]
+    fn hexagon_A2_svaddh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svaddhs"]
+    fn hexagon_A2_svaddhs(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svadduhs"]
+    fn hexagon_A2_svadduhs(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svavgh"]
+    fn hexagon_A2_svavgh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svavghs"]
+    fn hexagon_A2_svavghs(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svnavgh"]
+    fn hexagon_A2_svnavgh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svsubh"]
+    fn hexagon_A2_svsubh(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svsubhs"]
+    fn hexagon_A2_svsubhs(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.svsubuhs"]
+    fn hexagon_A2_svsubuhs(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.swiz"]
+    fn hexagon_A2_swiz(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.sxtb"]
+    fn hexagon_A2_sxtb(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.sxth"]
+    fn hexagon_A2_sxth(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.sxtw"]
+    fn hexagon_A2_sxtw(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.A2.tfr"]
+    fn hexagon_A2_tfr(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.tfrih"]
+    fn hexagon_A2_tfrih(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.tfril"]
+    fn hexagon_A2_tfril(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.tfrp"]
+    fn hexagon_A2_tfrp(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.tfrpi"]
+    fn hexagon_A2_tfrpi(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.A2.tfrsi"]
+    fn hexagon_A2_tfrsi(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.vabsh"]
+    fn hexagon_A2_vabsh(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vabshsat"]
+    fn hexagon_A2_vabshsat(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vabsw"]
+    fn hexagon_A2_vabsw(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vabswsat"]
+    fn hexagon_A2_vabswsat(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddb.map"]
+    fn hexagon_A2_vaddb_map(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddh"]
+    fn hexagon_A2_vaddh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddhs"]
+    fn hexagon_A2_vaddhs(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddub"]
+    fn hexagon_A2_vaddub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddubs"]
+    fn hexagon_A2_vaddubs(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vadduhs"]
+    fn hexagon_A2_vadduhs(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddw"]
+    fn hexagon_A2_vaddw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vaddws"]
+    fn hexagon_A2_vaddws(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavgh"]
+    fn hexagon_A2_vavgh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavghcr"]
+    fn hexagon_A2_vavghcr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavghr"]
+    fn hexagon_A2_vavghr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavgub"]
+    fn hexagon_A2_vavgub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavgubr"]
+    fn hexagon_A2_vavgubr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavguh"]
+    fn hexagon_A2_vavguh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavguhr"]
+    fn hexagon_A2_vavguhr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavguw"]
+    fn hexagon_A2_vavguw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavguwr"]
+    fn hexagon_A2_vavguwr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavgw"]
+    fn hexagon_A2_vavgw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavgwcr"]
+    fn hexagon_A2_vavgwcr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vavgwr"]
+    fn hexagon_A2_vavgwr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vcmpbeq"]
+    fn hexagon_A2_vcmpbeq(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmpbgtu"]
+    fn hexagon_A2_vcmpbgtu(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmpheq"]
+    fn hexagon_A2_vcmpheq(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmphgt"]
+    fn hexagon_A2_vcmphgt(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmphgtu"]
+    fn hexagon_A2_vcmphgtu(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmpweq"]
+    fn hexagon_A2_vcmpweq(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmpwgt"]
+    fn hexagon_A2_vcmpwgt(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vcmpwgtu"]
+    fn hexagon_A2_vcmpwgtu(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A2.vconj"]
+    fn hexagon_A2_vconj(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vmaxb"]
+    fn hexagon_A2_vmaxb(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vmaxh"]
+    fn hexagon_A2_vmaxh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vmaxub"]
+    fn hexagon_A2_vmaxub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vmaxuh"]
+    fn hexagon_A2_vmaxuh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vmaxuw"]
+    fn hexagon_A2_vmaxuw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vmaxw"]
+    fn hexagon_A2_vmaxw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vminb"]
+    fn hexagon_A2_vminb(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vminh"]
+    fn hexagon_A2_vminh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vminub"]
+    fn hexagon_A2_vminub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vminuh"]
+    fn hexagon_A2_vminuh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vminuw"]
+    fn hexagon_A2_vminuw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vminw"]
+    fn hexagon_A2_vminw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vnavgh"]
+    fn hexagon_A2_vnavgh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vnavghcr"]
+    fn hexagon_A2_vnavghcr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vnavghr"]
+    fn hexagon_A2_vnavghr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vnavgw"]
+    fn hexagon_A2_vnavgw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vnavgwcr"]
+    fn hexagon_A2_vnavgwcr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vnavgwr"]
+    fn hexagon_A2_vnavgwr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vraddub"]
+    fn hexagon_A2_vraddub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vraddub.acc"]
+    fn hexagon_A2_vraddub_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vrsadub"]
+    fn hexagon_A2_vrsadub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vrsadub.acc"]
+    fn hexagon_A2_vrsadub_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubb.map"]
+    fn hexagon_A2_vsubb_map(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubh"]
+    fn hexagon_A2_vsubh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubhs"]
+    fn hexagon_A2_vsubhs(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubub"]
+    fn hexagon_A2_vsubub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsububs"]
+    fn hexagon_A2_vsububs(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubuhs"]
+    fn hexagon_A2_vsubuhs(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubw"]
+    fn hexagon_A2_vsubw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.vsubws"]
+    fn hexagon_A2_vsubws(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.xor"]
+    fn hexagon_A2_xor(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.xorp"]
+    fn hexagon_A2_xorp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A2.zxtb"]
+    fn hexagon_A2_zxtb(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A2.zxth"]
+    fn hexagon_A2_zxth(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.andn"]
+    fn hexagon_A4_andn(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.andnp"]
+    fn hexagon_A4_andnp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A4.bitsplit"]
+    fn hexagon_A4_bitsplit(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.bitspliti"]
+    fn hexagon_A4_bitspliti(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.boundscheck"]
+    fn hexagon_A4_boundscheck(_: i32, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpbeq"]
+    fn hexagon_A4_cmpbeq(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpbeqi"]
+    fn hexagon_A4_cmpbeqi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpbgt"]
+    fn hexagon_A4_cmpbgt(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpbgti"]
+    fn hexagon_A4_cmpbgti(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpbgtu"]
+    fn hexagon_A4_cmpbgtu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpbgtui"]
+    fn hexagon_A4_cmpbgtui(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpheq"]
+    fn hexagon_A4_cmpheq(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmpheqi"]
+    fn hexagon_A4_cmpheqi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmphgt"]
+    fn hexagon_A4_cmphgt(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmphgti"]
+    fn hexagon_A4_cmphgti(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmphgtu"]
+    fn hexagon_A4_cmphgtu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cmphgtui"]
+    fn hexagon_A4_cmphgtui(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.combineir"]
+    fn hexagon_A4_combineir(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.combineri"]
+    fn hexagon_A4_combineri(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.cround.ri"]
+    fn hexagon_A4_cround_ri(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.cround.rr"]
+    fn hexagon_A4_cround_rr(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.modwrapu"]
+    fn hexagon_A4_modwrapu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.orn"]
+    fn hexagon_A4_orn(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.ornp"]
+    fn hexagon_A4_ornp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A4.rcmpeq"]
+    fn hexagon_A4_rcmpeq(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.rcmpeqi"]
+    fn hexagon_A4_rcmpeqi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.rcmpneq"]
+    fn hexagon_A4_rcmpneq(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.rcmpneqi"]
+    fn hexagon_A4_rcmpneqi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.round.ri"]
+    fn hexagon_A4_round_ri(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.round.ri.sat"]
+    fn hexagon_A4_round_ri_sat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.round.rr"]
+    fn hexagon_A4_round_rr(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.round.rr.sat"]
+    fn hexagon_A4_round_rr_sat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.tlbmatch"]
+    fn hexagon_A4_tlbmatch(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpbeq.any"]
+    fn hexagon_A4_vcmpbeq_any(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpbeqi"]
+    fn hexagon_A4_vcmpbeqi(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpbgt"]
+    fn hexagon_A4_vcmpbgt(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpbgti"]
+    fn hexagon_A4_vcmpbgti(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpbgtui"]
+    fn hexagon_A4_vcmpbgtui(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpheqi"]
+    fn hexagon_A4_vcmpheqi(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmphgti"]
+    fn hexagon_A4_vcmphgti(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmphgtui"]
+    fn hexagon_A4_vcmphgtui(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpweqi"]
+    fn hexagon_A4_vcmpweqi(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpwgti"]
+    fn hexagon_A4_vcmpwgti(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vcmpwgtui"]
+    fn hexagon_A4_vcmpwgtui(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A4.vrmaxh"]
+    fn hexagon_A4_vrmaxh(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrmaxuh"]
+    fn hexagon_A4_vrmaxuh(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrmaxuw"]
+    fn hexagon_A4_vrmaxuw(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrmaxw"]
+    fn hexagon_A4_vrmaxw(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrminh"]
+    fn hexagon_A4_vrminh(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrminuh"]
+    fn hexagon_A4_vrminuh(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrminuw"]
+    fn hexagon_A4_vrminuw(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A4.vrminw"]
+    fn hexagon_A4_vrminw(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A5.vaddhubs"]
+    fn hexagon_A5_vaddhubs(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.C2.all8"]
+    fn hexagon_C2_all8(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.and"]
+    fn hexagon_C2_and(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.andn"]
+    fn hexagon_C2_andn(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.any8"]
+    fn hexagon_C2_any8(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.bitsclr"]
+    fn hexagon_C2_bitsclr(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.bitsclri"]
+    fn hexagon_C2_bitsclri(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.bitsset"]
+    fn hexagon_C2_bitsset(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpeq"]
+    fn hexagon_C2_cmpeq(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpeqi"]
+    fn hexagon_C2_cmpeqi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpeqp"]
+    fn hexagon_C2_cmpeqp(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgei"]
+    fn hexagon_C2_cmpgei(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgeui"]
+    fn hexagon_C2_cmpgeui(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgt"]
+    fn hexagon_C2_cmpgt(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgti"]
+    fn hexagon_C2_cmpgti(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgtp"]
+    fn hexagon_C2_cmpgtp(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgtu"]
+    fn hexagon_C2_cmpgtu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgtui"]
+    fn hexagon_C2_cmpgtui(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpgtup"]
+    fn hexagon_C2_cmpgtup(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmplt"]
+    fn hexagon_C2_cmplt(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.cmpltu"]
+    fn hexagon_C2_cmpltu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.mask"]
+    fn hexagon_C2_mask(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.C2.mux"]
+    fn hexagon_C2_mux(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.muxii"]
+    fn hexagon_C2_muxii(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.muxir"]
+    fn hexagon_C2_muxir(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.muxri"]
+    fn hexagon_C2_muxri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.not"]
+    fn hexagon_C2_not(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.or"]
+    fn hexagon_C2_or(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.orn"]
+    fn hexagon_C2_orn(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.pxfer.map"]
+    fn hexagon_C2_pxfer_map(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.tfrpr"]
+    fn hexagon_C2_tfrpr(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.tfrrp"]
+    fn hexagon_C2_tfrrp(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.vitpack"]
+    fn hexagon_C2_vitpack(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C2.vmux"]
+    fn hexagon_C2_vmux(_: i32, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.C2.xor"]
+    fn hexagon_C2_xor(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.and.and"]
+    fn hexagon_C4_and_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.and.andn"]
+    fn hexagon_C4_and_andn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.and.or"]
+    fn hexagon_C4_and_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.and.orn"]
+    fn hexagon_C4_and_orn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.cmplte"]
+    fn hexagon_C4_cmplte(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.cmpltei"]
+    fn hexagon_C4_cmpltei(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.cmplteu"]
+    fn hexagon_C4_cmplteu(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.cmplteui"]
+    fn hexagon_C4_cmplteui(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.cmpneq"]
+    fn hexagon_C4_cmpneq(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.cmpneqi"]
+    fn hexagon_C4_cmpneqi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.fastcorner9"]
+    fn hexagon_C4_fastcorner9(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.fastcorner9.not"]
+    fn hexagon_C4_fastcorner9_not(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.nbitsclr"]
+    fn hexagon_C4_nbitsclr(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.nbitsclri"]
+    fn hexagon_C4_nbitsclri(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.nbitsset"]
+    fn hexagon_C4_nbitsset(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.or.and"]
+    fn hexagon_C4_or_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.or.andn"]
+    fn hexagon_C4_or_andn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.or.or"]
+    fn hexagon_C4_or_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.C4.or.orn"]
+    fn hexagon_C4_or_orn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.d2df"]
+    fn hexagon_F2_conv_d2df(_: i64) -> f64;
+    #[link_name = "llvm.hexagon.F2.conv.d2sf"]
+    fn hexagon_F2_conv_d2sf(_: i64) -> f32;
+    #[link_name = "llvm.hexagon.F2.conv.df2d"]
+    fn hexagon_F2_conv_df2d(_: f64) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.df2d.chop"]
+    fn hexagon_F2_conv_df2d_chop(_: f64) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.df2sf"]
+    fn hexagon_F2_conv_df2sf(_: f64) -> f32;
+    #[link_name = "llvm.hexagon.F2.conv.df2ud"]
+    fn hexagon_F2_conv_df2ud(_: f64) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.df2ud.chop"]
+    fn hexagon_F2_conv_df2ud_chop(_: f64) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.df2uw"]
+    fn hexagon_F2_conv_df2uw(_: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.df2uw.chop"]
+    fn hexagon_F2_conv_df2uw_chop(_: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.df2w"]
+    fn hexagon_F2_conv_df2w(_: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.df2w.chop"]
+    fn hexagon_F2_conv_df2w_chop(_: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.sf2d"]
+    fn hexagon_F2_conv_sf2d(_: f32) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.sf2d.chop"]
+    fn hexagon_F2_conv_sf2d_chop(_: f32) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.sf2df"]
+    fn hexagon_F2_conv_sf2df(_: f32) -> f64;
+    #[link_name = "llvm.hexagon.F2.conv.sf2ud"]
+    fn hexagon_F2_conv_sf2ud(_: f32) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.sf2ud.chop"]
+    fn hexagon_F2_conv_sf2ud_chop(_: f32) -> i64;
+    #[link_name = "llvm.hexagon.F2.conv.sf2uw"]
+    fn hexagon_F2_conv_sf2uw(_: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.sf2uw.chop"]
+    fn hexagon_F2_conv_sf2uw_chop(_: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.sf2w"]
+    fn hexagon_F2_conv_sf2w(_: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.sf2w.chop"]
+    fn hexagon_F2_conv_sf2w_chop(_: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.conv.ud2df"]
+    fn hexagon_F2_conv_ud2df(_: i64) -> f64;
+    #[link_name = "llvm.hexagon.F2.conv.ud2sf"]
+    fn hexagon_F2_conv_ud2sf(_: i64) -> f32;
+    #[link_name = "llvm.hexagon.F2.conv.uw2df"]
+    fn hexagon_F2_conv_uw2df(_: i32) -> f64;
+    #[link_name = "llvm.hexagon.F2.conv.uw2sf"]
+    fn hexagon_F2_conv_uw2sf(_: i32) -> f32;
+    #[link_name = "llvm.hexagon.F2.conv.w2df"]
+    fn hexagon_F2_conv_w2df(_: i32) -> f64;
+    #[link_name = "llvm.hexagon.F2.conv.w2sf"]
+    fn hexagon_F2_conv_w2sf(_: i32) -> f32;
+    #[link_name = "llvm.hexagon.F2.dfclass"]
+    fn hexagon_F2_dfclass(_: f64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.F2.dfcmpeq"]
+    fn hexagon_F2_dfcmpeq(_: f64, _: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.dfcmpge"]
+    fn hexagon_F2_dfcmpge(_: f64, _: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.dfcmpgt"]
+    fn hexagon_F2_dfcmpgt(_: f64, _: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.dfcmpuo"]
+    fn hexagon_F2_dfcmpuo(_: f64, _: f64) -> i32;
+    #[link_name = "llvm.hexagon.F2.dfimm.n"]
+    fn hexagon_F2_dfimm_n(_: i32) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfimm.p"]
+    fn hexagon_F2_dfimm_p(_: i32) -> f64;
+    #[link_name = "llvm.hexagon.F2.sfadd"]
+    fn hexagon_F2_sfadd(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfclass"]
+    fn hexagon_F2_sfclass(_: f32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.F2.sfcmpeq"]
+    fn hexagon_F2_sfcmpeq(_: f32, _: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.sfcmpge"]
+    fn hexagon_F2_sfcmpge(_: f32, _: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.sfcmpgt"]
+    fn hexagon_F2_sfcmpgt(_: f32, _: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.sfcmpuo"]
+    fn hexagon_F2_sfcmpuo(_: f32, _: f32) -> i32;
+    #[link_name = "llvm.hexagon.F2.sffixupd"]
+    fn hexagon_F2_sffixupd(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffixupn"]
+    fn hexagon_F2_sffixupn(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffixupr"]
+    fn hexagon_F2_sffixupr(_: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffma"]
+    fn hexagon_F2_sffma(_: f32, _: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffma.lib"]
+    fn hexagon_F2_sffma_lib(_: f32, _: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffma.sc"]
+    fn hexagon_F2_sffma_sc(_: f32, _: f32, _: f32, _: i32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffms"]
+    fn hexagon_F2_sffms(_: f32, _: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sffms.lib"]
+    fn hexagon_F2_sffms_lib(_: f32, _: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfimm.n"]
+    fn hexagon_F2_sfimm_n(_: i32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfimm.p"]
+    fn hexagon_F2_sfimm_p(_: i32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfmax"]
+    fn hexagon_F2_sfmax(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfmin"]
+    fn hexagon_F2_sfmin(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfmpy"]
+    fn hexagon_F2_sfmpy(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.F2.sfsub"]
+    fn hexagon_F2_sfsub(_: f32, _: f32) -> f32;
+    #[link_name = "llvm.hexagon.M2.acci"]
+    fn hexagon_M2_acci(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.accii"]
+    fn hexagon_M2_accii(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.cmaci.s0"]
+    fn hexagon_M2_cmaci_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmacr.s0"]
+    fn hexagon_M2_cmacr_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmacs.s0"]
+    fn hexagon_M2_cmacs_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmacs.s1"]
+    fn hexagon_M2_cmacs_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmacsc.s0"]
+    fn hexagon_M2_cmacsc_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmacsc.s1"]
+    fn hexagon_M2_cmacsc_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmpyi.s0"]
+    fn hexagon_M2_cmpyi_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmpyr.s0"]
+    fn hexagon_M2_cmpyr_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmpyrs.s0"]
+    fn hexagon_M2_cmpyrs_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.cmpyrs.s1"]
+    fn hexagon_M2_cmpyrs_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.cmpyrsc.s0"]
+    fn hexagon_M2_cmpyrsc_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.cmpyrsc.s1"]
+    fn hexagon_M2_cmpyrsc_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.cmpys.s0"]
+    fn hexagon_M2_cmpys_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmpys.s1"]
+    fn hexagon_M2_cmpys_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmpysc.s0"]
+    fn hexagon_M2_cmpysc_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cmpysc.s1"]
+    fn hexagon_M2_cmpysc_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cnacs.s0"]
+    fn hexagon_M2_cnacs_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cnacs.s1"]
+    fn hexagon_M2_cnacs_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cnacsc.s0"]
+    fn hexagon_M2_cnacsc_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.cnacsc.s1"]
+    fn hexagon_M2_cnacsc_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.dpmpyss.acc.s0"]
+    fn hexagon_M2_dpmpyss_acc_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.dpmpyss.nac.s0"]
+    fn hexagon_M2_dpmpyss_nac_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.dpmpyss.rnd.s0"]
+    fn hexagon_M2_dpmpyss_rnd_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.dpmpyss.s0"]
+    fn hexagon_M2_dpmpyss_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.dpmpyuu.acc.s0"]
+    fn hexagon_M2_dpmpyuu_acc_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.dpmpyuu.nac.s0"]
+    fn hexagon_M2_dpmpyuu_nac_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.dpmpyuu.s0"]
+    fn hexagon_M2_dpmpyuu_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.hmmpyh.rs1"]
+    fn hexagon_M2_hmmpyh_rs1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.hmmpyh.s1"]
+    fn hexagon_M2_hmmpyh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.hmmpyl.rs1"]
+    fn hexagon_M2_hmmpyl_rs1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.hmmpyl.s1"]
+    fn hexagon_M2_hmmpyl_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.maci"]
+    fn hexagon_M2_maci(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.macsin"]
+    fn hexagon_M2_macsin(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.macsip"]
+    fn hexagon_M2_macsip(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mmachs.rs0"]
+    fn hexagon_M2_mmachs_rs0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmachs.rs1"]
+    fn hexagon_M2_mmachs_rs1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmachs.s0"]
+    fn hexagon_M2_mmachs_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmachs.s1"]
+    fn hexagon_M2_mmachs_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacls.rs0"]
+    fn hexagon_M2_mmacls_rs0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacls.rs1"]
+    fn hexagon_M2_mmacls_rs1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacls.s0"]
+    fn hexagon_M2_mmacls_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacls.s1"]
+    fn hexagon_M2_mmacls_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacuhs.rs0"]
+    fn hexagon_M2_mmacuhs_rs0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacuhs.rs1"]
+    fn hexagon_M2_mmacuhs_rs1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacuhs.s0"]
+    fn hexagon_M2_mmacuhs_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmacuhs.s1"]
+    fn hexagon_M2_mmacuhs_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmaculs.rs0"]
+    fn hexagon_M2_mmaculs_rs0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmaculs.rs1"]
+    fn hexagon_M2_mmaculs_rs1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmaculs.s0"]
+    fn hexagon_M2_mmaculs_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmaculs.s1"]
+    fn hexagon_M2_mmaculs_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyh.rs0"]
+    fn hexagon_M2_mmpyh_rs0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyh.rs1"]
+    fn hexagon_M2_mmpyh_rs1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyh.s0"]
+    fn hexagon_M2_mmpyh_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyh.s1"]
+    fn hexagon_M2_mmpyh_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyl.rs0"]
+    fn hexagon_M2_mmpyl_rs0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyl.rs1"]
+    fn hexagon_M2_mmpyl_rs1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyl.s0"]
+    fn hexagon_M2_mmpyl_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyl.s1"]
+    fn hexagon_M2_mmpyl_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyuh.rs0"]
+    fn hexagon_M2_mmpyuh_rs0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyuh.rs1"]
+    fn hexagon_M2_mmpyuh_rs1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyuh.s0"]
+    fn hexagon_M2_mmpyuh_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyuh.s1"]
+    fn hexagon_M2_mmpyuh_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyul.rs0"]
+    fn hexagon_M2_mmpyul_rs0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyul.rs1"]
+    fn hexagon_M2_mmpyul_rs1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyul.s0"]
+    fn hexagon_M2_mmpyul_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mmpyul.s1"]
+    fn hexagon_M2_mmpyul_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.hh.s0"]
+    fn hexagon_M2_mpy_acc_hh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.hh.s1"]
+    fn hexagon_M2_mpy_acc_hh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.hl.s0"]
+    fn hexagon_M2_mpy_acc_hl_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.hl.s1"]
+    fn hexagon_M2_mpy_acc_hl_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.lh.s0"]
+    fn hexagon_M2_mpy_acc_lh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.lh.s1"]
+    fn hexagon_M2_mpy_acc_lh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.ll.s0"]
+    fn hexagon_M2_mpy_acc_ll_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.ll.s1"]
+    fn hexagon_M2_mpy_acc_ll_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.hh.s0"]
+    fn hexagon_M2_mpy_acc_sat_hh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.hh.s1"]
+    fn hexagon_M2_mpy_acc_sat_hh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.hl.s0"]
+    fn hexagon_M2_mpy_acc_sat_hl_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.hl.s1"]
+    fn hexagon_M2_mpy_acc_sat_hl_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.lh.s0"]
+    fn hexagon_M2_mpy_acc_sat_lh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.lh.s1"]
+    fn hexagon_M2_mpy_acc_sat_lh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.ll.s0"]
+    fn hexagon_M2_mpy_acc_sat_ll_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.acc.sat.ll.s1"]
+    fn hexagon_M2_mpy_acc_sat_ll_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.hh.s0"]
+    fn hexagon_M2_mpy_hh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.hh.s1"]
+    fn hexagon_M2_mpy_hh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.hl.s0"]
+    fn hexagon_M2_mpy_hl_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.hl.s1"]
+    fn hexagon_M2_mpy_hl_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.lh.s0"]
+    fn hexagon_M2_mpy_lh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.lh.s1"]
+    fn hexagon_M2_mpy_lh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.ll.s0"]
+    fn hexagon_M2_mpy_ll_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.ll.s1"]
+    fn hexagon_M2_mpy_ll_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.hh.s0"]
+    fn hexagon_M2_mpy_nac_hh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.hh.s1"]
+    fn hexagon_M2_mpy_nac_hh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.hl.s0"]
+    fn hexagon_M2_mpy_nac_hl_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.hl.s1"]
+    fn hexagon_M2_mpy_nac_hl_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.lh.s0"]
+    fn hexagon_M2_mpy_nac_lh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.lh.s1"]
+    fn hexagon_M2_mpy_nac_lh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.ll.s0"]
+    fn hexagon_M2_mpy_nac_ll_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.ll.s1"]
+    fn hexagon_M2_mpy_nac_ll_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.hh.s0"]
+    fn hexagon_M2_mpy_nac_sat_hh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.hh.s1"]
+    fn hexagon_M2_mpy_nac_sat_hh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.hl.s0"]
+    fn hexagon_M2_mpy_nac_sat_hl_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.hl.s1"]
+    fn hexagon_M2_mpy_nac_sat_hl_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.lh.s0"]
+    fn hexagon_M2_mpy_nac_sat_lh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.lh.s1"]
+    fn hexagon_M2_mpy_nac_sat_lh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.ll.s0"]
+    fn hexagon_M2_mpy_nac_sat_ll_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.nac.sat.ll.s1"]
+    fn hexagon_M2_mpy_nac_sat_ll_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.hh.s0"]
+    fn hexagon_M2_mpy_rnd_hh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.hh.s1"]
+    fn hexagon_M2_mpy_rnd_hh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.hl.s0"]
+    fn hexagon_M2_mpy_rnd_hl_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.hl.s1"]
+    fn hexagon_M2_mpy_rnd_hl_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.lh.s0"]
+    fn hexagon_M2_mpy_rnd_lh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.lh.s1"]
+    fn hexagon_M2_mpy_rnd_lh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.ll.s0"]
+    fn hexagon_M2_mpy_rnd_ll_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.rnd.ll.s1"]
+    fn hexagon_M2_mpy_rnd_ll_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.hh.s0"]
+    fn hexagon_M2_mpy_sat_hh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.hh.s1"]
+    fn hexagon_M2_mpy_sat_hh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.hl.s0"]
+    fn hexagon_M2_mpy_sat_hl_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.hl.s1"]
+    fn hexagon_M2_mpy_sat_hl_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.lh.s0"]
+    fn hexagon_M2_mpy_sat_lh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.lh.s1"]
+    fn hexagon_M2_mpy_sat_lh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.ll.s0"]
+    fn hexagon_M2_mpy_sat_ll_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.ll.s1"]
+    fn hexagon_M2_mpy_sat_ll_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.hh.s0"]
+    fn hexagon_M2_mpy_sat_rnd_hh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.hh.s1"]
+    fn hexagon_M2_mpy_sat_rnd_hh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.hl.s0"]
+    fn hexagon_M2_mpy_sat_rnd_hl_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.hl.s1"]
+    fn hexagon_M2_mpy_sat_rnd_hl_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.lh.s0"]
+    fn hexagon_M2_mpy_sat_rnd_lh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.lh.s1"]
+    fn hexagon_M2_mpy_sat_rnd_lh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.ll.s0"]
+    fn hexagon_M2_mpy_sat_rnd_ll_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.sat.rnd.ll.s1"]
+    fn hexagon_M2_mpy_sat_rnd_ll_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.up"]
+    fn hexagon_M2_mpy_up(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.up.s1"]
+    fn hexagon_M2_mpy_up_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpy.up.s1.sat"]
+    fn hexagon_M2_mpy_up_s1_sat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.hh.s0"]
+    fn hexagon_M2_mpyd_acc_hh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.hh.s1"]
+    fn hexagon_M2_mpyd_acc_hh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.hl.s0"]
+    fn hexagon_M2_mpyd_acc_hl_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.hl.s1"]
+    fn hexagon_M2_mpyd_acc_hl_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.lh.s0"]
+    fn hexagon_M2_mpyd_acc_lh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.lh.s1"]
+    fn hexagon_M2_mpyd_acc_lh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.ll.s0"]
+    fn hexagon_M2_mpyd_acc_ll_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.acc.ll.s1"]
+    fn hexagon_M2_mpyd_acc_ll_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.hh.s0"]
+    fn hexagon_M2_mpyd_hh_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.hh.s1"]
+    fn hexagon_M2_mpyd_hh_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.hl.s0"]
+    fn hexagon_M2_mpyd_hl_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.hl.s1"]
+    fn hexagon_M2_mpyd_hl_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.lh.s0"]
+    fn hexagon_M2_mpyd_lh_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.lh.s1"]
+    fn hexagon_M2_mpyd_lh_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.ll.s0"]
+    fn hexagon_M2_mpyd_ll_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.ll.s1"]
+    fn hexagon_M2_mpyd_ll_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.hh.s0"]
+    fn hexagon_M2_mpyd_nac_hh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.hh.s1"]
+    fn hexagon_M2_mpyd_nac_hh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.hl.s0"]
+    fn hexagon_M2_mpyd_nac_hl_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.hl.s1"]
+    fn hexagon_M2_mpyd_nac_hl_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.lh.s0"]
+    fn hexagon_M2_mpyd_nac_lh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.lh.s1"]
+    fn hexagon_M2_mpyd_nac_lh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.ll.s0"]
+    fn hexagon_M2_mpyd_nac_ll_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.nac.ll.s1"]
+    fn hexagon_M2_mpyd_nac_ll_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.hh.s0"]
+    fn hexagon_M2_mpyd_rnd_hh_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.hh.s1"]
+    fn hexagon_M2_mpyd_rnd_hh_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.hl.s0"]
+    fn hexagon_M2_mpyd_rnd_hl_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.hl.s1"]
+    fn hexagon_M2_mpyd_rnd_hl_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.lh.s0"]
+    fn hexagon_M2_mpyd_rnd_lh_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.lh.s1"]
+    fn hexagon_M2_mpyd_rnd_lh_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.ll.s0"]
+    fn hexagon_M2_mpyd_rnd_ll_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyd.rnd.ll.s1"]
+    fn hexagon_M2_mpyd_rnd_ll_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyi"]
+    fn hexagon_M2_mpyi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpysmi"]
+    fn hexagon_M2_mpysmi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpysu.up"]
+    fn hexagon_M2_mpysu_up(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.hh.s0"]
+    fn hexagon_M2_mpyu_acc_hh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.hh.s1"]
+    fn hexagon_M2_mpyu_acc_hh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.hl.s0"]
+    fn hexagon_M2_mpyu_acc_hl_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.hl.s1"]
+    fn hexagon_M2_mpyu_acc_hl_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.lh.s0"]
+    fn hexagon_M2_mpyu_acc_lh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.lh.s1"]
+    fn hexagon_M2_mpyu_acc_lh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.ll.s0"]
+    fn hexagon_M2_mpyu_acc_ll_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.acc.ll.s1"]
+    fn hexagon_M2_mpyu_acc_ll_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.hh.s0"]
+    fn hexagon_M2_mpyu_hh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.hh.s1"]
+    fn hexagon_M2_mpyu_hh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.hl.s0"]
+    fn hexagon_M2_mpyu_hl_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.hl.s1"]
+    fn hexagon_M2_mpyu_hl_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.lh.s0"]
+    fn hexagon_M2_mpyu_lh_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.lh.s1"]
+    fn hexagon_M2_mpyu_lh_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.ll.s0"]
+    fn hexagon_M2_mpyu_ll_s0(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.ll.s1"]
+    fn hexagon_M2_mpyu_ll_s1(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.hh.s0"]
+    fn hexagon_M2_mpyu_nac_hh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.hh.s1"]
+    fn hexagon_M2_mpyu_nac_hh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.hl.s0"]
+    fn hexagon_M2_mpyu_nac_hl_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.hl.s1"]
+    fn hexagon_M2_mpyu_nac_hl_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.lh.s0"]
+    fn hexagon_M2_mpyu_nac_lh_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.lh.s1"]
+    fn hexagon_M2_mpyu_nac_lh_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.ll.s0"]
+    fn hexagon_M2_mpyu_nac_ll_s0(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.nac.ll.s1"]
+    fn hexagon_M2_mpyu_nac_ll_s1(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyu.up"]
+    fn hexagon_M2_mpyu_up(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.hh.s0"]
+    fn hexagon_M2_mpyud_acc_hh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.hh.s1"]
+    fn hexagon_M2_mpyud_acc_hh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.hl.s0"]
+    fn hexagon_M2_mpyud_acc_hl_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.hl.s1"]
+    fn hexagon_M2_mpyud_acc_hl_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.lh.s0"]
+    fn hexagon_M2_mpyud_acc_lh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.lh.s1"]
+    fn hexagon_M2_mpyud_acc_lh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.ll.s0"]
+    fn hexagon_M2_mpyud_acc_ll_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.acc.ll.s1"]
+    fn hexagon_M2_mpyud_acc_ll_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.hh.s0"]
+    fn hexagon_M2_mpyud_hh_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.hh.s1"]
+    fn hexagon_M2_mpyud_hh_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.hl.s0"]
+    fn hexagon_M2_mpyud_hl_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.hl.s1"]
+    fn hexagon_M2_mpyud_hl_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.lh.s0"]
+    fn hexagon_M2_mpyud_lh_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.lh.s1"]
+    fn hexagon_M2_mpyud_lh_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.ll.s0"]
+    fn hexagon_M2_mpyud_ll_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.ll.s1"]
+    fn hexagon_M2_mpyud_ll_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.hh.s0"]
+    fn hexagon_M2_mpyud_nac_hh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.hh.s1"]
+    fn hexagon_M2_mpyud_nac_hh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.hl.s0"]
+    fn hexagon_M2_mpyud_nac_hl_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.hl.s1"]
+    fn hexagon_M2_mpyud_nac_hl_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.lh.s0"]
+    fn hexagon_M2_mpyud_nac_lh_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.lh.s1"]
+    fn hexagon_M2_mpyud_nac_lh_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.ll.s0"]
+    fn hexagon_M2_mpyud_nac_ll_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyud.nac.ll.s1"]
+    fn hexagon_M2_mpyud_nac_ll_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.mpyui"]
+    fn hexagon_M2_mpyui(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.nacci"]
+    fn hexagon_M2_nacci(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.naccii"]
+    fn hexagon_M2_naccii(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.subacc"]
+    fn hexagon_M2_subacc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.vabsdiffh"]
+    fn hexagon_M2_vabsdiffh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vabsdiffw"]
+    fn hexagon_M2_vabsdiffw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vcmac.s0.sat.i"]
+    fn hexagon_M2_vcmac_s0_sat_i(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vcmac.s0.sat.r"]
+    fn hexagon_M2_vcmac_s0_sat_r(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vcmpy.s0.sat.i"]
+    fn hexagon_M2_vcmpy_s0_sat_i(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vcmpy.s0.sat.r"]
+    fn hexagon_M2_vcmpy_s0_sat_r(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vcmpy.s1.sat.i"]
+    fn hexagon_M2_vcmpy_s1_sat_i(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vcmpy.s1.sat.r"]
+    fn hexagon_M2_vcmpy_s1_sat_r(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vdmacs.s0"]
+    fn hexagon_M2_vdmacs_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vdmacs.s1"]
+    fn hexagon_M2_vdmacs_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vdmpyrs.s0"]
+    fn hexagon_M2_vdmpyrs_s0(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M2.vdmpyrs.s1"]
+    fn hexagon_M2_vdmpyrs_s1(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M2.vdmpys.s0"]
+    fn hexagon_M2_vdmpys_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vdmpys.s1"]
+    fn hexagon_M2_vdmpys_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2"]
+    fn hexagon_M2_vmac2(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2es"]
+    fn hexagon_M2_vmac2es(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2es.s0"]
+    fn hexagon_M2_vmac2es_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2es.s1"]
+    fn hexagon_M2_vmac2es_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2s.s0"]
+    fn hexagon_M2_vmac2s_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2s.s1"]
+    fn hexagon_M2_vmac2s_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2su.s0"]
+    fn hexagon_M2_vmac2su_s0(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmac2su.s1"]
+    fn hexagon_M2_vmac2su_s1(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmpy2es.s0"]
+    fn hexagon_M2_vmpy2es_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmpy2es.s1"]
+    fn hexagon_M2_vmpy2es_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmpy2s.s0"]
+    fn hexagon_M2_vmpy2s_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmpy2s.s0pack"]
+    fn hexagon_M2_vmpy2s_s0pack(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.vmpy2s.s1"]
+    fn hexagon_M2_vmpy2s_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmpy2s.s1pack"]
+    fn hexagon_M2_vmpy2s_s1pack(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.vmpy2su.s0"]
+    fn hexagon_M2_vmpy2su_s0(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vmpy2su.s1"]
+    fn hexagon_M2_vmpy2su_s1(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vraddh"]
+    fn hexagon_M2_vraddh(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M2.vradduh"]
+    fn hexagon_M2_vradduh(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M2.vrcmaci.s0"]
+    fn hexagon_M2_vrcmaci_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmaci.s0c"]
+    fn hexagon_M2_vrcmaci_s0c(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmacr.s0"]
+    fn hexagon_M2_vrcmacr_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmacr.s0c"]
+    fn hexagon_M2_vrcmacr_s0c(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpyi.s0"]
+    fn hexagon_M2_vrcmpyi_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpyi.s0c"]
+    fn hexagon_M2_vrcmpyi_s0c(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpyr.s0"]
+    fn hexagon_M2_vrcmpyr_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpyr.s0c"]
+    fn hexagon_M2_vrcmpyr_s0c(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpys.acc.s1"]
+    fn hexagon_M2_vrcmpys_acc_s1(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpys.s1"]
+    fn hexagon_M2_vrcmpys_s1(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrcmpys.s1rp"]
+    fn hexagon_M2_vrcmpys_s1rp(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M2.vrmac.s0"]
+    fn hexagon_M2_vrmac_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.vrmpy.s0"]
+    fn hexagon_M2_vrmpy_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M2.xor.xacc"]
+    fn hexagon_M2_xor_xacc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.and.and"]
+    fn hexagon_M4_and_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.and.andn"]
+    fn hexagon_M4_and_andn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.and.or"]
+    fn hexagon_M4_and_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.and.xor"]
+    fn hexagon_M4_and_xor(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.cmpyi.wh"]
+    fn hexagon_M4_cmpyi_wh(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.cmpyi.whc"]
+    fn hexagon_M4_cmpyi_whc(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.cmpyr.wh"]
+    fn hexagon_M4_cmpyr_wh(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.cmpyr.whc"]
+    fn hexagon_M4_cmpyr_whc(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.mac.up.s1.sat"]
+    fn hexagon_M4_mac_up_s1_sat(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.mpyri.addi"]
+    fn hexagon_M4_mpyri_addi(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.mpyri.addr"]
+    fn hexagon_M4_mpyri_addr(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.mpyri.addr.u2"]
+    fn hexagon_M4_mpyri_addr_u2(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.mpyrr.addi"]
+    fn hexagon_M4_mpyrr_addi(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.mpyrr.addr"]
+    fn hexagon_M4_mpyrr_addr(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.nac.up.s1.sat"]
+    fn hexagon_M4_nac_up_s1_sat(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.or.and"]
+    fn hexagon_M4_or_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.or.andn"]
+    fn hexagon_M4_or_andn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.or.or"]
+    fn hexagon_M4_or_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.or.xor"]
+    fn hexagon_M4_or_xor(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.pmpyw"]
+    fn hexagon_M4_pmpyw(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M4.pmpyw.acc"]
+    fn hexagon_M4_pmpyw_acc(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M4.vpmpyh"]
+    fn hexagon_M4_vpmpyh(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M4.vpmpyh.acc"]
+    fn hexagon_M4_vpmpyh_acc(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyeh.acc.s0"]
+    fn hexagon_M4_vrmpyeh_acc_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyeh.acc.s1"]
+    fn hexagon_M4_vrmpyeh_acc_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyeh.s0"]
+    fn hexagon_M4_vrmpyeh_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyeh.s1"]
+    fn hexagon_M4_vrmpyeh_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyoh.acc.s0"]
+    fn hexagon_M4_vrmpyoh_acc_s0(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyoh.acc.s1"]
+    fn hexagon_M4_vrmpyoh_acc_s1(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyoh.s0"]
+    fn hexagon_M4_vrmpyoh_s0(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.vrmpyoh.s1"]
+    fn hexagon_M4_vrmpyoh_s1(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M4.xor.and"]
+    fn hexagon_M4_xor_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.xor.andn"]
+    fn hexagon_M4_xor_andn(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.xor.or"]
+    fn hexagon_M4_xor_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M4.xor.xacc"]
+    fn hexagon_M4_xor_xacc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M5.vdmacbsu"]
+    fn hexagon_M5_vdmacbsu(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M5.vdmpybsu"]
+    fn hexagon_M5_vdmpybsu(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M5.vmacbsu"]
+    fn hexagon_M5_vmacbsu(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M5.vmacbuu"]
+    fn hexagon_M5_vmacbuu(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M5.vmpybsu"]
+    fn hexagon_M5_vmpybsu(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M5.vmpybuu"]
+    fn hexagon_M5_vmpybuu(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.M5.vrmacbsu"]
+    fn hexagon_M5_vrmacbsu(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M5.vrmacbuu"]
+    fn hexagon_M5_vrmacbuu(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M5.vrmpybsu"]
+    fn hexagon_M5_vrmpybsu(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M5.vrmpybuu"]
+    fn hexagon_M5_vrmpybuu(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.addasl.rrri"]
+    fn hexagon_S2_addasl_rrri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.p"]
+    fn hexagon_S2_asl_i_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.p.acc"]
+    fn hexagon_S2_asl_i_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.p.and"]
+    fn hexagon_S2_asl_i_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.p.nac"]
+    fn hexagon_S2_asl_i_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.p.or"]
+    fn hexagon_S2_asl_i_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.p.xacc"]
+    fn hexagon_S2_asl_i_p_xacc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.r"]
+    fn hexagon_S2_asl_i_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.r.acc"]
+    fn hexagon_S2_asl_i_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.r.and"]
+    fn hexagon_S2_asl_i_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.r.nac"]
+    fn hexagon_S2_asl_i_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.r.or"]
+    fn hexagon_S2_asl_i_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.r.sat"]
+    fn hexagon_S2_asl_i_r_sat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.r.xacc"]
+    fn hexagon_S2_asl_i_r_xacc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.i.vh"]
+    fn hexagon_S2_asl_i_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.i.vw"]
+    fn hexagon_S2_asl_i_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.p"]
+    fn hexagon_S2_asl_r_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.p.acc"]
+    fn hexagon_S2_asl_r_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.p.and"]
+    fn hexagon_S2_asl_r_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.p.nac"]
+    fn hexagon_S2_asl_r_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.p.or"]
+    fn hexagon_S2_asl_r_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.p.xor"]
+    fn hexagon_S2_asl_r_p_xor(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.r"]
+    fn hexagon_S2_asl_r_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.r.r.acc"]
+    fn hexagon_S2_asl_r_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.r.r.and"]
+    fn hexagon_S2_asl_r_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.r.r.nac"]
+    fn hexagon_S2_asl_r_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.r.r.or"]
+    fn hexagon_S2_asl_r_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.r.r.sat"]
+    fn hexagon_S2_asl_r_r_sat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asl.r.vh"]
+    fn hexagon_S2_asl_r_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asl.r.vw"]
+    fn hexagon_S2_asl_r_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p"]
+    fn hexagon_S2_asr_i_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p.acc"]
+    fn hexagon_S2_asr_i_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p.and"]
+    fn hexagon_S2_asr_i_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p.nac"]
+    fn hexagon_S2_asr_i_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p.or"]
+    fn hexagon_S2_asr_i_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p.rnd"]
+    fn hexagon_S2_asr_i_p_rnd(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.p.rnd.goodsyntax"]
+    fn hexagon_S2_asr_i_p_rnd_goodsyntax(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.r"]
+    fn hexagon_S2_asr_i_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.r.acc"]
+    fn hexagon_S2_asr_i_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.r.and"]
+    fn hexagon_S2_asr_i_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.r.nac"]
+    fn hexagon_S2_asr_i_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.r.or"]
+    fn hexagon_S2_asr_i_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.r.rnd"]
+    fn hexagon_S2_asr_i_r_rnd(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.r.rnd.goodsyntax"]
+    fn hexagon_S2_asr_i_r_rnd_goodsyntax(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.svw.trun"]
+    fn hexagon_S2_asr_i_svw_trun(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.i.vh"]
+    fn hexagon_S2_asr_i_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.i.vw"]
+    fn hexagon_S2_asr_i_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.p"]
+    fn hexagon_S2_asr_r_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.p.acc"]
+    fn hexagon_S2_asr_r_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.p.and"]
+    fn hexagon_S2_asr_r_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.p.nac"]
+    fn hexagon_S2_asr_r_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.p.or"]
+    fn hexagon_S2_asr_r_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.p.xor"]
+    fn hexagon_S2_asr_r_p_xor(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.r"]
+    fn hexagon_S2_asr_r_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.r.acc"]
+    fn hexagon_S2_asr_r_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.r.and"]
+    fn hexagon_S2_asr_r_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.r.nac"]
+    fn hexagon_S2_asr_r_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.r.or"]
+    fn hexagon_S2_asr_r_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.r.sat"]
+    fn hexagon_S2_asr_r_r_sat(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.svw.trun"]
+    fn hexagon_S2_asr_r_svw_trun(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.asr.r.vh"]
+    fn hexagon_S2_asr_r_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.asr.r.vw"]
+    fn hexagon_S2_asr_r_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.brev"]
+    fn hexagon_S2_brev(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.brevp"]
+    fn hexagon_S2_brevp(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.cl0"]
+    fn hexagon_S2_cl0(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.cl0p"]
+    fn hexagon_S2_cl0p(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.cl1"]
+    fn hexagon_S2_cl1(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.cl1p"]
+    fn hexagon_S2_cl1p(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.clb"]
+    fn hexagon_S2_clb(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.clbnorm"]
+    fn hexagon_S2_clbnorm(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.clbp"]
+    fn hexagon_S2_clbp(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.clrbit.i"]
+    fn hexagon_S2_clrbit_i(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.clrbit.r"]
+    fn hexagon_S2_clrbit_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.ct0"]
+    fn hexagon_S2_ct0(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.ct0p"]
+    fn hexagon_S2_ct0p(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.ct1"]
+    fn hexagon_S2_ct1(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.ct1p"]
+    fn hexagon_S2_ct1p(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.deinterleave"]
+    fn hexagon_S2_deinterleave(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.extractu"]
+    fn hexagon_S2_extractu(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.extractu.rp"]
+    fn hexagon_S2_extractu_rp(_: i32, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.extractup"]
+    fn hexagon_S2_extractup(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.extractup.rp"]
+    fn hexagon_S2_extractup_rp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.insert"]
+    fn hexagon_S2_insert(_: i32, _: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.insert.rp"]
+    fn hexagon_S2_insert_rp(_: i32, _: i32, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.insertp"]
+    fn hexagon_S2_insertp(_: i64, _: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.insertp.rp"]
+    fn hexagon_S2_insertp_rp(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.interleave"]
+    fn hexagon_S2_interleave(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.lfsp"]
+    fn hexagon_S2_lfsp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.p"]
+    fn hexagon_S2_lsl_r_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.p.acc"]
+    fn hexagon_S2_lsl_r_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.p.and"]
+    fn hexagon_S2_lsl_r_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.p.nac"]
+    fn hexagon_S2_lsl_r_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.p.or"]
+    fn hexagon_S2_lsl_r_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.p.xor"]
+    fn hexagon_S2_lsl_r_p_xor(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.r"]
+    fn hexagon_S2_lsl_r_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsl.r.r.acc"]
+    fn hexagon_S2_lsl_r_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsl.r.r.and"]
+    fn hexagon_S2_lsl_r_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsl.r.r.nac"]
+    fn hexagon_S2_lsl_r_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsl.r.r.or"]
+    fn hexagon_S2_lsl_r_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsl.r.vh"]
+    fn hexagon_S2_lsl_r_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsl.r.vw"]
+    fn hexagon_S2_lsl_r_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.p"]
+    fn hexagon_S2_lsr_i_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.p.acc"]
+    fn hexagon_S2_lsr_i_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.p.and"]
+    fn hexagon_S2_lsr_i_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.p.nac"]
+    fn hexagon_S2_lsr_i_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.p.or"]
+    fn hexagon_S2_lsr_i_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.p.xacc"]
+    fn hexagon_S2_lsr_i_p_xacc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.r"]
+    fn hexagon_S2_lsr_i_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.i.r.acc"]
+    fn hexagon_S2_lsr_i_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.i.r.and"]
+    fn hexagon_S2_lsr_i_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.i.r.nac"]
+    fn hexagon_S2_lsr_i_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.i.r.or"]
+    fn hexagon_S2_lsr_i_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.i.r.xacc"]
+    fn hexagon_S2_lsr_i_r_xacc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.i.vh"]
+    fn hexagon_S2_lsr_i_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.i.vw"]
+    fn hexagon_S2_lsr_i_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.p"]
+    fn hexagon_S2_lsr_r_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.p.acc"]
+    fn hexagon_S2_lsr_r_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.p.and"]
+    fn hexagon_S2_lsr_r_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.p.nac"]
+    fn hexagon_S2_lsr_r_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.p.or"]
+    fn hexagon_S2_lsr_r_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.p.xor"]
+    fn hexagon_S2_lsr_r_p_xor(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.r"]
+    fn hexagon_S2_lsr_r_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.r.r.acc"]
+    fn hexagon_S2_lsr_r_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.r.r.and"]
+    fn hexagon_S2_lsr_r_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.r.r.nac"]
+    fn hexagon_S2_lsr_r_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.r.r.or"]
+    fn hexagon_S2_lsr_r_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.lsr.r.vh"]
+    fn hexagon_S2_lsr_r_vh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.lsr.r.vw"]
+    fn hexagon_S2_lsr_r_vw(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.packhl"]
+    fn hexagon_S2_packhl(_: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.parityp"]
+    fn hexagon_S2_parityp(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.setbit.i"]
+    fn hexagon_S2_setbit_i(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.setbit.r"]
+    fn hexagon_S2_setbit_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.shuffeb"]
+    fn hexagon_S2_shuffeb(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.shuffeh"]
+    fn hexagon_S2_shuffeh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.shuffob"]
+    fn hexagon_S2_shuffob(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.shuffoh"]
+    fn hexagon_S2_shuffoh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.svsathb"]
+    fn hexagon_S2_svsathb(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.svsathub"]
+    fn hexagon_S2_svsathub(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.tableidxb.goodsyntax"]
+    fn hexagon_S2_tableidxb_goodsyntax(_: i32, _: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.tableidxd.goodsyntax"]
+    fn hexagon_S2_tableidxd_goodsyntax(_: i32, _: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.tableidxh.goodsyntax"]
+    fn hexagon_S2_tableidxh_goodsyntax(_: i32, _: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.tableidxw.goodsyntax"]
+    fn hexagon_S2_tableidxw_goodsyntax(_: i32, _: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.togglebit.i"]
+    fn hexagon_S2_togglebit_i(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.togglebit.r"]
+    fn hexagon_S2_togglebit_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.tstbit.i"]
+    fn hexagon_S2_tstbit_i(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.tstbit.r"]
+    fn hexagon_S2_tstbit_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.valignib"]
+    fn hexagon_S2_valignib(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.valignrb"]
+    fn hexagon_S2_valignrb(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vcnegh"]
+    fn hexagon_S2_vcnegh(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vcrotate"]
+    fn hexagon_S2_vcrotate(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vrcnegh"]
+    fn hexagon_S2_vrcnegh(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vrndpackwh"]
+    fn hexagon_S2_vrndpackwh(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vrndpackwhs"]
+    fn hexagon_S2_vrndpackwhs(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vsathb"]
+    fn hexagon_S2_vsathb(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vsathb.nopack"]
+    fn hexagon_S2_vsathb_nopack(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsathub"]
+    fn hexagon_S2_vsathub(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vsathub.nopack"]
+    fn hexagon_S2_vsathub_nopack(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsatwh"]
+    fn hexagon_S2_vsatwh(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vsatwh.nopack"]
+    fn hexagon_S2_vsatwh_nopack(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsatwuh"]
+    fn hexagon_S2_vsatwuh(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vsatwuh.nopack"]
+    fn hexagon_S2_vsatwuh_nopack(_: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsplatrb"]
+    fn hexagon_S2_vsplatrb(_: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.vsplatrh"]
+    fn hexagon_S2_vsplatrh(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vspliceib"]
+    fn hexagon_S2_vspliceib(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsplicerb"]
+    fn hexagon_S2_vsplicerb(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsxtbh"]
+    fn hexagon_S2_vsxtbh(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vsxthw"]
+    fn hexagon_S2_vsxthw(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vtrunehb"]
+    fn hexagon_S2_vtrunehb(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vtrunewh"]
+    fn hexagon_S2_vtrunewh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.vtrunohb"]
+    fn hexagon_S2_vtrunohb(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S2.vtrunowh"]
+    fn hexagon_S2_vtrunowh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S2.vzxtbh"]
+    fn hexagon_S2_vzxtbh(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.S2.vzxthw"]
+    fn hexagon_S2_vzxthw(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.S4.addaddi"]
+    fn hexagon_S4_addaddi(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.addi.asl.ri"]
+    fn hexagon_S4_addi_asl_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.addi.lsr.ri"]
+    fn hexagon_S4_addi_lsr_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.andi.asl.ri"]
+    fn hexagon_S4_andi_asl_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.andi.lsr.ri"]
+    fn hexagon_S4_andi_lsr_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.clbaddi"]
+    fn hexagon_S4_clbaddi(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.clbpaddi"]
+    fn hexagon_S4_clbpaddi(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.clbpnorm"]
+    fn hexagon_S4_clbpnorm(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S4.extract"]
+    fn hexagon_S4_extract(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.extract.rp"]
+    fn hexagon_S4_extract_rp(_: i32, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.S4.extractp"]
+    fn hexagon_S4_extractp(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S4.extractp.rp"]
+    fn hexagon_S4_extractp_rp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S4.lsli"]
+    fn hexagon_S4_lsli(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.ntstbit.i"]
+    fn hexagon_S4_ntstbit_i(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.ntstbit.r"]
+    fn hexagon_S4_ntstbit_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.or.andi"]
+    fn hexagon_S4_or_andi(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.or.andix"]
+    fn hexagon_S4_or_andix(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.or.ori"]
+    fn hexagon_S4_or_ori(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.ori.asl.ri"]
+    fn hexagon_S4_ori_asl_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.ori.lsr.ri"]
+    fn hexagon_S4_ori_lsr_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.parity"]
+    fn hexagon_S4_parity(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.subaddi"]
+    fn hexagon_S4_subaddi(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.subi.asl.ri"]
+    fn hexagon_S4_subi_asl_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.subi.lsr.ri"]
+    fn hexagon_S4_subi_lsr_ri(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S4.vrcrotate"]
+    fn hexagon_S4_vrcrotate(_: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S4.vrcrotate.acc"]
+    fn hexagon_S4_vrcrotate_acc(_: i64, _: i64, _: i32, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S4.vxaddsubh"]
+    fn hexagon_S4_vxaddsubh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S4.vxaddsubhr"]
+    fn hexagon_S4_vxaddsubhr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S4.vxaddsubw"]
+    fn hexagon_S4_vxaddsubw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S4.vxsubaddh"]
+    fn hexagon_S4_vxsubaddh(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S4.vxsubaddhr"]
+    fn hexagon_S4_vxsubaddhr(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S4.vxsubaddw"]
+    fn hexagon_S4_vxsubaddw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S5.asrhub.rnd.sat.goodsyntax"]
+    fn hexagon_S5_asrhub_rnd_sat_goodsyntax(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S5.asrhub.sat"]
+    fn hexagon_S5_asrhub_sat(_: i64, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S5.popcountp"]
+    fn hexagon_S5_popcountp(_: i64) -> i32;
+    #[link_name = "llvm.hexagon.S5.vasrhrnd.goodsyntax"]
+    fn hexagon_S5_vasrhrnd_goodsyntax(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.Y2.dccleana"]
+    fn hexagon_Y2_dccleana(_: i32);
+    #[link_name = "llvm.hexagon.Y2.dccleaninva"]
+    fn hexagon_Y2_dccleaninva(_: i32);
+    #[link_name = "llvm.hexagon.Y2.dcfetch"]
+    fn hexagon_Y2_dcfetch(_: i32);
+    #[link_name = "llvm.hexagon.Y2.dcinva"]
+    fn hexagon_Y2_dcinva(_: i32);
+    #[link_name = "llvm.hexagon.Y2.dczeroa"]
+    fn hexagon_Y2_dczeroa(_: i32);
+    #[link_name = "llvm.hexagon.Y4.l2fetch"]
+    fn hexagon_Y4_l2fetch(_: i32, _: i32);
+    #[link_name = "llvm.hexagon.Y5.l2fetch"]
+    fn hexagon_Y5_l2fetch(_: i32, _: i64);
+    #[link_name = "llvm.hexagon.S6.rol.i.p"]
+    fn hexagon_S6_rol_i_p(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.rol.i.p.acc"]
+    fn hexagon_S6_rol_i_p_acc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.rol.i.p.and"]
+    fn hexagon_S6_rol_i_p_and(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.rol.i.p.nac"]
+    fn hexagon_S6_rol_i_p_nac(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.rol.i.p.or"]
+    fn hexagon_S6_rol_i_p_or(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.rol.i.p.xacc"]
+    fn hexagon_S6_rol_i_p_xacc(_: i64, _: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.rol.i.r"]
+    fn hexagon_S6_rol_i_r(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S6.rol.i.r.acc"]
+    fn hexagon_S6_rol_i_r_acc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S6.rol.i.r.and"]
+    fn hexagon_S6_rol_i_r_and(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S6.rol.i.r.nac"]
+    fn hexagon_S6_rol_i_r_nac(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S6.rol.i.r.or"]
+    fn hexagon_S6_rol_i_r_or(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S6.rol.i.r.xacc"]
+    fn hexagon_S6_rol_i_r_xacc(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.M6.vabsdiffb"]
+    fn hexagon_M6_vabsdiffb(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M6.vabsdiffub"]
+    fn hexagon_M6_vabsdiffub(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S6.vsplatrbp"]
+    fn hexagon_S6_vsplatrbp(_: i32) -> i64;
+    #[link_name = "llvm.hexagon.S6.vtrunehb.ppp"]
+    fn hexagon_S6_vtrunehb_ppp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.S6.vtrunohb.ppp"]
+    fn hexagon_S6_vtrunohb_ppp(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.A6.vcmpbeq.notany"]
+    fn hexagon_A6_vcmpbeq_notany(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.F2.dfadd"]
+    fn hexagon_F2_dfadd(_: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfsub"]
+    fn hexagon_F2_dfsub(_: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.M2.mnaci"]
+    fn hexagon_M2_mnaci(_: i32, _: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.S2.mask"]
+    fn hexagon_S2_mask(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A7.clip"]
+    fn hexagon_A7_clip(_: i32, _: i32) -> i32;
+    #[link_name = "llvm.hexagon.A7.croundd.ri"]
+    fn hexagon_A7_croundd_ri(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A7.croundd.rr"]
+    fn hexagon_A7_croundd_rr(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.A7.vclip"]
+    fn hexagon_A7_vclip(_: i64, _: i32) -> i64;
+    #[link_name = "llvm.hexagon.F2.dfmax"]
+    fn hexagon_F2_dfmax(_: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfmin"]
+    fn hexagon_F2_dfmin(_: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfmpyfix"]
+    fn hexagon_F2_dfmpyfix(_: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfmpyhh"]
+    fn hexagon_F2_dfmpyhh(_: f64, _: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfmpylh"]
+    fn hexagon_F2_dfmpylh(_: f64, _: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.F2.dfmpyll"]
+    fn hexagon_F2_dfmpyll(_: f64, _: f64) -> f64;
+    #[link_name = "llvm.hexagon.M7.dcmpyiw"]
+    fn hexagon_M7_dcmpyiw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyiw.acc"]
+    fn hexagon_M7_dcmpyiw_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyiwc"]
+    fn hexagon_M7_dcmpyiwc(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyiwc.acc"]
+    fn hexagon_M7_dcmpyiwc_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyrw"]
+    fn hexagon_M7_dcmpyrw(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyrw.acc"]
+    fn hexagon_M7_dcmpyrw_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyrwc"]
+    fn hexagon_M7_dcmpyrwc(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.dcmpyrwc.acc"]
+    fn hexagon_M7_dcmpyrwc_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.vdmpy"]
+    fn hexagon_M7_vdmpy(_: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.vdmpy.acc"]
+    fn hexagon_M7_vdmpy_acc(_: i64, _: i64, _: i64) -> i64;
+    #[link_name = "llvm.hexagon.M7.wcmpyiw"]
+    fn hexagon_M7_wcmpyiw(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyiw.rnd"]
+    fn hexagon_M7_wcmpyiw_rnd(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyiwc"]
+    fn hexagon_M7_wcmpyiwc(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyiwc.rnd"]
+    fn hexagon_M7_wcmpyiwc_rnd(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyrw"]
+    fn hexagon_M7_wcmpyrw(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyrw.rnd"]
+    fn hexagon_M7_wcmpyrw_rnd(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyrwc"]
+    fn hexagon_M7_wcmpyrwc(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.M7.wcmpyrwc.rnd"]
+    fn hexagon_M7_wcmpyrwc_rnd(_: i64, _: i64) -> i32;
+    #[link_name = "llvm.hexagon.Y6.dmlink"]
+    fn hexagon_Y6_dmlink(_: i32, _: i32);
+    #[link_name = "llvm.hexagon.Y6.dmpause"]
+    fn hexagon_Y6_dmpause() -> i32;
+    #[link_name = "llvm.hexagon.Y6.dmpoll"]
+    fn hexagon_Y6_dmpoll() -> i32;
+    #[link_name = "llvm.hexagon.Y6.dmresume"]
+    fn hexagon_Y6_dmresume(_: i32);
+    #[link_name = "llvm.hexagon.Y6.dmstart"]
+    fn hexagon_Y6_dmstart(_: i32);
+    #[link_name = "llvm.hexagon.Y6.dmwait"]
+    fn hexagon_Y6_dmwait() -> i32;
+}
+
+/// `Rd32=abs(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(abs))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_abs_R(rs: i32) -> i32 {
+    hexagon_A2_abs(rs)
+}
+
+/// `Rdd32=abs(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(abs))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_abs_P(rss: i64) -> i64 {
+    hexagon_A2_absp(rss)
+}
+
+/// `Rd32=abs(Rs32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(abs))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_abs_R_sat(rs: i32) -> i32 {
+    hexagon_A2_abssat(rs)
+}
+
+/// `Rd32=add(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_add(rs, rt)
+}
+
+/// `Rd32=add(Rt32.h,Rs32.h):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RhRh_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_hh(rt, rs)
+}
+
+/// `Rd32=add(Rt32.h,Rs32.l):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RhRl_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_hl(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.h):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRh_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_lh(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.l):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRl_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_ll(rt, rs)
+}
+
+/// `Rd32=add(Rt32.h,Rs32.h):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RhRh_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_sat_hh(rt, rs)
+}
+
+/// `Rd32=add(Rt32.h,Rs32.l):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RhRl_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_sat_hl(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.h):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRh_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_sat_lh(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.l):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRl_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_h16_sat_ll(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.h)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRh(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_l16_hl(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.l)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRl(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_l16_ll(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.h):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRh_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_l16_sat_hl(rt, rs)
+}
+
+/// `Rd32=add(Rt32.l,Rs32.l):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RlRl_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_addh_l16_sat_ll(rt, rs)
+}
+
+/// `Rd32=add(Rs32,#s16)`
+///
+/// Instruction Type: ALU32_ADDI
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(add, IS16 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RI<const IS16: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS16, 16);
+    hexagon_A2_addi(rs, IS16)
+}
+
+/// `Rdd32=add(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_add_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_addp(rss, rtt)
+}
+
+/// `Rdd32=add(Rss32,Rtt32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_add_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_addpsat(rss, rtt)
+}
+
+/// `Rd32=add(Rs32,Rt32):sat`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_RR_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_addsat(rs, rt)
+}
+
+/// `Rdd32=add(Rs32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_add_RP(rs: i32, rtt: i64) -> i64 {
+    hexagon_A2_addsp(rs, rtt)
+}
+
+/// `Rd32=and(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_and_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_and(rs, rt)
+}
+
+/// `Rd32=and(Rs32,#s10)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(and, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_and_RI<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_A2_andir(rs, IS10)
+}
+
+/// `Rdd32=and(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_and_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_andp(rss, rtt)
+}
+
+/// `Rd32=aslh(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(aslh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslh_R(rs: i32) -> i32 {
+    hexagon_A2_aslh(rs)
+}
+
+/// `Rd32=asrh(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asrh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asrh_R(rs: i32) -> i32 {
+    hexagon_A2_asrh(rs)
+}
+
+/// `Rd32=combine(Rt32.h,Rs32.h)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(combine))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_combine_RhRh(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_combine_hh(rt, rs)
+}
+
+/// `Rd32=combine(Rt32.h,Rs32.l)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(combine))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_combine_RhRl(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_combine_hl(rt, rs)
+}
+
+/// `Rd32=combine(Rt32.l,Rs32.h)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(combine))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_combine_RlRh(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_combine_lh(rt, rs)
+}
+
+/// `Rd32=combine(Rt32.l,Rs32.l)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(combine))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_combine_RlRl(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_combine_ll(rt, rs)
+}
+
+/// `Rdd32=combine(#s8,#S8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 1)]
+#[cfg_attr(test, assert_instr(combine, IS8 = 0, IS8_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_combine_II<const IS8: i32, const IS8_2: i32>() -> i64 {
+    static_assert_simm_bits!(IS8, 8);
+    static_assert_simm_bits!(IS8_2, 8);
+    hexagon_A2_combineii(IS8, IS8_2)
+}
+
+/// `Rdd32=combine(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(combine))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_combine_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_A2_combinew(rs, rt)
+}
+
+/// `Rd32=max(Rs32,Rt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(max))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_max_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_max(rs, rt)
+}
+
+/// `Rdd32=max(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(max))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_max_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_maxp(rss, rtt)
+}
+
+/// `Rd32=maxu(Rs32,Rt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(maxu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_maxu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_maxu(rs, rt)
+}
+
+/// `Rdd32=maxu(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(maxu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_maxu_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_maxup(rss, rtt)
+}
+
+/// `Rd32=min(Rt32,Rs32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(min))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_min_RR(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_min(rt, rs)
+}
+
+/// `Rdd32=min(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(min))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_min_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_minp(rtt, rss)
+}
+
+/// `Rd32=minu(Rt32,Rs32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(minu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_minu_RR(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_minu(rt, rs)
+}
+
+/// `Rdd32=minu(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(minu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_minu_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_minup(rtt, rss)
+}
+
+/// `Rd32=neg(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(neg))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_neg_R(rs: i32) -> i32 {
+    hexagon_A2_neg(rs)
+}
+
+/// `Rdd32=neg(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(neg))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_neg_P(rss: i64) -> i64 {
+    hexagon_A2_negp(rss)
+}
+
+/// `Rd32=neg(Rs32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(neg))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_neg_R_sat(rs: i32) -> i32 {
+    hexagon_A2_negsat(rs)
+}
+
+/// `Rd32=not(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(not))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_not_R(rs: i32) -> i32 {
+    hexagon_A2_not(rs)
+}
+
+/// `Rdd32=not(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(not))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_not_P(rss: i64) -> i64 {
+    hexagon_A2_notp(rss)
+}
+
+/// `Rd32=or(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_or_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_or(rs, rt)
+}
+
+/// `Rd32=or(Rs32,#s10)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(or, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_or_RI<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_A2_orir(rs, IS10)
+}
+
+/// `Rdd32=or(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_or_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_orp(rss, rtt)
+}
+
+/// `Rd32=round(Rss32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(round))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_round_P_sat(rss: i64) -> i32 {
+    hexagon_A2_roundsat(rss)
+}
+
+/// `Rd32=sat(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sat))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sat_P(rss: i64) -> i32 {
+    hexagon_A2_sat(rss)
+}
+
+/// `Rd32=satb(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(satb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_satb_R(rs: i32) -> i32 {
+    hexagon_A2_satb(rs)
+}
+
+/// `Rd32=sath(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sath))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sath_R(rs: i32) -> i32 {
+    hexagon_A2_sath(rs)
+}
+
+/// `Rd32=satub(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(satub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_satub_R(rs: i32) -> i32 {
+    hexagon_A2_satub(rs)
+}
+
+/// `Rd32=satuh(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(satuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_satuh_R(rs: i32) -> i32 {
+    hexagon_A2_satuh(rs)
+}
+
+/// `Rd32=sub(Rt32,Rs32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RR(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_sub(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.h,Rs32.h):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RhRh_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_hh(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.h,Rs32.l):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RhRl_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_hl(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.h):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRh_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_lh(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.l):<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRl_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_ll(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.h,Rs32.h):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RhRh_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_sat_hh(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.h,Rs32.l):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RhRl_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_sat_hl(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.h):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRh_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_sat_lh(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.l):sat:<<16`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRl_sat_s16(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_h16_sat_ll(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.h)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRh(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_l16_hl(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.l)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRl(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_l16_ll(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.h):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRh_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_l16_sat_hl(rt, rs)
+}
+
+/// `Rd32=sub(Rt32.l,Rs32.l):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RlRl_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subh_l16_sat_ll(rt, rs)
+}
+
+/// `Rdd32=sub(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_sub_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_subp(rtt, rss)
+}
+
+/// `Rd32=sub(#s10,Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(sub, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_IR<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_A2_subri(IS10, rs)
+}
+
+/// `Rd32=sub(Rt32,Rs32):sat`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_RR_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_subsat(rt, rs)
+}
+
+/// `Rd32=vaddh(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vaddh_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_svaddh(rs, rt)
+}
+
+/// `Rd32=vaddh(Rs32,Rt32):sat`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vaddh_RR_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_svaddhs(rs, rt)
+}
+
+/// `Rd32=vadduh(Rs32,Rt32):sat`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vadduh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vadduh_RR_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_svadduhs(rs, rt)
+}
+
+/// `Rd32=vavgh(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vavgh_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_svavgh(rs, rt)
+}
+
+/// `Rd32=vavgh(Rs32,Rt32):rnd`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vavgh_RR_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_svavghs(rs, rt)
+}
+
+/// `Rd32=vnavgh(Rt32,Rs32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vnavgh_RR(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_svnavgh(rt, rs)
+}
+
+/// `Rd32=vsubh(Rt32,Rs32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsubh_RR(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_svsubh(rt, rs)
+}
+
+/// `Rd32=vsubh(Rt32,Rs32):sat`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsubh_RR_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_svsubhs(rt, rs)
+}
+
+/// `Rd32=vsubuh(Rt32,Rs32):sat`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsubuh_RR_sat(rt: i32, rs: i32) -> i32 {
+    hexagon_A2_svsubuhs(rt, rs)
+}
+
+/// `Rd32=swiz(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(swiz))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_swiz_R(rs: i32) -> i32 {
+    hexagon_A2_swiz(rs)
+}
+
+/// `Rd32=sxtb(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sxtb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sxtb_R(rs: i32) -> i32 {
+    hexagon_A2_sxtb(rs)
+}
+
+/// `Rd32=sxth(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sxth))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sxth_R(rs: i32) -> i32 {
+    hexagon_A2_sxth(rs)
+}
+
+/// `Rdd32=sxtw(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sxtw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_sxtw_R(rs: i32) -> i64 {
+    hexagon_A2_sxtw(rs)
+}
+
+/// `Rd32=Rs32`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_equals_R(rs: i32) -> i32 {
+    hexagon_A2_tfr(rs)
+}
+
+/// `Rx32.h=#u16`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_Rh_equals_I<const IU16: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU16, 16);
+    hexagon_A2_tfrih(rx, IU16 as i32)
+}
+
+/// `Rx32.l=#u16`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_Rl_equals_I<const IU16: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU16, 16);
+    hexagon_A2_tfril(rx, IU16 as i32)
+}
+
+/// `Rdd32=Rss32`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_equals_P(rss: i64) -> i64 {
+    hexagon_A2_tfrp(rss)
+}
+
+/// `Rdd32=#s8`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_equals_I<const IS8: i32>() -> i64 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A2_tfrpi(IS8)
+}
+
+/// `Rd32=#s16`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_equals_I<const IS16: i32>() -> i32 {
+    static_assert_simm_bits!(IS16, 16);
+    hexagon_A2_tfrsi(IS16)
+}
+
+/// `Rdd32=vabsh(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vabsh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsh_P(rss: i64) -> i64 {
+    hexagon_A2_vabsh(rss)
+}
+
+/// `Rdd32=vabsh(Rss32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vabsh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsh_P_sat(rss: i64) -> i64 {
+    hexagon_A2_vabshsat(rss)
+}
+
+/// `Rdd32=vabsw(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vabsw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsw_P(rss: i64) -> i64 {
+    hexagon_A2_vabsw(rss)
+}
+
+/// `Rdd32=vabsw(Rss32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vabsw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsw_P_sat(rss: i64) -> i64 {
+    hexagon_A2_vabswsat(rss)
+}
+
+/// `Rdd32=vaddb(Rss32,Rtt32)`
+///
+/// Instruction Type: MAPPING
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddb_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddb_map(rss, rtt)
+}
+
+/// `Rdd32=vaddh(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddh(rss, rtt)
+}
+
+/// `Rdd32=vaddh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddhs(rss, rtt)
+}
+
+/// `Rdd32=vaddub(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddub_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddub(rss, rtt)
+}
+
+/// `Rdd32=vaddub(Rss32,Rtt32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddub_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddubs(rss, rtt)
+}
+
+/// `Rdd32=vadduh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vadduh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vadduh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vadduhs(rss, rtt)
+}
+
+/// `Rdd32=vaddw(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddw_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddw(rss, rtt)
+}
+
+/// `Rdd32=vaddw(Rss32,Rtt32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaddw_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vaddws(rss, rtt)
+}
+
+/// `Rdd32=vavgh(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavgh(rss, rtt)
+}
+
+/// `Rdd32=vavgh(Rss32,Rtt32):crnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgh_PP_crnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavghcr(rss, rtt)
+}
+
+/// `Rdd32=vavgh(Rss32,Rtt32):rnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgh_PP_rnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavghr(rss, rtt)
+}
+
+/// `Rdd32=vavgub(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgub_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavgub(rss, rtt)
+}
+
+/// `Rdd32=vavgub(Rss32,Rtt32):rnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgub_PP_rnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavgubr(rss, rtt)
+}
+
+/// `Rdd32=vavguh(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavguh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavguh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavguh(rss, rtt)
+}
+
+/// `Rdd32=vavguh(Rss32,Rtt32):rnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavguh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavguh_PP_rnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavguhr(rss, rtt)
+}
+
+/// `Rdd32=vavguw(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavguw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavguw_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavguw(rss, rtt)
+}
+
+/// `Rdd32=vavguw(Rss32,Rtt32):rnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavguw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavguw_PP_rnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavguwr(rss, rtt)
+}
+
+/// `Rdd32=vavgw(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgw_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavgw(rss, rtt)
+}
+
+/// `Rdd32=vavgw(Rss32,Rtt32):crnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgw_PP_crnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavgwcr(rss, rtt)
+}
+
+/// `Rdd32=vavgw(Rss32,Rtt32):rnd`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vavgw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vavgw_PP_rnd(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vavgwr(rss, rtt)
+}
+
+/// `Pd4=vcmpb.eq(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpb_eq_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmpbeq(rss, rtt)
+}
+
+/// `Pd4=vcmpb.gtu(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpb_gtu_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmpbgtu(rss, rtt)
+}
+
+/// `Pd4=vcmph.eq(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmph))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmph_eq_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmpheq(rss, rtt)
+}
+
+/// `Pd4=vcmph.gt(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmph))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmph_gt_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmphgt(rss, rtt)
+}
+
+/// `Pd4=vcmph.gtu(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmph))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmph_gtu_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmphgtu(rss, rtt)
+}
+
+/// `Pd4=vcmpw.eq(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpw_eq_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmpweq(rss, rtt)
+}
+
+/// `Pd4=vcmpw.gt(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpw_gt_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmpwgt(rss, rtt)
+}
+
+/// `Pd4=vcmpw.gtu(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpw_gtu_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A2_vcmpwgtu(rss, rtt)
+}
+
+/// `Rdd32=vconj(Rss32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vconj))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vconj_P_sat(rss: i64) -> i64 {
+    hexagon_A2_vconj(rss)
+}
+
+/// `Rdd32=vmaxb(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmaxb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmaxb_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vmaxb(rtt, rss)
+}
+
+/// `Rdd32=vmaxh(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmaxh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmaxh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vmaxh(rtt, rss)
+}
+
+/// `Rdd32=vmaxub(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmaxub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmaxub_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vmaxub(rtt, rss)
+}
+
+/// `Rdd32=vmaxuh(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmaxuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmaxuh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vmaxuh(rtt, rss)
+}
+
+/// `Rdd32=vmaxuw(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmaxuw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmaxuw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vmaxuw(rtt, rss)
+}
+
+/// `Rdd32=vmaxw(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmaxw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmaxw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vmaxw(rtt, rss)
+}
+
+/// `Rdd32=vminb(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vminb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vminb_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vminb(rtt, rss)
+}
+
+/// `Rdd32=vminh(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vminh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vminh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vminh(rtt, rss)
+}
+
+/// `Rdd32=vminub(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vminub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vminub_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vminub(rtt, rss)
+}
+
+/// `Rdd32=vminuh(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vminuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vminuh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vminuh(rtt, rss)
+}
+
+/// `Rdd32=vminuw(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vminuw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vminuw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vminuw(rtt, rss)
+}
+
+/// `Rdd32=vminw(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vminw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vminw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vminw(rtt, rss)
+}
+
+/// `Rdd32=vnavgh(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vnavgh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vnavgh(rtt, rss)
+}
+
+/// `Rdd32=vnavgh(Rtt32,Rss32):crnd:sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vnavgh_PP_crnd_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vnavghcr(rtt, rss)
+}
+
+/// `Rdd32=vnavgh(Rtt32,Rss32):rnd:sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vnavgh_PP_rnd_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vnavghr(rtt, rss)
+}
+
+/// `Rdd32=vnavgw(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vnavgw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vnavgw(rtt, rss)
+}
+
+/// `Rdd32=vnavgw(Rtt32,Rss32):crnd:sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vnavgw_PP_crnd_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vnavgwcr(rtt, rss)
+}
+
+/// `Rdd32=vnavgw(Rtt32,Rss32):rnd:sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vnavgw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vnavgw_PP_rnd_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vnavgwr(rtt, rss)
+}
+
+/// `Rdd32=vraddub(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vraddub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vraddub_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vraddub(rss, rtt)
+}
+
+/// `Rxx32+=vraddub(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vraddub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vraddubacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vraddub_acc(rxx, rss, rtt)
+}
+
+/// `Rdd32=vrsadub(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrsadub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrsadub_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vrsadub(rss, rtt)
+}
+
+/// `Rxx32+=vrsadub(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrsadub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrsadubacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vrsadub_acc(rxx, rss, rtt)
+}
+
+/// `Rdd32=vsubb(Rss32,Rtt32)`
+///
+/// Instruction Type: MAPPING
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubb_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_vsubb_map(rss, rtt)
+}
+
+/// `Rdd32=vsubh(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsubh(rtt, rss)
+}
+
+/// `Rdd32=vsubh(Rtt32,Rss32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubh_PP_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsubhs(rtt, rss)
+}
+
+/// `Rdd32=vsubub(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubub_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsubub(rtt, rss)
+}
+
+/// `Rdd32=vsubub(Rtt32,Rss32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubub_PP_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsububs(rtt, rss)
+}
+
+/// `Rdd32=vsubuh(Rtt32,Rss32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubuh_PP_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsubuhs(rtt, rss)
+}
+
+/// `Rdd32=vsubw(Rtt32,Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsubw(rtt, rss)
+}
+
+/// `Rdd32=vsubw(Rtt32,Rss32):sat`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsubw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsubw_PP_sat(rtt: i64, rss: i64) -> i64 {
+    hexagon_A2_vsubws(rtt, rss)
+}
+
+/// `Rd32=xor(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_xor_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A2_xor(rs, rt)
+}
+
+/// `Rdd32=xor(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_xor_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_A2_xorp(rss, rtt)
+}
+
+/// `Rd32=zxtb(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(zxtb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_zxtb_R(rs: i32) -> i32 {
+    hexagon_A2_zxtb(rs)
+}
+
+/// `Rd32=zxth(Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(zxth))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_zxth_R(rs: i32) -> i32 {
+    hexagon_A2_zxth(rs)
+}
+
+/// `Rd32=and(Rt32,~Rs32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_and_RnR(rt: i32, rs: i32) -> i32 {
+    hexagon_A4_andn(rt, rs)
+}
+
+/// `Rdd32=and(Rtt32,~Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_and_PnP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A4_andnp(rtt, rss)
+}
+
+/// `Rdd32=bitsplit(Rs32,Rt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(bitsplit))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_bitsplit_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_A4_bitsplit(rs, rt)
+}
+
+/// `Rdd32=bitsplit(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(bitsplit, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_bitsplit_RI<const IU5: u32>(rs: i32) -> i64 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_A4_bitspliti(rs, IU5 as i32)
+}
+
+/// `Pd4=boundscheck(Rs32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(boundscheck))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_boundscheck_RP(rs: i32, rtt: i64) -> i32 {
+    hexagon_A4_boundscheck(rs, rtt)
+}
+
+/// `Pd4=cmpb.eq(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmpb_eq_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cmpbeq(rs, rt)
+}
+
+/// `Pd4=cmpb.eq(Rs32,#u8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmpb, IU8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmpb_eq_RI<const IU8: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    hexagon_A4_cmpbeqi(rs, IU8 as i32)
+}
+
+/// `Pd4=cmpb.gt(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmpb_gt_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cmpbgt(rs, rt)
+}
+
+/// `Pd4=cmpb.gt(Rs32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmpb, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmpb_gt_RI<const IS8: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_cmpbgti(rs, IS8)
+}
+
+/// `Pd4=cmpb.gtu(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmpb_gtu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cmpbgtu(rs, rt)
+}
+
+/// `Pd4=cmpb.gtu(Rs32,#u7)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmpb, IU7 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmpb_gtu_RI<const IU7: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU7, 7);
+    hexagon_A4_cmpbgtui(rs, IU7 as i32)
+}
+
+/// `Pd4=cmph.eq(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmph))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmph_eq_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cmpheq(rs, rt)
+}
+
+/// `Pd4=cmph.eq(Rs32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmph, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmph_eq_RI<const IS8: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_cmpheqi(rs, IS8)
+}
+
+/// `Pd4=cmph.gt(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmph))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmph_gt_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cmphgt(rs, rt)
+}
+
+/// `Pd4=cmph.gt(Rs32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmph, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmph_gt_RI<const IS8: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_cmphgti(rs, IS8)
+}
+
+/// `Pd4=cmph.gtu(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmph))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmph_gtu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cmphgtu(rs, rt)
+}
+
+/// `Pd4=cmph.gtu(Rs32,#u7)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmph, IU7 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmph_gtu_RI<const IU7: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU7, 7);
+    hexagon_A4_cmphgtui(rs, IU7 as i32)
+}
+
+/// `Rdd32=combine(#s8,Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(combine, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_combine_IR<const IS8: i32>(rs: i32) -> i64 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_combineir(IS8, rs)
+}
+
+/// `Rdd32=combine(Rs32,#s8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(combine, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_combine_RI<const IS8: i32>(rs: i32) -> i64 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_combineri(rs, IS8)
+}
+
+/// `Rd32=cround(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cround, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cround_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_A4_cround_ri(rs, IU5 as i32)
+}
+
+/// `Rd32=cround(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cround))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cround_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_cround_rr(rs, rt)
+}
+
+/// `Rd32=modwrap(Rs32,Rt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(modwrap))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_modwrap_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_modwrapu(rs, rt)
+}
+
+/// `Rd32=or(Rt32,~Rs32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_or_RnR(rt: i32, rs: i32) -> i32 {
+    hexagon_A4_orn(rt, rs)
+}
+
+/// `Rdd32=or(Rtt32,~Rss32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_or_PnP(rtt: i64, rss: i64) -> i64 {
+    hexagon_A4_ornp(rtt, rss)
+}
+
+/// `Rd32=cmp.eq(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmp_eq_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_rcmpeq(rs, rt)
+}
+
+/// `Rd32=cmp.eq(Rs32,#s8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmp, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmp_eq_RI<const IS8: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_rcmpeqi(rs, IS8)
+}
+
+/// `Rd32=!cmp.eq(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_not_cmp_eq_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_rcmpneq(rs, rt)
+}
+
+/// `Rd32=!cmp.eq(Rs32,#s8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_not_cmp_eq_RI<const IS8: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_rcmpneqi(rs, IS8)
+}
+
+/// `Rd32=round(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(round, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_round_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_A4_round_ri(rs, IU5 as i32)
+}
+
+/// `Rd32=round(Rs32,#u5):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(round, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_round_RI_sat<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_A4_round_ri_sat(rs, IU5 as i32)
+}
+
+/// `Rd32=round(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(round))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_round_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_round_rr(rs, rt)
+}
+
+/// `Rd32=round(Rs32,Rt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(round))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_round_RR_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_A4_round_rr_sat(rs, rt)
+}
+
+/// `Pd4=tlbmatch(Rss32,Rt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(tlbmatch))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_tlbmatch_PR(rss: i64, rt: i32) -> i32 {
+    hexagon_A4_tlbmatch(rss, rt)
+}
+
+/// `Pd4=any8(vcmpb.eq(Rss32,Rtt32))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(any8))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_any8_vcmpb_eq_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A4_vcmpbeq_any(rss, rtt)
+}
+
+/// `Pd4=vcmpb.eq(Rss32,#u8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmpb, IU8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpb_eq_PI<const IU8: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    hexagon_A4_vcmpbeqi(rss, IU8 as i32)
+}
+
+/// `Pd4=vcmpb.gt(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpb_gt_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A4_vcmpbgt(rss, rtt)
+}
+
+/// `Pd4=vcmpb.gt(Rss32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmpb, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpb_gt_PI<const IS8: i32>(rss: i64) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_vcmpbgti(rss, IS8)
+}
+
+/// `Pd4=vcmpb.gtu(Rss32,#u7)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmpb, IU7 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpb_gtu_PI<const IU7: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU7, 7);
+    hexagon_A4_vcmpbgtui(rss, IU7 as i32)
+}
+
+/// `Pd4=vcmph.eq(Rss32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmph, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmph_eq_PI<const IS8: i32>(rss: i64) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_vcmpheqi(rss, IS8)
+}
+
+/// `Pd4=vcmph.gt(Rss32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmph, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmph_gt_PI<const IS8: i32>(rss: i64) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_vcmphgti(rss, IS8)
+}
+
+/// `Pd4=vcmph.gtu(Rss32,#u7)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmph, IU7 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmph_gtu_PI<const IU7: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU7, 7);
+    hexagon_A4_vcmphgtui(rss, IU7 as i32)
+}
+
+/// `Pd4=vcmpw.eq(Rss32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmpw, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpw_eq_PI<const IS8: i32>(rss: i64) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_vcmpweqi(rss, IS8)
+}
+
+/// `Pd4=vcmpw.gt(Rss32,#s8)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmpw, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpw_gt_PI<const IS8: i32>(rss: i64) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_A4_vcmpwgti(rss, IS8)
+}
+
+/// `Pd4=vcmpw.gtu(Rss32,#u7)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vcmpw, IU7 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_vcmpw_gtu_PI<const IU7: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU7, 7);
+    hexagon_A4_vcmpwgtui(rss, IU7 as i32)
+}
+
+/// `Rxx32=vrmaxh(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmaxh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmaxh_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrmaxh(rxx, rss, ru)
+}
+
+/// `Rxx32=vrmaxuh(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmaxuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmaxuh_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrmaxuh(rxx, rss, ru)
+}
+
+/// `Rxx32=vrmaxuw(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmaxuw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmaxuw_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrmaxuw(rxx, rss, ru)
+}
+
+/// `Rxx32=vrmaxw(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmaxw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmaxw_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrmaxw(rxx, rss, ru)
+}
+
+/// `Rxx32=vrminh(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrminh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrminh_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrminh(rxx, rss, ru)
+}
+
+/// `Rxx32=vrminuh(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrminuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrminuh_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrminuh(rxx, rss, ru)
+}
+
+/// `Rxx32=vrminuw(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrminuw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrminuw_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrminuw(rxx, rss, ru)
+}
+
+/// `Rxx32=vrminw(Rss32,Ru32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrminw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrminw_PR(rxx: i64, rss: i64, ru: i32) -> i64 {
+    hexagon_A4_vrminw(rxx, rss, ru)
+}
+
+/// `Rd32=vaddhub(Rss32,Rtt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaddhub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vaddhub_PP_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_A5_vaddhubs(rss, rtt)
+}
+
+/// `Pd4=all8(Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(all8))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_all8_p(ps: i32) -> i32 {
+    hexagon_C2_all8(ps)
+}
+
+/// `Pd4=and(Pt4,Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_and_pp(pt: i32, ps: i32) -> i32 {
+    hexagon_C2_and(pt, ps)
+}
+
+/// `Pd4=and(Pt4,!Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_and_pnp(pt: i32, ps: i32) -> i32 {
+    hexagon_C2_andn(pt, ps)
+}
+
+/// `Pd4=any8(Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(any8))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_any8_p(ps: i32) -> i32 {
+    hexagon_C2_any8(ps)
+}
+
+/// `Pd4=bitsclr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(bitsclr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_bitsclr_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_bitsclr(rs, rt)
+}
+
+/// `Pd4=bitsclr(Rs32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(bitsclr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_bitsclr_RI<const IU6: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_C2_bitsclri(rs, IU6 as i32)
+}
+
+/// `Pd4=bitsset(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(bitsset))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_bitsset_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_bitsset(rs, rt)
+}
+
+/// `Pd4=cmp.eq(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_eq_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_cmpeq(rs, rt)
+}
+
+/// `Pd4=cmp.eq(Rs32,#s10)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmp, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_eq_RI<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_C2_cmpeqi(rs, IS10)
+}
+
+/// `Pd4=cmp.eq(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_eq_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_C2_cmpeqp(rss, rtt)
+}
+
+/// `Pd4=cmp.ge(Rs32,#s8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmp, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_ge_RI<const IS8: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_C2_cmpgei(rs, IS8)
+}
+
+/// `Pd4=cmp.geu(Rs32,#u8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmp, IU8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_geu_RI<const IU8: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    hexagon_C2_cmpgeui(rs, IU8 as i32)
+}
+
+/// `Pd4=cmp.gt(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_gt_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_cmpgt(rs, rt)
+}
+
+/// `Pd4=cmp.gt(Rs32,#s10)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmp, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_gt_RI<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_C2_cmpgti(rs, IS10)
+}
+
+/// `Pd4=cmp.gt(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_gt_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_C2_cmpgtp(rss, rtt)
+}
+
+/// `Pd4=cmp.gtu(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_gtu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_cmpgtu(rs, rt)
+}
+
+/// `Pd4=cmp.gtu(Rs32,#u9)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cmp, IU9 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_gtu_RI<const IU9: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU9, 9);
+    hexagon_C2_cmpgtui(rs, IU9 as i32)
+}
+
+/// `Pd4=cmp.gtu(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_gtu_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_C2_cmpgtup(rss, rtt)
+}
+
+/// `Pd4=cmp.lt(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_lt_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_cmplt(rs, rt)
+}
+
+/// `Pd4=cmp.ltu(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_cmp_ltu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C2_cmpltu(rs, rt)
+}
+
+/// `Rdd32=mask(Pt4)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mask))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mask_p(pt: i32) -> i64 {
+    hexagon_C2_mask(pt)
+}
+
+/// `Rd32=mux(Pu4,Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mux))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mux_pRR(pu: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_C2_mux(pu, rs, rt)
+}
+
+/// `Rd32=mux(Pu4,#s8,#S8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1, 2)]
+#[cfg_attr(test, assert_instr(mux, IS8 = 0, IS8_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mux_pII<const IS8: i32, const IS8_2: i32>(pu: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    static_assert_simm_bits!(IS8_2, 8);
+    hexagon_C2_muxii(pu, IS8, IS8_2)
+}
+
+/// `Rd32=mux(Pu4,Rs32,#s8)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(mux, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mux_pRI<const IS8: i32>(pu: i32, rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_C2_muxir(pu, rs, IS8)
+}
+
+/// `Rd32=mux(Pu4,#s8,Rs32)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(mux, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mux_pIR<const IS8: i32>(pu: i32, rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_C2_muxri(pu, IS8, rs)
+}
+
+/// `Pd4=not(Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(not))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_p(ps: i32) -> i32 {
+    hexagon_C2_not(ps)
+}
+
+/// `Pd4=or(Pt4,Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_or_pp(pt: i32, ps: i32) -> i32 {
+    hexagon_C2_or(pt, ps)
+}
+
+/// `Pd4=or(Pt4,!Ps4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_or_pnp(pt: i32, ps: i32) -> i32 {
+    hexagon_C2_orn(pt, ps)
+}
+
+/// `Pd4=Ps4`
+///
+/// Instruction Type: MAPPING
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_equals_p(ps: i32) -> i32 {
+    hexagon_C2_pxfer_map(ps)
+}
+
+/// `Rd32=Ps4`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_equals_p(ps: i32) -> i32 {
+    hexagon_C2_tfrpr(ps)
+}
+
+/// `Pd4=Rs32`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_equals_R(rs: i32) -> i32 {
+    hexagon_C2_tfrrp(rs)
+}
+
+/// `Rd32=vitpack(Ps4,Pt4)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vitpack))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vitpack_pp(ps: i32, pt: i32) -> i32 {
+    hexagon_C2_vitpack(ps, pt)
+}
+
+/// `Rdd32=vmux(Pu4,Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmux))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmux_pPP(pu: i32, rss: i64, rtt: i64) -> i64 {
+    hexagon_C2_vmux(pu, rss, rtt)
+}
+
+/// `Pd4=xor(Ps4,Pt4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_xor_pp(ps: i32, pt: i32) -> i32 {
+    hexagon_C2_xor(ps, pt)
+}
+
+/// `Pd4=and(Ps4,and(Pt4,Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_and_and_ppp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_and_and(ps, pt, pu)
+}
+
+/// `Pd4=and(Ps4,and(Pt4,!Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_and_and_ppnp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_and_andn(ps, pt, pu)
+}
+
+/// `Pd4=and(Ps4,or(Pt4,Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_and_or_ppp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_and_or(ps, pt, pu)
+}
+
+/// `Pd4=and(Ps4,or(Pt4,!Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_and_or_ppnp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_and_orn(ps, pt, pu)
+}
+
+/// `Pd4=!cmp.gt(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_cmp_gt_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C4_cmplte(rs, rt)
+}
+
+/// `Pd4=!cmp.gt(Rs32,#s10)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_cmp_gt_RI<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_C4_cmpltei(rs, IS10)
+}
+
+/// `Pd4=!cmp.gtu(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_cmp_gtu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C4_cmplteu(rs, rt)
+}
+
+/// `Pd4=!cmp.gtu(Rs32,#u9)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_cmp_gtu_RI<const IU9: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU9, 9);
+    hexagon_C4_cmplteui(rs, IU9 as i32)
+}
+
+/// `Pd4=!cmp.eq(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_cmp_eq_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C4_cmpneq(rs, rt)
+}
+
+/// `Pd4=!cmp.eq(Rs32,#s10)`
+///
+/// Instruction Type: ALU32_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_cmp_eq_RI<const IS10: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_C4_cmpneqi(rs, IS10)
+}
+
+/// `Pd4=fastcorner9(Ps4,Pt4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(fastcorner9))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_fastcorner9_pp(ps: i32, pt: i32) -> i32 {
+    hexagon_C4_fastcorner9(ps, pt)
+}
+
+/// `Pd4=!fastcorner9(Ps4,Pt4)`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_fastcorner9_pp(ps: i32, pt: i32) -> i32 {
+    hexagon_C4_fastcorner9_not(ps, pt)
+}
+
+/// `Pd4=!bitsclr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_bitsclr_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C4_nbitsclr(rs, rt)
+}
+
+/// `Pd4=!bitsclr(Rs32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_bitsclr_RI<const IU6: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_C4_nbitsclri(rs, IU6 as i32)
+}
+
+/// `Pd4=!bitsset(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_bitsset_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_C4_nbitsset(rs, rt)
+}
+
+/// `Pd4=or(Ps4,and(Pt4,Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_or_and_ppp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_or_and(ps, pt, pu)
+}
+
+/// `Pd4=or(Ps4,and(Pt4,!Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_or_and_ppnp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_or_andn(ps, pt, pu)
+}
+
+/// `Pd4=or(Ps4,or(Pt4,Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_or_or_ppp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_or_or(ps, pt, pu)
+}
+
+/// `Pd4=or(Ps4,or(Pt4,!Pu4))`
+///
+/// Instruction Type: CR
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_or_or_ppnp(ps: i32, pt: i32, pu: i32) -> i32 {
+    hexagon_C4_or_orn(ps, pt, pu)
+}
+
+/// `Rdd32=convert_d2df(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_d2df))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_d2df_P(rss: i64) -> f64 {
+    hexagon_F2_conv_d2df(rss)
+}
+
+/// `Rd32=convert_d2sf(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_d2sf))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_d2sf_P(rss: i64) -> f32 {
+    hexagon_F2_conv_d2sf(rss)
+}
+
+/// `Rdd32=convert_df2d(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2d))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_df2d_P(rss: f64) -> i64 {
+    hexagon_F2_conv_df2d(rss)
+}
+
+/// `Rdd32=convert_df2d(Rss32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2d))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_df2d_P_chop(rss: f64) -> i64 {
+    hexagon_F2_conv_df2d_chop(rss)
+}
+
+/// `Rd32=convert_df2sf(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2sf))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_df2sf_P(rss: f64) -> f32 {
+    hexagon_F2_conv_df2sf(rss)
+}
+
+/// `Rdd32=convert_df2ud(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2ud))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_df2ud_P(rss: f64) -> i64 {
+    hexagon_F2_conv_df2ud(rss)
+}
+
+/// `Rdd32=convert_df2ud(Rss32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2ud))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_df2ud_P_chop(rss: f64) -> i64 {
+    hexagon_F2_conv_df2ud_chop(rss)
+}
+
+/// `Rd32=convert_df2uw(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2uw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_df2uw_P(rss: f64) -> i32 {
+    hexagon_F2_conv_df2uw(rss)
+}
+
+/// `Rd32=convert_df2uw(Rss32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2uw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_df2uw_P_chop(rss: f64) -> i32 {
+    hexagon_F2_conv_df2uw_chop(rss)
+}
+
+/// `Rd32=convert_df2w(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2w))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_df2w_P(rss: f64) -> i32 {
+    hexagon_F2_conv_df2w(rss)
+}
+
+/// `Rd32=convert_df2w(Rss32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_df2w))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_df2w_P_chop(rss: f64) -> i32 {
+    hexagon_F2_conv_df2w_chop(rss)
+}
+
+/// `Rdd32=convert_sf2d(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2d))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_sf2d_R(rs: f32) -> i64 {
+    hexagon_F2_conv_sf2d(rs)
+}
+
+/// `Rdd32=convert_sf2d(Rs32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2d))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_sf2d_R_chop(rs: f32) -> i64 {
+    hexagon_F2_conv_sf2d_chop(rs)
+}
+
+/// `Rdd32=convert_sf2df(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2df))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_sf2df_R(rs: f32) -> f64 {
+    hexagon_F2_conv_sf2df(rs)
+}
+
+/// `Rdd32=convert_sf2ud(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2ud))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_sf2ud_R(rs: f32) -> i64 {
+    hexagon_F2_conv_sf2ud(rs)
+}
+
+/// `Rdd32=convert_sf2ud(Rs32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2ud))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_sf2ud_R_chop(rs: f32) -> i64 {
+    hexagon_F2_conv_sf2ud_chop(rs)
+}
+
+/// `Rd32=convert_sf2uw(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2uw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_sf2uw_R(rs: f32) -> i32 {
+    hexagon_F2_conv_sf2uw(rs)
+}
+
+/// `Rd32=convert_sf2uw(Rs32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2uw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_sf2uw_R_chop(rs: f32) -> i32 {
+    hexagon_F2_conv_sf2uw_chop(rs)
+}
+
+/// `Rd32=convert_sf2w(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2w))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_sf2w_R(rs: f32) -> i32 {
+    hexagon_F2_conv_sf2w(rs)
+}
+
+/// `Rd32=convert_sf2w(Rs32):chop`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_sf2w))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_sf2w_R_chop(rs: f32) -> i32 {
+    hexagon_F2_conv_sf2w_chop(rs)
+}
+
+/// `Rdd32=convert_ud2df(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_ud2df))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_ud2df_P(rss: i64) -> f64 {
+    hexagon_F2_conv_ud2df(rss)
+}
+
+/// `Rd32=convert_ud2sf(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_ud2sf))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_ud2sf_P(rss: i64) -> f32 {
+    hexagon_F2_conv_ud2sf(rss)
+}
+
+/// `Rdd32=convert_uw2df(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_uw2df))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_uw2df_R(rs: i32) -> f64 {
+    hexagon_F2_conv_uw2df(rs)
+}
+
+/// `Rd32=convert_uw2sf(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_uw2sf))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_uw2sf_R(rs: i32) -> f32 {
+    hexagon_F2_conv_uw2sf(rs)
+}
+
+/// `Rdd32=convert_w2df(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_w2df))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_convert_w2df_R(rs: i32) -> f64 {
+    hexagon_F2_conv_w2df(rs)
+}
+
+/// `Rd32=convert_w2sf(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(convert_w2sf))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_convert_w2sf_R(rs: i32) -> f32 {
+    hexagon_F2_conv_w2sf(rs)
+}
+
+/// `Pd4=dfclass(Rss32,#u5)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(dfclass, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_dfclass_PI<const IU5: u32>(rss: f64) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_F2_dfclass(rss, IU5 as i32)
+}
+
+/// `Pd4=dfcmp.eq(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_dfcmp_eq_PP(rss: f64, rtt: f64) -> i32 {
+    hexagon_F2_dfcmpeq(rss, rtt)
+}
+
+/// `Pd4=dfcmp.ge(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_dfcmp_ge_PP(rss: f64, rtt: f64) -> i32 {
+    hexagon_F2_dfcmpge(rss, rtt)
+}
+
+/// `Pd4=dfcmp.gt(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_dfcmp_gt_PP(rss: f64, rtt: f64) -> i32 {
+    hexagon_F2_dfcmpgt(rss, rtt)
+}
+
+/// `Pd4=dfcmp.uo(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_dfcmp_uo_PP(rss: f64, rtt: f64) -> i32 {
+    hexagon_F2_dfcmpuo(rss, rtt)
+}
+
+/// `Rdd32=dfmake(#u10):neg`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(dfmake, IU10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmake_I_neg<const IU10: u32>() -> f64 {
+    static_assert_uimm_bits!(IU10, 10);
+    hexagon_F2_dfimm_n(IU10 as i32)
+}
+
+/// `Rdd32=dfmake(#u10):pos`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(dfmake, IU10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmake_I_pos<const IU10: u32>() -> f64 {
+    static_assert_uimm_bits!(IU10, 10);
+    hexagon_F2_dfimm_p(IU10 as i32)
+}
+
+/// `Rd32=sfadd(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfadd))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfadd_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sfadd(rs, rt)
+}
+
+/// `Pd4=sfclass(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(sfclass, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_sfclass_RI<const IU5: u32>(rs: f32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_F2_sfclass(rs, IU5 as i32)
+}
+
+/// `Pd4=sfcmp.eq(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_sfcmp_eq_RR(rs: f32, rt: f32) -> i32 {
+    hexagon_F2_sfcmpeq(rs, rt)
+}
+
+/// `Pd4=sfcmp.ge(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_sfcmp_ge_RR(rs: f32, rt: f32) -> i32 {
+    hexagon_F2_sfcmpge(rs, rt)
+}
+
+/// `Pd4=sfcmp.gt(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_sfcmp_gt_RR(rs: f32, rt: f32) -> i32 {
+    hexagon_F2_sfcmpgt(rs, rt)
+}
+
+/// `Pd4=sfcmp.uo(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfcmp))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_sfcmp_uo_RR(rs: f32, rt: f32) -> i32 {
+    hexagon_F2_sfcmpuo(rs, rt)
+}
+
+/// `Rd32=sffixupd(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sffixupd))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sffixupd_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sffixupd(rs, rt)
+}
+
+/// `Rd32=sffixupn(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sffixupn))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sffixupn_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sffixupn(rs, rt)
+}
+
+/// `Rd32=sffixupr(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sffixupr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sffixupr_R(rs: f32) -> f32 {
+    hexagon_F2_sffixupr(rs)
+}
+
+/// `Rx32+=sfmpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmpyacc_RR(rx: f32, rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sffma(rx, rs, rt)
+}
+
+/// `Rx32+=sfmpy(Rs32,Rt32):lib`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmpyacc_RR_lib(rx: f32, rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sffma_lib(rx, rs, rt)
+}
+
+/// `Rx32+=sfmpy(Rs32,Rt32,Pu4):scale`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmpyacc_RRp_scale(rx: f32, rs: f32, rt: f32, pu: i32) -> f32 {
+    hexagon_F2_sffma_sc(rx, rs, rt, pu)
+}
+
+/// `Rx32-=sfmpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmpynac_RR(rx: f32, rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sffms(rx, rs, rt)
+}
+
+/// `Rx32-=sfmpy(Rs32,Rt32):lib`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmpynac_RR_lib(rx: f32, rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sffms_lib(rx, rs, rt)
+}
+
+/// `Rd32=sfmake(#u10):neg`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(sfmake, IU10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmake_I_neg<const IU10: u32>() -> f32 {
+    static_assert_uimm_bits!(IU10, 10);
+    hexagon_F2_sfimm_n(IU10 as i32)
+}
+
+/// `Rd32=sfmake(#u10):pos`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(sfmake, IU10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmake_I_pos<const IU10: u32>() -> f32 {
+    static_assert_uimm_bits!(IU10, 10);
+    hexagon_F2_sfimm_p(IU10 as i32)
+}
+
+/// `Rd32=sfmax(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmax))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmax_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sfmax(rs, rt)
+}
+
+/// `Rd32=sfmin(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmin))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmin_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sfmin(rs, rt)
+}
+
+/// `Rd32=sfmpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfmpy_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sfmpy(rs, rt)
+}
+
+/// `Rd32=sfsub(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sfsub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sfsub_RR(rs: f32, rt: f32) -> f32 {
+    hexagon_F2_sfsub(rs, rt)
+}
+
+/// `Rx32+=add(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_addacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_acci(rx, rs, rt)
+}
+
+/// `Rx32+=add(Rs32,#s8)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(add, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_addacc_RI<const IS8: i32>(rx: i32, rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_M2_accii(rx, rs, IS8)
+}
+
+/// `Rxx32+=cmpyi(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyiacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmaci_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=cmpyr(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyracc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmacr_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=cmpy(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyacc_RR_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmacs_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=cmpy(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyacc_RR_s1_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmacs_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=cmpy(Rs32,Rt32*):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyacc_RR_conj_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmacsc_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=cmpy(Rs32,Rt32*):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyacc_RR_conj_s1_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmacsc_s1(rxx, rs, rt)
+}
+
+/// `Rdd32=cmpyi(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyi_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmpyi_s0(rs, rt)
+}
+
+/// `Rdd32=cmpyr(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyr_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmpyr_s0(rs, rt)
+}
+
+/// `Rd32=cmpy(Rs32,Rt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpy_RR_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_cmpyrs_s0(rs, rt)
+}
+
+/// `Rd32=cmpy(Rs32,Rt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpy_RR_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_cmpyrs_s1(rs, rt)
+}
+
+/// `Rd32=cmpy(Rs32,Rt32*):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpy_RR_conj_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_cmpyrsc_s0(rs, rt)
+}
+
+/// `Rd32=cmpy(Rs32,Rt32*):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpy_RR_conj_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_cmpyrsc_s1(rs, rt)
+}
+
+/// `Rdd32=cmpy(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpy_RR_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmpys_s0(rs, rt)
+}
+
+/// `Rdd32=cmpy(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpy_RR_s1_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmpys_s1(rs, rt)
+}
+
+/// `Rdd32=cmpy(Rs32,Rt32*):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpy_RR_conj_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmpysc_s0(rs, rt)
+}
+
+/// `Rdd32=cmpy(Rs32,Rt32*):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpy_RR_conj_s1_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cmpysc_s1(rs, rt)
+}
+
+/// `Rxx32-=cmpy(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpynac_RR_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cnacs_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=cmpy(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpynac_RR_s1_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cnacs_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=cmpy(Rs32,Rt32*):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpynac_RR_conj_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cnacsc_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=cmpy(Rs32,Rt32*):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpynac_RR_conj_s1_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_cnacsc_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_dpmpyss_acc_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_dpmpyss_nac_s0(rxx, rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RR_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_dpmpyss_rnd_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_dpmpyss_s0(rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_dpmpyuu_acc_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_dpmpyuu_nac_s0(rxx, rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_dpmpyuu_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32.h):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RRh_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_hmmpyh_rs1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RRh_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_hmmpyh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32.l):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RRl_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_hmmpyl_rs1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RRl_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_hmmpyl_s1(rs, rt)
+}
+
+/// `Rx32+=mpyi(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyiacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_maci(rx, rs, rt)
+}
+
+/// `Rx32-=mpyi(Rs32,#u8)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(mpyi, IU8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyinac_RI<const IU8: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    hexagon_M2_macsin(rx, rs, IU8 as i32)
+}
+
+/// `Rx32+=mpyi(Rs32,#u8)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(mpyi, IU8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyiacc_RI<const IU8: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    hexagon_M2_macsip(rx, rs, IU8 as i32)
+}
+
+/// `Rxx32+=vmpywoh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywohacc_PP_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmachs_rs0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywoh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywohacc_PP_s1_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmachs_rs1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywoh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywohacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmachs_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywoh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywohacc_PP_s1_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmachs_s1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywehacc_PP_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacls_rs0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywehacc_PP_s1_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacls_rs1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywehacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacls_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywehacc_PP_s1_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacls_s1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywouh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouhacc_PP_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacuhs_rs0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywouh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouhacc_PP_s1_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacuhs_rs1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywouh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouhacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacuhs_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpywouh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouhacc_PP_s1_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmacuhs_s1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweuh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuhacc_PP_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmaculs_rs0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweuh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuhacc_PP_s1_rnd_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmaculs_rs1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweuh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuhacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmaculs_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyweuh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuhacc_PP_s1_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmaculs_s1(rxx, rss, rtt)
+}
+
+/// `Rdd32=vmpywoh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywoh_PP_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyh_rs0(rss, rtt)
+}
+
+/// `Rdd32=vmpywoh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywoh_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyh_rs1(rss, rtt)
+}
+
+/// `Rdd32=vmpywoh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywoh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyh_s0(rss, rtt)
+}
+
+/// `Rdd32=vmpywoh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywoh_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyh_s1(rss, rtt)
+}
+
+/// `Rdd32=vmpyweh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweh_PP_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyl_rs0(rss, rtt)
+}
+
+/// `Rdd32=vmpyweh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweh_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyl_rs1(rss, rtt)
+}
+
+/// `Rdd32=vmpyweh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyl_s0(rss, rtt)
+}
+
+/// `Rdd32=vmpyweh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweh_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyl_s1(rss, rtt)
+}
+
+/// `Rdd32=vmpywouh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouh_PP_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyuh_rs0(rss, rtt)
+}
+
+/// `Rdd32=vmpywouh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouh_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyuh_rs1(rss, rtt)
+}
+
+/// `Rdd32=vmpywouh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyuh_s0(rss, rtt)
+}
+
+/// `Rdd32=vmpywouh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpywouh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpywouh_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyuh_s1(rss, rtt)
+}
+
+/// `Rdd32=vmpyweuh(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuh_PP_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyul_rs0(rss, rtt)
+}
+
+/// `Rdd32=vmpyweuh(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuh_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyul_rs1(rss, rtt)
+}
+
+/// `Rdd32=vmpyweuh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyul_s0(rss, rtt)
+}
+
+/// `Rdd32=vmpyweuh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyweuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyweuh_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_mmpyul_s1(rss, rtt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_hh_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_hh_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_hl_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_hl_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_lh_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_lh_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_ll_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_ll_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.h):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRh_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_hh_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRh_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_hh_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.l):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRl_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_hl_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.h,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RhRl_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_hl_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.h):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRh_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_lh_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRh_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_lh_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.l):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRl_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_ll_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpy(Rs32.l,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RlRl_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_acc_sat_ll_s1(rx, rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_hh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_hh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_hl_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_hl_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_lh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_lh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_ll_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_ll_s1(rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_hh_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_hh_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_hl_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_hl_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_lh_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_lh_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_ll_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_ll_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.h):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRh_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_hh_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRh_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_hh_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.l):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRl_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_hl_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.h,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RhRl_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_hl_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.h):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRh_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_lh_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRh_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_lh_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.l):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRl_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_ll_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpy(Rs32.l,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RlRl_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_nac_sat_ll_s1(rx, rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_hh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_s1_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_hh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_hl_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_s1_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_hl_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_lh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_s1_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_lh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_ll_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_s1_rnd(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_rnd_ll_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_hh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_hh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_hl_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_hl_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_lh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_lh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_ll_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_ll_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_hh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.h):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRh_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_hh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_hl_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.h,Rt32.l):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RhRl_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_hl_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_lh_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.h):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRh_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_lh_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_ll_s0(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32.l,Rt32.l):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RlRl_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_sat_rnd_ll_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_up(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RR_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_up_s1(rs, rt)
+}
+
+/// `Rd32=mpy(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpy_RR_s1_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpy_up_s1_sat(rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RhRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_hh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RhRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_hh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RhRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_hl_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RhRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_hl_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RlRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_lh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RlRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_lh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RlRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_ll_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpy(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyacc_RlRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_acc_ll_s1(rxx, rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRh(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_hh_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRh_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_hh_s1(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRl(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_hl_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRl_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_hl_s1(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRh(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_lh_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRh_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_lh_s1(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRl(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_ll_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRl_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_ll_s1(rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RhRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_hh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RhRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_hh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RhRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_hl_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RhRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_hl_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RlRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_lh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RlRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_lh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RlRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_ll_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpy(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpynac_RlRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_nac_ll_s1(rxx, rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.h):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRh_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_hh_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.h):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRh_s1_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_hh_s1(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.l):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRl_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_hl_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.h,Rt32.l):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RhRl_s1_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_hl_s1(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.h):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRh_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_lh_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.h):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRh_s1_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_lh_s1(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.l):rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRl_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_ll_s0(rs, rt)
+}
+
+/// `Rdd32=mpy(Rs32.l,Rt32.l):<<1:rnd`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpy_RlRl_s1_rnd(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyd_rnd_ll_s1(rs, rt)
+}
+
+/// `Rd32=mpyi(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyi_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyi(rs, rt)
+}
+
+/// `Rd32=mpyi(Rs32,#m9)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyi_RI(rs: i32, im9: i32) -> i32 {
+    hexagon_M2_mpysmi(rs, im9)
+}
+
+/// `Rd32=mpysu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpysu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpysu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpysu_up(rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RhRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_hh_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RhRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_hh_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RhRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_hl_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RhRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_hl_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RlRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_lh_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RlRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_lh_s1(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RlRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_ll_s0(rx, rs, rt)
+}
+
+/// `Rx32+=mpyu(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyuacc_RlRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_acc_ll_s1(rx, rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RhRh(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_hh_s0(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RhRh_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_hh_s1(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RhRl(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_hl_s0(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RhRl_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_hl_s1(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RlRh(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_lh_s0(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RlRh_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_lh_s1(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RlRl(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_ll_s0(rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RlRl_s1(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_ll_s1(rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RhRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_hh_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RhRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_hh_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RhRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_hl_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RhRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_hl_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RlRh(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_lh_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RlRh_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_lh_s1(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RlRl(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_ll_s0(rx, rs, rt)
+}
+
+/// `Rx32-=mpyu(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyunac_RlRl_s1(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_nac_ll_s1(rx, rs, rt)
+}
+
+/// `Rd32=mpyu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyu_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyu_up(rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RhRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_hh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RhRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_hh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RhRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_hl_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RhRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_hl_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RlRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_lh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RlRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_lh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RlRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_ll_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=mpyu(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyuacc_RlRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_acc_ll_s1(rxx, rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RhRh(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_hh_s0(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RhRh_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_hh_s1(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RhRl(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_hl_s0(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RhRl_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_hl_s1(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RlRh(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_lh_s0(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RlRh_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_lh_s1(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RlRl(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_ll_s0(rs, rt)
+}
+
+/// `Rdd32=mpyu(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyu_RlRl_s1(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_ll_s1(rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.h,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RhRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_hh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.h,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RhRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_hh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.h,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RhRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_hl_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.h,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RhRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_hl_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.l,Rt32.h)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RlRh(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_lh_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.l,Rt32.h):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RlRh_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_lh_s1(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.l,Rt32.l)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RlRl(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_ll_s0(rxx, rs, rt)
+}
+
+/// `Rxx32-=mpyu(Rs32.l,Rt32.l):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_mpyunac_RlRl_s1(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_mpyud_nac_ll_s1(rxx, rs, rt)
+}
+
+/// `Rd32=mpyui(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpyui))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyui_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mpyui(rs, rt)
+}
+
+/// `Rx32-=add(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_addnac_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_nacci(rx, rs, rt)
+}
+
+/// `Rx32-=add(Rs32,#s8)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(add, IS8 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_addnac_RI<const IS8: i32>(rx: i32, rs: i32) -> i32 {
+    static_assert_simm_bits!(IS8, 8);
+    hexagon_M2_naccii(rx, rs, IS8)
+}
+
+/// `Rx32+=sub(Rt32,Rs32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(sub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_subacc_RR(rx: i32, rt: i32, rs: i32) -> i32 {
+    hexagon_M2_subacc(rx, rt, rs)
+}
+
+/// `Rdd32=vabsdiffh(Rtt32,Rss32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vabsdiffh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsdiffh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_M2_vabsdiffh(rtt, rss)
+}
+
+/// `Rdd32=vabsdiffw(Rtt32,Rss32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vabsdiffw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsdiffw_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_M2_vabsdiffw(rtt, rss)
+}
+
+/// `Rxx32+=vcmpyi(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcmpyiacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vcmac_s0_sat_i(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vcmpyr(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcmpyracc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vcmac_s0_sat_r(rxx, rss, rtt)
+}
+
+/// `Rdd32=vcmpyi(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcmpyi_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vcmpy_s0_sat_i(rss, rtt)
+}
+
+/// `Rdd32=vcmpyr(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcmpyr_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vcmpy_s0_sat_r(rss, rtt)
+}
+
+/// `Rdd32=vcmpyi(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcmpyi_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vcmpy_s1_sat_i(rss, rtt)
+}
+
+/// `Rdd32=vcmpyr(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcmpyr_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vcmpy_s1_sat_r(rss, rtt)
+}
+
+/// `Rxx32+=vdmpy(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpyacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vdmacs_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vdmpy(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpyacc_PP_s1_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vdmacs_s1(rxx, rss, rtt)
+}
+
+/// `Rd32=vdmpy(Rss32,Rtt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vdmpy_PP_rnd_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M2_vdmpyrs_s0(rss, rtt)
+}
+
+/// `Rd32=vdmpy(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vdmpy_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M2_vdmpyrs_s1(rss, rtt)
+}
+
+/// `Rdd32=vdmpy(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpy_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vdmpys_s0(rss, rtt)
+}
+
+/// `Rdd32=vdmpy(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpy_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vdmpys_s1(rss, rtt)
+}
+
+/// `Rxx32+=vmpyh(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmac2(rxx, rs, rt)
+}
+
+/// `Rxx32+=vmpyeh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyeh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyehacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vmac2es(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyeh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyeh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyehacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vmac2es_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyeh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyeh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyehacc_PP_s1_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vmac2es_s1(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vmpyh(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhacc_RR_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmac2s_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=vmpyh(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhacc_RR_s1_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmac2s_s1(rxx, rs, rt)
+}
+
+/// `Rxx32+=vmpyhsu(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyhsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhsuacc_RR_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmac2su_s0(rxx, rs, rt)
+}
+
+/// `Rxx32+=vmpyhsu(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyhsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhsuacc_RR_s1_sat(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmac2su_s1(rxx, rs, rt)
+}
+
+/// `Rdd32=vmpyeh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyeh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyeh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vmpy2es_s0(rss, rtt)
+}
+
+/// `Rdd32=vmpyeh(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyeh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyeh_PP_s1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vmpy2es_s1(rss, rtt)
+}
+
+/// `Rdd32=vmpyh(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyh_RR_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmpy2s_s0(rs, rt)
+}
+
+/// `Rd32=vmpyh(Rs32,Rt32):rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vmpyh_RR_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_vmpy2s_s0pack(rs, rt)
+}
+
+/// `Rdd32=vmpyh(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyh_RR_s1_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmpy2s_s1(rs, rt)
+}
+
+/// `Rd32=vmpyh(Rs32,Rt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vmpyh_RR_s1_rnd_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_M2_vmpy2s_s1pack(rs, rt)
+}
+
+/// `Rdd32=vmpyhsu(Rs32,Rt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyhsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhsu_RR_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmpy2su_s0(rs, rt)
+}
+
+/// `Rdd32=vmpyhsu(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpyhsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpyhsu_RR_s1_sat(rs: i32, rt: i32) -> i64 {
+    hexagon_M2_vmpy2su_s1(rs, rt)
+}
+
+/// `Rd32=vraddh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vraddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vraddh_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_M2_vraddh(rss, rtt)
+}
+
+/// `Rd32=vradduh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vradduh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vradduh_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_M2_vradduh(rss, rtt)
+}
+
+/// `Rxx32+=vrcmpyi(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyiacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmaci_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vrcmpyi(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyiacc_PP_conj(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmaci_s0c(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vrcmpyr(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyracc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmacr_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vrcmpyr(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyracc_PP_conj(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmacr_s0c(rxx, rss, rtt)
+}
+
+/// `Rdd32=vrcmpyi(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyi_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmpyi_s0(rss, rtt)
+}
+
+/// `Rdd32=vrcmpyi(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyi_PP_conj(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmpyi_s0c(rss, rtt)
+}
+
+/// `Rdd32=vrcmpyr(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyr_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmpyr_s0(rss, rtt)
+}
+
+/// `Rdd32=vrcmpyr(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpyr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpyr_PP_conj(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrcmpyr_s0c(rss, rtt)
+}
+
+/// `Rxx32+=vrcmpys(Rss32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpys))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpysacc_PR_s1_sat(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_M2_vrcmpys_acc_s1(rxx, rss, rt)
+}
+
+/// `Rdd32=vrcmpys(Rss32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpys))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcmpys_PR_s1_sat(rss: i64, rt: i32) -> i64 {
+    hexagon_M2_vrcmpys_s1(rss, rt)
+}
+
+/// `Rd32=vrcmpys(Rss32,Rt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcmpys))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vrcmpys_PR_s1_rnd_sat(rss: i64, rt: i32) -> i32 {
+    hexagon_M2_vrcmpys_s1rp(rss, rt)
+}
+
+/// `Rxx32+=vrmpyh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpyhacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrmac_s0(rxx, rss, rtt)
+}
+
+/// `Rdd32=vrmpyh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpyh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M2_vrmpy_s0(rss, rtt)
+}
+
+/// `Rx32^=xor(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_xorxacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_xor_xacc(rx, rs, rt)
+}
+
+/// `Rx32&=and(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andand_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_and_and(rx, rs, rt)
+}
+
+/// `Rx32&=and(Rs32,~Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andand_RnR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_and_andn(rx, rs, rt)
+}
+
+/// `Rx32&=or(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_orand_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_and_or(rx, rs, rt)
+}
+
+/// `Rx32&=xor(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_xorand_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_and_xor(rx, rs, rt)
+}
+
+/// `Rd32=cmpyiwh(Rss32,Rt32):<<1:rnd:sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyiwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyiwh_PR_s1_rnd_sat(rss: i64, rt: i32) -> i32 {
+    hexagon_M4_cmpyi_wh(rss, rt)
+}
+
+/// `Rd32=cmpyiwh(Rss32,Rt32*):<<1:rnd:sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyiwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyiwh_PR_conj_s1_rnd_sat(rss: i64, rt: i32) -> i32 {
+    hexagon_M4_cmpyi_whc(rss, rt)
+}
+
+/// `Rd32=cmpyrwh(Rss32,Rt32):<<1:rnd:sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyrwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyrwh_PR_s1_rnd_sat(rss: i64, rt: i32) -> i32 {
+    hexagon_M4_cmpyr_wh(rss, rt)
+}
+
+/// `Rd32=cmpyrwh(Rss32,Rt32*):<<1:rnd:sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cmpyrwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyrwh_PR_conj_s1_rnd_sat(rss: i64, rt: i32) -> i32 {
+    hexagon_M4_cmpyr_whc(rss, rt)
+}
+
+/// `Rx32+=mpy(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyacc_RR_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_mac_up_s1_sat(rx, rs, rt)
+}
+
+/// `Rd32=add(#u6,mpyi(Rs32,#U6))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(add, IU6 = 0, IU6_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_mpyi_IRI<const IU6: u32, const IU6_2: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU6, 6);
+    static_assert_uimm_bits!(IU6_2, 6);
+    hexagon_M4_mpyri_addi(IU6 as i32, rs, IU6_2 as i32)
+}
+
+/// `Rd32=add(Ru32,mpyi(Rs32,#u6))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(add, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_mpyi_RRI<const IU6: u32>(ru: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_M4_mpyri_addr(ru, rs, IU6 as i32)
+}
+
+/// `Rd32=add(Ru32,mpyi(#u6:2,Rs32))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(add, IU6_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_mpyi_RIR<const IU6_2: u32>(ru: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU6_2, 6);
+    hexagon_M4_mpyri_addr_u2(ru, IU6_2 as i32, rs)
+}
+
+/// `Rd32=add(#u6,mpyi(Rs32,Rt32))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(add, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_mpyi_IRR<const IU6: u32>(rs: i32, rt: i32) -> i32 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_M4_mpyrr_addi(IU6 as i32, rs, rt)
+}
+
+/// `Ry32=add(Ru32,mpyi(Ry32,Rs32))`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(add))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_mpyi_RRR(ru: i32, ry: i32, rs: i32) -> i32 {
+    hexagon_M4_mpyrr_addr(ru, ry, rs)
+}
+
+/// `Rx32-=mpy(Rs32,Rt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mpy))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpynac_RR_s1_sat(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_nac_up_s1_sat(rx, rs, rt)
+}
+
+/// `Rx32|=and(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andor_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_or_and(rx, rs, rt)
+}
+
+/// `Rx32|=and(Rs32,~Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andor_RnR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_or_andn(rx, rs, rt)
+}
+
+/// `Rx32|=or(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_oror_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_or_or(rx, rs, rt)
+}
+
+/// `Rx32|=xor(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_xoror_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_or_xor(rx, rs, rt)
+}
+
+/// `Rdd32=pmpyw(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(pmpyw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_pmpyw_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M4_pmpyw(rs, rt)
+}
+
+/// `Rxx32^=pmpyw(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(pmpyw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_pmpywxacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M4_pmpyw_acc(rxx, rs, rt)
+}
+
+/// `Rdd32=vpmpyh(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vpmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vpmpyh_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M4_vpmpyh(rs, rt)
+}
+
+/// `Rxx32^=vpmpyh(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vpmpyh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vpmpyhxacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M4_vpmpyh_acc(rxx, rs, rt)
+}
+
+/// `Rxx32+=vrmpyweh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpywehacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyeh_acc_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vrmpyweh(Rss32,Rtt32):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpywehacc_PP_s1(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyeh_acc_s1(rxx, rss, rtt)
+}
+
+/// `Rdd32=vrmpyweh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpyweh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyeh_s0(rss, rtt)
+}
+
+/// `Rdd32=vrmpyweh(Rss32,Rtt32):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpyweh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpyweh_PP_s1(rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyeh_s1(rss, rtt)
+}
+
+/// `Rxx32+=vrmpywoh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpywohacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyoh_acc_s0(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vrmpywoh(Rss32,Rtt32):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpywohacc_PP_s1(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyoh_acc_s1(rxx, rss, rtt)
+}
+
+/// `Rdd32=vrmpywoh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpywoh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyoh_s0(rss, rtt)
+}
+
+/// `Rdd32=vrmpywoh(Rss32,Rtt32):<<1`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpywoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpywoh_PP_s1(rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_vrmpyoh_s1(rss, rtt)
+}
+
+/// `Rx32^=and(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andxacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_xor_and(rx, rs, rt)
+}
+
+/// `Rx32^=and(Rs32,~Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(and))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andxacc_RnR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_xor_andn(rx, rs, rt)
+}
+
+/// `Rx32^=or(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(or))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_orxacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M4_xor_or(rx, rs, rt)
+}
+
+/// `Rxx32^=xor(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(xor))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_xorxacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M4_xor_xacc(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vdmpybsu(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpybsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpybsuacc_PP_sat(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M5_vdmacbsu(rxx, rss, rtt)
+}
+
+/// `Rdd32=vdmpybsu(Rss32,Rtt32):sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vdmpybsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpybsu_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_M5_vdmpybsu(rss, rtt)
+}
+
+/// `Rxx32+=vmpybsu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpybsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpybsuacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M5_vmacbsu(rxx, rs, rt)
+}
+
+/// `Rxx32+=vmpybu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpybu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpybuacc_RR(rxx: i64, rs: i32, rt: i32) -> i64 {
+    hexagon_M5_vmacbuu(rxx, rs, rt)
+}
+
+/// `Rdd32=vmpybsu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpybsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpybsu_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M5_vmpybsu(rs, rt)
+}
+
+/// `Rdd32=vmpybu(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vmpybu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vmpybu_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_M5_vmpybuu(rs, rt)
+}
+
+/// `Rxx32+=vrmpybsu(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpybsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpybsuacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M5_vrmacbsu(rxx, rss, rtt)
+}
+
+/// `Rxx32+=vrmpybu(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpybu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpybuacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M5_vrmacbuu(rxx, rss, rtt)
+}
+
+/// `Rdd32=vrmpybsu(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpybsu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpybsu_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M5_vrmpybsu(rss, rtt)
+}
+
+/// `Rdd32=vrmpybu(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrmpybu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrmpybu_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M5_vrmpybuu(rss, rtt)
+}
+
+/// `Rd32=addasl(Rt32,Rs32,#u3)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(addasl, IU3 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_addasl_RRI<const IU3: u32>(rt: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU3, 3);
+    hexagon_S2_addasl_rrri(rt, rs, IU3 as i32)
+}
+
+/// `Rdd32=asl(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asl, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asl_PI<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asl_i_p(rss, IU6 as i32)
+}
+
+/// `Rxx32+=asl(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslacc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asl_i_p_acc(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32&=asl(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asland_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asl_i_p_and(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32-=asl(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslnac_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asl_i_p_nac(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32|=asl(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslor_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asl_i_p_or(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32^=asl(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslxacc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asl_i_p_xacc(rxx, rss, IU6 as i32)
+}
+
+/// `Rd32=asl(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asl_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r(rs, IU5 as i32)
+}
+
+/// `Rx32+=asl(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslacc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r_acc(rx, rs, IU5 as i32)
+}
+
+/// `Rx32&=asl(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asland_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r_and(rx, rs, IU5 as i32)
+}
+
+/// `Rx32-=asl(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslnac_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r_nac(rx, rs, IU5 as i32)
+}
+
+/// `Rx32|=asl(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslor_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r_or(rx, rs, IU5 as i32)
+}
+
+/// `Rd32=asl(Rs32,#u5):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asl_RI_sat<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r_sat(rs, IU5 as i32)
+}
+
+/// `Rx32^=asl(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asl, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslxacc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_r_xacc(rx, rs, IU5 as i32)
+}
+
+/// `Rdd32=vaslh(Rss32,#u4)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vaslh, IU4 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaslh_PI<const IU4: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU4, 4);
+    hexagon_S2_asl_i_vh(rss, IU4 as i32)
+}
+
+/// `Rdd32=vaslw(Rss32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vaslw, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaslw_PI<const IU5: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asl_i_vw(rss, IU5 as i32)
+}
+
+/// `Rdd32=asl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asl_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_p(rss, rt)
+}
+
+/// `Rxx32+=asl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_p_acc(rxx, rss, rt)
+}
+
+/// `Rxx32&=asl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asland_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_p_and(rxx, rss, rt)
+}
+
+/// `Rxx32-=asl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslnac_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_p_nac(rxx, rss, rt)
+}
+
+/// `Rxx32|=asl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslor_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_p_or(rxx, rss, rt)
+}
+
+/// `Rxx32^=asl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_aslxacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_p_xor(rxx, rss, rt)
+}
+
+/// `Rd32=asl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asl_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asl_r_r(rs, rt)
+}
+
+/// `Rx32+=asl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asl_r_r_acc(rx, rs, rt)
+}
+
+/// `Rx32&=asl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asland_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asl_r_r_and(rx, rs, rt)
+}
+
+/// `Rx32-=asl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslnac_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asl_r_r_nac(rx, rs, rt)
+}
+
+/// `Rx32|=asl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_aslor_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asl_r_r_or(rx, rs, rt)
+}
+
+/// `Rd32=asl(Rs32,Rt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asl_RR_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asl_r_r_sat(rs, rt)
+}
+
+/// `Rdd32=vaslh(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaslh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaslh_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_vh(rss, rt)
+}
+
+/// `Rdd32=vaslw(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vaslw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vaslw_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asl_r_vw(rss, rt)
+}
+
+/// `Rdd32=asr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asr_PI<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p(rss, IU6 as i32)
+}
+
+/// `Rxx32+=asr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asracc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p_acc(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32&=asr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asrand_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p_and(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32-=asr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asrnac_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p_nac(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32|=asr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asror_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p_or(rxx, rss, IU6 as i32)
+}
+
+/// `Rdd32=asr(Rss32,#u6):rnd`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asr_PI_rnd<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p_rnd(rss, IU6 as i32)
+}
+
+/// `Rdd32=asrrnd(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asrrnd, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asrrnd_PI<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_asr_i_p_rnd_goodsyntax(rss, IU6 as i32)
+}
+
+/// `Rd32=asr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asr_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r(rs, IU5 as i32)
+}
+
+/// `Rx32+=asr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asracc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r_acc(rx, rs, IU5 as i32)
+}
+
+/// `Rx32&=asr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asrand_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r_and(rx, rs, IU5 as i32)
+}
+
+/// `Rx32-=asr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asrnac_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r_nac(rx, rs, IU5 as i32)
+}
+
+/// `Rx32|=asr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(asr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asror_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r_or(rx, rs, IU5 as i32)
+}
+
+/// `Rd32=asr(Rs32,#u5):rnd`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asr_RI_rnd<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r_rnd(rs, IU5 as i32)
+}
+
+/// `Rd32=asrrnd(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(asrrnd, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asrrnd_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_r_rnd_goodsyntax(rs, IU5 as i32)
+}
+
+/// `Rd32=vasrw(Rss32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vasrw, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vasrw_PI<const IU5: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_svw_trun(rss, IU5 as i32)
+}
+
+/// `Rdd32=vasrh(Rss32,#u4)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vasrh, IU4 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vasrh_PI<const IU4: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU4, 4);
+    hexagon_S2_asr_i_vh(rss, IU4 as i32)
+}
+
+/// `Rdd32=vasrw(Rss32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vasrw, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vasrw_PI<const IU5: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_asr_i_vw(rss, IU5 as i32)
+}
+
+/// `Rdd32=asr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asr_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_p(rss, rt)
+}
+
+/// `Rxx32+=asr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asracc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_p_acc(rxx, rss, rt)
+}
+
+/// `Rxx32&=asr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asrand_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_p_and(rxx, rss, rt)
+}
+
+/// `Rxx32-=asr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asrnac_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_p_nac(rxx, rss, rt)
+}
+
+/// `Rxx32|=asr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asror_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_p_or(rxx, rss, rt)
+}
+
+/// `Rxx32^=asr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_asrxacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_p_xor(rxx, rss, rt)
+}
+
+/// `Rd32=asr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asr_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asr_r_r(rs, rt)
+}
+
+/// `Rx32+=asr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asracc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asr_r_r_acc(rx, rs, rt)
+}
+
+/// `Rx32&=asr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asrand_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asr_r_r_and(rx, rs, rt)
+}
+
+/// `Rx32-=asr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asrnac_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asr_r_r_nac(rx, rs, rt)
+}
+
+/// `Rx32|=asr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asror_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asr_r_r_or(rx, rs, rt)
+}
+
+/// `Rd32=asr(Rs32,Rt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(asr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_asr_RR_sat(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_asr_r_r_sat(rs, rt)
+}
+
+/// `Rd32=vasrw(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vasrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vasrw_PR(rss: i64, rt: i32) -> i32 {
+    hexagon_S2_asr_r_svw_trun(rss, rt)
+}
+
+/// `Rdd32=vasrh(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vasrh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vasrh_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_vh(rss, rt)
+}
+
+/// `Rdd32=vasrw(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vasrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vasrw_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_asr_r_vw(rss, rt)
+}
+
+/// `Rd32=brev(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(brev))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_brev_R(rs: i32) -> i32 {
+    hexagon_S2_brev(rs)
+}
+
+/// `Rdd32=brev(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(brev))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_brev_P(rss: i64) -> i64 {
+    hexagon_S2_brevp(rss)
+}
+
+/// `Rd32=cl0(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cl0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cl0_R(rs: i32) -> i32 {
+    hexagon_S2_cl0(rs)
+}
+
+/// `Rd32=cl0(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cl0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cl0_P(rss: i64) -> i32 {
+    hexagon_S2_cl0p(rss)
+}
+
+/// `Rd32=cl1(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cl1))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cl1_R(rs: i32) -> i32 {
+    hexagon_S2_cl1(rs)
+}
+
+/// `Rd32=cl1(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cl1))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cl1_P(rss: i64) -> i32 {
+    hexagon_S2_cl1p(rss)
+}
+
+/// `Rd32=clb(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(clb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_clb_R(rs: i32) -> i32 {
+    hexagon_S2_clb(rs)
+}
+
+/// `Rd32=normamt(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(normamt))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_normamt_R(rs: i32) -> i32 {
+    hexagon_S2_clbnorm(rs)
+}
+
+/// `Rd32=clb(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(clb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_clb_P(rss: i64) -> i32 {
+    hexagon_S2_clbp(rss)
+}
+
+/// `Rd32=clrbit(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(clrbit, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_clrbit_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_clrbit_i(rs, IU5 as i32)
+}
+
+/// `Rd32=clrbit(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(clrbit))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_clrbit_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_clrbit_r(rs, rt)
+}
+
+/// `Rd32=ct0(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(ct0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_ct0_R(rs: i32) -> i32 {
+    hexagon_S2_ct0(rs)
+}
+
+/// `Rd32=ct0(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(ct0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_ct0_P(rss: i64) -> i32 {
+    hexagon_S2_ct0p(rss)
+}
+
+/// `Rd32=ct1(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(ct1))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_ct1_R(rs: i32) -> i32 {
+    hexagon_S2_ct1(rs)
+}
+
+/// `Rd32=ct1(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(ct1))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_ct1_P(rss: i64) -> i32 {
+    hexagon_S2_ct1p(rss)
+}
+
+/// `Rdd32=deinterleave(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(deinterleave))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_deinterleave_P(rss: i64) -> i64 {
+    hexagon_S2_deinterleave(rss)
+}
+
+/// `Rd32=extractu(Rs32,#u5,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1, 2)]
+#[cfg_attr(test, assert_instr(extractu, IU5 = 0, IU5_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_extractu_RII<const IU5: u32, const IU5_2: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    static_assert_uimm_bits!(IU5_2, 5);
+    hexagon_S2_extractu(rs, IU5 as i32, IU5_2 as i32)
+}
+
+/// `Rd32=extractu(Rs32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(extractu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_extractu_RP(rs: i32, rtt: i64) -> i32 {
+    hexagon_S2_extractu_rp(rs, rtt)
+}
+
+/// `Rdd32=extractu(Rss32,#u6,#U6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1, 2)]
+#[cfg_attr(test, assert_instr(extractu, IU6 = 0, IU6_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_extractu_PII<const IU6: u32, const IU6_2: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    static_assert_uimm_bits!(IU6_2, 6);
+    hexagon_S2_extractup(rss, IU6 as i32, IU6_2 as i32)
+}
+
+/// `Rdd32=extractu(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(extractu))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_extractu_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_extractup_rp(rss, rtt)
+}
+
+/// `Rx32=insert(Rs32,#u5,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2, 3)]
+#[cfg_attr(test, assert_instr(insert, IU5 = 0, IU5_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_insert_RII<const IU5: u32, const IU5_2: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    static_assert_uimm_bits!(IU5_2, 5);
+    hexagon_S2_insert(rx, rs, IU5 as i32, IU5_2 as i32)
+}
+
+/// `Rx32=insert(Rs32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(insert))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_insert_RP(rx: i32, rs: i32, rtt: i64) -> i32 {
+    hexagon_S2_insert_rp(rx, rs, rtt)
+}
+
+/// `Rxx32=insert(Rss32,#u6,#U6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2, 3)]
+#[cfg_attr(test, assert_instr(insert, IU6 = 0, IU6_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_insert_PII<const IU6: u32, const IU6_2: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    static_assert_uimm_bits!(IU6_2, 6);
+    hexagon_S2_insertp(rxx, rss, IU6 as i32, IU6_2 as i32)
+}
+
+/// `Rxx32=insert(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(insert))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_insert_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_insertp_rp(rxx, rss, rtt)
+}
+
+/// `Rdd32=interleave(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(interleave))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_interleave_P(rss: i64) -> i64 {
+    hexagon_S2_interleave(rss)
+}
+
+/// `Rdd32=lfs(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lfs))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lfs_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_lfsp(rss, rtt)
+}
+
+/// `Rdd32=lsl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsl_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_p(rss, rt)
+}
+
+/// `Rxx32+=lsl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lslacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_p_acc(rxx, rss, rt)
+}
+
+/// `Rxx32&=lsl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsland_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_p_and(rxx, rss, rt)
+}
+
+/// `Rxx32-=lsl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lslnac_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_p_nac(rxx, rss, rt)
+}
+
+/// `Rxx32|=lsl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lslor_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_p_or(rxx, rss, rt)
+}
+
+/// `Rxx32^=lsl(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lslxacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_p_xor(rxx, rss, rt)
+}
+
+/// `Rd32=lsl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsl_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsl_r_r(rs, rt)
+}
+
+/// `Rx32+=lsl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lslacc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsl_r_r_acc(rx, rs, rt)
+}
+
+/// `Rx32&=lsl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsland_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsl_r_r_and(rx, rs, rt)
+}
+
+/// `Rx32-=lsl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lslnac_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsl_r_r_nac(rx, rs, rt)
+}
+
+/// `Rx32|=lsl(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lslor_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsl_r_r_or(rx, rs, rt)
+}
+
+/// `Rdd32=vlslh(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vlslh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vlslh_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_vh(rss, rt)
+}
+
+/// `Rdd32=vlslw(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vlslw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vlslw_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsl_r_vw(rss, rt)
+}
+
+/// `Rdd32=lsr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(lsr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsr_PI<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_lsr_i_p(rss, IU6 as i32)
+}
+
+/// `Rxx32+=lsr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsracc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_lsr_i_p_acc(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32&=lsr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsrand_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_lsr_i_p_and(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32-=lsr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsrnac_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_lsr_i_p_nac(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32|=lsr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsror_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_lsr_i_p_or(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32^=lsr(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsrxacc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S2_lsr_i_p_xacc(rxx, rss, IU6 as i32)
+}
+
+/// `Rd32=lsr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(lsr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsr_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_r(rs, IU5 as i32)
+}
+
+/// `Rx32+=lsr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsracc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_r_acc(rx, rs, IU5 as i32)
+}
+
+/// `Rx32&=lsr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsrand_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_r_and(rx, rs, IU5 as i32)
+}
+
+/// `Rx32-=lsr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsrnac_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_r_nac(rx, rs, IU5 as i32)
+}
+
+/// `Rx32|=lsr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsror_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_r_or(rx, rs, IU5 as i32)
+}
+
+/// `Rx32^=lsr(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(lsr, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsrxacc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_r_xacc(rx, rs, IU5 as i32)
+}
+
+/// `Rdd32=vlsrh(Rss32,#u4)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vlsrh, IU4 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vlsrh_PI<const IU4: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU4, 4);
+    hexagon_S2_lsr_i_vh(rss, IU4 as i32)
+}
+
+/// `Rdd32=vlsrw(Rss32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vlsrw, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vlsrw_PI<const IU5: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_lsr_i_vw(rss, IU5 as i32)
+}
+
+/// `Rdd32=lsr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsr_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_p(rss, rt)
+}
+
+/// `Rxx32+=lsr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsracc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_p_acc(rxx, rss, rt)
+}
+
+/// `Rxx32&=lsr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsrand_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_p_and(rxx, rss, rt)
+}
+
+/// `Rxx32-=lsr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsrnac_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_p_nac(rxx, rss, rt)
+}
+
+/// `Rxx32|=lsr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsror_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_p_or(rxx, rss, rt)
+}
+
+/// `Rxx32^=lsr(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_lsrxacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_p_xor(rxx, rss, rt)
+}
+
+/// `Rd32=lsr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsr_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsr_r_r(rs, rt)
+}
+
+/// `Rx32+=lsr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsracc_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsr_r_r_acc(rx, rs, rt)
+}
+
+/// `Rx32&=lsr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsrand_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsr_r_r_and(rx, rs, rt)
+}
+
+/// `Rx32-=lsr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsrnac_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsr_r_r_nac(rx, rs, rt)
+}
+
+/// `Rx32|=lsr(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(lsr))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsror_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_S2_lsr_r_r_or(rx, rs, rt)
+}
+
+/// `Rdd32=vlsrh(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vlsrh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vlsrh_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_vh(rss, rt)
+}
+
+/// `Rdd32=vlsrw(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vlsrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vlsrw_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_lsr_r_vw(rss, rt)
+}
+
+/// `Rdd32=packhl(Rs32,Rt32)`
+///
+/// Instruction Type: ALU32_3op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(packhl))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_packhl_RR(rs: i32, rt: i32) -> i64 {
+    hexagon_S2_packhl(rs, rt)
+}
+
+/// `Rd32=parity(Rss32,Rtt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(parity))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_parity_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_S2_parityp(rss, rtt)
+}
+
+/// `Rd32=setbit(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(setbit, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_setbit_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_setbit_i(rs, IU5 as i32)
+}
+
+/// `Rd32=setbit(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(setbit))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_setbit_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_setbit_r(rs, rt)
+}
+
+/// `Rdd32=shuffeb(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(shuffeb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_shuffeb_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_shuffeb(rss, rtt)
+}
+
+/// `Rdd32=shuffeh(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(shuffeh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_shuffeh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_shuffeh(rss, rtt)
+}
+
+/// `Rdd32=shuffob(Rtt32,Rss32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(shuffob))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_shuffob_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_S2_shuffob(rtt, rss)
+}
+
+/// `Rdd32=shuffoh(Rtt32,Rss32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(shuffoh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_shuffoh_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_S2_shuffoh(rtt, rss)
+}
+
+/// `Rd32=vsathb(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsathb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsathb_R(rs: i32) -> i32 {
+    hexagon_S2_svsathb(rs)
+}
+
+/// `Rd32=vsathub(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsathub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsathub_R(rs: i32) -> i32 {
+    hexagon_S2_svsathub(rs)
+}
+
+/// `Rx32=tableidxb(Rs32,#u4,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(2, 3)]
+#[cfg_attr(test, assert_instr(tableidxb, IU4 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_tableidxb_RII<const IU4: u32, const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU4, 4);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_tableidxb_goodsyntax(rx, rs, IU4 as i32, IU5 as i32)
+}
+
+/// `Rx32=tableidxd(Rs32,#u4,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(2, 3)]
+#[cfg_attr(test, assert_instr(tableidxd, IU4 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_tableidxd_RII<const IU4: u32, const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU4, 4);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_tableidxd_goodsyntax(rx, rs, IU4 as i32, IU5 as i32)
+}
+
+/// `Rx32=tableidxh(Rs32,#u4,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(2, 3)]
+#[cfg_attr(test, assert_instr(tableidxh, IU4 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_tableidxh_RII<const IU4: u32, const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU4, 4);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_tableidxh_goodsyntax(rx, rs, IU4 as i32, IU5 as i32)
+}
+
+/// `Rx32=tableidxw(Rs32,#u4,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(2, 3)]
+#[cfg_attr(test, assert_instr(tableidxw, IU4 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_tableidxw_RII<const IU4: u32, const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU4, 4);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_tableidxw_goodsyntax(rx, rs, IU4 as i32, IU5 as i32)
+}
+
+/// `Rd32=togglebit(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(togglebit, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_togglebit_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_togglebit_i(rs, IU5 as i32)
+}
+
+/// `Rd32=togglebit(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(togglebit))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_togglebit_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_togglebit_r(rs, rt)
+}
+
+/// `Pd4=tstbit(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(tstbit, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_tstbit_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S2_tstbit_i(rs, IU5 as i32)
+}
+
+/// `Pd4=tstbit(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(tstbit))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_tstbit_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S2_tstbit_r(rs, rt)
+}
+
+/// `Rdd32=valignb(Rtt32,Rss32,#u3)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(valignb, IU3 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_valignb_PPI<const IU3: u32>(rtt: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU3, 3);
+    hexagon_S2_valignib(rtt, rss, IU3 as i32)
+}
+
+/// `Rdd32=valignb(Rtt32,Rss32,Pu4)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(valignb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_valignb_PPp(rtt: i64, rss: i64, pu: i32) -> i64 {
+    hexagon_S2_valignrb(rtt, rss, pu)
+}
+
+/// `Rdd32=vcnegh(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcnegh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcnegh_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_vcnegh(rss, rt)
+}
+
+/// `Rdd32=vcrotate(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vcrotate))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vcrotate_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_S2_vcrotate(rss, rt)
+}
+
+/// `Rxx32+=vrcnegh(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrcnegh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcneghacc_PR(rxx: i64, rss: i64, rt: i32) -> i64 {
+    hexagon_S2_vrcnegh(rxx, rss, rt)
+}
+
+/// `Rd32=vrndwh(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrndwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vrndwh_P(rss: i64) -> i32 {
+    hexagon_S2_vrndpackwh(rss)
+}
+
+/// `Rd32=vrndwh(Rss32):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vrndwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vrndwh_P_sat(rss: i64) -> i32 {
+    hexagon_S2_vrndpackwhs(rss)
+}
+
+/// `Rd32=vsathb(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsathb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsathb_P(rss: i64) -> i32 {
+    hexagon_S2_vsathb(rss)
+}
+
+/// `Rdd32=vsathb(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsathb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsathb_P(rss: i64) -> i64 {
+    hexagon_S2_vsathb_nopack(rss)
+}
+
+/// `Rd32=vsathub(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsathub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsathub_P(rss: i64) -> i32 {
+    hexagon_S2_vsathub(rss)
+}
+
+/// `Rdd32=vsathub(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsathub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsathub_P(rss: i64) -> i64 {
+    hexagon_S2_vsathub_nopack(rss)
+}
+
+/// `Rd32=vsatwh(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsatwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsatwh_P(rss: i64) -> i32 {
+    hexagon_S2_vsatwh(rss)
+}
+
+/// `Rdd32=vsatwh(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsatwh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsatwh_P(rss: i64) -> i64 {
+    hexagon_S2_vsatwh_nopack(rss)
+}
+
+/// `Rd32=vsatwuh(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsatwuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsatwuh_P(rss: i64) -> i32 {
+    hexagon_S2_vsatwuh(rss)
+}
+
+/// `Rdd32=vsatwuh(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsatwuh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsatwuh_P(rss: i64) -> i64 {
+    hexagon_S2_vsatwuh_nopack(rss)
+}
+
+/// `Rd32=vsplatb(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsplatb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vsplatb_R(rs: i32) -> i32 {
+    hexagon_S2_vsplatrb(rs)
+}
+
+/// `Rdd32=vsplath(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsplath))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsplath_R(rs: i32) -> i64 {
+    hexagon_S2_vsplatrh(rs)
+}
+
+/// `Rdd32=vspliceb(Rss32,Rtt32,#u3)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(vspliceb, IU3 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vspliceb_PPI<const IU3: u32>(rss: i64, rtt: i64) -> i64 {
+    static_assert_uimm_bits!(IU3, 3);
+    hexagon_S2_vspliceib(rss, rtt, IU3 as i32)
+}
+
+/// `Rdd32=vspliceb(Rss32,Rtt32,Pu4)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vspliceb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vspliceb_PPp(rss: i64, rtt: i64, pu: i32) -> i64 {
+    hexagon_S2_vsplicerb(rss, rtt, pu)
+}
+
+/// `Rdd32=vsxtbh(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsxtbh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsxtbh_R(rs: i32) -> i64 {
+    hexagon_S2_vsxtbh(rs)
+}
+
+/// `Rdd32=vsxthw(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vsxthw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsxthw_R(rs: i32) -> i64 {
+    hexagon_S2_vsxthw(rs)
+}
+
+/// `Rd32=vtrunehb(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vtrunehb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vtrunehb_P(rss: i64) -> i32 {
+    hexagon_S2_vtrunehb(rss)
+}
+
+/// `Rdd32=vtrunewh(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vtrunewh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vtrunewh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_vtrunewh(rss, rtt)
+}
+
+/// `Rd32=vtrunohb(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vtrunohb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vtrunohb_P(rss: i64) -> i32 {
+    hexagon_S2_vtrunohb(rss)
+}
+
+/// `Rdd32=vtrunowh(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vtrunowh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vtrunowh_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S2_vtrunowh(rss, rtt)
+}
+
+/// `Rdd32=vzxtbh(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vzxtbh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vzxtbh_R(rs: i32) -> i64 {
+    hexagon_S2_vzxtbh(rs)
+}
+
+/// `Rdd32=vzxthw(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vzxthw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vzxthw_R(rs: i32) -> i64 {
+    hexagon_S2_vzxthw(rs)
+}
+
+/// `Rd32=add(Rs32,add(Ru32,#s6))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(add, IS6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_add_RRI<const IS6: i32>(rs: i32, ru: i32) -> i32 {
+    static_assert_simm_bits!(IS6, 6);
+    hexagon_S4_addaddi(rs, ru, IS6)
+}
+
+/// `Rx32=add(#u8,asl(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(add, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_asl_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_addi_asl_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rx32=add(#u8,lsr(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(add, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_lsr_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_addi_lsr_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rx32=and(#u8,asl(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(and, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_and_asl_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_andi_asl_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rx32=and(#u8,lsr(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(and, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_and_lsr_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_andi_lsr_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rd32=add(clb(Rs32),#s6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(add, IS6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_clb_RI<const IS6: i32>(rs: i32) -> i32 {
+    static_assert_simm_bits!(IS6, 6);
+    hexagon_S4_clbaddi(rs, IS6)
+}
+
+/// `Rd32=add(clb(Rss32),#s6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(add, IS6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_clb_PI<const IS6: i32>(rss: i64) -> i32 {
+    static_assert_simm_bits!(IS6, 6);
+    hexagon_S4_clbpaddi(rss, IS6)
+}
+
+/// `Rd32=normamt(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(normamt))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_normamt_P(rss: i64) -> i32 {
+    hexagon_S4_clbpnorm(rss)
+}
+
+/// `Rd32=extract(Rs32,#u5,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1, 2)]
+#[cfg_attr(test, assert_instr(extract, IU5 = 0, IU5_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_extract_RII<const IU5: u32, const IU5_2: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    static_assert_uimm_bits!(IU5_2, 5);
+    hexagon_S4_extract(rs, IU5 as i32, IU5_2 as i32)
+}
+
+/// `Rd32=extract(Rs32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(extract))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_extract_RP(rs: i32, rtt: i64) -> i32 {
+    hexagon_S4_extract_rp(rs, rtt)
+}
+
+/// `Rdd32=extract(Rss32,#u6,#U6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1, 2)]
+#[cfg_attr(test, assert_instr(extract, IU6 = 0, IU6_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_extract_PII<const IU6: u32, const IU6_2: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    static_assert_uimm_bits!(IU6_2, 6);
+    hexagon_S4_extractp(rss, IU6 as i32, IU6_2 as i32)
+}
+
+/// `Rdd32=extract(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(extract))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_extract_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_extractp_rp(rss, rtt)
+}
+
+/// `Rd32=lsl(#s6,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0)]
+#[cfg_attr(test, assert_instr(lsl, IS6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_lsl_IR<const IS6: i32>(rt: i32) -> i32 {
+    static_assert_simm_bits!(IS6, 6);
+    hexagon_S4_lsli(IS6, rt)
+}
+
+/// `Pd4=!tstbit(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_tstbit_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_ntstbit_i(rs, IU5 as i32)
+}
+
+/// `Pd4=!tstbit(Rs32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_tstbit_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S4_ntstbit_r(rs, rt)
+}
+
+/// `Rx32|=and(Rs32,#s10)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(and, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_andor_RI<const IS10: i32>(rx: i32, rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_S4_or_andi(rx, rs, IS10)
+}
+
+/// `Rx32=or(Ru32,and(Rx32,#s10))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(or, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_or_and_RRI<const IS10: i32>(ru: i32, rx: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_S4_or_andix(ru, rx, IS10)
+}
+
+/// `Rx32|=or(Rs32,#s10)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(or, IS10 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_oror_RI<const IS10: i32>(rx: i32, rs: i32) -> i32 {
+    static_assert_simm_bits!(IS10, 10);
+    hexagon_S4_or_ori(rx, rs, IS10)
+}
+
+/// `Rx32=or(#u8,asl(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(or, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_or_asl_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_ori_asl_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rx32=or(#u8,lsr(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(or, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_or_lsr_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_ori_lsr_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rd32=parity(Rs32,Rt32)`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(parity))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_parity_RR(rs: i32, rt: i32) -> i32 {
+    hexagon_S4_parity(rs, rt)
+}
+
+/// `Rd32=add(Rs32,sub(#s6,Ru32))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(add, IS6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_add_sub_RIR<const IS6: i32>(rs: i32, ru: i32) -> i32 {
+    static_assert_simm_bits!(IS6, 6);
+    hexagon_S4_subaddi(rs, IS6, ru)
+}
+
+/// `Rx32=sub(#u8,asl(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(sub, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_asl_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_subi_asl_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rx32=sub(#u8,lsr(Rx32,#U5))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(0, 2)]
+#[cfg_attr(test, assert_instr(sub, IU8 = 0, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_sub_lsr_IRI<const IU8: u32, const IU5: u32>(rx: i32) -> i32 {
+    static_assert_uimm_bits!(IU8, 8);
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S4_subi_lsr_ri(IU8 as i32, rx, IU5 as i32)
+}
+
+/// `Rdd32=vrcrotate(Rss32,Rt32,#u2)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(vrcrotate, IU2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcrotate_PRI<const IU2: u32>(rss: i64, rt: i32) -> i64 {
+    static_assert_uimm_bits!(IU2, 2);
+    hexagon_S4_vrcrotate(rss, rt, IU2 as i32)
+}
+
+/// `Rxx32+=vrcrotate(Rss32,Rt32,#u2)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(3)]
+#[cfg_attr(test, assert_instr(vrcrotate, IU2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vrcrotateacc_PRI<const IU2: u32>(rxx: i64, rss: i64, rt: i32) -> i64 {
+    static_assert_uimm_bits!(IU2, 2);
+    hexagon_S4_vrcrotate_acc(rxx, rss, rt, IU2 as i32)
+}
+
+/// `Rdd32=vxaddsubh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vxaddsubh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vxaddsubh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_vxaddsubh(rss, rtt)
+}
+
+/// `Rdd32=vxaddsubh(Rss32,Rtt32):rnd:>>1:sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vxaddsubh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vxaddsubh_PP_rnd_rs1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_vxaddsubhr(rss, rtt)
+}
+
+/// `Rdd32=vxaddsubw(Rss32,Rtt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vxaddsubw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vxaddsubw_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_vxaddsubw(rss, rtt)
+}
+
+/// `Rdd32=vxsubaddh(Rss32,Rtt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vxsubaddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vxsubaddh_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_vxsubaddh(rss, rtt)
+}
+
+/// `Rdd32=vxsubaddh(Rss32,Rtt32):rnd:>>1:sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vxsubaddh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vxsubaddh_PP_rnd_rs1_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_vxsubaddhr(rss, rtt)
+}
+
+/// `Rdd32=vxsubaddw(Rss32,Rtt32):sat`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(vxsubaddw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vxsubaddw_PP_sat(rss: i64, rtt: i64) -> i64 {
+    hexagon_S4_vxsubaddw(rss, rtt)
+}
+
+/// `Rd32=vasrhub(Rss32,#u4):rnd:sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vasrhub, IU4 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vasrhub_PI_rnd_sat<const IU4: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU4, 4);
+    hexagon_S5_asrhub_rnd_sat_goodsyntax(rss, IU4 as i32)
+}
+
+/// `Rd32=vasrhub(Rss32,#u4):sat`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vasrhub, IU4 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_vasrhub_PI_sat<const IU4: u32>(rss: i64) -> i32 {
+    static_assert_uimm_bits!(IU4, 4);
+    hexagon_S5_asrhub_sat(rss, IU4 as i32)
+}
+
+/// `Rd32=popcount(Rss32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+#[inline(always)]
+#[cfg_attr(test, assert_instr(popcount))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_popcount_P(rss: i64) -> i32 {
+    hexagon_S5_popcountp(rss)
+}
+
+/// `Rdd32=vasrh(Rss32,#u4):rnd`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vasrh, IU4 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vasrh_PI_rnd<const IU4: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU4, 4);
+    hexagon_S5_vasrhrnd_goodsyntax(rss, IU4 as i32)
+}
+
+/// `dccleana(Rs32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dccleana))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dccleana_A(rs: i32) {
+    hexagon_Y2_dccleana(rs)
+}
+
+/// `dccleaninva(Rs32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dccleaninva))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dccleaninva_A(rs: i32) {
+    hexagon_Y2_dccleaninva(rs)
+}
+
+/// `dcfetch(Rs32)`
+///
+/// Instruction Type: MAPPING
+/// Execution Slots: SLOT0123
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dcfetch))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dcfetch_A(rs: i32) {
+    hexagon_Y2_dcfetch(rs)
+}
+
+/// `dcinva(Rs32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dcinva))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dcinva_A(rs: i32) {
+    hexagon_Y2_dcinva(rs)
+}
+
+/// `dczeroa(Rs32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+#[inline(always)]
+#[cfg_attr(test, assert_instr(dczeroa))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dczeroa_A(rs: i32) {
+    hexagon_Y2_dczeroa(rs)
+}
+
+/// `l2fetch(Rs32,Rt32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+#[inline(always)]
+#[cfg_attr(test, assert_instr(l2fetch))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_l2fetch_AR(rs: i32, rt: i32) {
+    hexagon_Y4_l2fetch(rs, rt)
+}
+
+/// `l2fetch(Rs32,Rtt32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+#[inline(always)]
+#[cfg_attr(test, assert_instr(l2fetch))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_l2fetch_AP(rs: i32, rtt: i64) {
+    hexagon_Y5_l2fetch(rs, rtt)
+}
+
+/// `Rdd32=rol(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(rol, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_rol_PI<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S6_rol_i_p(rss, IU6 as i32)
+}
+
+/// `Rxx32+=rol(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_rolacc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S6_rol_i_p_acc(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32&=rol(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_roland_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S6_rol_i_p_and(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32-=rol(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_rolnac_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S6_rol_i_p_nac(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32|=rol(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_rolor_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S6_rol_i_p_or(rxx, rss, IU6 as i32)
+}
+
+/// `Rxx32^=rol(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_rolxacc_PI<const IU6: u32>(rxx: i64, rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_S6_rol_i_p_xacc(rxx, rss, IU6 as i32)
+}
+
+/// `Rd32=rol(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(rol, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_rol_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S6_rol_i_r(rs, IU5 as i32)
+}
+
+/// `Rx32+=rol(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_rolacc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S6_rol_i_r_acc(rx, rs, IU5 as i32)
+}
+
+/// `Rx32&=rol(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_roland_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S6_rol_i_r_and(rx, rs, IU5 as i32)
+}
+
+/// `Rx32-=rol(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_rolnac_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S6_rol_i_r_nac(rx, rs, IU5 as i32)
+}
+
+/// `Rx32|=rol(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_rolor_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S6_rol_i_r_or(rx, rs, IU5 as i32)
+}
+
+/// `Rx32^=rol(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V60
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v60"))]
+#[rustc_legacy_const_generics(2)]
+#[cfg_attr(test, assert_instr(rol, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_rolxacc_RI<const IU5: u32>(rx: i32, rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_S6_rol_i_r_xacc(rx, rs, IU5 as i32)
+}
+
+/// `Rdd32=vabsdiffb(Rtt32,Rss32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V62
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v62"))]
+#[cfg_attr(test, assert_instr(vabsdiffb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsdiffb_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_M6_vabsdiffb(rtt, rss)
+}
+
+/// `Rdd32=vabsdiffub(Rtt32,Rss32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V62
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v62"))]
+#[cfg_attr(test, assert_instr(vabsdiffub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vabsdiffub_PP(rtt: i64, rss: i64) -> i64 {
+    hexagon_M6_vabsdiffub(rtt, rss)
+}
+
+/// `Rdd32=vsplatb(Rs32)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V62
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v62"))]
+#[cfg_attr(test, assert_instr(vsplatb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vsplatb_R(rs: i32) -> i64 {
+    hexagon_S6_vsplatrbp(rs)
+}
+
+/// `Rdd32=vtrunehb(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+/// Requires: V62
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v62"))]
+#[cfg_attr(test, assert_instr(vtrunehb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vtrunehb_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S6_vtrunehb_ppp(rss, rtt)
+}
+
+/// `Rdd32=vtrunohb(Rss32,Rtt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+/// Requires: V62
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v62"))]
+#[cfg_attr(test, assert_instr(vtrunohb))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vtrunohb_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_S6_vtrunohb_ppp(rss, rtt)
+}
+
+/// `Pd4=!any8(vcmpb.eq(Rss32,Rtt32))`
+///
+/// Instruction Type: ALU64
+/// Execution Slots: SLOT23
+/// Requires: V65
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v65"))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_p_not_any8_vcmpb_eq_PP(rss: i64, rtt: i64) -> i32 {
+    hexagon_A6_vcmpbeq_notany(rss, rtt)
+}
+
+/// `Rdd32=dfadd(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V66
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v66"))]
+#[cfg_attr(test, assert_instr(dfadd))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfadd_PP(rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfadd(rss, rtt)
+}
+
+/// `Rdd32=dfsub(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V66
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v66"))]
+#[cfg_attr(test, assert_instr(dfsub))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfsub_PP(rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfsub(rss, rtt)
+}
+
+/// `Rx32-=mpyi(Rs32,Rt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V66
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v66"))]
+#[cfg_attr(test, assert_instr(mpyi))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mpyinac_RR(rx: i32, rs: i32, rt: i32) -> i32 {
+    hexagon_M2_mnaci(rx, rs, rt)
+}
+
+/// `Rd32=mask(#u5,#U5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V66
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v66"))]
+#[rustc_legacy_const_generics(0, 1)]
+#[cfg_attr(test, assert_instr(mask, IU5 = 0, IU5_2 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_mask_II<const IU5: u32, const IU5_2: u32>() -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    static_assert_uimm_bits!(IU5_2, 5);
+    hexagon_S2_mask(IU5 as i32, IU5_2 as i32)
+}
+
+/// `Rd32=clip(Rs32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(clip, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_clip_RI<const IU5: u32>(rs: i32) -> i32 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_A7_clip(rs, IU5 as i32)
+}
+
+/// `Rdd32=cround(Rss32,#u6)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(cround, IU6 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cround_PI<const IU6: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU6, 6);
+    hexagon_A7_croundd_ri(rss, IU6 as i32)
+}
+
+/// `Rdd32=cround(Rss32,Rt32)`
+///
+/// Instruction Type: S_3op
+/// Execution Slots: SLOT23
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cround))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cround_PR(rss: i64, rt: i32) -> i64 {
+    hexagon_A7_croundd_rr(rss, rt)
+}
+
+/// `Rdd32=vclip(Rss32,#u5)`
+///
+/// Instruction Type: S_2op
+/// Execution Slots: SLOT23
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[rustc_legacy_const_generics(1)]
+#[cfg_attr(test, assert_instr(vclip, IU5 = 0))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vclip_PI<const IU5: u32>(rss: i64) -> i64 {
+    static_assert_uimm_bits!(IU5, 5);
+    hexagon_A7_vclip(rss, IU5 as i32)
+}
+
+/// `Rdd32=dfmax(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V67
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67"))]
+#[cfg_attr(test, assert_instr(dfmax))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmax_PP(rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfmax(rss, rtt)
+}
+
+/// `Rdd32=dfmin(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V67
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67"))]
+#[cfg_attr(test, assert_instr(dfmin))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmin_PP(rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfmin(rss, rtt)
+}
+
+/// `Rdd32=dfmpyfix(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V67
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67"))]
+#[cfg_attr(test, assert_instr(dfmpyfix))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmpyfix_PP(rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfmpyfix(rss, rtt)
+}
+
+/// `Rxx32+=dfmpyhh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V67
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67"))]
+#[cfg_attr(test, assert_instr(dfmpyhh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmpyhhacc_PP(rxx: f64, rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfmpyhh(rxx, rss, rtt)
+}
+
+/// `Rxx32+=dfmpylh(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V67
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67"))]
+#[cfg_attr(test, assert_instr(dfmpylh))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmpylhacc_PP(rxx: f64, rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfmpylh(rxx, rss, rtt)
+}
+
+/// `Rdd32=dfmpyll(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT23
+/// Requires: V67
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67"))]
+#[cfg_attr(test, assert_instr(dfmpyll))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_dfmpyll_PP(rss: f64, rtt: f64) -> f64 {
+    hexagon_F2_dfmpyll(rss, rtt)
+}
+
+/// `Rdd32=cmpyiw(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyiw_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyiw(rss, rtt)
+}
+
+/// `Rxx32+=cmpyiw(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyiwacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyiw_acc(rxx, rss, rtt)
+}
+
+/// `Rdd32=cmpyiw(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyiw_PP_conj(rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyiwc(rss, rtt)
+}
+
+/// `Rxx32+=cmpyiw(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyiwacc_PP_conj(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyiwc_acc(rxx, rss, rtt)
+}
+
+/// `Rdd32=cmpyrw(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyrw_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyrw(rss, rtt)
+}
+
+/// `Rxx32+=cmpyrw(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyrwacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyrw_acc(rxx, rss, rtt)
+}
+
+/// `Rdd32=cmpyrw(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyrw_PP_conj(rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyrwc(rss, rtt)
+}
+
+/// `Rxx32+=cmpyrw(Rss32,Rtt32*)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_cmpyrwacc_PP_conj(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_dcmpyrwc_acc(rxx, rss, rtt)
+}
+
+/// `Rdd32=vdmpyw(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(vdmpyw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpyw_PP(rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_vdmpy(rss, rtt)
+}
+
+/// `Rxx32+=vdmpyw(Rss32,Rtt32)`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(vdmpyw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_P_vdmpywacc_PP(rxx: i64, rss: i64, rtt: i64) -> i64 {
+    hexagon_M7_vdmpy_acc(rxx, rss, rtt)
+}
+
+/// `Rd32=cmpyiw(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyiw_PP_s1_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyiw(rss, rtt)
+}
+
+/// `Rd32=cmpyiw(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyiw_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyiw_rnd(rss, rtt)
+}
+
+/// `Rd32=cmpyiw(Rss32,Rtt32*):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyiw_PP_conj_s1_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyiwc(rss, rtt)
+}
+
+/// `Rd32=cmpyiw(Rss32,Rtt32*):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyiw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyiw_PP_conj_s1_rnd_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyiwc_rnd(rss, rtt)
+}
+
+/// `Rd32=cmpyrw(Rss32,Rtt32):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyrw_PP_s1_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyrw(rss, rtt)
+}
+
+/// `Rd32=cmpyrw(Rss32,Rtt32):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyrw_PP_s1_rnd_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyrw_rnd(rss, rtt)
+}
+
+/// `Rd32=cmpyrw(Rss32,Rtt32*):<<1:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyrw_PP_conj_s1_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyrwc(rss, rtt)
+}
+
+/// `Rd32=cmpyrw(Rss32,Rtt32*):<<1:rnd:sat`
+///
+/// Instruction Type: M
+/// Execution Slots: SLOT3
+/// Requires: V67, Audio
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v67,audio"))]
+#[cfg_attr(test, assert_instr(cmpyrw))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_cmpyrw_PP_conj_s1_rnd_sat(rss: i64, rtt: i64) -> i32 {
+    hexagon_M7_wcmpyrwc_rnd(rss, rtt)
+}
+
+/// `dmlink(Rs32,Rt32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+/// Requires: V68
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v68"))]
+#[cfg_attr(test, assert_instr(dmlink))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dmlink_AA(rs: i32, rt: i32) {
+    hexagon_Y6_dmlink(rs, rt)
+}
+
+/// `Rd32=dmpause`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+/// Requires: V68
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v68"))]
+#[cfg_attr(test, assert_instr(dmpause))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_dmpause() -> i32 {
+    hexagon_Y6_dmpause()
+}
+
+/// `Rd32=dmpoll`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+/// Requires: V68
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v68"))]
+#[cfg_attr(test, assert_instr(dmpoll))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_dmpoll() -> i32 {
+    hexagon_Y6_dmpoll()
+}
+
+/// `dmresume(Rs32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+/// Requires: V68
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v68"))]
+#[cfg_attr(test, assert_instr(dmresume))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dmresume_A(rs: i32) {
+    hexagon_Y6_dmresume(rs)
+}
+
+/// `dmstart(Rs32)`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+/// Requires: V68
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v68"))]
+#[cfg_attr(test, assert_instr(dmstart))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_dmstart_A(rs: i32) {
+    hexagon_Y6_dmstart(rs)
+}
+
+/// `Rd32=dmwait`
+///
+/// Instruction Type: ST
+/// Execution Slots: SLOT0
+/// Requires: V68
+#[inline(always)]
+#[cfg_attr(target_arch = "hexagon", target_feature(enable = "v68"))]
+#[cfg_attr(test, assert_instr(dmwait))]
+#[unstable(feature = "stdarch_hexagon", issue = "151523")]
+pub unsafe fn Q6_R_dmwait() -> i32 {
+    hexagon_Y6_dmwait()
+}

--- a/crates/stdarch-gen-hexagon-scalar/Cargo.toml
+++ b/crates/stdarch-gen-hexagon-scalar/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "stdarch-gen-hexagon-scalar"
+version = "0.1.0"
+authors = ["The Rust Project Developers"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]
+regex = "1.10"

--- a/crates/stdarch-gen-hexagon-scalar/hexagon_protos.h
+++ b/crates/stdarch-gen-hexagon-scalar/hexagon_protos.h
@@ -1,0 +1,8439 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Automatically generated file, do not edit!
+//===----------------------------------------------------------------------===//
+
+
+
+#ifndef __HEXAGON_PROTOS_H_
+#define __HEXAGON_PROTOS_H_ 1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=abs(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_abs_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_abs_R __builtin_HEXAGON_A2_abs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=abs(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_abs_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_abs_P __builtin_HEXAGON_A2_absp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=abs(Rs32):sat
+   C Intrinsic Prototype: Word32 Q6_R_abs_R_sat(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_abs_R_sat __builtin_HEXAGON_A2_abssat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_add_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_add_RR __builtin_HEXAGON_A2_add
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.h,Rs32.h):<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RhRh_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RhRh_s16 __builtin_HEXAGON_A2_addh_h16_hh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.h,Rs32.l):<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RhRl_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RhRl_s16 __builtin_HEXAGON_A2_addh_h16_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.h):<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRh_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRh_s16 __builtin_HEXAGON_A2_addh_h16_lh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.l):<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRl_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRl_s16 __builtin_HEXAGON_A2_addh_h16_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.h,Rs32.h):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RhRh_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RhRh_sat_s16 __builtin_HEXAGON_A2_addh_h16_sat_hh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.h,Rs32.l):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RhRl_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RhRl_sat_s16 __builtin_HEXAGON_A2_addh_h16_sat_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.h):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRh_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRh_sat_s16 __builtin_HEXAGON_A2_addh_h16_sat_lh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.l):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRl_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRl_sat_s16 __builtin_HEXAGON_A2_addh_h16_sat_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.h)
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRh(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRh __builtin_HEXAGON_A2_addh_l16_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.l)
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRl(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRl __builtin_HEXAGON_A2_addh_l16_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRh_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRh_sat __builtin_HEXAGON_A2_addh_l16_sat_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rt32.l,Rs32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_add_RlRl_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_RlRl_sat __builtin_HEXAGON_A2_addh_l16_sat_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rs32,#s16)
+   C Intrinsic Prototype: Word32 Q6_R_add_RI(Word32 Rs, Word32 Is16)
+   Instruction Type:      ALU32_ADDI
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_add_RI __builtin_HEXAGON_A2_addi
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=add(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_add_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_add_PP __builtin_HEXAGON_A2_addp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=add(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_add_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_add_PP_sat __builtin_HEXAGON_A2_addpsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_add_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_add_RR_sat __builtin_HEXAGON_A2_addsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=add(Rs32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_add_RP(Word32 Rs, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_add_RP __builtin_HEXAGON_A2_addsp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=and(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_and_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_and_RR __builtin_HEXAGON_A2_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=and(Rs32,#s10)
+   C Intrinsic Prototype: Word32 Q6_R_and_RI(Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_and_RI __builtin_HEXAGON_A2_andir
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=and(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_and_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_and_PP __builtin_HEXAGON_A2_andp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=aslh(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_aslh_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_aslh_R __builtin_HEXAGON_A2_aslh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asrh(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_asrh_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_asrh_R __builtin_HEXAGON_A2_asrh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=combine(Rt32.h,Rs32.h)
+   C Intrinsic Prototype: Word32 Q6_R_combine_RhRh(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_combine_RhRh __builtin_HEXAGON_A2_combine_hh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=combine(Rt32.h,Rs32.l)
+   C Intrinsic Prototype: Word32 Q6_R_combine_RhRl(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_combine_RhRl __builtin_HEXAGON_A2_combine_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=combine(Rt32.l,Rs32.h)
+   C Intrinsic Prototype: Word32 Q6_R_combine_RlRh(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_combine_RlRh __builtin_HEXAGON_A2_combine_lh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=combine(Rt32.l,Rs32.l)
+   C Intrinsic Prototype: Word32 Q6_R_combine_RlRl(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_combine_RlRl __builtin_HEXAGON_A2_combine_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=combine(#s8,#S8)
+   C Intrinsic Prototype: Word64 Q6_P_combine_II(Word32 Is8, Word32 IS8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_combine_II __builtin_HEXAGON_A2_combineii
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=combine(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_combine_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_combine_RR __builtin_HEXAGON_A2_combinew
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=max(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_max_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_max_RR __builtin_HEXAGON_A2_max
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=max(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_max_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_max_PP __builtin_HEXAGON_A2_maxp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=maxu(Rs32,Rt32)
+   C Intrinsic Prototype: UWord32 Q6_R_maxu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_maxu_RR __builtin_HEXAGON_A2_maxu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=maxu(Rss32,Rtt32)
+   C Intrinsic Prototype: UWord64 Q6_P_maxu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_maxu_PP __builtin_HEXAGON_A2_maxup
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=min(Rt32,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_min_RR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_min_RR __builtin_HEXAGON_A2_min
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=min(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_min_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_min_PP __builtin_HEXAGON_A2_minp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=minu(Rt32,Rs32)
+   C Intrinsic Prototype: UWord32 Q6_R_minu_RR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_minu_RR __builtin_HEXAGON_A2_minu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=minu(Rtt32,Rss32)
+   C Intrinsic Prototype: UWord64 Q6_P_minu_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_minu_PP __builtin_HEXAGON_A2_minup
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=neg(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_neg_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_neg_R __builtin_HEXAGON_A2_neg
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=neg(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_neg_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_neg_P __builtin_HEXAGON_A2_negp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=neg(Rs32):sat
+   C Intrinsic Prototype: Word32 Q6_R_neg_R_sat(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_neg_R_sat __builtin_HEXAGON_A2_negsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=not(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_not_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_not_R __builtin_HEXAGON_A2_not
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=not(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_not_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_not_P __builtin_HEXAGON_A2_notp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=or(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_or_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_or_RR __builtin_HEXAGON_A2_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=or(Rs32,#s10)
+   C Intrinsic Prototype: Word32 Q6_R_or_RI(Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_or_RI __builtin_HEXAGON_A2_orir
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=or(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_or_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_or_PP __builtin_HEXAGON_A2_orp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=round(Rss32):sat
+   C Intrinsic Prototype: Word32 Q6_R_round_P_sat(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_round_P_sat __builtin_HEXAGON_A2_roundsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sat(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_sat_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sat_P __builtin_HEXAGON_A2_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=satb(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_satb_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_satb_R __builtin_HEXAGON_A2_satb
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sath(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_sath_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sath_R __builtin_HEXAGON_A2_sath
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=satub(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_satub_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_satub_R __builtin_HEXAGON_A2_satub
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=satuh(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_satuh_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_satuh_R __builtin_HEXAGON_A2_satuh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_sub_RR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_sub_RR __builtin_HEXAGON_A2_sub
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.h,Rs32.h):<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RhRh_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RhRh_s16 __builtin_HEXAGON_A2_subh_h16_hh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.h,Rs32.l):<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RhRl_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RhRl_s16 __builtin_HEXAGON_A2_subh_h16_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.h):<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRh_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRh_s16 __builtin_HEXAGON_A2_subh_h16_lh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.l):<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRl_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRl_s16 __builtin_HEXAGON_A2_subh_h16_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.h,Rs32.h):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RhRh_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RhRh_sat_s16 __builtin_HEXAGON_A2_subh_h16_sat_hh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.h,Rs32.l):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RhRl_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RhRl_sat_s16 __builtin_HEXAGON_A2_subh_h16_sat_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.h):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRh_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRh_sat_s16 __builtin_HEXAGON_A2_subh_h16_sat_lh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.l):sat:<<16
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRl_sat_s16(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRl_sat_s16 __builtin_HEXAGON_A2_subh_h16_sat_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.h)
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRh(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRh __builtin_HEXAGON_A2_subh_l16_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.l)
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRl(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRl __builtin_HEXAGON_A2_subh_l16_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRh_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRh_sat __builtin_HEXAGON_A2_subh_l16_sat_hl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32.l,Rs32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_sub_RlRl_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_RlRl_sat __builtin_HEXAGON_A2_subh_l16_sat_ll
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=sub(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_sub_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_sub_PP __builtin_HEXAGON_A2_subp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(#s10,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_sub_IR(Word32 Is10, Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_sub_IR __builtin_HEXAGON_A2_subri
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sub(Rt32,Rs32):sat
+   C Intrinsic Prototype: Word32 Q6_R_sub_RR_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_sub_RR_sat __builtin_HEXAGON_A2_subsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vaddh(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_vaddh_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vaddh_RR __builtin_HEXAGON_A2_svaddh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vaddh(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_vaddh_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vaddh_RR_sat __builtin_HEXAGON_A2_svaddhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vadduh(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_vadduh_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vadduh_RR_sat __builtin_HEXAGON_A2_svadduhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vavgh(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_vavgh_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vavgh_RR __builtin_HEXAGON_A2_svavgh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vavgh(Rs32,Rt32):rnd
+   C Intrinsic Prototype: Word32 Q6_R_vavgh_RR_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vavgh_RR_rnd __builtin_HEXAGON_A2_svavghs
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vnavgh(Rt32,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_vnavgh_RR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vnavgh_RR __builtin_HEXAGON_A2_svnavgh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsubh(Rt32,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_vsubh_RR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vsubh_RR __builtin_HEXAGON_A2_svsubh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsubh(Rt32,Rs32):sat
+   C Intrinsic Prototype: Word32 Q6_R_vsubh_RR_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vsubh_RR_sat __builtin_HEXAGON_A2_svsubhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsubuh(Rt32,Rs32):sat
+   C Intrinsic Prototype: Word32 Q6_R_vsubuh_RR_sat(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vsubuh_RR_sat __builtin_HEXAGON_A2_svsubuhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=swiz(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_swiz_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_swiz_R __builtin_HEXAGON_A2_swiz
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sxtb(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_sxtb_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_sxtb_R __builtin_HEXAGON_A2_sxtb
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sxth(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_sxth_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_sxth_R __builtin_HEXAGON_A2_sxth
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=sxtw(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_sxtw_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_sxtw_R __builtin_HEXAGON_A2_sxtw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=Rs32
+   C Intrinsic Prototype: Word32 Q6_R_equals_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_equals_R __builtin_HEXAGON_A2_tfr
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32.h=#u16
+   C Intrinsic Prototype: Word32 Q6_Rh_equals_I(Word32 Rx, Word32 Iu16)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_Rh_equals_I __builtin_HEXAGON_A2_tfrih
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32.l=#u16
+   C Intrinsic Prototype: Word32 Q6_Rl_equals_I(Word32 Rx, Word32 Iu16)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_Rl_equals_I __builtin_HEXAGON_A2_tfril
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=Rss32
+   C Intrinsic Prototype: Word64 Q6_P_equals_P(Word64 Rss)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_equals_P __builtin_HEXAGON_A2_tfrp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=#s8
+   C Intrinsic Prototype: Word64 Q6_P_equals_I(Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_equals_I __builtin_HEXAGON_A2_tfrpi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=#s16
+   C Intrinsic Prototype: Word32 Q6_R_equals_I(Word32 Is16)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_equals_I __builtin_HEXAGON_A2_tfrsi
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsh(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vabsh_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsh_P __builtin_HEXAGON_A2_vabsh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsh(Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vabsh_P_sat(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsh_P_sat __builtin_HEXAGON_A2_vabshsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsw(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vabsw_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsw_P __builtin_HEXAGON_A2_vabsw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsw(Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vabsw_P_sat(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsw_P_sat __builtin_HEXAGON_A2_vabswsat
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddb(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vaddb_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      MAPPING
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_vaddb_PP __builtin_HEXAGON_A2_vaddb_map
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vaddh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaddh_PP __builtin_HEXAGON_A2_vaddh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vaddh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaddh_PP_sat __builtin_HEXAGON_A2_vaddhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddub(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vaddub_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaddub_PP __builtin_HEXAGON_A2_vaddub
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddub(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vaddub_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaddub_PP_sat __builtin_HEXAGON_A2_vaddubs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vadduh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vadduh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vadduh_PP_sat __builtin_HEXAGON_A2_vadduhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vaddw_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaddw_PP __builtin_HEXAGON_A2_vaddw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaddw(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vaddw_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaddw_PP_sat __builtin_HEXAGON_A2_vaddws
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vavgh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgh_PP __builtin_HEXAGON_A2_vavgh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgh(Rss32,Rtt32):crnd
+   C Intrinsic Prototype: Word64 Q6_P_vavgh_PP_crnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgh_PP_crnd __builtin_HEXAGON_A2_vavghcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgh(Rss32,Rtt32):rnd
+   C Intrinsic Prototype: Word64 Q6_P_vavgh_PP_rnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgh_PP_rnd __builtin_HEXAGON_A2_vavghr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgub(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vavgub_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgub_PP __builtin_HEXAGON_A2_vavgub
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgub(Rss32,Rtt32):rnd
+   C Intrinsic Prototype: Word64 Q6_P_vavgub_PP_rnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgub_PP_rnd __builtin_HEXAGON_A2_vavgubr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavguh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vavguh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavguh_PP __builtin_HEXAGON_A2_vavguh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavguh(Rss32,Rtt32):rnd
+   C Intrinsic Prototype: Word64 Q6_P_vavguh_PP_rnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavguh_PP_rnd __builtin_HEXAGON_A2_vavguhr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavguw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vavguw_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavguw_PP __builtin_HEXAGON_A2_vavguw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavguw(Rss32,Rtt32):rnd
+   C Intrinsic Prototype: Word64 Q6_P_vavguw_PP_rnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavguw_PP_rnd __builtin_HEXAGON_A2_vavguwr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vavgw_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgw_PP __builtin_HEXAGON_A2_vavgw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgw(Rss32,Rtt32):crnd
+   C Intrinsic Prototype: Word64 Q6_P_vavgw_PP_crnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgw_PP_crnd __builtin_HEXAGON_A2_vavgwcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vavgw(Rss32,Rtt32):rnd
+   C Intrinsic Prototype: Word64 Q6_P_vavgw_PP_rnd(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vavgw_PP_rnd __builtin_HEXAGON_A2_vavgwr
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpb.eq(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmpb_eq_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpb_eq_PP __builtin_HEXAGON_A2_vcmpbeq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpb.gtu(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmpb_gtu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpb_gtu_PP __builtin_HEXAGON_A2_vcmpbgtu
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmph.eq(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmph_eq_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmph_eq_PP __builtin_HEXAGON_A2_vcmpheq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmph.gt(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmph_gt_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmph_gt_PP __builtin_HEXAGON_A2_vcmphgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmph.gtu(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmph_gtu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmph_gtu_PP __builtin_HEXAGON_A2_vcmphgtu
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpw.eq(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmpw_eq_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpw_eq_PP __builtin_HEXAGON_A2_vcmpweq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpw.gt(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmpw_gt_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpw_gt_PP __builtin_HEXAGON_A2_vcmpwgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpw.gtu(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmpw_gtu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpw_gtu_PP __builtin_HEXAGON_A2_vcmpwgtu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vconj(Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vconj_P_sat(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vconj_P_sat __builtin_HEXAGON_A2_vconj
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmaxb(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vmaxb_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmaxb_PP __builtin_HEXAGON_A2_vmaxb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmaxh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vmaxh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmaxh_PP __builtin_HEXAGON_A2_vmaxh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmaxub(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vmaxub_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmaxub_PP __builtin_HEXAGON_A2_vmaxub
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmaxuh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vmaxuh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmaxuh_PP __builtin_HEXAGON_A2_vmaxuh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmaxuw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vmaxuw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmaxuw_PP __builtin_HEXAGON_A2_vmaxuw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmaxw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vmaxw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmaxw_PP __builtin_HEXAGON_A2_vmaxw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vminb(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vminb_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vminb_PP __builtin_HEXAGON_A2_vminb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vminh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vminh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vminh_PP __builtin_HEXAGON_A2_vminh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vminub(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vminub_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vminub_PP __builtin_HEXAGON_A2_vminub
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vminuh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vminuh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vminuh_PP __builtin_HEXAGON_A2_vminuh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vminuw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vminuw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vminuw_PP __builtin_HEXAGON_A2_vminuw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vminw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vminw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vminw_PP __builtin_HEXAGON_A2_vminw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vnavgh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vnavgh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vnavgh_PP __builtin_HEXAGON_A2_vnavgh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vnavgh(Rtt32,Rss32):crnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vnavgh_PP_crnd_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vnavgh_PP_crnd_sat __builtin_HEXAGON_A2_vnavghcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vnavgh(Rtt32,Rss32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vnavgh_PP_rnd_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vnavgh_PP_rnd_sat __builtin_HEXAGON_A2_vnavghr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vnavgw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vnavgw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vnavgw_PP __builtin_HEXAGON_A2_vnavgw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vnavgw(Rtt32,Rss32):crnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vnavgw_PP_crnd_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vnavgw_PP_crnd_sat __builtin_HEXAGON_A2_vnavgwcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vnavgw(Rtt32,Rss32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vnavgw_PP_rnd_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vnavgw_PP_rnd_sat __builtin_HEXAGON_A2_vnavgwr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vraddub(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vraddub_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vraddub_PP __builtin_HEXAGON_A2_vraddub
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vraddub(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vraddubacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vraddubacc_PP __builtin_HEXAGON_A2_vraddub_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrsadub(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrsadub_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrsadub_PP __builtin_HEXAGON_A2_vrsadub
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrsadub(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrsadubacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrsadubacc_PP __builtin_HEXAGON_A2_vrsadub_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubb(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vsubb_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      MAPPING
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_vsubb_PP __builtin_HEXAGON_A2_vsubb_map
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsubh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubh_PP __builtin_HEXAGON_A2_vsubh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubh(Rtt32,Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vsubh_PP_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubh_PP_sat __builtin_HEXAGON_A2_vsubhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubub(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsubub_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubub_PP __builtin_HEXAGON_A2_vsubub
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubub(Rtt32,Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vsubub_PP_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubub_PP_sat __builtin_HEXAGON_A2_vsububs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubuh(Rtt32,Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vsubuh_PP_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubuh_PP_sat __builtin_HEXAGON_A2_vsubuhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsubw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubw_PP __builtin_HEXAGON_A2_vsubw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsubw(Rtt32,Rss32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vsubw_PP_sat(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsubw_PP_sat __builtin_HEXAGON_A2_vsubws
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=xor(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_xor_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_xor_RR __builtin_HEXAGON_A2_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=xor(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_xor_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_xor_PP __builtin_HEXAGON_A2_xorp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=zxtb(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_zxtb_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_zxtb_R __builtin_HEXAGON_A2_zxtb
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=zxth(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_zxth_R(Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_zxth_R __builtin_HEXAGON_A2_zxth
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=and(Rt32,~Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_and_RnR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_and_RnR __builtin_HEXAGON_A4_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=and(Rtt32,~Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_and_PnP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_and_PnP __builtin_HEXAGON_A4_andnp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=bitsplit(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_bitsplit_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_bitsplit_RR __builtin_HEXAGON_A4_bitsplit
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=bitsplit(Rs32,#u5)
+   C Intrinsic Prototype: Word64 Q6_P_bitsplit_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_bitsplit_RI __builtin_HEXAGON_A4_bitspliti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=boundscheck(Rs32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_boundscheck_RP(Word32 Rs, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_boundscheck_RP __builtin_HEXAGON_A4_boundscheck
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmpb.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmpb_eq_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmpb_eq_RR __builtin_HEXAGON_A4_cmpbeq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmpb.eq(Rs32,#u8)
+   C Intrinsic Prototype: Byte Q6_p_cmpb_eq_RI(Word32 Rs, Word32 Iu8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmpb_eq_RI __builtin_HEXAGON_A4_cmpbeqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmpb.gt(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmpb_gt_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmpb_gt_RR __builtin_HEXAGON_A4_cmpbgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmpb.gt(Rs32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_cmpb_gt_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmpb_gt_RI __builtin_HEXAGON_A4_cmpbgti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmpb.gtu(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmpb_gtu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmpb_gtu_RR __builtin_HEXAGON_A4_cmpbgtu
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmpb.gtu(Rs32,#u7)
+   C Intrinsic Prototype: Byte Q6_p_cmpb_gtu_RI(Word32 Rs, Word32 Iu7)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmpb_gtu_RI __builtin_HEXAGON_A4_cmpbgtui
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmph.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmph_eq_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmph_eq_RR __builtin_HEXAGON_A4_cmpheq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmph.eq(Rs32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_cmph_eq_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmph_eq_RI __builtin_HEXAGON_A4_cmpheqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmph.gt(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmph_gt_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmph_gt_RR __builtin_HEXAGON_A4_cmphgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmph.gt(Rs32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_cmph_gt_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmph_gt_RI __builtin_HEXAGON_A4_cmphgti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmph.gtu(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmph_gtu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmph_gtu_RR __builtin_HEXAGON_A4_cmphgtu
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmph.gtu(Rs32,#u7)
+   C Intrinsic Prototype: Byte Q6_p_cmph_gtu_RI(Word32 Rs, Word32 Iu7)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmph_gtu_RI __builtin_HEXAGON_A4_cmphgtui
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=combine(#s8,Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_combine_IR(Word32 Is8, Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_combine_IR __builtin_HEXAGON_A4_combineir
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=combine(Rs32,#s8)
+   C Intrinsic Prototype: Word64 Q6_P_combine_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_combine_RI __builtin_HEXAGON_A4_combineri
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cround(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_cround_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cround_RI __builtin_HEXAGON_A4_cround_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cround(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_cround_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cround_RR __builtin_HEXAGON_A4_cround_rr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=modwrap(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_modwrap_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_modwrap_RR __builtin_HEXAGON_A4_modwrapu
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=or(Rt32,~Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_or_RnR(Word32 Rt, Word32 Rs)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_or_RnR __builtin_HEXAGON_A4_orn
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=or(Rtt32,~Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_or_PnP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_or_PnP __builtin_HEXAGON_A4_ornp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmp.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_cmp_eq_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_cmp_eq_RR __builtin_HEXAGON_A4_rcmpeq
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmp.eq(Rs32,#s8)
+   C Intrinsic Prototype: Word32 Q6_R_cmp_eq_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_cmp_eq_RI __builtin_HEXAGON_A4_rcmpeqi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=!cmp.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_not_cmp_eq_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_not_cmp_eq_RR __builtin_HEXAGON_A4_rcmpneq
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=!cmp.eq(Rs32,#s8)
+   C Intrinsic Prototype: Word32 Q6_R_not_cmp_eq_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_not_cmp_eq_RI __builtin_HEXAGON_A4_rcmpneqi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=round(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_round_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_round_RI __builtin_HEXAGON_A4_round_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=round(Rs32,#u5):sat
+   C Intrinsic Prototype: Word32 Q6_R_round_RI_sat(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_round_RI_sat __builtin_HEXAGON_A4_round_ri_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=round(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_round_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_round_RR __builtin_HEXAGON_A4_round_rr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=round(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_round_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_round_RR_sat __builtin_HEXAGON_A4_round_rr_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=tlbmatch(Rss32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_tlbmatch_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_tlbmatch_PR __builtin_HEXAGON_A4_tlbmatch
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=any8(vcmpb.eq(Rss32,Rtt32))
+   C Intrinsic Prototype: Byte Q6_p_any8_vcmpb_eq_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_any8_vcmpb_eq_PP __builtin_HEXAGON_A4_vcmpbeq_any
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpb.eq(Rss32,#u8)
+   C Intrinsic Prototype: Byte Q6_p_vcmpb_eq_PI(Word64 Rss, Word32 Iu8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpb_eq_PI __builtin_HEXAGON_A4_vcmpbeqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpb.gt(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_vcmpb_gt_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpb_gt_PP __builtin_HEXAGON_A4_vcmpbgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpb.gt(Rss32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_vcmpb_gt_PI(Word64 Rss, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpb_gt_PI __builtin_HEXAGON_A4_vcmpbgti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpb.gtu(Rss32,#u7)
+   C Intrinsic Prototype: Byte Q6_p_vcmpb_gtu_PI(Word64 Rss, Word32 Iu7)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpb_gtu_PI __builtin_HEXAGON_A4_vcmpbgtui
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmph.eq(Rss32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_vcmph_eq_PI(Word64 Rss, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmph_eq_PI __builtin_HEXAGON_A4_vcmpheqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmph.gt(Rss32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_vcmph_gt_PI(Word64 Rss, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmph_gt_PI __builtin_HEXAGON_A4_vcmphgti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmph.gtu(Rss32,#u7)
+   C Intrinsic Prototype: Byte Q6_p_vcmph_gtu_PI(Word64 Rss, Word32 Iu7)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmph_gtu_PI __builtin_HEXAGON_A4_vcmphgtui
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpw.eq(Rss32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_vcmpw_eq_PI(Word64 Rss, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpw_eq_PI __builtin_HEXAGON_A4_vcmpweqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpw.gt(Rss32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_vcmpw_gt_PI(Word64 Rss, Word32 Is8)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpw_gt_PI __builtin_HEXAGON_A4_vcmpwgti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=vcmpw.gtu(Rss32,#u7)
+   C Intrinsic Prototype: Byte Q6_p_vcmpw_gtu_PI(Word64 Rss, Word32 Iu7)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_vcmpw_gtu_PI __builtin_HEXAGON_A4_vcmpwgtui
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrmaxh(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmaxh_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmaxh_PR __builtin_HEXAGON_A4_vrmaxh
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrmaxuh(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmaxuh_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmaxuh_PR __builtin_HEXAGON_A4_vrmaxuh
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrmaxuw(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmaxuw_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmaxuw_PR __builtin_HEXAGON_A4_vrmaxuw
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrmaxw(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmaxw_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmaxw_PR __builtin_HEXAGON_A4_vrmaxw
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrminh(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrminh_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrminh_PR __builtin_HEXAGON_A4_vrminh
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrminuh(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrminuh_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrminuh_PR __builtin_HEXAGON_A4_vrminuh
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrminuw(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrminuw_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrminuw_PR __builtin_HEXAGON_A4_vrminuw
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=vrminw(Rss32,Ru32)
+   C Intrinsic Prototype: Word64 Q6_P_vrminw_PR(Word64 Rxx, Word64 Rss, Word32 Ru)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrminw_PR __builtin_HEXAGON_A4_vrminw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vaddhub(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_vaddhub_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vaddhub_PP_sat __builtin_HEXAGON_A5_vaddhubs
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=all8(Ps4)
+   C Intrinsic Prototype: Byte Q6_p_all8_p(Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_all8_p __builtin_HEXAGON_C2_all8
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=and(Pt4,Ps4)
+   C Intrinsic Prototype: Byte Q6_p_and_pp(Byte Pt, Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_and_pp __builtin_HEXAGON_C2_and
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=and(Pt4,!Ps4)
+   C Intrinsic Prototype: Byte Q6_p_and_pnp(Byte Pt, Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_and_pnp __builtin_HEXAGON_C2_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=any8(Ps4)
+   C Intrinsic Prototype: Byte Q6_p_any8_p(Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_any8_p __builtin_HEXAGON_C2_any8
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=bitsclr(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_bitsclr_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_bitsclr_RR __builtin_HEXAGON_C2_bitsclr
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=bitsclr(Rs32,#u6)
+   C Intrinsic Prototype: Byte Q6_p_bitsclr_RI(Word32 Rs, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_bitsclr_RI __builtin_HEXAGON_C2_bitsclri
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=bitsset(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_bitsset_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_bitsset_RR __builtin_HEXAGON_C2_bitsset
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_eq_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_eq_RR __builtin_HEXAGON_C2_cmpeq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.eq(Rs32,#s10)
+   C Intrinsic Prototype: Byte Q6_p_cmp_eq_RI(Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_eq_RI __builtin_HEXAGON_C2_cmpeqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.eq(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_eq_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmp_eq_PP __builtin_HEXAGON_C2_cmpeqp
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.ge(Rs32,#s8)
+   C Intrinsic Prototype: Byte Q6_p_cmp_ge_RI(Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_ge_RI __builtin_HEXAGON_C2_cmpgei
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.geu(Rs32,#u8)
+   C Intrinsic Prototype: Byte Q6_p_cmp_geu_RI(Word32 Rs, Word32 Iu8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_geu_RI __builtin_HEXAGON_C2_cmpgeui
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.gt(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_gt_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_gt_RR __builtin_HEXAGON_C2_cmpgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.gt(Rs32,#s10)
+   C Intrinsic Prototype: Byte Q6_p_cmp_gt_RI(Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_gt_RI __builtin_HEXAGON_C2_cmpgti
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.gt(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_gt_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmp_gt_PP __builtin_HEXAGON_C2_cmpgtp
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.gtu(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_gtu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_gtu_RR __builtin_HEXAGON_C2_cmpgtu
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.gtu(Rs32,#u9)
+   C Intrinsic Prototype: Byte Q6_p_cmp_gtu_RI(Word32 Rs, Word32 Iu9)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_gtu_RI __builtin_HEXAGON_C2_cmpgtui
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.gtu(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_gtu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_cmp_gtu_PP __builtin_HEXAGON_C2_cmpgtup
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.lt(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_lt_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_lt_RR __builtin_HEXAGON_C2_cmplt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=cmp.ltu(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_cmp_ltu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_cmp_ltu_RR __builtin_HEXAGON_C2_cmpltu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mask(Pt4)
+   C Intrinsic Prototype: Word64 Q6_P_mask_p(Byte Pt)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mask_p __builtin_HEXAGON_C2_mask
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mux(Pu4,Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mux_pRR(Byte Pu, Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_mux_pRR __builtin_HEXAGON_C2_mux
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mux(Pu4,#s8,#S8)
+   C Intrinsic Prototype: Word32 Q6_R_mux_pII(Byte Pu, Word32 Is8, Word32 IS8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_mux_pII __builtin_HEXAGON_C2_muxii
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mux(Pu4,Rs32,#s8)
+   C Intrinsic Prototype: Word32 Q6_R_mux_pRI(Byte Pu, Word32 Rs, Word32 Is8)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_mux_pRI __builtin_HEXAGON_C2_muxir
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mux(Pu4,#s8,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_mux_pIR(Byte Pu, Word32 Is8, Word32 Rs)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_mux_pIR __builtin_HEXAGON_C2_muxri
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=not(Ps4)
+   C Intrinsic Prototype: Byte Q6_p_not_p(Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_p __builtin_HEXAGON_C2_not
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=or(Pt4,Ps4)
+   C Intrinsic Prototype: Byte Q6_p_or_pp(Byte Pt, Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_or_pp __builtin_HEXAGON_C2_or
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=or(Pt4,!Ps4)
+   C Intrinsic Prototype: Byte Q6_p_or_pnp(Byte Pt, Byte Ps)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_or_pnp __builtin_HEXAGON_C2_orn
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=Ps4
+   C Intrinsic Prototype: Byte Q6_p_equals_p(Byte Ps)
+   Instruction Type:      MAPPING
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_equals_p __builtin_HEXAGON_C2_pxfer_map
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=Ps4
+   C Intrinsic Prototype: Word32 Q6_R_equals_p(Byte Ps)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_equals_p __builtin_HEXAGON_C2_tfrpr
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=Rs32
+   C Intrinsic Prototype: Byte Q6_p_equals_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_equals_R __builtin_HEXAGON_C2_tfrrp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vitpack(Ps4,Pt4)
+   C Intrinsic Prototype: Word32 Q6_R_vitpack_pp(Byte Ps, Byte Pt)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vitpack_pp __builtin_HEXAGON_C2_vitpack
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmux(Pu4,Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmux_pPP(Byte Pu, Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmux_pPP __builtin_HEXAGON_C2_vmux
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=xor(Ps4,Pt4)
+   C Intrinsic Prototype: Byte Q6_p_xor_pp(Byte Ps, Byte Pt)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_xor_pp __builtin_HEXAGON_C2_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=and(Ps4,and(Pt4,Pu4))
+   C Intrinsic Prototype: Byte Q6_p_and_and_ppp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_and_and_ppp __builtin_HEXAGON_C4_and_and
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=and(Ps4,and(Pt4,!Pu4))
+   C Intrinsic Prototype: Byte Q6_p_and_and_ppnp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_and_and_ppnp __builtin_HEXAGON_C4_and_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=and(Ps4,or(Pt4,Pu4))
+   C Intrinsic Prototype: Byte Q6_p_and_or_ppp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_and_or_ppp __builtin_HEXAGON_C4_and_or
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=and(Ps4,or(Pt4,!Pu4))
+   C Intrinsic Prototype: Byte Q6_p_and_or_ppnp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_and_or_ppnp __builtin_HEXAGON_C4_and_orn
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!cmp.gt(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_not_cmp_gt_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_not_cmp_gt_RR __builtin_HEXAGON_C4_cmplte
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!cmp.gt(Rs32,#s10)
+   C Intrinsic Prototype: Byte Q6_p_not_cmp_gt_RI(Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_not_cmp_gt_RI __builtin_HEXAGON_C4_cmpltei
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!cmp.gtu(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_not_cmp_gtu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_not_cmp_gtu_RR __builtin_HEXAGON_C4_cmplteu
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!cmp.gtu(Rs32,#u9)
+   C Intrinsic Prototype: Byte Q6_p_not_cmp_gtu_RI(Word32 Rs, Word32 Iu9)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_not_cmp_gtu_RI __builtin_HEXAGON_C4_cmplteui
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!cmp.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_not_cmp_eq_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_not_cmp_eq_RR __builtin_HEXAGON_C4_cmpneq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!cmp.eq(Rs32,#s10)
+   C Intrinsic Prototype: Byte Q6_p_not_cmp_eq_RI(Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU32_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_p_not_cmp_eq_RI __builtin_HEXAGON_C4_cmpneqi
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=fastcorner9(Ps4,Pt4)
+   C Intrinsic Prototype: Byte Q6_p_fastcorner9_pp(Byte Ps, Byte Pt)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_fastcorner9_pp __builtin_HEXAGON_C4_fastcorner9
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!fastcorner9(Ps4,Pt4)
+   C Intrinsic Prototype: Byte Q6_p_not_fastcorner9_pp(Byte Ps, Byte Pt)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_fastcorner9_pp __builtin_HEXAGON_C4_fastcorner9_not
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!bitsclr(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_not_bitsclr_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_bitsclr_RR __builtin_HEXAGON_C4_nbitsclr
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!bitsclr(Rs32,#u6)
+   C Intrinsic Prototype: Byte Q6_p_not_bitsclr_RI(Word32 Rs, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_bitsclr_RI __builtin_HEXAGON_C4_nbitsclri
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!bitsset(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_not_bitsset_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_bitsset_RR __builtin_HEXAGON_C4_nbitsset
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=or(Ps4,and(Pt4,Pu4))
+   C Intrinsic Prototype: Byte Q6_p_or_and_ppp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_or_and_ppp __builtin_HEXAGON_C4_or_and
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=or(Ps4,and(Pt4,!Pu4))
+   C Intrinsic Prototype: Byte Q6_p_or_and_ppnp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_or_and_ppnp __builtin_HEXAGON_C4_or_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=or(Ps4,or(Pt4,Pu4))
+   C Intrinsic Prototype: Byte Q6_p_or_or_ppp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_or_or_ppp __builtin_HEXAGON_C4_or_or
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=or(Ps4,or(Pt4,!Pu4))
+   C Intrinsic Prototype: Byte Q6_p_or_or_ppnp(Byte Ps, Byte Pt, Byte Pu)
+   Instruction Type:      CR
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_or_or_ppnp __builtin_HEXAGON_C4_or_orn
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_d2df(Rss32)
+   C Intrinsic Prototype: Float64 Q6_P_convert_d2df_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_d2df_P __builtin_HEXAGON_F2_conv_d2df
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_d2sf(Rss32)
+   C Intrinsic Prototype: Float32 Q6_R_convert_d2sf_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_d2sf_P __builtin_HEXAGON_F2_conv_d2sf
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_df2d(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_convert_df2d_P(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_df2d_P __builtin_HEXAGON_F2_conv_df2d
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_df2d(Rss32):chop
+   C Intrinsic Prototype: Word64 Q6_P_convert_df2d_P_chop(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_df2d_P_chop __builtin_HEXAGON_F2_conv_df2d_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_df2sf(Rss32)
+   C Intrinsic Prototype: Float32 Q6_R_convert_df2sf_P(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_df2sf_P __builtin_HEXAGON_F2_conv_df2sf
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_df2ud(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_convert_df2ud_P(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_df2ud_P __builtin_HEXAGON_F2_conv_df2ud
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_df2ud(Rss32):chop
+   C Intrinsic Prototype: Word64 Q6_P_convert_df2ud_P_chop(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_df2ud_P_chop __builtin_HEXAGON_F2_conv_df2ud_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_df2uw(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_convert_df2uw_P(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_df2uw_P __builtin_HEXAGON_F2_conv_df2uw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_df2uw(Rss32):chop
+   C Intrinsic Prototype: Word32 Q6_R_convert_df2uw_P_chop(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_df2uw_P_chop __builtin_HEXAGON_F2_conv_df2uw_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_df2w(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_convert_df2w_P(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_df2w_P __builtin_HEXAGON_F2_conv_df2w
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_df2w(Rss32):chop
+   C Intrinsic Prototype: Word32 Q6_R_convert_df2w_P_chop(Float64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_df2w_P_chop __builtin_HEXAGON_F2_conv_df2w_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_sf2d(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_convert_sf2d_R(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_sf2d_R __builtin_HEXAGON_F2_conv_sf2d
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_sf2d(Rs32):chop
+   C Intrinsic Prototype: Word64 Q6_P_convert_sf2d_R_chop(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_sf2d_R_chop __builtin_HEXAGON_F2_conv_sf2d_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_sf2df(Rs32)
+   C Intrinsic Prototype: Float64 Q6_P_convert_sf2df_R(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_sf2df_R __builtin_HEXAGON_F2_conv_sf2df
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_sf2ud(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_convert_sf2ud_R(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_sf2ud_R __builtin_HEXAGON_F2_conv_sf2ud
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_sf2ud(Rs32):chop
+   C Intrinsic Prototype: Word64 Q6_P_convert_sf2ud_R_chop(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_sf2ud_R_chop __builtin_HEXAGON_F2_conv_sf2ud_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_sf2uw(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_convert_sf2uw_R(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_sf2uw_R __builtin_HEXAGON_F2_conv_sf2uw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_sf2uw(Rs32):chop
+   C Intrinsic Prototype: Word32 Q6_R_convert_sf2uw_R_chop(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_sf2uw_R_chop __builtin_HEXAGON_F2_conv_sf2uw_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_sf2w(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_convert_sf2w_R(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_sf2w_R __builtin_HEXAGON_F2_conv_sf2w
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_sf2w(Rs32):chop
+   C Intrinsic Prototype: Word32 Q6_R_convert_sf2w_R_chop(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_sf2w_R_chop __builtin_HEXAGON_F2_conv_sf2w_chop
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_ud2df(Rss32)
+   C Intrinsic Prototype: Float64 Q6_P_convert_ud2df_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_ud2df_P __builtin_HEXAGON_F2_conv_ud2df
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_ud2sf(Rss32)
+   C Intrinsic Prototype: Float32 Q6_R_convert_ud2sf_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_ud2sf_P __builtin_HEXAGON_F2_conv_ud2sf
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_uw2df(Rs32)
+   C Intrinsic Prototype: Float64 Q6_P_convert_uw2df_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_uw2df_R __builtin_HEXAGON_F2_conv_uw2df
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_uw2sf(Rs32)
+   C Intrinsic Prototype: Float32 Q6_R_convert_uw2sf_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_uw2sf_R __builtin_HEXAGON_F2_conv_uw2sf
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=convert_w2df(Rs32)
+   C Intrinsic Prototype: Float64 Q6_P_convert_w2df_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_convert_w2df_R __builtin_HEXAGON_F2_conv_w2df
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=convert_w2sf(Rs32)
+   C Intrinsic Prototype: Float32 Q6_R_convert_w2sf_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_convert_w2sf_R __builtin_HEXAGON_F2_conv_w2sf
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=dfclass(Rss32,#u5)
+   C Intrinsic Prototype: Byte Q6_p_dfclass_PI(Float64 Rss, Word32 Iu5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_dfclass_PI __builtin_HEXAGON_F2_dfclass
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=dfcmp.eq(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_dfcmp_eq_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_dfcmp_eq_PP __builtin_HEXAGON_F2_dfcmpeq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=dfcmp.ge(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_dfcmp_ge_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_dfcmp_ge_PP __builtin_HEXAGON_F2_dfcmpge
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=dfcmp.gt(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_dfcmp_gt_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_dfcmp_gt_PP __builtin_HEXAGON_F2_dfcmpgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=dfcmp.uo(Rss32,Rtt32)
+   C Intrinsic Prototype: Byte Q6_p_dfcmp_uo_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_dfcmp_uo_PP __builtin_HEXAGON_F2_dfcmpuo
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfmake(#u10):neg
+   C Intrinsic Prototype: Float64 Q6_P_dfmake_I_neg(Word32 Iu10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmake_I_neg __builtin_HEXAGON_F2_dfimm_n
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfmake(#u10):pos
+   C Intrinsic Prototype: Float64 Q6_P_dfmake_I_pos(Word32 Iu10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmake_I_pos __builtin_HEXAGON_F2_dfimm_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfadd(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfadd_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfadd_RR __builtin_HEXAGON_F2_sfadd
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=sfclass(Rs32,#u5)
+   C Intrinsic Prototype: Byte Q6_p_sfclass_RI(Float32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_sfclass_RI __builtin_HEXAGON_F2_sfclass
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=sfcmp.eq(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_sfcmp_eq_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_sfcmp_eq_RR __builtin_HEXAGON_F2_sfcmpeq
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=sfcmp.ge(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_sfcmp_ge_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_sfcmp_ge_RR __builtin_HEXAGON_F2_sfcmpge
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=sfcmp.gt(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_sfcmp_gt_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_sfcmp_gt_RR __builtin_HEXAGON_F2_sfcmpgt
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=sfcmp.uo(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_sfcmp_uo_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_sfcmp_uo_RR __builtin_HEXAGON_F2_sfcmpuo
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sffixupd(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sffixupd_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sffixupd_RR __builtin_HEXAGON_F2_sffixupd
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sffixupn(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sffixupn_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sffixupn_RR __builtin_HEXAGON_F2_sffixupn
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sffixupr(Rs32)
+   C Intrinsic Prototype: Float32 Q6_R_sffixupr_R(Float32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sffixupr_R __builtin_HEXAGON_F2_sffixupr
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=sfmpy(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfmpyacc_RR(Float32 Rx, Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmpyacc_RR __builtin_HEXAGON_F2_sffma
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=sfmpy(Rs32,Rt32):lib
+   C Intrinsic Prototype: Float32 Q6_R_sfmpyacc_RR_lib(Float32 Rx, Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmpyacc_RR_lib __builtin_HEXAGON_F2_sffma_lib
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=sfmpy(Rs32,Rt32,Pu4):scale
+   C Intrinsic Prototype: Float32 Q6_R_sfmpyacc_RRp_scale(Float32 Rx, Float32 Rs, Float32 Rt, Byte Pu)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmpyacc_RRp_scale __builtin_HEXAGON_F2_sffma_sc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=sfmpy(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfmpynac_RR(Float32 Rx, Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmpynac_RR __builtin_HEXAGON_F2_sffms
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=sfmpy(Rs32,Rt32):lib
+   C Intrinsic Prototype: Float32 Q6_R_sfmpynac_RR_lib(Float32 Rx, Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmpynac_RR_lib __builtin_HEXAGON_F2_sffms_lib
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfmake(#u10):neg
+   C Intrinsic Prototype: Float32 Q6_R_sfmake_I_neg(Word32 Iu10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmake_I_neg __builtin_HEXAGON_F2_sfimm_n
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfmake(#u10):pos
+   C Intrinsic Prototype: Float32 Q6_R_sfmake_I_pos(Word32 Iu10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmake_I_pos __builtin_HEXAGON_F2_sfimm_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfmax(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfmax_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmax_RR __builtin_HEXAGON_F2_sfmax
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfmin(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfmin_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmin_RR __builtin_HEXAGON_F2_sfmin
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfmpy(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfmpy_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfmpy_RR __builtin_HEXAGON_F2_sfmpy
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=sfsub(Rs32,Rt32)
+   C Intrinsic Prototype: Float32 Q6_R_sfsub_RR(Float32 Rs, Float32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sfsub_RR __builtin_HEXAGON_F2_sfsub
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memb(Rx32++#s4:0:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memb_IM_circ(void** Rx, Word32 Is4_0, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memb_IM_circ __builtin_HEXAGON_L2_loadrb_pci
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memb(Rx32++I:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memb_M_circ(void** Rx, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memb_M_circ __builtin_HEXAGON_L2_loadrb_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=memd(Rx32++#s4:3:circ(Mu2))
+   C Intrinsic Prototype: Word64 Q6_P_memd_IM_circ(void** Rx, Word32 Is4_3, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_P_memd_IM_circ __builtin_HEXAGON_L2_loadrd_pci
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=memd(Rx32++I:circ(Mu2))
+   C Intrinsic Prototype: Word64 Q6_P_memd_M_circ(void** Rx, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_P_memd_M_circ __builtin_HEXAGON_L2_loadrd_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memh(Rx32++#s4:1:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memh_IM_circ(void** Rx, Word32 Is4_1, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memh_IM_circ __builtin_HEXAGON_L2_loadrh_pci
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memh(Rx32++I:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memh_M_circ(void** Rx, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memh_M_circ __builtin_HEXAGON_L2_loadrh_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memw(Rx32++#s4:2:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memw_IM_circ(void** Rx, Word32 Is4_2, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memw_IM_circ __builtin_HEXAGON_L2_loadri_pci
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memw(Rx32++I:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memw_M_circ(void** Rx, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memw_M_circ __builtin_HEXAGON_L2_loadri_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memub(Rx32++#s4:0:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memub_IM_circ(void** Rx, Word32 Is4_0, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memub_IM_circ __builtin_HEXAGON_L2_loadrub_pci
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memub(Rx32++I:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memub_M_circ(void** Rx, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memub_M_circ __builtin_HEXAGON_L2_loadrub_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memuh(Rx32++#s4:1:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memuh_IM_circ(void** Rx, Word32 Is4_1, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memuh_IM_circ __builtin_HEXAGON_L2_loadruh_pci
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=memuh(Rx32++I:circ(Mu2))
+   C Intrinsic Prototype: Word32 Q6_R_memuh_M_circ(void** Rx, Word32 Mu, void* BaseAddress)
+   Instruction Type:      LD
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_R_memuh_M_circ __builtin_HEXAGON_L2_loadruh_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=add(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_addacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_addacc_RR __builtin_HEXAGON_M2_acci
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=add(Rs32,#s8)
+   C Intrinsic Prototype: Word32 Q6_R_addacc_RI(Word32 Rx, Word32 Rs, Word32 Is8)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_addacc_RI __builtin_HEXAGON_M2_accii
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpyi(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyiacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyiacc_RR __builtin_HEXAGON_M2_cmaci_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpyr(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyracc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyracc_RR __builtin_HEXAGON_M2_cmacr_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpy(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpyacc_RR_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyacc_RR_sat __builtin_HEXAGON_M2_cmacs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpy(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpyacc_RR_s1_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyacc_RR_s1_sat __builtin_HEXAGON_M2_cmacs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpy(Rs32,Rt32*):sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpyacc_RR_conj_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyacc_RR_conj_sat __builtin_HEXAGON_M2_cmacsc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpy(Rs32,Rt32*):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpyacc_RR_conj_s1_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyacc_RR_conj_s1_sat __builtin_HEXAGON_M2_cmacsc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpyi(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyi_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyi_RR __builtin_HEXAGON_M2_cmpyi_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpyr(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyr_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpyr_RR __builtin_HEXAGON_M2_cmpyr_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpy(Rs32,Rt32):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpy_RR_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpy_RR_rnd_sat __builtin_HEXAGON_M2_cmpyrs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpy(Rs32,Rt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpy_RR_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpy_RR_s1_rnd_sat __builtin_HEXAGON_M2_cmpyrs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpy(Rs32,Rt32*):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpy_RR_conj_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpy_RR_conj_rnd_sat __builtin_HEXAGON_M2_cmpyrsc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpy(Rs32,Rt32*):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpy_RR_conj_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpy_RR_conj_s1_rnd_sat __builtin_HEXAGON_M2_cmpyrsc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpy(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpy_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpy_RR_sat __builtin_HEXAGON_M2_cmpys_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpy(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpy_RR_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpy_RR_s1_sat __builtin_HEXAGON_M2_cmpys_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpy(Rs32,Rt32*):sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpy_RR_conj_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpy_RR_conj_sat __builtin_HEXAGON_M2_cmpysc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpy(Rs32,Rt32*):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpy_RR_conj_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpy_RR_conj_s1_sat __builtin_HEXAGON_M2_cmpysc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=cmpy(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpynac_RR_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpynac_RR_sat __builtin_HEXAGON_M2_cnacs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=cmpy(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpynac_RR_s1_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpynac_RR_s1_sat __builtin_HEXAGON_M2_cnacs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=cmpy(Rs32,Rt32*):sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpynac_RR_conj_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpynac_RR_conj_sat __builtin_HEXAGON_M2_cnacsc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=cmpy(Rs32,Rt32*):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_cmpynac_RR_conj_s1_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cmpynac_RR_conj_s1_sat __builtin_HEXAGON_M2_cnacsc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RR __builtin_HEXAGON_M2_dpmpyss_acc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RR __builtin_HEXAGON_M2_dpmpyss_nac_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32):rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RR_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RR_rnd __builtin_HEXAGON_M2_dpmpyss_rnd_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RR __builtin_HEXAGON_M2_dpmpyss_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RR __builtin_HEXAGON_M2_dpmpyuu_acc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RR __builtin_HEXAGON_M2_dpmpyuu_nac_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32,Rt32)
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RR __builtin_HEXAGON_M2_dpmpyuu_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32.h):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RRh_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RRh_s1_rnd_sat __builtin_HEXAGON_M2_hmmpyh_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RRh_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RRh_s1_sat __builtin_HEXAGON_M2_hmmpyh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32.l):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RRl_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RRl_s1_rnd_sat __builtin_HEXAGON_M2_hmmpyl_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RRl_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RRl_s1_sat __builtin_HEXAGON_M2_hmmpyl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyi(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mpyiacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyiacc_RR __builtin_HEXAGON_M2_maci
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyi(Rs32,#u8)
+   C Intrinsic Prototype: Word32 Q6_R_mpyinac_RI(Word32 Rx, Word32 Rs, Word32 Iu8)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyinac_RI __builtin_HEXAGON_M2_macsin
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyi(Rs32,#u8)
+   C Intrinsic Prototype: Word32 Q6_R_mpyiacc_RI(Word32 Rx, Word32 Rs, Word32 Iu8)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyiacc_RI __builtin_HEXAGON_M2_macsip
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywoh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywohacc_PP_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywohacc_PP_rnd_sat __builtin_HEXAGON_M2_mmachs_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywoh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywohacc_PP_s1_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywohacc_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmachs_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywoh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywohacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywohacc_PP_sat __builtin_HEXAGON_M2_mmachs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywoh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywohacc_PP_s1_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywohacc_PP_s1_sat __builtin_HEXAGON_M2_mmachs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywehacc_PP_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywehacc_PP_rnd_sat __builtin_HEXAGON_M2_mmacls_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywehacc_PP_s1_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywehacc_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmacls_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywehacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywehacc_PP_sat __builtin_HEXAGON_M2_mmacls_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywehacc_PP_s1_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywehacc_PP_s1_sat __builtin_HEXAGON_M2_mmacls_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywouh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouhacc_PP_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouhacc_PP_rnd_sat __builtin_HEXAGON_M2_mmacuhs_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywouh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouhacc_PP_s1_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouhacc_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmacuhs_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywouh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouhacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouhacc_PP_sat __builtin_HEXAGON_M2_mmacuhs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpywouh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouhacc_PP_s1_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouhacc_PP_s1_sat __builtin_HEXAGON_M2_mmacuhs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweuh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuhacc_PP_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuhacc_PP_rnd_sat __builtin_HEXAGON_M2_mmaculs_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweuh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuhacc_PP_s1_rnd_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuhacc_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmaculs_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweuh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuhacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuhacc_PP_sat __builtin_HEXAGON_M2_mmaculs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyweuh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuhacc_PP_s1_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuhacc_PP_s1_sat __builtin_HEXAGON_M2_mmaculs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywoh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywoh_PP_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywoh_PP_rnd_sat __builtin_HEXAGON_M2_mmpyh_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywoh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywoh_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywoh_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmpyh_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywoh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywoh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywoh_PP_sat __builtin_HEXAGON_M2_mmpyh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywoh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywoh_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywoh_PP_s1_sat __builtin_HEXAGON_M2_mmpyh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweh_PP_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweh_PP_rnd_sat __builtin_HEXAGON_M2_mmpyl_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweh_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweh_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmpyl_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweh_PP_sat __builtin_HEXAGON_M2_mmpyl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweh_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweh_PP_s1_sat __builtin_HEXAGON_M2_mmpyl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywouh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouh_PP_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouh_PP_rnd_sat __builtin_HEXAGON_M2_mmpyuh_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywouh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouh_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouh_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmpyuh_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywouh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouh_PP_sat __builtin_HEXAGON_M2_mmpyuh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpywouh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpywouh_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpywouh_PP_s1_sat __builtin_HEXAGON_M2_mmpyuh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweuh(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuh_PP_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuh_PP_rnd_sat __builtin_HEXAGON_M2_mmpyul_rs0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweuh(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuh_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuh_PP_s1_rnd_sat __builtin_HEXAGON_M2_mmpyul_rs1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweuh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuh_PP_sat __builtin_HEXAGON_M2_mmpyul_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyweuh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyweuh_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyweuh_PP_s1_sat __builtin_HEXAGON_M2_mmpyul_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRh __builtin_HEXAGON_M2_mpy_acc_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRh_s1 __builtin_HEXAGON_M2_mpy_acc_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRl __builtin_HEXAGON_M2_mpy_acc_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRl_s1 __builtin_HEXAGON_M2_mpy_acc_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRh __builtin_HEXAGON_M2_mpy_acc_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRh_s1 __builtin_HEXAGON_M2_mpy_acc_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRl __builtin_HEXAGON_M2_mpy_acc_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRl_s1 __builtin_HEXAGON_M2_mpy_acc_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRh_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRh_sat __builtin_HEXAGON_M2_mpy_acc_sat_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRh_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRh_s1_sat __builtin_HEXAGON_M2_mpy_acc_sat_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRl_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRl_sat __builtin_HEXAGON_M2_mpy_acc_sat_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.h,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RhRl_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RhRl_s1_sat __builtin_HEXAGON_M2_mpy_acc_sat_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRh_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRh_sat __builtin_HEXAGON_M2_mpy_acc_sat_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRh_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRh_s1_sat __builtin_HEXAGON_M2_mpy_acc_sat_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRl_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRl_sat __builtin_HEXAGON_M2_mpy_acc_sat_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32.l,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RlRl_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RlRl_s1_sat __builtin_HEXAGON_M2_mpy_acc_sat_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh __builtin_HEXAGON_M2_mpy_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_s1 __builtin_HEXAGON_M2_mpy_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl __builtin_HEXAGON_M2_mpy_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_s1 __builtin_HEXAGON_M2_mpy_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh __builtin_HEXAGON_M2_mpy_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_s1 __builtin_HEXAGON_M2_mpy_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl __builtin_HEXAGON_M2_mpy_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_s1 __builtin_HEXAGON_M2_mpy_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRh __builtin_HEXAGON_M2_mpy_nac_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRh_s1 __builtin_HEXAGON_M2_mpy_nac_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRl __builtin_HEXAGON_M2_mpy_nac_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRl_s1 __builtin_HEXAGON_M2_mpy_nac_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRh __builtin_HEXAGON_M2_mpy_nac_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRh_s1 __builtin_HEXAGON_M2_mpy_nac_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRl __builtin_HEXAGON_M2_mpy_nac_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRl_s1 __builtin_HEXAGON_M2_mpy_nac_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRh_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRh_sat __builtin_HEXAGON_M2_mpy_nac_sat_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRh_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRh_s1_sat __builtin_HEXAGON_M2_mpy_nac_sat_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRl_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRl_sat __builtin_HEXAGON_M2_mpy_nac_sat_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.h,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RhRl_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RhRl_s1_sat __builtin_HEXAGON_M2_mpy_nac_sat_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRh_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRh_sat __builtin_HEXAGON_M2_mpy_nac_sat_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRh_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRh_s1_sat __builtin_HEXAGON_M2_mpy_nac_sat_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRl_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRl_sat __builtin_HEXAGON_M2_mpy_nac_sat_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32.l,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RlRl_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RlRl_s1_sat __builtin_HEXAGON_M2_mpy_nac_sat_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_rnd __builtin_HEXAGON_M2_mpy_rnd_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):<<1:rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_s1_rnd __builtin_HEXAGON_M2_mpy_rnd_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_rnd __builtin_HEXAGON_M2_mpy_rnd_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):<<1:rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_s1_rnd __builtin_HEXAGON_M2_mpy_rnd_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_rnd __builtin_HEXAGON_M2_mpy_rnd_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):<<1:rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_s1_rnd __builtin_HEXAGON_M2_mpy_rnd_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_rnd __builtin_HEXAGON_M2_mpy_rnd_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):<<1:rnd
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_s1_rnd __builtin_HEXAGON_M2_mpy_rnd_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_sat __builtin_HEXAGON_M2_mpy_sat_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_s1_sat __builtin_HEXAGON_M2_mpy_sat_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_sat __builtin_HEXAGON_M2_mpy_sat_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_s1_sat __builtin_HEXAGON_M2_mpy_sat_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_sat __builtin_HEXAGON_M2_mpy_sat_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_s1_sat __builtin_HEXAGON_M2_mpy_sat_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_sat __builtin_HEXAGON_M2_mpy_sat_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_s1_sat __builtin_HEXAGON_M2_mpy_sat_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.h):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRh_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRh_s1_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.h,Rt32.l):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RhRl_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RhRl_s1_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.h):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRh_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRh_s1_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32.l,Rt32.l):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RlRl_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RlRl_s1_rnd_sat __builtin_HEXAGON_M2_mpy_sat_rnd_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RR __builtin_HEXAGON_M2_mpy_up
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RR_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RR_s1 __builtin_HEXAGON_M2_mpy_up_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpy(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpy_RR_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpy_RR_s1_sat __builtin_HEXAGON_M2_mpy_up_s1_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RhRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RhRh __builtin_HEXAGON_M2_mpyd_acc_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RhRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RhRh_s1 __builtin_HEXAGON_M2_mpyd_acc_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RhRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RhRl __builtin_HEXAGON_M2_mpyd_acc_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RhRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RhRl_s1 __builtin_HEXAGON_M2_mpyd_acc_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RlRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RlRh __builtin_HEXAGON_M2_mpyd_acc_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RlRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RlRh_s1 __builtin_HEXAGON_M2_mpyd_acc_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RlRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RlRl __builtin_HEXAGON_M2_mpyd_acc_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpy(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyacc_RlRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyacc_RlRl_s1 __builtin_HEXAGON_M2_mpyd_acc_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRh __builtin_HEXAGON_M2_mpyd_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRh_s1 __builtin_HEXAGON_M2_mpyd_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRl __builtin_HEXAGON_M2_mpyd_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRl_s1 __builtin_HEXAGON_M2_mpyd_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRh __builtin_HEXAGON_M2_mpyd_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRh_s1 __builtin_HEXAGON_M2_mpyd_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRl __builtin_HEXAGON_M2_mpyd_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRl_s1 __builtin_HEXAGON_M2_mpyd_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RhRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RhRh __builtin_HEXAGON_M2_mpyd_nac_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RhRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RhRh_s1 __builtin_HEXAGON_M2_mpyd_nac_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RhRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RhRl __builtin_HEXAGON_M2_mpyd_nac_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RhRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RhRl_s1 __builtin_HEXAGON_M2_mpyd_nac_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RlRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RlRh __builtin_HEXAGON_M2_mpyd_nac_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RlRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RlRh_s1 __builtin_HEXAGON_M2_mpyd_nac_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RlRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RlRl __builtin_HEXAGON_M2_mpyd_nac_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpy(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpynac_RlRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpynac_RlRl_s1 __builtin_HEXAGON_M2_mpyd_nac_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.h):rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRh_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRh_rnd __builtin_HEXAGON_M2_mpyd_rnd_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.h):<<1:rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRh_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRh_s1_rnd __builtin_HEXAGON_M2_mpyd_rnd_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.l):rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRl_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRl_rnd __builtin_HEXAGON_M2_mpyd_rnd_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.h,Rt32.l):<<1:rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RhRl_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RhRl_s1_rnd __builtin_HEXAGON_M2_mpyd_rnd_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.h):rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRh_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRh_rnd __builtin_HEXAGON_M2_mpyd_rnd_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.h):<<1:rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRh_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRh_s1_rnd __builtin_HEXAGON_M2_mpyd_rnd_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.l):rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRl_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRl_rnd __builtin_HEXAGON_M2_mpyd_rnd_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpy(Rs32.l,Rt32.l):<<1:rnd
+   C Intrinsic Prototype: Word64 Q6_P_mpy_RlRl_s1_rnd(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpy_RlRl_s1_rnd __builtin_HEXAGON_M2_mpyd_rnd_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyi(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mpyi_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyi_RR __builtin_HEXAGON_M2_mpyi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyi(Rs32,#m9)
+   C Intrinsic Prototype: Word32 Q6_R_mpyi_RI(Word32 Rs, Word32 Im9)
+   Instruction Type:      M
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_mpyi_RI __builtin_HEXAGON_M2_mpysmi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpysu(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mpysu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpysu_RR __builtin_HEXAGON_M2_mpysu_up
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RhRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RhRh __builtin_HEXAGON_M2_mpyu_acc_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RhRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RhRh_s1 __builtin_HEXAGON_M2_mpyu_acc_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RhRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RhRl __builtin_HEXAGON_M2_mpyu_acc_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RhRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RhRl_s1 __builtin_HEXAGON_M2_mpyu_acc_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RlRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RlRh __builtin_HEXAGON_M2_mpyu_acc_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RlRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RlRh_s1 __builtin_HEXAGON_M2_mpyu_acc_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RlRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RlRl __builtin_HEXAGON_M2_mpyu_acc_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpyu(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyuacc_RlRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyuacc_RlRl_s1 __builtin_HEXAGON_M2_mpyu_acc_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RhRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RhRh __builtin_HEXAGON_M2_mpyu_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RhRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RhRh_s1 __builtin_HEXAGON_M2_mpyu_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RhRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RhRl __builtin_HEXAGON_M2_mpyu_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RhRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RhRl_s1 __builtin_HEXAGON_M2_mpyu_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RlRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RlRh __builtin_HEXAGON_M2_mpyu_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RlRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RlRh_s1 __builtin_HEXAGON_M2_mpyu_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RlRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RlRl __builtin_HEXAGON_M2_mpyu_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RlRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RlRl_s1 __builtin_HEXAGON_M2_mpyu_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RhRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RhRh __builtin_HEXAGON_M2_mpyu_nac_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RhRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RhRh_s1 __builtin_HEXAGON_M2_mpyu_nac_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RhRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RhRl __builtin_HEXAGON_M2_mpyu_nac_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RhRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RhRl_s1 __builtin_HEXAGON_M2_mpyu_nac_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RlRh(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RlRh __builtin_HEXAGON_M2_mpyu_nac_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RlRh_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RlRh_s1 __builtin_HEXAGON_M2_mpyu_nac_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RlRl(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RlRl __builtin_HEXAGON_M2_mpyu_nac_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyu(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word32 Q6_R_mpyunac_RlRl_s1(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyunac_RlRl_s1 __builtin_HEXAGON_M2_mpyu_nac_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyu(Rs32,Rt32)
+   C Intrinsic Prototype: UWord32 Q6_R_mpyu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyu_RR __builtin_HEXAGON_M2_mpyu_up
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RhRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RhRh __builtin_HEXAGON_M2_mpyud_acc_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RhRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RhRh_s1 __builtin_HEXAGON_M2_mpyud_acc_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RhRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RhRl __builtin_HEXAGON_M2_mpyud_acc_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RhRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RhRl_s1 __builtin_HEXAGON_M2_mpyud_acc_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RlRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RlRh __builtin_HEXAGON_M2_mpyud_acc_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RlRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RlRh_s1 __builtin_HEXAGON_M2_mpyud_acc_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RlRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RlRl __builtin_HEXAGON_M2_mpyud_acc_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=mpyu(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyuacc_RlRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyuacc_RlRl_s1 __builtin_HEXAGON_M2_mpyud_acc_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RhRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RhRh __builtin_HEXAGON_M2_mpyud_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RhRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RhRh_s1 __builtin_HEXAGON_M2_mpyud_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RhRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RhRl __builtin_HEXAGON_M2_mpyud_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RhRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RhRl_s1 __builtin_HEXAGON_M2_mpyud_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RlRh(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RlRh __builtin_HEXAGON_M2_mpyud_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RlRh_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RlRh_s1 __builtin_HEXAGON_M2_mpyud_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RlRl(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RlRl __builtin_HEXAGON_M2_mpyud_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=mpyu(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: UWord64 Q6_P_mpyu_RlRl_s1(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyu_RlRl_s1 __builtin_HEXAGON_M2_mpyud_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.h,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RhRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RhRh __builtin_HEXAGON_M2_mpyud_nac_hh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.h,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RhRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RhRh_s1 __builtin_HEXAGON_M2_mpyud_nac_hh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.h,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RhRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RhRl __builtin_HEXAGON_M2_mpyud_nac_hl_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.h,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RhRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RhRl_s1 __builtin_HEXAGON_M2_mpyud_nac_hl_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.l,Rt32.h)
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RlRh(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RlRh __builtin_HEXAGON_M2_mpyud_nac_lh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.l,Rt32.h):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RlRh_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RlRh_s1 __builtin_HEXAGON_M2_mpyud_nac_lh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.l,Rt32.l)
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RlRl(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RlRl __builtin_HEXAGON_M2_mpyud_nac_ll_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=mpyu(Rs32.l,Rt32.l):<<1
+   C Intrinsic Prototype: Word64 Q6_P_mpyunac_RlRl_s1(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_mpyunac_RlRl_s1 __builtin_HEXAGON_M2_mpyud_nac_ll_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mpyui(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mpyui_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_mpyui_RR __builtin_HEXAGON_M2_mpyui
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=add(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_addnac_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_addnac_RR __builtin_HEXAGON_M2_nacci
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=add(Rs32,#s8)
+   C Intrinsic Prototype: Word32 Q6_R_addnac_RI(Word32 Rx, Word32 Rs, Word32 Is8)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_addnac_RI __builtin_HEXAGON_M2_naccii
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=sub(Rt32,Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_subacc_RR(Word32 Rx, Word32 Rt, Word32 Rs)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_subacc_RR __builtin_HEXAGON_M2_subacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsdiffh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vabsdiffh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsdiffh_PP __builtin_HEXAGON_M2_vabsdiffh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsdiffw(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vabsdiffw_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsdiffw_PP __builtin_HEXAGON_M2_vabsdiffw
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vcmpyi(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vcmpyiacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcmpyiacc_PP_sat __builtin_HEXAGON_M2_vcmac_s0_sat_i
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vcmpyr(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vcmpyracc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcmpyracc_PP_sat __builtin_HEXAGON_M2_vcmac_s0_sat_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vcmpyi(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vcmpyi_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcmpyi_PP_sat __builtin_HEXAGON_M2_vcmpy_s0_sat_i
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vcmpyr(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vcmpyr_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcmpyr_PP_sat __builtin_HEXAGON_M2_vcmpy_s0_sat_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vcmpyi(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vcmpyi_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcmpyi_PP_s1_sat __builtin_HEXAGON_M2_vcmpy_s1_sat_i
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vcmpyr(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vcmpyr_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcmpyr_PP_s1_sat __builtin_HEXAGON_M2_vcmpy_s1_sat_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vdmpy(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vdmpyacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vdmpyacc_PP_sat __builtin_HEXAGON_M2_vdmacs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vdmpy(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vdmpyacc_PP_s1_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vdmpyacc_PP_s1_sat __builtin_HEXAGON_M2_vdmacs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vdmpy(Rss32,Rtt32):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_vdmpy_PP_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vdmpy_PP_rnd_sat __builtin_HEXAGON_M2_vdmpyrs_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vdmpy(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_vdmpy_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vdmpy_PP_s1_rnd_sat __builtin_HEXAGON_M2_vdmpyrs_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vdmpy(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vdmpy_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vdmpy_PP_sat __builtin_HEXAGON_M2_vdmpys_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vdmpy(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vdmpy_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vdmpy_PP_s1_sat __builtin_HEXAGON_M2_vdmpys_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyh(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhacc_RR __builtin_HEXAGON_M2_vmac2
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyeh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmpyehacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyehacc_PP __builtin_HEXAGON_M2_vmac2es
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyeh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyehacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyehacc_PP_sat __builtin_HEXAGON_M2_vmac2es_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyeh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyehacc_PP_s1_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyehacc_PP_s1_sat __builtin_HEXAGON_M2_vmac2es_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyh(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhacc_RR_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhacc_RR_sat __builtin_HEXAGON_M2_vmac2s_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyh(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhacc_RR_s1_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhacc_RR_s1_sat __builtin_HEXAGON_M2_vmac2s_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyhsu(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhsuacc_RR_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhsuacc_RR_sat __builtin_HEXAGON_M2_vmac2su_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpyhsu(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhsuacc_RR_s1_sat(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhsuacc_RR_s1_sat __builtin_HEXAGON_M2_vmac2su_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyeh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyeh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyeh_PP_sat __builtin_HEXAGON_M2_vmpy2es_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyeh(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyeh_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyeh_PP_s1_sat __builtin_HEXAGON_M2_vmpy2es_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyh(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyh_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyh_RR_sat __builtin_HEXAGON_M2_vmpy2s_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vmpyh(Rs32,Rt32):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_vmpyh_RR_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vmpyh_RR_rnd_sat __builtin_HEXAGON_M2_vmpy2s_s0pack
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyh(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyh_RR_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyh_RR_s1_sat __builtin_HEXAGON_M2_vmpy2s_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vmpyh(Rs32,Rt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_vmpyh_RR_s1_rnd_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vmpyh_RR_s1_rnd_sat __builtin_HEXAGON_M2_vmpy2s_s1pack
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyhsu(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhsu_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhsu_RR_sat __builtin_HEXAGON_M2_vmpy2su_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpyhsu(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vmpyhsu_RR_s1_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpyhsu_RR_s1_sat __builtin_HEXAGON_M2_vmpy2su_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vraddh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word32 Q6_R_vraddh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vraddh_PP __builtin_HEXAGON_M2_vraddh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vradduh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word32 Q6_R_vradduh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vradduh_PP __builtin_HEXAGON_M2_vradduh
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcmpyi(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyiacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyiacc_PP __builtin_HEXAGON_M2_vrcmaci_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcmpyi(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyiacc_PP_conj(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyiacc_PP_conj __builtin_HEXAGON_M2_vrcmaci_s0c
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcmpyr(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyracc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyracc_PP __builtin_HEXAGON_M2_vrcmacr_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcmpyr(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyracc_PP_conj(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyracc_PP_conj __builtin_HEXAGON_M2_vrcmacr_s0c
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrcmpyi(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyi_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyi_PP __builtin_HEXAGON_M2_vrcmpyi_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrcmpyi(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyi_PP_conj(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyi_PP_conj __builtin_HEXAGON_M2_vrcmpyi_s0c
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrcmpyr(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyr_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyr_PP __builtin_HEXAGON_M2_vrcmpyr_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrcmpyr(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpyr_PP_conj(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcmpyr_PP_conj __builtin_HEXAGON_M2_vrcmpyr_s0c
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcmpys(Rss32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpysacc_PR_s1_sat(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_vrcmpysacc_PR_s1_sat __builtin_HEXAGON_M2_vrcmpys_acc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrcmpys(Rss32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vrcmpys_PR_s1_sat(Word64 Rss, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_vrcmpys_PR_s1_sat __builtin_HEXAGON_M2_vrcmpys_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vrcmpys(Rss32,Rt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_vrcmpys_PR_s1_rnd_sat(Word64 Rss, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vrcmpys_PR_s1_rnd_sat __builtin_HEXAGON_M2_vrcmpys_s1rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpyh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpyhacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpyhacc_PP __builtin_HEXAGON_M2_vrmac_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpyh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpyh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpyh_PP __builtin_HEXAGON_M2_vrmpy_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=xor(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_xorxacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_xorxacc_RR __builtin_HEXAGON_M2_xor_xacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=and(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_andand_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andand_RR __builtin_HEXAGON_M4_and_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=and(Rs32,~Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_andand_RnR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andand_RnR __builtin_HEXAGON_M4_and_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=or(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_orand_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_orand_RR __builtin_HEXAGON_M4_and_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=xor(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_xorand_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_xorand_RR __builtin_HEXAGON_M4_and_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyiwh(Rss32,Rt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyiwh_PR_s1_rnd_sat(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpyiwh_PR_s1_rnd_sat __builtin_HEXAGON_M4_cmpyi_wh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyiwh(Rss32,Rt32*):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyiwh_PR_conj_s1_rnd_sat(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpyiwh_PR_conj_s1_rnd_sat __builtin_HEXAGON_M4_cmpyi_whc
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyrwh(Rss32,Rt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyrwh_PR_s1_rnd_sat(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpyrwh_PR_s1_rnd_sat __builtin_HEXAGON_M4_cmpyr_wh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyrwh(Rss32,Rt32*):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyrwh_PR_conj_s1_rnd_sat(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cmpyrwh_PR_conj_s1_rnd_sat __builtin_HEXAGON_M4_cmpyr_whc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=mpy(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpyacc_RR_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyacc_RR_s1_sat __builtin_HEXAGON_M4_mac_up_s1_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(#u6,mpyi(Rs32,#U6))
+   C Intrinsic Prototype: Word32 Q6_R_add_mpyi_IRI(Word32 Iu6, Word32 Rs, Word32 IU6)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_mpyi_IRI __builtin_HEXAGON_M4_mpyri_addi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Ru32,mpyi(Rs32,#u6))
+   C Intrinsic Prototype: Word32 Q6_R_add_mpyi_RRI(Word32 Ru, Word32 Rs, Word32 Iu6)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_mpyi_RRI __builtin_HEXAGON_M4_mpyri_addr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Ru32,mpyi(#u6:2,Rs32))
+   C Intrinsic Prototype: Word32 Q6_R_add_mpyi_RIR(Word32 Ru, Word32 Iu6_2, Word32 Rs)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_mpyi_RIR __builtin_HEXAGON_M4_mpyri_addr_u2
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(#u6,mpyi(Rs32,Rt32))
+   C Intrinsic Prototype: Word32 Q6_R_add_mpyi_IRR(Word32 Iu6, Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_mpyi_IRR __builtin_HEXAGON_M4_mpyrr_addi
+
+/* ==========================================================================
+   Assembly Syntax:       Ry32=add(Ru32,mpyi(Ry32,Rs32))
+   C Intrinsic Prototype: Word32 Q6_R_add_mpyi_RRR(Word32 Ru, Word32 Ry, Word32 Rs)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_mpyi_RRR __builtin_HEXAGON_M4_mpyrr_addr
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpy(Rs32,Rt32):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_mpynac_RR_s1_sat(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpynac_RR_s1_sat __builtin_HEXAGON_M4_nac_up_s1_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=and(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_andor_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andor_RR __builtin_HEXAGON_M4_or_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=and(Rs32,~Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_andor_RnR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andor_RnR __builtin_HEXAGON_M4_or_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=or(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_oror_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_oror_RR __builtin_HEXAGON_M4_or_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=xor(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_xoror_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_xoror_RR __builtin_HEXAGON_M4_or_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=pmpyw(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_pmpyw_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_pmpyw_RR __builtin_HEXAGON_M4_pmpyw
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=pmpyw(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_pmpywxacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_pmpywxacc_RR __builtin_HEXAGON_M4_pmpyw_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vpmpyh(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vpmpyh_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vpmpyh_RR __builtin_HEXAGON_M4_vpmpyh
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=vpmpyh(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vpmpyhxacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vpmpyhxacc_RR __builtin_HEXAGON_M4_vpmpyh_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpyweh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpywehacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpywehacc_PP __builtin_HEXAGON_M4_vrmpyeh_acc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpyweh(Rss32,Rtt32):<<1
+   C Intrinsic Prototype: Word64 Q6_P_vrmpywehacc_PP_s1(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpywehacc_PP_s1 __builtin_HEXAGON_M4_vrmpyeh_acc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpyweh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpyweh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpyweh_PP __builtin_HEXAGON_M4_vrmpyeh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpyweh(Rss32,Rtt32):<<1
+   C Intrinsic Prototype: Word64 Q6_P_vrmpyweh_PP_s1(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpyweh_PP_s1 __builtin_HEXAGON_M4_vrmpyeh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpywoh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpywohacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpywohacc_PP __builtin_HEXAGON_M4_vrmpyoh_acc_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpywoh(Rss32,Rtt32):<<1
+   C Intrinsic Prototype: Word64 Q6_P_vrmpywohacc_PP_s1(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpywohacc_PP_s1 __builtin_HEXAGON_M4_vrmpyoh_acc_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpywoh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpywoh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpywoh_PP __builtin_HEXAGON_M4_vrmpyoh_s0
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpywoh(Rss32,Rtt32):<<1
+   C Intrinsic Prototype: Word64 Q6_P_vrmpywoh_PP_s1(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpywoh_PP_s1 __builtin_HEXAGON_M4_vrmpyoh_s1
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=and(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_andxacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andxacc_RR __builtin_HEXAGON_M4_xor_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=and(Rs32,~Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_andxacc_RnR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andxacc_RnR __builtin_HEXAGON_M4_xor_andn
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=or(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_orxacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_orxacc_RR __builtin_HEXAGON_M4_xor_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=xor(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_xorxacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_xorxacc_PP __builtin_HEXAGON_M4_xor_xacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vdmpybsu(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vdmpybsuacc_PP_sat(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vdmpybsuacc_PP_sat __builtin_HEXAGON_M5_vdmacbsu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vdmpybsu(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vdmpybsu_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vdmpybsu_PP_sat __builtin_HEXAGON_M5_vdmpybsu
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpybsu(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmpybsuacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpybsuacc_RR __builtin_HEXAGON_M5_vmacbsu
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vmpybu(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmpybuacc_RR(Word64 Rxx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpybuacc_RR __builtin_HEXAGON_M5_vmacbuu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpybsu(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmpybsu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpybsu_RR __builtin_HEXAGON_M5_vmpybsu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vmpybu(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vmpybu_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vmpybu_RR __builtin_HEXAGON_M5_vmpybuu
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpybsu(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpybsuacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpybsuacc_PP __builtin_HEXAGON_M5_vrmacbsu
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrmpybu(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpybuacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpybuacc_PP __builtin_HEXAGON_M5_vrmacbuu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpybsu(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpybsu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpybsu_PP __builtin_HEXAGON_M5_vrmpybsu
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrmpybu(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrmpybu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrmpybu_PP __builtin_HEXAGON_M5_vrmpybuu
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=addasl(Rt32,Rs32,#u3)
+   C Intrinsic Prototype: Word32 Q6_R_addasl_RRI(Word32 Rt, Word32 Rs, Word32 Iu3)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_addasl_RRI __builtin_HEXAGON_S2_addasl_rrri
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=asl(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asl_PI(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asl_PI __builtin_HEXAGON_S2_asl_i_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=asl(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_aslacc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslacc_PI __builtin_HEXAGON_S2_asl_i_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=asl(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asland_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asland_PI __builtin_HEXAGON_S2_asl_i_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=asl(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_aslnac_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslnac_PI __builtin_HEXAGON_S2_asl_i_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=asl(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_aslor_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslor_PI __builtin_HEXAGON_S2_asl_i_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=asl(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_aslxacc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslxacc_PI __builtin_HEXAGON_S2_asl_i_p_xacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asl(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asl_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asl_RI __builtin_HEXAGON_S2_asl_i_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=asl(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_aslacc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslacc_RI __builtin_HEXAGON_S2_asl_i_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=asl(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asland_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asland_RI __builtin_HEXAGON_S2_asl_i_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=asl(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_aslnac_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslnac_RI __builtin_HEXAGON_S2_asl_i_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=asl(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_aslor_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslor_RI __builtin_HEXAGON_S2_asl_i_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asl(Rs32,#u5):sat
+   C Intrinsic Prototype: Word32 Q6_R_asl_RI_sat(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asl_RI_sat __builtin_HEXAGON_S2_asl_i_r_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=asl(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_aslxacc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslxacc_RI __builtin_HEXAGON_S2_asl_i_r_xacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaslh(Rss32,#u4)
+   C Intrinsic Prototype: Word64 Q6_P_vaslh_PI(Word64 Rss, Word32 Iu4)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaslh_PI __builtin_HEXAGON_S2_asl_i_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaslw(Rss32,#u5)
+   C Intrinsic Prototype: Word64 Q6_P_vaslw_PI(Word64 Rss, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaslw_PI __builtin_HEXAGON_S2_asl_i_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=asl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asl_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asl_PR __builtin_HEXAGON_S2_asl_r_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=asl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_aslacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslacc_PR __builtin_HEXAGON_S2_asl_r_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=asl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asland_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asland_PR __builtin_HEXAGON_S2_asl_r_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=asl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_aslnac_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslnac_PR __builtin_HEXAGON_S2_asl_r_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=asl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_aslor_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslor_PR __builtin_HEXAGON_S2_asl_r_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=asl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_aslxacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_aslxacc_PR __builtin_HEXAGON_S2_asl_r_p_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asl_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asl_RR __builtin_HEXAGON_S2_asl_r_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=asl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_aslacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslacc_RR __builtin_HEXAGON_S2_asl_r_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=asl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asland_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asland_RR __builtin_HEXAGON_S2_asl_r_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=asl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_aslnac_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslnac_RR __builtin_HEXAGON_S2_asl_r_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=asl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_aslor_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_aslor_RR __builtin_HEXAGON_S2_asl_r_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asl(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_asl_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asl_RR_sat __builtin_HEXAGON_S2_asl_r_r_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaslh(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vaslh_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaslh_PR __builtin_HEXAGON_S2_asl_r_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vaslw(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vaslw_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vaslw_PR __builtin_HEXAGON_S2_asl_r_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=asr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asr_PI(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asr_PI __builtin_HEXAGON_S2_asr_i_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=asr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asracc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asracc_PI __builtin_HEXAGON_S2_asr_i_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=asr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asrand_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asrand_PI __builtin_HEXAGON_S2_asr_i_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=asr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asrnac_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asrnac_PI __builtin_HEXAGON_S2_asr_i_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=asr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asror_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asror_PI __builtin_HEXAGON_S2_asr_i_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=asr(Rss32,#u6):rnd
+   C Intrinsic Prototype: Word64 Q6_P_asr_PI_rnd(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asr_PI_rnd __builtin_HEXAGON_S2_asr_i_p_rnd
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=asrrnd(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_asrrnd_PI(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_asrrnd_PI __builtin_HEXAGON_S2_asr_i_p_rnd_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asr_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asr_RI __builtin_HEXAGON_S2_asr_i_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=asr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asracc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asracc_RI __builtin_HEXAGON_S2_asr_i_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=asr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asrand_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asrand_RI __builtin_HEXAGON_S2_asr_i_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=asr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asrnac_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asrnac_RI __builtin_HEXAGON_S2_asr_i_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=asr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asror_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asror_RI __builtin_HEXAGON_S2_asr_i_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asr(Rs32,#u5):rnd
+   C Intrinsic Prototype: Word32 Q6_R_asr_RI_rnd(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asr_RI_rnd __builtin_HEXAGON_S2_asr_i_r_rnd
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asrrnd(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_asrrnd_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_asrrnd_RI __builtin_HEXAGON_S2_asr_i_r_rnd_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vasrw(Rss32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_vasrw_PI(Word64 Rss, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vasrw_PI __builtin_HEXAGON_S2_asr_i_svw_trun
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vasrh(Rss32,#u4)
+   C Intrinsic Prototype: Word64 Q6_P_vasrh_PI(Word64 Rss, Word32 Iu4)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vasrh_PI __builtin_HEXAGON_S2_asr_i_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vasrw(Rss32,#u5)
+   C Intrinsic Prototype: Word64 Q6_P_vasrw_PI(Word64 Rss, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vasrw_PI __builtin_HEXAGON_S2_asr_i_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=asr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asr_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asr_PR __builtin_HEXAGON_S2_asr_r_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=asr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asracc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asracc_PR __builtin_HEXAGON_S2_asr_r_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=asr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asrand_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asrand_PR __builtin_HEXAGON_S2_asr_r_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=asr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asrnac_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asrnac_PR __builtin_HEXAGON_S2_asr_r_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=asr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asror_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asror_PR __builtin_HEXAGON_S2_asr_r_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=asr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_asrxacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_asrxacc_PR __builtin_HEXAGON_S2_asr_r_p_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asr_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asr_RR __builtin_HEXAGON_S2_asr_r_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=asr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asracc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asracc_RR __builtin_HEXAGON_S2_asr_r_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=asr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asrand_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asrand_RR __builtin_HEXAGON_S2_asr_r_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=asr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asrnac_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asrnac_RR __builtin_HEXAGON_S2_asr_r_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=asr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_asror_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asror_RR __builtin_HEXAGON_S2_asr_r_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=asr(Rs32,Rt32):sat
+   C Intrinsic Prototype: Word32 Q6_R_asr_RR_sat(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_asr_RR_sat __builtin_HEXAGON_S2_asr_r_r_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vasrw(Rss32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_vasrw_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vasrw_PR __builtin_HEXAGON_S2_asr_r_svw_trun
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vasrh(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vasrh_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vasrh_PR __builtin_HEXAGON_S2_asr_r_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vasrw(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vasrw_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vasrw_PR __builtin_HEXAGON_S2_asr_r_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=brev(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_brev_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_brev_R __builtin_HEXAGON_S2_brev
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=brev(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_brev_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_brev_P __builtin_HEXAGON_S2_brevp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cl0(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_cl0_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cl0_R __builtin_HEXAGON_S2_cl0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cl0(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_cl0_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cl0_P __builtin_HEXAGON_S2_cl0p
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cl1(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_cl1_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cl1_R __builtin_HEXAGON_S2_cl1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cl1(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_cl1_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_cl1_P __builtin_HEXAGON_S2_cl1p
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=clb(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_clb_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_clb_R __builtin_HEXAGON_S2_clb
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=normamt(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_normamt_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_normamt_R __builtin_HEXAGON_S2_clbnorm
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=clb(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_clb_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_clb_P __builtin_HEXAGON_S2_clbp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=clrbit(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_clrbit_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_clrbit_RI __builtin_HEXAGON_S2_clrbit_i
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=clrbit(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_clrbit_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_clrbit_RR __builtin_HEXAGON_S2_clrbit_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=ct0(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_ct0_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_ct0_R __builtin_HEXAGON_S2_ct0
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=ct0(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_ct0_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_ct0_P __builtin_HEXAGON_S2_ct0p
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=ct1(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_ct1_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_ct1_R __builtin_HEXAGON_S2_ct1
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=ct1(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_ct1_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_ct1_P __builtin_HEXAGON_S2_ct1p
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=deinterleave(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_deinterleave_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_deinterleave_P __builtin_HEXAGON_S2_deinterleave
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=extractu(Rs32,#u5,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_extractu_RII(Word32 Rs, Word32 Iu5, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_extractu_RII __builtin_HEXAGON_S2_extractu
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=extractu(Rs32,Rtt32)
+   C Intrinsic Prototype: Word32 Q6_R_extractu_RP(Word32 Rs, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_extractu_RP __builtin_HEXAGON_S2_extractu_rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=extractu(Rss32,#u6,#U6)
+   C Intrinsic Prototype: Word64 Q6_P_extractu_PII(Word64 Rss, Word32 Iu6, Word32 IU6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_extractu_PII __builtin_HEXAGON_S2_extractup
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=extractu(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_extractu_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_extractu_PP __builtin_HEXAGON_S2_extractup_rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=insert(Rs32,#u5,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_insert_RII(Word32 Rx, Word32 Rs, Word32 Iu5, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_insert_RII __builtin_HEXAGON_S2_insert
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=insert(Rs32,Rtt32)
+   C Intrinsic Prototype: Word32 Q6_R_insert_RP(Word32 Rx, Word32 Rs, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_insert_RP __builtin_HEXAGON_S2_insert_rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=insert(Rss32,#u6,#U6)
+   C Intrinsic Prototype: Word64 Q6_P_insert_PII(Word64 Rxx, Word64 Rss, Word32 Iu6, Word32 IU6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_insert_PII __builtin_HEXAGON_S2_insertp
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32=insert(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_insert_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_insert_PP __builtin_HEXAGON_S2_insertp_rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=interleave(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_interleave_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_interleave_P __builtin_HEXAGON_S2_interleave
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=lfs(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_lfs_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lfs_PP __builtin_HEXAGON_S2_lfsp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=lsl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsl_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsl_PR __builtin_HEXAGON_S2_lsl_r_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=lsl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lslacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lslacc_PR __builtin_HEXAGON_S2_lsl_r_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=lsl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsland_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsland_PR __builtin_HEXAGON_S2_lsl_r_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=lsl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lslnac_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lslnac_PR __builtin_HEXAGON_S2_lsl_r_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=lsl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lslor_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lslor_PR __builtin_HEXAGON_S2_lsl_r_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=lsl(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lslxacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lslxacc_PR __builtin_HEXAGON_S2_lsl_r_p_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=lsl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsl_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsl_RR __builtin_HEXAGON_S2_lsl_r_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=lsl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lslacc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lslacc_RR __builtin_HEXAGON_S2_lsl_r_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=lsl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsland_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsland_RR __builtin_HEXAGON_S2_lsl_r_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=lsl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lslnac_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lslnac_RR __builtin_HEXAGON_S2_lsl_r_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=lsl(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lslor_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lslor_RR __builtin_HEXAGON_S2_lsl_r_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vlslh(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vlslh_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vlslh_PR __builtin_HEXAGON_S2_lsl_r_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vlslw(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vlslw_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vlslw_PR __builtin_HEXAGON_S2_lsl_r_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=lsr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_lsr_PI(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsr_PI __builtin_HEXAGON_S2_lsr_i_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=lsr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_lsracc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsracc_PI __builtin_HEXAGON_S2_lsr_i_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=lsr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_lsrand_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsrand_PI __builtin_HEXAGON_S2_lsr_i_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=lsr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_lsrnac_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsrnac_PI __builtin_HEXAGON_S2_lsr_i_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=lsr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_lsror_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsror_PI __builtin_HEXAGON_S2_lsr_i_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=lsr(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_lsrxacc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsrxacc_PI __builtin_HEXAGON_S2_lsr_i_p_xacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=lsr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_lsr_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsr_RI __builtin_HEXAGON_S2_lsr_i_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=lsr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_lsracc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsracc_RI __builtin_HEXAGON_S2_lsr_i_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=lsr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_lsrand_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsrand_RI __builtin_HEXAGON_S2_lsr_i_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=lsr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_lsrnac_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsrnac_RI __builtin_HEXAGON_S2_lsr_i_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=lsr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_lsror_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsror_RI __builtin_HEXAGON_S2_lsr_i_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=lsr(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_lsrxacc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsrxacc_RI __builtin_HEXAGON_S2_lsr_i_r_xacc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vlsrh(Rss32,#u4)
+   C Intrinsic Prototype: Word64 Q6_P_vlsrh_PI(Word64 Rss, Word32 Iu4)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vlsrh_PI __builtin_HEXAGON_S2_lsr_i_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vlsrw(Rss32,#u5)
+   C Intrinsic Prototype: Word64 Q6_P_vlsrw_PI(Word64 Rss, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vlsrw_PI __builtin_HEXAGON_S2_lsr_i_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=lsr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsr_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsr_PR __builtin_HEXAGON_S2_lsr_r_p
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=lsr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsracc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsracc_PR __builtin_HEXAGON_S2_lsr_r_p_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=lsr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsrand_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsrand_PR __builtin_HEXAGON_S2_lsr_r_p_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=lsr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsrnac_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsrnac_PR __builtin_HEXAGON_S2_lsr_r_p_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=lsr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsror_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsror_PR __builtin_HEXAGON_S2_lsr_r_p_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=lsr(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_lsrxacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_lsrxacc_PR __builtin_HEXAGON_S2_lsr_r_p_xor
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=lsr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsr_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsr_RR __builtin_HEXAGON_S2_lsr_r_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=lsr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsracc_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsracc_RR __builtin_HEXAGON_S2_lsr_r_r_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=lsr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsrand_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsrand_RR __builtin_HEXAGON_S2_lsr_r_r_and
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=lsr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsrnac_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsrnac_RR __builtin_HEXAGON_S2_lsr_r_r_nac
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=lsr(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsror_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsror_RR __builtin_HEXAGON_S2_lsr_r_r_or
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vlsrh(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vlsrh_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vlsrh_PR __builtin_HEXAGON_S2_lsr_r_vh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vlsrw(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vlsrw_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vlsrw_PR __builtin_HEXAGON_S2_lsr_r_vw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=packhl(Rs32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_packhl_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU32_3op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_packhl_RR __builtin_HEXAGON_S2_packhl
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=parity(Rss32,Rtt32)
+   C Intrinsic Prototype: Word32 Q6_R_parity_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_parity_PP __builtin_HEXAGON_S2_parityp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=setbit(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_setbit_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_setbit_RI __builtin_HEXAGON_S2_setbit_i
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=setbit(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_setbit_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_setbit_RR __builtin_HEXAGON_S2_setbit_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=shuffeb(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_shuffeb_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_shuffeb_PP __builtin_HEXAGON_S2_shuffeb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=shuffeh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_shuffeh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_shuffeh_PP __builtin_HEXAGON_S2_shuffeh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=shuffob(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_shuffob_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_shuffob_PP __builtin_HEXAGON_S2_shuffob
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=shuffoh(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_shuffoh_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_shuffoh_PP __builtin_HEXAGON_S2_shuffoh
+
+/* ==========================================================================
+   Assembly Syntax:       memb(Rx32++#s4:0:circ(Mu2))=Rt32
+   C Intrinsic Prototype: void Q6_memb_IMR_circ(void** Rx, Word32 Is4_0, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memb_IMR_circ __builtin_HEXAGON_S2_storerb_pci
+
+/* ==========================================================================
+   Assembly Syntax:       memb(Rx32++I:circ(Mu2))=Rt32
+   C Intrinsic Prototype: void Q6_memb_MR_circ(void** Rx, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memb_MR_circ __builtin_HEXAGON_S2_storerb_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       memd(Rx32++#s4:3:circ(Mu2))=Rtt32
+   C Intrinsic Prototype: void Q6_memd_IMP_circ(void** Rx, Word32 Is4_3, Word32 Mu, Word64 Rtt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memd_IMP_circ __builtin_HEXAGON_S2_storerd_pci
+
+/* ==========================================================================
+   Assembly Syntax:       memd(Rx32++I:circ(Mu2))=Rtt32
+   C Intrinsic Prototype: void Q6_memd_MP_circ(void** Rx, Word32 Mu, Word64 Rtt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memd_MP_circ __builtin_HEXAGON_S2_storerd_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       memh(Rx32++#s4:1:circ(Mu2))=Rt32.h
+   C Intrinsic Prototype: void Q6_memh_IMRh_circ(void** Rx, Word32 Is4_1, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memh_IMRh_circ __builtin_HEXAGON_S2_storerf_pci
+
+/* ==========================================================================
+   Assembly Syntax:       memh(Rx32++I:circ(Mu2))=Rt32.h
+   C Intrinsic Prototype: void Q6_memh_MRh_circ(void** Rx, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memh_MRh_circ __builtin_HEXAGON_S2_storerf_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       memh(Rx32++#s4:1:circ(Mu2))=Rt32
+   C Intrinsic Prototype: void Q6_memh_IMR_circ(void** Rx, Word32 Is4_1, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memh_IMR_circ __builtin_HEXAGON_S2_storerh_pci
+
+/* ==========================================================================
+   Assembly Syntax:       memh(Rx32++I:circ(Mu2))=Rt32
+   C Intrinsic Prototype: void Q6_memh_MR_circ(void** Rx, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memh_MR_circ __builtin_HEXAGON_S2_storerh_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       memw(Rx32++#s4:2:circ(Mu2))=Rt32
+   C Intrinsic Prototype: void Q6_memw_IMR_circ(void** Rx, Word32 Is4_2, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memw_IMR_circ __builtin_HEXAGON_S2_storeri_pci
+
+/* ==========================================================================
+   Assembly Syntax:       memw(Rx32++I:circ(Mu2))=Rt32
+   C Intrinsic Prototype: void Q6_memw_MR_circ(void** Rx, Word32 Mu, Word32 Rt, void* BaseAddress)
+   Instruction Type:      ST
+   Execution Slots:       SLOT01
+   ========================================================================== */
+
+#define Q6_memw_MR_circ __builtin_HEXAGON_S2_storeri_pcr
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsathb(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_vsathb_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsathb_R __builtin_HEXAGON_S2_svsathb
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsathub(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_vsathub_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsathub_R __builtin_HEXAGON_S2_svsathub
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=tableidxb(Rs32,#u4,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_tableidxb_RII(Word32 Rx, Word32 Rs, Word32 Iu4, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_tableidxb_RII __builtin_HEXAGON_S2_tableidxb_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=tableidxd(Rs32,#u4,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_tableidxd_RII(Word32 Rx, Word32 Rs, Word32 Iu4, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_tableidxd_RII __builtin_HEXAGON_S2_tableidxd_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=tableidxh(Rs32,#u4,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_tableidxh_RII(Word32 Rx, Word32 Rs, Word32 Iu4, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_tableidxh_RII __builtin_HEXAGON_S2_tableidxh_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=tableidxw(Rs32,#u4,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_tableidxw_RII(Word32 Rx, Word32 Rs, Word32 Iu4, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_tableidxw_RII __builtin_HEXAGON_S2_tableidxw_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=togglebit(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_togglebit_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_togglebit_RI __builtin_HEXAGON_S2_togglebit_i
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=togglebit(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_togglebit_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_togglebit_RR __builtin_HEXAGON_S2_togglebit_r
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=tstbit(Rs32,#u5)
+   C Intrinsic Prototype: Byte Q6_p_tstbit_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_tstbit_RI __builtin_HEXAGON_S2_tstbit_i
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=tstbit(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_tstbit_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_tstbit_RR __builtin_HEXAGON_S2_tstbit_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=valignb(Rtt32,Rss32,#u3)
+   C Intrinsic Prototype: Word64 Q6_P_valignb_PPI(Word64 Rtt, Word64 Rss, Word32 Iu3)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_valignb_PPI __builtin_HEXAGON_S2_valignib
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=valignb(Rtt32,Rss32,Pu4)
+   C Intrinsic Prototype: Word64 Q6_P_valignb_PPp(Word64 Rtt, Word64 Rss, Byte Pu)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_valignb_PPp __builtin_HEXAGON_S2_valignrb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vcnegh(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vcnegh_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcnegh_PR __builtin_HEXAGON_S2_vcnegh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vcrotate(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vcrotate_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vcrotate_PR __builtin_HEXAGON_S2_vcrotate
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcnegh(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_vrcneghacc_PR(Word64 Rxx, Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcneghacc_PR __builtin_HEXAGON_S2_vrcnegh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vrndwh(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vrndwh_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vrndwh_P __builtin_HEXAGON_S2_vrndpackwh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vrndwh(Rss32):sat
+   C Intrinsic Prototype: Word32 Q6_R_vrndwh_P_sat(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vrndwh_P_sat __builtin_HEXAGON_S2_vrndpackwhs
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsathb(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vsathb_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsathb_P __builtin_HEXAGON_S2_vsathb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsathb(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsathb_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsathb_P __builtin_HEXAGON_S2_vsathb_nopack
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsathub(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vsathub_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsathub_P __builtin_HEXAGON_S2_vsathub
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsathub(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsathub_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsathub_P __builtin_HEXAGON_S2_vsathub_nopack
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsatwh(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vsatwh_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsatwh_P __builtin_HEXAGON_S2_vsatwh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsatwh(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsatwh_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsatwh_P __builtin_HEXAGON_S2_vsatwh_nopack
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsatwuh(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vsatwuh_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsatwuh_P __builtin_HEXAGON_S2_vsatwuh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsatwuh(Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vsatwuh_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsatwuh_P __builtin_HEXAGON_S2_vsatwuh_nopack
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vsplatb(Rs32)
+   C Intrinsic Prototype: Word32 Q6_R_vsplatb_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vsplatb_R __builtin_HEXAGON_S2_vsplatrb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsplath(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_vsplath_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsplath_R __builtin_HEXAGON_S2_vsplatrh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vspliceb(Rss32,Rtt32,#u3)
+   C Intrinsic Prototype: Word64 Q6_P_vspliceb_PPI(Word64 Rss, Word64 Rtt, Word32 Iu3)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vspliceb_PPI __builtin_HEXAGON_S2_vspliceib
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vspliceb(Rss32,Rtt32,Pu4)
+   C Intrinsic Prototype: Word64 Q6_P_vspliceb_PPp(Word64 Rss, Word64 Rtt, Byte Pu)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vspliceb_PPp __builtin_HEXAGON_S2_vsplicerb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsxtbh(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_vsxtbh_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsxtbh_R __builtin_HEXAGON_S2_vsxtbh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsxthw(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_vsxthw_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsxthw_R __builtin_HEXAGON_S2_vsxthw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vtrunehb(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vtrunehb_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vtrunehb_P __builtin_HEXAGON_S2_vtrunehb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vtrunewh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vtrunewh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vtrunewh_PP __builtin_HEXAGON_S2_vtrunewh
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vtrunohb(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_vtrunohb_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vtrunohb_P __builtin_HEXAGON_S2_vtrunohb
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vtrunowh(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vtrunowh_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vtrunowh_PP __builtin_HEXAGON_S2_vtrunowh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vzxtbh(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_vzxtbh_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vzxtbh_R __builtin_HEXAGON_S2_vzxtbh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vzxthw(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_vzxthw_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vzxthw_R __builtin_HEXAGON_S2_vzxthw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rs32,add(Ru32,#s6))
+   C Intrinsic Prototype: Word32 Q6_R_add_add_RRI(Word32 Rs, Word32 Ru, Word32 Is6)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_add_RRI __builtin_HEXAGON_S4_addaddi
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=add(#u8,asl(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_add_asl_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_asl_IRI __builtin_HEXAGON_S4_addi_asl_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=add(#u8,lsr(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_add_lsr_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_lsr_IRI __builtin_HEXAGON_S4_addi_lsr_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=and(#u8,asl(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_and_asl_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_and_asl_IRI __builtin_HEXAGON_S4_andi_asl_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=and(#u8,lsr(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_and_lsr_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_and_lsr_IRI __builtin_HEXAGON_S4_andi_lsr_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(clb(Rs32),#s6)
+   C Intrinsic Prototype: Word32 Q6_R_add_clb_RI(Word32 Rs, Word32 Is6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_clb_RI __builtin_HEXAGON_S4_clbaddi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(clb(Rss32),#s6)
+   C Intrinsic Prototype: Word32 Q6_R_add_clb_PI(Word64 Rss, Word32 Is6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_clb_PI __builtin_HEXAGON_S4_clbpaddi
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=normamt(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_normamt_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_normamt_P __builtin_HEXAGON_S4_clbpnorm
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=extract(Rs32,#u5,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_extract_RII(Word32 Rs, Word32 Iu5, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_extract_RII __builtin_HEXAGON_S4_extract
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=extract(Rs32,Rtt32)
+   C Intrinsic Prototype: Word32 Q6_R_extract_RP(Word32 Rs, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_extract_RP __builtin_HEXAGON_S4_extract_rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=extract(Rss32,#u6,#U6)
+   C Intrinsic Prototype: Word64 Q6_P_extract_PII(Word64 Rss, Word32 Iu6, Word32 IU6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_extract_PII __builtin_HEXAGON_S4_extractp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=extract(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_extract_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_extract_PP __builtin_HEXAGON_S4_extractp_rp
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=lsl(#s6,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_lsl_IR(Word32 Is6, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_lsl_IR __builtin_HEXAGON_S4_lsli
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!tstbit(Rs32,#u5)
+   C Intrinsic Prototype: Byte Q6_p_not_tstbit_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_tstbit_RI __builtin_HEXAGON_S4_ntstbit_i
+
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!tstbit(Rs32,Rt32)
+   C Intrinsic Prototype: Byte Q6_p_not_tstbit_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_tstbit_RR __builtin_HEXAGON_S4_ntstbit_r
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=and(Rs32,#s10)
+   C Intrinsic Prototype: Word32 Q6_R_andor_RI(Word32 Rx, Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_andor_RI __builtin_HEXAGON_S4_or_andi
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=or(Ru32,and(Rx32,#s10))
+   C Intrinsic Prototype: Word32 Q6_R_or_and_RRI(Word32 Ru, Word32 Rx, Word32 Is10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_or_and_RRI __builtin_HEXAGON_S4_or_andix
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=or(Rs32,#s10)
+   C Intrinsic Prototype: Word32 Q6_R_oror_RI(Word32 Rx, Word32 Rs, Word32 Is10)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_oror_RI __builtin_HEXAGON_S4_or_ori
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=or(#u8,asl(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_or_asl_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_or_asl_IRI __builtin_HEXAGON_S4_ori_asl_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=or(#u8,lsr(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_or_lsr_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_or_lsr_IRI __builtin_HEXAGON_S4_ori_lsr_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=parity(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_parity_RR(Word32 Rs, Word32 Rt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_parity_RR __builtin_HEXAGON_S4_parity
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=add(Rs32,sub(#s6,Ru32))
+   C Intrinsic Prototype: Word32 Q6_R_add_sub_RIR(Word32 Rs, Word32 Is6, Word32 Ru)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_add_sub_RIR __builtin_HEXAGON_S4_subaddi
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=sub(#u8,asl(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_sub_asl_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_asl_IRI __builtin_HEXAGON_S4_subi_asl_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rx32=sub(#u8,lsr(Rx32,#U5))
+   C Intrinsic Prototype: Word32 Q6_R_sub_lsr_IRI(Word32 Iu8, Word32 Rx, Word32 IU5)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_sub_lsr_IRI __builtin_HEXAGON_S4_subi_lsr_ri
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vrcrotate(Rss32,Rt32,#u2)
+   C Intrinsic Prototype: Word64 Q6_P_vrcrotate_PRI(Word64 Rss, Word32 Rt, Word32 Iu2)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcrotate_PRI __builtin_HEXAGON_S4_vrcrotate
+
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vrcrotate(Rss32,Rt32,#u2)
+   C Intrinsic Prototype: Word64 Q6_P_vrcrotateacc_PRI(Word64 Rxx, Word64 Rss, Word32 Rt, Word32 Iu2)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vrcrotateacc_PRI __builtin_HEXAGON_S4_vrcrotate_acc
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vxaddsubh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vxaddsubh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vxaddsubh_PP_sat __builtin_HEXAGON_S4_vxaddsubh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vxaddsubh(Rss32,Rtt32):rnd:>>1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vxaddsubh_PP_rnd_rs1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vxaddsubh_PP_rnd_rs1_sat __builtin_HEXAGON_S4_vxaddsubhr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vxaddsubw(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vxaddsubw_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vxaddsubw_PP_sat __builtin_HEXAGON_S4_vxaddsubw
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vxsubaddh(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vxsubaddh_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vxsubaddh_PP_sat __builtin_HEXAGON_S4_vxsubaddh
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vxsubaddh(Rss32,Rtt32):rnd:>>1:sat
+   C Intrinsic Prototype: Word64 Q6_P_vxsubaddh_PP_rnd_rs1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vxsubaddh_PP_rnd_rs1_sat __builtin_HEXAGON_S4_vxsubaddhr
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vxsubaddw(Rss32,Rtt32):sat
+   C Intrinsic Prototype: Word64 Q6_P_vxsubaddw_PP_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vxsubaddw_PP_sat __builtin_HEXAGON_S4_vxsubaddw
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vasrhub(Rss32,#u4):rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_vasrhub_PI_rnd_sat(Word64 Rss, Word32 Iu4)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_R_vasrhub_PI_rnd_sat __builtin_HEXAGON_S5_asrhub_rnd_sat_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=vasrhub(Rss32,#u4):sat
+   C Intrinsic Prototype: Word32 Q6_R_vasrhub_PI_sat(Word64 Rss, Word32 Iu4)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_vasrhub_PI_sat __builtin_HEXAGON_S5_asrhub_sat
+
+/* ==========================================================================
+   Assembly Syntax:       Rd32=popcount(Rss32)
+   C Intrinsic Prototype: Word32 Q6_R_popcount_P(Word64 Rss)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_popcount_P __builtin_HEXAGON_S5_popcountp
+
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vasrh(Rss32,#u4):rnd
+   C Intrinsic Prototype: Word64 Q6_P_vasrh_PI_rnd(Word64 Rss, Word32 Iu4)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_P_vasrh_PI_rnd __builtin_HEXAGON_S5_vasrhrnd_goodsyntax
+
+/* ==========================================================================
+   Assembly Syntax:       dccleana(Rs32)
+   C Intrinsic Prototype: void Q6_dccleana_A(Address Rs)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dccleana_A __builtin_HEXAGON_Y2_dccleana
+
+/* ==========================================================================
+   Assembly Syntax:       dccleaninva(Rs32)
+   C Intrinsic Prototype: void Q6_dccleaninva_A(Address Rs)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dccleaninva_A __builtin_HEXAGON_Y2_dccleaninva
+
+/* ==========================================================================
+   Assembly Syntax:       dcfetch(Rs32)
+   C Intrinsic Prototype: void Q6_dcfetch_A(Address Rs)
+   Instruction Type:      MAPPING
+   Execution Slots:       SLOT0123
+   ========================================================================== */
+
+#define Q6_dcfetch_A __builtin_HEXAGON_Y2_dcfetch
+
+/* ==========================================================================
+   Assembly Syntax:       dcinva(Rs32)
+   C Intrinsic Prototype: void Q6_dcinva_A(Address Rs)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dcinva_A __builtin_HEXAGON_Y2_dcinva
+
+/* ==========================================================================
+   Assembly Syntax:       dczeroa(Rs32)
+   C Intrinsic Prototype: void Q6_dczeroa_A(Address Rs)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dczeroa_A __builtin_HEXAGON_Y2_dczeroa
+
+/* ==========================================================================
+   Assembly Syntax:       l2fetch(Rs32,Rt32)
+   C Intrinsic Prototype: void Q6_l2fetch_AR(Address Rs, Word32 Rt)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_l2fetch_AR __builtin_HEXAGON_Y4_l2fetch
+
+/* ==========================================================================
+   Assembly Syntax:       l2fetch(Rs32,Rtt32)
+   C Intrinsic Prototype: void Q6_l2fetch_AP(Address Rs, Word64 Rtt)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_l2fetch_AP __builtin_HEXAGON_Y5_l2fetch
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=rol(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_rol_PI(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_rol_PI __builtin_HEXAGON_S6_rol_i_p
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=rol(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_rolacc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_rolacc_PI __builtin_HEXAGON_S6_rol_i_p_acc
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rxx32&=rol(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_roland_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_roland_PI __builtin_HEXAGON_S6_rol_i_p_and
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rxx32-=rol(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_rolnac_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_rolnac_PI __builtin_HEXAGON_S6_rol_i_p_nac
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rxx32|=rol(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_rolor_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_rolor_PI __builtin_HEXAGON_S6_rol_i_p_or
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rxx32^=rol(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_rolxacc_PI(Word64 Rxx, Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_rolxacc_PI __builtin_HEXAGON_S6_rol_i_p_xacc
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rd32=rol(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_rol_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_rol_RI __builtin_HEXAGON_S6_rol_i_r
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rx32+=rol(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_rolacc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_rolacc_RI __builtin_HEXAGON_S6_rol_i_r_acc
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rx32&=rol(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_roland_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_roland_RI __builtin_HEXAGON_S6_rol_i_r_and
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=rol(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_rolnac_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_rolnac_RI __builtin_HEXAGON_S6_rol_i_r_nac
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rx32|=rol(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_rolor_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_rolor_RI __builtin_HEXAGON_S6_rol_i_r_or
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 60
+/* ==========================================================================
+   Assembly Syntax:       Rx32^=rol(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_rolxacc_RI(Word32 Rx, Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_rolxacc_RI __builtin_HEXAGON_S6_rol_i_r_xacc
+#endif /* __HEXAGON_ARCH___ >= 60 */
+
+#if __HEXAGON_ARCH__ >= 62
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsdiffb(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vabsdiffb_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsdiffb_PP __builtin_HEXAGON_M6_vabsdiffb
+#endif /* __HEXAGON_ARCH___ >= 62 */
+
+#if __HEXAGON_ARCH__ >= 62
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vabsdiffub(Rtt32,Rss32)
+   C Intrinsic Prototype: Word64 Q6_P_vabsdiffub_PP(Word64 Rtt, Word64 Rss)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vabsdiffub_PP __builtin_HEXAGON_M6_vabsdiffub
+#endif /* __HEXAGON_ARCH___ >= 62 */
+
+#if __HEXAGON_ARCH__ >= 62
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vsplatb(Rs32)
+   C Intrinsic Prototype: Word64 Q6_P_vsplatb_R(Word32 Rs)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vsplatb_R __builtin_HEXAGON_S6_vsplatrbp
+#endif /* __HEXAGON_ARCH___ >= 62 */
+
+#if __HEXAGON_ARCH__ >= 62
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vtrunehb(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vtrunehb_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vtrunehb_PP __builtin_HEXAGON_S6_vtrunehb_ppp
+#endif /* __HEXAGON_ARCH___ >= 62 */
+
+#if __HEXAGON_ARCH__ >= 62
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vtrunohb(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vtrunohb_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vtrunohb_PP __builtin_HEXAGON_S6_vtrunohb_ppp
+#endif /* __HEXAGON_ARCH___ >= 62 */
+
+#if __HEXAGON_ARCH__ >= 65
+/* ==========================================================================
+   Assembly Syntax:       Pd4=!any8(vcmpb.eq(Rss32,Rtt32))
+   C Intrinsic Prototype: Byte Q6_p_not_any8_vcmpb_eq_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      ALU64
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_p_not_any8_vcmpb_eq_PP __builtin_HEXAGON_A6_vcmpbeq_notany
+#endif /* __HEXAGON_ARCH___ >= 65 */
+
+#if __HEXAGON_ARCH__ >= 66
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfadd(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfadd_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfadd_PP __builtin_HEXAGON_F2_dfadd
+#endif /* __HEXAGON_ARCH___ >= 66 */
+
+#if __HEXAGON_ARCH__ >= 66
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfsub(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfsub_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfsub_PP __builtin_HEXAGON_F2_dfsub
+#endif /* __HEXAGON_ARCH___ >= 66 */
+
+#if __HEXAGON_ARCH__ >= 66
+/* ==========================================================================
+   Assembly Syntax:       Rx32-=mpyi(Rs32,Rt32)
+   C Intrinsic Prototype: Word32 Q6_R_mpyinac_RR(Word32 Rx, Word32 Rs, Word32 Rt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mpyinac_RR __builtin_HEXAGON_M2_mnaci
+#endif /* __HEXAGON_ARCH___ >= 66 */
+
+#if __HEXAGON_ARCH__ >= 66
+/* ==========================================================================
+   Assembly Syntax:       Rd32=mask(#u5,#U5)
+   C Intrinsic Prototype: Word32 Q6_R_mask_II(Word32 Iu5, Word32 IU5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_mask_II __builtin_HEXAGON_S2_mask
+#endif /* __HEXAGON_ARCH___ >= 66 */
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=clip(Rs32,#u5)
+   C Intrinsic Prototype: Word32 Q6_R_clip_RI(Word32 Rs, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_R_clip_RI __builtin_HEXAGON_A7_clip
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cround(Rss32,#u6)
+   C Intrinsic Prototype: Word64 Q6_P_cround_PI(Word64 Rss, Word32 Iu6)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cround_PI __builtin_HEXAGON_A7_croundd_ri
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cround(Rss32,Rt32)
+   C Intrinsic Prototype: Word64 Q6_P_cround_PR(Word64 Rss, Word32 Rt)
+   Instruction Type:      S_3op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_cround_PR __builtin_HEXAGON_A7_croundd_rr
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vclip(Rss32,#u5)
+   C Intrinsic Prototype: Word64 Q6_P_vclip_PI(Word64 Rss, Word32 Iu5)
+   Instruction Type:      S_2op
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_vclip_PI __builtin_HEXAGON_A7_vclip
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfmax(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfmax_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmax_PP __builtin_HEXAGON_F2_dfmax
+#endif /* __HEXAGON_ARCH___ >= 67 */
+
+#if __HEXAGON_ARCH__ >= 67
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfmin(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfmin_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmin_PP __builtin_HEXAGON_F2_dfmin
+#endif /* __HEXAGON_ARCH___ >= 67 */
+
+#if __HEXAGON_ARCH__ >= 67
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfmpyfix(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfmpyfix_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmpyfix_PP __builtin_HEXAGON_F2_dfmpyfix
+#endif /* __HEXAGON_ARCH___ >= 67 */
+
+#if __HEXAGON_ARCH__ >= 67
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=dfmpyhh(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfmpyhhacc_PP(Float64 Rxx, Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmpyhhacc_PP __builtin_HEXAGON_F2_dfmpyhh
+#endif /* __HEXAGON_ARCH___ >= 67 */
+
+#if __HEXAGON_ARCH__ >= 67
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=dfmpylh(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfmpylhacc_PP(Float64 Rxx, Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmpylhacc_PP __builtin_HEXAGON_F2_dfmpylh
+#endif /* __HEXAGON_ARCH___ >= 67 */
+
+#if __HEXAGON_ARCH__ >= 67
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=dfmpyll(Rss32,Rtt32)
+   C Intrinsic Prototype: Float64 Q6_P_dfmpyll_PP(Float64 Rss, Float64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT23
+   ========================================================================== */
+
+#define Q6_P_dfmpyll_PP __builtin_HEXAGON_F2_dfmpyll
+#endif /* __HEXAGON_ARCH___ >= 67 */
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpyiw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyiw_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyiw_PP __builtin_HEXAGON_M7_dcmpyiw
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpyiw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyiwacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyiwacc_PP __builtin_HEXAGON_M7_dcmpyiw_acc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpyiw(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyiw_PP_conj(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyiw_PP_conj __builtin_HEXAGON_M7_dcmpyiwc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpyiw(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyiwacc_PP_conj(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyiwacc_PP_conj __builtin_HEXAGON_M7_dcmpyiwc_acc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpyrw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyrw_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyrw_PP __builtin_HEXAGON_M7_dcmpyrw
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpyrw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyrwacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyrwacc_PP __builtin_HEXAGON_M7_dcmpyrw_acc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=cmpyrw(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyrw_PP_conj(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyrw_PP_conj __builtin_HEXAGON_M7_dcmpyrwc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=cmpyrw(Rss32,Rtt32*)
+   C Intrinsic Prototype: Word64 Q6_P_cmpyrwacc_PP_conj(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_cmpyrwacc_PP_conj __builtin_HEXAGON_M7_dcmpyrwc_acc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rdd32=vdmpyw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vdmpyw_PP(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_vdmpyw_PP __builtin_HEXAGON_M7_vdmpy
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rxx32+=vdmpyw(Rss32,Rtt32)
+   C Intrinsic Prototype: Word64 Q6_P_vdmpywacc_PP(Word64 Rxx, Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_P_vdmpywacc_PP __builtin_HEXAGON_M7_vdmpy_acc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyiw(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyiw_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyiw_PP_s1_sat __builtin_HEXAGON_M7_wcmpyiw
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyiw(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyiw_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyiw_PP_s1_rnd_sat __builtin_HEXAGON_M7_wcmpyiw_rnd
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyiw(Rss32,Rtt32*):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyiw_PP_conj_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyiw_PP_conj_s1_sat __builtin_HEXAGON_M7_wcmpyiwc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyiw(Rss32,Rtt32*):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyiw_PP_conj_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyiw_PP_conj_s1_rnd_sat __builtin_HEXAGON_M7_wcmpyiwc_rnd
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyrw(Rss32,Rtt32):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyrw_PP_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyrw_PP_s1_sat __builtin_HEXAGON_M7_wcmpyrw
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyrw(Rss32,Rtt32):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyrw_PP_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyrw_PP_s1_rnd_sat __builtin_HEXAGON_M7_wcmpyrw_rnd
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyrw(Rss32,Rtt32*):<<1:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyrw_PP_conj_s1_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyrw_PP_conj_s1_sat __builtin_HEXAGON_M7_wcmpyrwc
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 67 && defined __HEXAGON_AUDIO__
+/* ==========================================================================
+   Assembly Syntax:       Rd32=cmpyrw(Rss32,Rtt32*):<<1:rnd:sat
+   C Intrinsic Prototype: Word32 Q6_R_cmpyrw_PP_conj_s1_rnd_sat(Word64 Rss, Word64 Rtt)
+   Instruction Type:      M
+   Execution Slots:       SLOT3
+   ========================================================================== */
+
+#define Q6_R_cmpyrw_PP_conj_s1_rnd_sat __builtin_HEXAGON_M7_wcmpyrwc_rnd
+#endif /* __HEXAGON_ARCH___ >= 67  && defined __HEXAGON_AUDIO__*/
+
+#if __HEXAGON_ARCH__ >= 68
+/* ==========================================================================
+   Assembly Syntax:       dmlink(Rs32,Rt32)
+   C Intrinsic Prototype: void Q6_dmlink_AA(Address Rs, Address Rt)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dmlink_AA __builtin_HEXAGON_Y6_dmlink
+#endif /* __HEXAGON_ARCH___ >= 68 */
+
+#if __HEXAGON_ARCH__ >= 68
+/* ==========================================================================
+   Assembly Syntax:       Rd32=dmpause
+   C Intrinsic Prototype: Word32 Q6_R_dmpause()
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_R_dmpause __builtin_HEXAGON_Y6_dmpause
+#endif /* __HEXAGON_ARCH___ >= 68 */
+
+#if __HEXAGON_ARCH__ >= 68
+/* ==========================================================================
+   Assembly Syntax:       Rd32=dmpoll
+   C Intrinsic Prototype: Word32 Q6_R_dmpoll()
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_R_dmpoll __builtin_HEXAGON_Y6_dmpoll
+#endif /* __HEXAGON_ARCH___ >= 68 */
+
+#if __HEXAGON_ARCH__ >= 68
+/* ==========================================================================
+   Assembly Syntax:       dmresume(Rs32)
+   C Intrinsic Prototype: void Q6_dmresume_A(Address Rs)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dmresume_A __builtin_HEXAGON_Y6_dmresume
+#endif /* __HEXAGON_ARCH___ >= 68 */
+
+#if __HEXAGON_ARCH__ >= 68
+/* ==========================================================================
+   Assembly Syntax:       dmstart(Rs32)
+   C Intrinsic Prototype: void Q6_dmstart_A(Address Rs)
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_dmstart_A __builtin_HEXAGON_Y6_dmstart
+#endif /* __HEXAGON_ARCH___ >= 68 */
+
+#if __HEXAGON_ARCH__ >= 68
+/* ==========================================================================
+   Assembly Syntax:       Rd32=dmwait
+   C Intrinsic Prototype: Word32 Q6_R_dmwait()
+   Instruction Type:      ST
+   Execution Slots:       SLOT0
+   ========================================================================== */
+
+#define Q6_R_dmwait __builtin_HEXAGON_Y6_dmwait
+#endif /* __HEXAGON_ARCH___ >= 68 */
+
+#include <hexagon_circ_brev_intrinsics.h>
+#ifdef __HVX__
+#include <hvx_hexagon_protos.h>
+#endif /* __HVX__ */
+#endif

--- a/crates/stdarch-gen-hexagon-scalar/src/main.rs
+++ b/crates/stdarch-gen-hexagon-scalar/src/main.rs
@@ -1,0 +1,672 @@
+//! Hexagon Scalar Code Generator
+//!
+//! This generator creates scalar.rs from the LLVM `hexagon_protos.h` header file.
+//! It parses the C intrinsic prototypes and generates Rust wrapper functions
+//! with appropriate attributes for all scalar (non-HVX) Hexagon intrinsics.
+//!
+//! The generated module provides ~901 scalar intrinsic wrappers covering:
+//! - Arithmetic, multiply, shift, saturate operations
+//! - Compare, floating-point, and other scalar operations
+//!
+//! Intrinsics with `void*`/`void**` parameters (circular-addressing) are skipped
+//! because they have no corresponding LLVM intrinsic.
+//!
+//! Usage:
+//!     cd crates/stdarch-gen-hexagon-scalar
+//!     cargo run
+//!     # Output is written to ../core_arch/src/hexagon/scalar.rs
+
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+/// Extract the instruction mnemonic from the assembly syntax string.
+///
+/// Examples:
+/// - `Rd32=abs(Rs32)` → Some("abs")
+/// - `Rd32=add(Rs32,Rt32):sat` → Some("add")
+/// - `Rx32+=mpy(Rs32,Rt32)` → Some("mpy")
+/// - `Rd32=dmpause` → Some("dmpause")
+/// - `dmlink(Rs32,Rt32)` → Some("dmlink")
+/// - `Rd32=Rs32` → None (simple transfer)
+/// - `Rx32.h=#u16` → None (immediate load)
+/// - `Rdd32=#s8` → None (immediate load)
+fn extract_instr_name(asm_syntax: &str) -> Option<String> {
+    // Find the operator: +=, -=, or =
+    let after_op = if let Some(pos) = asm_syntax.find("+=") {
+        &asm_syntax[pos + 2..]
+    } else if let Some(pos) = asm_syntax.find("-=") {
+        &asm_syntax[pos + 2..]
+    } else if let Some(pos) = asm_syntax.find('=') {
+        &asm_syntax[pos + 1..]
+    } else {
+        // No assignment operator: try function-call-style syntax like "dmlink(Rs32,Rt32)".
+        // The mnemonic is the leading lowercase identifier.
+        return extract_leading_mnemonic(asm_syntax);
+    };
+
+    // After the operator, we expect a lowercase letter starting the mnemonic.
+    // Skip if it starts with uppercase (register name like Rs32) or # (immediate).
+    extract_leading_mnemonic(after_op)
+}
+
+/// Extract a leading lowercase mnemonic from the given string.
+///
+/// Returns `Some(mnemonic)` if the string starts with a lowercase ASCII letter,
+/// collecting all subsequent alphanumeric/underscore characters. Returns `None`
+/// if the string is empty or starts with an uppercase letter, `#`, etc.
+fn extract_leading_mnemonic(s: &str) -> Option<String> {
+    let first_char = s.chars().next()?;
+    if !first_char.is_ascii_lowercase() {
+        return None;
+    }
+    let mnemonic: String = s
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if mnemonic.is_empty() {
+        None
+    } else {
+        Some(mnemonic)
+    }
+}
+
+/// The tracking issue number for the stdarch_hexagon feature
+const TRACKING_ISSUE: &str = "151523";
+
+/// LLVM version the header file is from (for reference)
+const LLVM_VERSION: &str = "22.1.0";
+
+/// Local header file path (checked into the repository)
+const HEADER_FILE: &str = "hexagon_protos.h";
+
+/// Rust type representation for scalar intrinsics
+#[derive(Debug, Clone, PartialEq)]
+enum RustType {
+    I32,
+    I64,
+    F32,
+    F64,
+    Unit,
+}
+
+impl RustType {
+    fn from_c_type(c_type: &str) -> Option<Self> {
+        match c_type.trim() {
+            "Word32" | "UWord32" | "Byte" | "Address" => Some(RustType::I32),
+            "Word64" | "UWord64" => Some(RustType::I64),
+            "Float32" => Some(RustType::F32),
+            "Float64" => Some(RustType::F64),
+            "void" => Some(RustType::Unit),
+            _ => None,
+        }
+    }
+
+    fn to_rust_str(&self) -> &'static str {
+        match self {
+            RustType::I32 => "i32",
+            RustType::I64 => "i64",
+            RustType::F32 => "f32",
+            RustType::F64 => "f64",
+            RustType::Unit => "()",
+        }
+    }
+}
+
+/// Information about an immediate operand parameter.
+///
+/// Detected from C prototype parameter names like `Is16` (signed 16-bit),
+/// `Iu5` (unsigned 5-bit), `IU5` (unsigned 5-bit secondary), `Iu6_2`
+/// (unsigned 6-bit with 2-bit alignment).
+#[derive(Debug, Clone)]
+struct ImmediateInfo {
+    /// Whether this is a signed immediate
+    signed: bool,
+    /// Number of bits in the immediate field
+    bits: u32,
+}
+
+/// Arch guard for an intrinsic
+#[derive(Debug, Clone, PartialEq)]
+enum ArchGuard {
+    /// No guard (base v5/v55 intrinsics)
+    None,
+    /// `#if __HEXAGON_ARCH__ >= N`
+    Arch(u32),
+    /// `#if __HEXAGON_ARCH__ >= N && defined __HEXAGON_AUDIO__`
+    ArchAudio(u32),
+}
+
+impl ArchGuard {
+    /// Returns a doc comment describing the required architecture version,
+    /// or None if no specific version is needed.
+    fn requires_doc(&self) -> Option<String> {
+        match self {
+            ArchGuard::None => Option::None,
+            ArchGuard::Arch(ver) => Some(format!("Requires: V{}", ver)),
+            ArchGuard::ArchAudio(ver) => Some(format!("Requires: V{}, Audio", ver)),
+        }
+    }
+
+    /// Returns a `#[cfg_attr(target_arch = "hexagon", target_feature(enable = "..."))]`
+    /// attribute string, or None for base intrinsics that have no user-facing feature gate.
+    fn target_feature_attr(&self) -> Option<String> {
+        match self {
+            ArchGuard::None => None,
+            ArchGuard::Arch(ver) => Some(format!(
+                "#[cfg_attr(target_arch = \"hexagon\", target_feature(enable = \"v{}\"))]",
+                ver
+            )),
+            ArchGuard::ArchAudio(ver) => Some(format!(
+                "#[cfg_attr(target_arch = \"hexagon\", target_feature(enable = \"v{},audio\"))]",
+                ver
+            )),
+        }
+    }
+}
+
+/// Parsed scalar intrinsic information
+#[derive(Debug, Clone)]
+struct ScalarIntrinsic {
+    /// Q6 name (e.g., "Q6_R_add_RR")
+    q6_name: String,
+    /// Builtin suffix (e.g., "A2_add") - from __builtin_HEXAGON_A2_add
+    builtin_name: String,
+    /// Assembly syntax
+    asm_syntax: String,
+    /// Instruction type
+    instr_type: String,
+    /// Execution slots
+    exec_slots: String,
+    /// Return type
+    return_type: RustType,
+    /// Parameters (name, type, optional immediate info)
+    params: Vec<(String, RustType, Option<ImmediateInfo>)>,
+    /// Architecture guard
+    arch_guard: ArchGuard,
+}
+
+impl ScalarIntrinsic {
+    /// Generate the LLVM link name: A2_add -> llvm.hexagon.A2.add
+    fn llvm_link_name(&self) -> String {
+        format!("llvm.hexagon.{}", self.builtin_name.replace('_', "."))
+    }
+
+    /// Generate the Rust function name: Q6_R_add_RR -> Q6_R_add_RR
+    ///
+    /// We preserve the original case because the Q6 naming convention uses
+    /// case to distinguish register types:
+    /// - `P` (uppercase) = 64-bit register pair (Word64)
+    /// - `p` (lowercase) = predicate register (Byte)
+    fn rust_fn_name(&self) -> String {
+        self.q6_name.clone()
+    }
+
+    /// Generate the extern function name: A2_add -> hexagon_A2_add
+    fn extern_fn_name(&self) -> String {
+        format!("hexagon_{}", self.builtin_name)
+    }
+}
+
+/// Read the local header file
+fn read_header(crate_dir: &Path) -> Result<String, String> {
+    let header_path = crate_dir.join(HEADER_FILE);
+    println!("Reading scalar header from: {}", header_path.display());
+    println!("  (LLVM version: {})", LLVM_VERSION);
+
+    std::fs::read_to_string(&header_path).map_err(|e| {
+        format!(
+            "Failed to read header file {}: {}",
+            header_path.display(),
+            e
+        )
+    })
+}
+
+/// Detect whether a C parameter name represents an immediate operand.
+///
+/// C prototype parameter names follow the pattern `I[usUS]\d+` for immediates:
+/// - `Is16` → signed 16-bit
+/// - `Iu5` → unsigned 5-bit
+/// - `IS8` → signed 8-bit (secondary)
+/// - `IU5` → unsigned 5-bit (secondary)
+/// - `Iu6_2` → unsigned 6-bit (with alignment suffix)
+fn detect_immediate(original_name: &str, imm_re: &Regex) -> Option<ImmediateInfo> {
+    imm_re.captures(original_name).map(|caps| {
+        let sign_char = &caps[1];
+        let bits: u32 = caps[2].parse().unwrap();
+        ImmediateInfo {
+            signed: sign_char == "s" || sign_char == "S",
+            bits,
+        }
+    })
+}
+
+/// Parse a C function prototype to extract return type and parameters
+fn parse_prototype(
+    prototype: &str,
+    proto_re: &Regex,
+    param_re: &Regex,
+    imm_re: &Regex,
+) -> Option<(RustType, Vec<(String, RustType, Option<ImmediateInfo>)>)> {
+    if let Some(caps) = proto_re.captures(prototype) {
+        let return_type_str = caps[1].trim();
+        let params_str = &caps[2];
+
+        // Skip if return type is unknown
+        let return_type = RustType::from_c_type(return_type_str)?;
+
+        let mut params = Vec::new();
+        if !params_str.trim().is_empty() {
+            let mut name_counts: HashMap<String, u32> = HashMap::new();
+            for param in params_str.split(',') {
+                let param = param.trim();
+                if let Some(pcaps) = param_re.captures(param) {
+                    let ptype_str = &pcaps[1];
+                    let original_name = &pcaps[2];
+                    let base_name = original_name.to_lowercase();
+
+                    // Skip intrinsics with void* or void** params
+                    if ptype_str.contains("void") {
+                        return None;
+                    }
+
+                    if let Some(ptype) = RustType::from_c_type(ptype_str) {
+                        // Detect immediate operands from the original C name
+                        let imm_info = detect_immediate(original_name, imm_re);
+
+                        // De-duplicate parameter names by appending a suffix
+                        let count = name_counts.entry(base_name.clone()).or_insert(0);
+                        *count += 1;
+                        let pname = if *count > 1 {
+                            format!("{}_{}", base_name, count)
+                        } else {
+                            base_name
+                        };
+                        params.push((pname, ptype, imm_info));
+                    } else {
+                        return None; // Unknown type
+                    }
+                }
+            }
+        }
+
+        Some((return_type, params))
+    } else {
+        None
+    }
+}
+
+/// Parse the header file to extract all scalar intrinsics
+fn parse_header(content: &str) -> Vec<ScalarIntrinsic> {
+    let mut intrinsics = Vec::new();
+
+    // Pre-compile all regexes once
+    let arch_guard_re = Regex::new(r"#if __HEXAGON_ARCH__ >= (\d+)(.*)").unwrap();
+    let q6_define_re = Regex::new(r"#define\s+(Q6_\w+)\s+__builtin_HEXAGON_(\w+)").unwrap();
+    let proto_re = Regex::new(r"(\w+)\s+Q6_\w+\(([^)]*)\)").unwrap();
+    let param_re = Regex::new(r"(\w+\*{0,2})\s+(\w+)").unwrap();
+    let imm_re = Regex::new(r"^I([uUsS])(\d+)").unwrap();
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut current_guard = ArchGuard::None;
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i].trim();
+
+        // Track #if guards
+        if let Some(caps) = arch_guard_re.captures(line) {
+            let arch_ver: u32 = caps[1].parse().unwrap_or(0);
+            let rest = &caps[2];
+            if rest.contains("__HEXAGON_AUDIO__") {
+                current_guard = ArchGuard::ArchAudio(arch_ver);
+            } else {
+                current_guard = ArchGuard::Arch(arch_ver);
+            }
+            i += 1;
+            continue;
+        }
+
+        // Track #endif to reset guard
+        if line.starts_with("#endif")
+            && !line.contains("__HEXAGON_PROTOS_H_")
+            && !line.contains("__HVX__")
+        {
+            current_guard = ArchGuard::None;
+            i += 1;
+            continue;
+        }
+
+        // Look for comment blocks with Assembly Syntax
+        if line.contains("Assembly Syntax:") {
+            let mut asm_syntax = String::new();
+            let mut prototype = String::new();
+            let mut instr_type = String::new();
+            let mut exec_slots = String::new();
+
+            // Parse the comment block
+            let mut j = i;
+            while j < lines.len() && !lines[j].trim().starts_with("#define") {
+                let cline = lines[j];
+                if cline.contains("Assembly Syntax:") {
+                    if let Some(pos) = cline.find("Assembly Syntax:") {
+                        asm_syntax = cline[pos + 16..].trim().to_string();
+                    }
+                } else if cline.contains("C Intrinsic Prototype:") {
+                    if let Some(pos) = cline.find("C Intrinsic Prototype:") {
+                        prototype = cline[pos + 22..].trim().to_string();
+                    }
+                } else if cline.contains("Instruction Type:") {
+                    if let Some(pos) = cline.find("Instruction Type:") {
+                        instr_type = cline[pos + 17..].trim().to_string();
+                    }
+                } else if cline.contains("Execution Slots:") {
+                    if let Some(pos) = cline.find("Execution Slots:") {
+                        exec_slots = cline[pos + 16..].trim().to_string();
+                    }
+                }
+                j += 1;
+            }
+
+            // Find the #define line
+            while j < lines.len() && !lines[j].trim().starts_with("#define") {
+                j += 1;
+            }
+
+            if j < lines.len() {
+                let define_line = lines[j];
+
+                if let Some(caps) = q6_define_re.captures(define_line) {
+                    let q6_name = caps[1].to_string();
+                    let builtin_name = caps[2].to_string();
+
+                    // Parse the C prototype
+                    if let Some((return_type, params)) =
+                        parse_prototype(&prototype, &proto_re, &param_re, &imm_re)
+                    {
+                        intrinsics.push(ScalarIntrinsic {
+                            q6_name,
+                            builtin_name,
+                            asm_syntax,
+                            instr_type,
+                            exec_slots,
+                            return_type,
+                            params,
+                            arch_guard: current_guard.clone(),
+                        });
+                    }
+                }
+            }
+            i = j + 1;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    intrinsics
+}
+
+/// Generate the module documentation
+fn generate_module_doc() -> String {
+    r#"//! Hexagon scalar intrinsics
+//!
+//! This module provides intrinsics for scalar (non-HVX) Hexagon DSP operations,
+//! including arithmetic, multiply, shift, saturate, compare, and floating-point
+//! operations.
+//!
+//! [Hexagon V68 Programmer's Reference Manual](https://docs.qualcomm.com/doc/80-N2040-45)
+//!
+//! ## Naming Convention
+//!
+//! Function names preserve the original Q6 naming case because the convention
+//! uses case to distinguish register types:
+//! - `P` (uppercase) = 64-bit register pair (`Word64`)
+//! - `p` (lowercase) = predicate register (`Byte`)
+//!
+//! For example, `Q6_P_and_PP` operates on 64-bit pairs while `Q6_p_and_pp`
+//! operates on predicate registers.
+//!
+//! ## Architecture Versions
+//!
+//! Most scalar intrinsics are available on all Hexagon architectures.
+//! Some intrinsics require specific architecture versions (v60, v62, v65,
+//! v66, v67, v68, or v67+audio) and carry
+//! `#[target_feature(enable = "v68")]` (or the appropriate version).
+//! Enable these with `-C target-feature=+v68` or by setting the target CPU
+//! via `-C target-cpu=hexagonv68`.
+//!
+//! Each version includes all features from previous versions.
+
+#![allow(non_snake_case)]
+
+#[cfg(test)]
+use stdarch_test::assert_instr;
+"#
+    .to_string()
+}
+
+/// Generate the extern block with LLVM intrinsic declarations
+fn generate_extern_block(intrinsics: &[ScalarIntrinsic]) -> String {
+    let mut output = String::new();
+
+    output.push_str("// LLVM intrinsic declarations for Hexagon scalar operations\n");
+    output.push_str("#[allow(improper_ctypes)]\n");
+    output.push_str("unsafe extern \"unadjusted\" {\n");
+
+    for info in intrinsics {
+        let link_name = info.llvm_link_name();
+        let fn_name = info.extern_fn_name();
+
+        let params_str = if info.params.is_empty() {
+            String::new()
+        } else {
+            info.params
+                .iter()
+                .map(|(_, t, _)| format!("_: {}", t.to_rust_str()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        let return_str = if info.return_type == RustType::Unit {
+            String::new()
+        } else {
+            format!(" -> {}", info.return_type.to_rust_str())
+        };
+
+        output.push_str(&format!(
+            "    #[link_name = \"{}\"]\n    fn {}({}){return_str};\n",
+            link_name, fn_name, params_str
+        ));
+    }
+
+    output.push_str("}\n");
+    output
+}
+
+/// Generate wrapper functions for all intrinsics
+fn generate_functions(intrinsics: &[ScalarIntrinsic]) -> String {
+    let mut output = String::new();
+
+    for info in intrinsics {
+        let rust_name = info.rust_fn_name();
+        let extern_name = info.extern_fn_name();
+
+        // Collect immediate parameter info: (original_index, const_name, ImmediateInfo)
+        let imm_params: Vec<(usize, String, &ImmediateInfo)> = info
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (name, _, imm))| imm.as_ref().map(|im| (i, name.to_uppercase(), im)))
+            .collect();
+
+        // Doc comment
+        output.push_str(&format!("/// `{}`\n", info.asm_syntax));
+        output.push_str("///\n");
+        output.push_str(&format!("/// Instruction Type: {}\n", info.instr_type));
+        output.push_str(&format!("/// Execution Slots: {}\n", info.exec_slots));
+        if let Some(req) = info.arch_guard.requires_doc() {
+            output.push_str(&format!("/// {}\n", req));
+        }
+
+        // Attributes
+        output.push_str("#[inline(always)]\n");
+        if let Some(tf_attr) = info.arch_guard.target_feature_attr() {
+            output.push_str(&format!("{}\n", tf_attr));
+        }
+
+        // Immediate parameters become const generics but are passed as positional
+        // arguments at the call site: Q6_R_add_RI(rs, 42) rather than Q6_R_add_RI::<42>(rs).
+        // This matches the assembly syntax where the immediate is an operand.
+        if !imm_params.is_empty() {
+            let indices: Vec<String> = imm_params.iter().map(|(i, _, _)| i.to_string()).collect();
+            output.push_str(&format!(
+                "#[rustc_legacy_const_generics({})]\n",
+                indices.join(", ")
+            ));
+        }
+
+        if let Some(instr) = extract_instr_name(&info.asm_syntax) {
+            if imm_params.is_empty() {
+                output.push_str(&format!("#[cfg_attr(test, assert_instr({}))]\n", instr));
+            } else {
+                // Provide default values for const generics in assert_instr
+                let defaults: Vec<String> = imm_params
+                    .iter()
+                    .map(|(_, name, _)| format!("{} = 0", name))
+                    .collect();
+                output.push_str(&format!(
+                    "#[cfg_attr(test, assert_instr({}, {}))]\n",
+                    instr,
+                    defaults.join(", ")
+                ));
+            }
+        }
+
+        output.push_str(&format!(
+            "#[unstable(feature = \"stdarch_hexagon\", issue = \"{}\")]\n",
+            TRACKING_ISSUE
+        ));
+
+        // Function signature: regular params exclude immediates, const generics added
+        let regular_params_str = info
+            .params
+            .iter()
+            .filter(|(_, _, imm)| imm.is_none())
+            .map(|(name, ty, _)| format!("{}: {}", name, ty.to_rust_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let return_str = if info.return_type == RustType::Unit {
+            String::new()
+        } else {
+            format!(" -> {}", info.return_type.to_rust_str())
+        };
+
+        if imm_params.is_empty() {
+            output.push_str(&format!(
+                "pub unsafe fn {}({}){} {{\n",
+                rust_name, regular_params_str, return_str
+            ));
+        } else {
+            let const_generics: Vec<String> = imm_params
+                .iter()
+                .map(|(_, name, imm)| {
+                    let ty = if imm.signed { "i32" } else { "u32" };
+                    format!("const {}: {}", name, ty)
+                })
+                .collect();
+            output.push_str(&format!(
+                "pub unsafe fn {}<{}>({}){} {{\n",
+                rust_name,
+                const_generics.join(", "),
+                regular_params_str,
+                return_str
+            ));
+        }
+
+        // Function body: static assertions then call
+        for (_, const_name, imm_info) in &imm_params {
+            if imm_info.signed {
+                output.push_str(&format!(
+                    "    static_assert_simm_bits!({}, {});\n",
+                    const_name, imm_info.bits
+                ));
+            } else {
+                output.push_str(&format!(
+                    "    static_assert_uimm_bits!({}, {});\n",
+                    const_name, imm_info.bits
+                ));
+            }
+        }
+
+        // Call args: use original order, using const generic names for immediates.
+        // Unsigned const generics (u32) need a cast to i32 for the extern call.
+        let args_str = info
+            .params
+            .iter()
+            .map(|(name, _, imm)| match imm {
+                Some(info) if !info.signed => format!("{} as i32", name.to_uppercase()),
+                Some(_) => name.to_uppercase(),
+                None => name.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        output.push_str(&format!("    {}({})\n", extern_name, args_str));
+        output.push_str("}\n\n");
+    }
+
+    output
+}
+
+/// Generate the complete scalar.rs file
+fn generate_scalar_file(intrinsics: &[ScalarIntrinsic], output_path: &Path) -> Result<(), String> {
+    let mut output =
+        File::create(output_path).map_err(|e| format!("Failed to create output: {}", e))?;
+
+    writeln!(output, "{}", generate_module_doc()).map_err(|e| e.to_string())?;
+    writeln!(output, "").map_err(|e| e.to_string())?;
+    writeln!(output, "{}", generate_extern_block(intrinsics)).map_err(|e| e.to_string())?;
+    writeln!(output, "{}", generate_functions(intrinsics)).map_err(|e| e.to_string())?;
+
+    // Flush before running rustfmt
+    drop(output);
+
+    // Run rustfmt on the generated file
+    let status = std::process::Command::new("rustfmt")
+        .arg(output_path)
+        .status()
+        .map_err(|e| format!("Failed to run rustfmt: {}", e))?;
+
+    if !status.success() {
+        return Err("rustfmt failed".to_string());
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<(), String> {
+    println!("=== Hexagon Scalar Code Generator ===\n");
+
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::current_dir().unwrap());
+
+    let header_content = read_header(&crate_dir)?;
+    println!("Read {} bytes", header_content.len());
+
+    let intrinsics = parse_header(&header_content);
+    println!("Parsed {} scalar intrinsics", intrinsics.len());
+
+    let hexagon_dir = crate_dir.join("../core_arch/src/hexagon");
+    let scalar_path = hexagon_dir.join("scalar.rs");
+
+    generate_scalar_file(&intrinsics, &scalar_path)?;
+    println!("Generated scalar.rs at {}", scalar_path.display());
+
+    Ok(())
+}

--- a/examples/gaussian.rs
+++ b/examples/gaussian.rs
@@ -296,13 +296,14 @@ fn main() {
     // Run reference
     gaussian3x3u8_reference(&src.0, WIDTH, WIDTH, HEIGHT, &mut dst_ref);
 
-    // Verify HVX matches reference (allowing small rounding differences)
+    // Verify HVX matches reference (allowing small rounding differences).
+    use core_arch::arch::hexagon::scalar::{Q6_R_abs_R, Q6_R_max_RR};
     let mut max_diff = 0i32;
     for y in 1..HEIGHT - 1 {
         for x in 1..WIDTH - 1 {
             let idx = y * WIDTH + x;
-            let diff = (dst_hvx.0[idx] as i32 - dst_ref[idx] as i32).abs();
-            max_diff = max_diff.max(diff);
+            let diff = unsafe { Q6_R_abs_R(dst_hvx.0[idx] as i32 - dst_ref[idx] as i32) };
+            max_diff = unsafe { Q6_R_max_RR(max_diff, diff) };
             // Allow up to 1 LSB difference due to rounding
             assert!(
                 diff <= 1,


### PR DESCRIPTION
Add scalar (non-HVX) intrinsic wrappers for Hexagon DSP operations covering arithmetic, multiply, shift, saturate, compare, and floating-point instructions, mapping to llvm.hexagon.* LLVM builtins.

Includes the stdarch-gen-hexagon-scalar code generator crate which produces scalar.rs from the LLVM hexagon_protos.h header file, and a CI step to verify the generated output stays in sync.