### PR TITLE
mark `vstl1_*` functions as unsafe

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -25421,107 +25421,119 @@ pub unsafe fn vst4q_u64(a: *mut u64, b: uint64x2x4_t) {
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1_lane_f64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1_lane_f64<const LANE: i32>(ptr: *mut f64, val: float64x1_t) {
+pub unsafe fn vstl1_lane_f64<const LANE: i32>(ptr: *mut f64, val: float64x1_t) {
     static_assert!(LANE == 0);
-    unsafe { vstl1_lane_s64::<LANE>(ptr as *mut i64, transmute(val)) }
+    vstl1_lane_s64::<LANE>(ptr as *mut i64, transmute(val))
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1q_lane_f64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1q_lane_f64<const LANE: i32>(ptr: *mut f64, val: float64x2_t) {
+pub unsafe fn vstl1q_lane_f64<const LANE: i32>(ptr: *mut f64, val: float64x2_t) {
     static_assert_uimm_bits!(LANE, 1);
-    unsafe { vstl1q_lane_s64::<LANE>(ptr as *mut i64, transmute(val)) }
+    vstl1q_lane_s64::<LANE>(ptr as *mut i64, transmute(val))
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1_lane_u64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1_lane_u64<const LANE: i32>(ptr: *mut u64, val: uint64x1_t) {
+pub unsafe fn vstl1_lane_u64<const LANE: i32>(ptr: *mut u64, val: uint64x1_t) {
     static_assert!(LANE == 0);
-    unsafe { vstl1_lane_s64::<LANE>(ptr as *mut i64, transmute(val)) }
+    vstl1_lane_s64::<LANE>(ptr as *mut i64, transmute(val))
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1q_lane_u64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1q_lane_u64<const LANE: i32>(ptr: *mut u64, val: uint64x2_t) {
+pub unsafe fn vstl1q_lane_u64<const LANE: i32>(ptr: *mut u64, val: uint64x2_t) {
     static_assert_uimm_bits!(LANE, 1);
-    unsafe { vstl1q_lane_s64::<LANE>(ptr as *mut i64, transmute(val)) }
+    vstl1q_lane_s64::<LANE>(ptr as *mut i64, transmute(val))
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1_lane_p64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1_lane_p64<const LANE: i32>(ptr: *mut p64, val: poly64x1_t) {
+pub unsafe fn vstl1_lane_p64<const LANE: i32>(ptr: *mut p64, val: poly64x1_t) {
     static_assert!(LANE == 0);
-    unsafe { vstl1_lane_s64::<LANE>(ptr as *mut i64, transmute(val)) }
+    vstl1_lane_s64::<LANE>(ptr as *mut i64, transmute(val))
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1q_lane_p64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1q_lane_p64<const LANE: i32>(ptr: *mut p64, val: poly64x2_t) {
+pub unsafe fn vstl1q_lane_p64<const LANE: i32>(ptr: *mut p64, val: poly64x2_t) {
     static_assert_uimm_bits!(LANE, 1);
-    unsafe { vstl1q_lane_s64::<LANE>(ptr as *mut i64, transmute(val)) }
+    vstl1q_lane_s64::<LANE>(ptr as *mut i64, transmute(val))
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1_lane_s64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1_lane_s64<const LANE: i32>(ptr: *mut i64, val: int64x1_t) {
+pub unsafe fn vstl1_lane_s64<const LANE: i32>(ptr: *mut i64, val: int64x1_t) {
     static_assert!(LANE == 0);
     let atomic_dst = ptr as *mut crate::sync::atomic::AtomicI64;
-    unsafe {
-        let lane: i64 = simd_extract!(val, LANE as u32);
-        (*atomic_dst).store(transmute(lane), crate::sync::atomic::Ordering::Release)
-    }
+    let lane: i64 = simd_extract!(val, LANE as u32);
+    (*atomic_dst).store(transmute(lane), crate::sync::atomic::Ordering::Release)
 }
 #[doc = "Store-Release a single-element structure from one lane of one register."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vstl1q_lane_s64)"]
+#[doc = "## Safety"]
+#[doc = "  * The pointer in `ptr` must satisfy the requirements of [`core::ptr::write`]."]
 #[inline(always)]
 #[target_feature(enable = "neon,rcpc3")]
 #[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(stl1, LANE = 0))]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 #[cfg(target_has_atomic = "64")]
-pub fn vstl1q_lane_s64<const LANE: i32>(ptr: *mut i64, val: int64x2_t) {
+pub unsafe fn vstl1q_lane_s64<const LANE: i32>(ptr: *mut i64, val: int64x2_t) {
     static_assert_uimm_bits!(LANE, 1);
     let atomic_dst = ptr as *mut crate::sync::atomic::AtomicI64;
-    unsafe {
-        let lane: i64 = simd_extract!(val, LANE as u32);
-        (*atomic_dst).store(transmute(lane), crate::sync::atomic::Ordering::Release)
-    }
+    let lane: i64 = simd_extract!(val, LANE as u32);
+    (*atomic_dst).store(transmute(lane), crate::sync::atomic::Ordering::Release)
 }
 #[doc = "Subtract"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsub_f64)"]

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -4459,7 +4459,9 @@ intrinsics:
     doc: "Store-Release a single-element structure from one lane of one register."
     arguments: ["ptr: {type[0]}", "val: {neon_type[1]}"]
     static_defs: ["const LANE: i32"]
-    safety: safe
+    safety:
+      unsafe:
+        - pointer_write: ptr
     attr:
       - FnCall: [target_feature, ['enable = "neon,rcpc3"']]
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env= "msvc"']]}]]}, {FnCall: [assert_instr, [stl1, 'LANE = 0']]}]]
@@ -4488,7 +4490,9 @@ intrinsics:
     doc: "Store-Release a single-element structure from one lane of one register."
     arguments: ["ptr: {type[0]}", "val: {neon_type[1]}"]
     static_defs: ["const LANE: i32"]
-    safety: safe
+    safety:
+      unsafe:
+        - pointer_write: ptr
     attr:
       - FnCall: [target_feature, ['enable = "neon,rcpc3"']]
       - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env= "msvc"']]}]]}, {FnCall: [assert_instr, [stl1, 'LANE = 0']]}]]

--- a/crates/stdarch-gen-arm/src/intrinsic.rs
+++ b/crates/stdarch-gen-arm/src/intrinsic.rs
@@ -806,6 +806,7 @@ pub enum UnsafetyComment {
     NonTemporal,
     Neon,
     NoProvenance(String),
+    PointerWrite(String),
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -873,6 +874,10 @@ impl fmt::Display for UnsafetyComment {
                 "Addresses passed in `{arg}` lack provenance, so this is similar to using a \
                 `usize as ptr` cast (or [`core::ptr::with_exposed_provenance`]) on each lane \
                 before  using it."
+            ),
+            Self::PointerWrite(arg) => write!(
+                f,
+                "The pointer in `{arg}` must satisfy the requirements of [`core::ptr::write`]."
             ),
             Self::UnpredictableOnFault => write!(
                 f,


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/155751

these functions write to a raw pointer, and so are clearly unsafe to use

