### PR TITLE
Revert changing number of passes depending on number of parameters

### DIFF
--- a/crates/intrinsic-test/src/common/argument.rs
+++ b/crates/intrinsic-test/src/common/argument.rs
@@ -1,5 +1,6 @@
 use super::cli::Language;
 use super::constraint::Constraint;
+use super::gen_rust::PASSES;
 use super::indentation::Indentation;
 use super::intrinsic_helpers::IntrinsicTypeDefinition;
 
@@ -178,7 +179,7 @@ where
             .enumerate()
             .map(|(idx, arg)| {
                 format!(
-                    "{indentation}{ty} {name} = cast<{ty}>({load}(&{name}_vals[i+{idx}]));\n",
+                    "{indentation}{ty} {name} = cast<{ty}>({load}(&{name}_vals[(i+{idx}) % {PASSES}]));\n",
                     ty = arg.to_c_type(),
                     name = arg.generate_name(),
                     load = if arg.is_simd() {
@@ -199,17 +200,20 @@ where
             .filter(|&arg| !arg.has_constraint())
             .enumerate()
             .map(|(idx, arg)| {
-                let load = if arg.is_simd() {
-                    arg.ty.get_load_function(Language::Rust)
+                if arg.is_simd() {
+                    format!(
+                        "{indentation}let {name} = {load}({vals_name}.as_ptr().add((i+{idx}) % {PASSES}) as _);\n",
+                        name = arg.generate_name(),
+                        vals_name = arg.rust_vals_array_name(),
+                        load = arg.ty.get_load_function(Language::Rust),
+                    )
                 } else {
-                    "*".to_string()
-                };
-                let typecast = if load.len() > 2 { "as _" } else { "" };
-                format!(
-                    "{indentation}let {name} = {load}({vals_name}.as_ptr().offset(i+{idx}){typecast});\n",
-                    name = arg.generate_name(),
-                    vals_name = arg.rust_vals_array_name(),
-                )
+                    format!(
+                        "{indentation}let {name} = {vals_name}[(i+{idx}) % {PASSES}];\n",
+                        name = arg.generate_name(),
+                        vals_name = arg.rust_vals_array_name(),
+                    )
+                }
             })
             .collect()
     }

--- a/crates/intrinsic-test/src/common/gen_c.rs
+++ b/crates/intrinsic-test/src/common/gen_c.rs
@@ -25,13 +25,6 @@ pub fn generate_c_test_loop<T: IntrinsicTypeDefinition + Sized>(
     passes: u32,
 ) -> std::io::Result<()> {
     let body_indentation = indentation.nested();
-    // Successive arguments are offset increasingly from their value array start
-    let passes = passes + 1
-        - intrinsic
-            .arguments
-            .iter()
-            .filter(|&arg| !arg.has_constraint())
-            .count() as u32;
     writeln!(
         w,
         "{indentation}for (int i=0; i<{passes}; i++) {{\n\

--- a/crates/intrinsic-test/src/common/gen_rust.rs
+++ b/crates/intrinsic-test/src/common/gen_rust.rs
@@ -214,12 +214,6 @@ pub fn generate_rust_test_loop<T: IntrinsicTypeDefinition>(
     passes: u32,
 ) -> std::io::Result<()> {
     let intrinsic_name = &intrinsic.name;
-    let passes = passes + 1
-        - intrinsic
-            .arguments
-            .iter()
-            .filter(|&arg| !arg.has_constraint())
-            .count() as u32;
 
     // Each function (and each specialization) has its own type. Erase that type with a cast.
     let mut coerce = String::from("unsafe fn(");


### PR DESCRIPTION
this causes buffer overflow in some x86 intrinsics with more than 20 parameters, e.g. _mm512_set_ph, so I decided to go to wrapping

cc @adamgemmell as this was added in rust-lang/stdarch#2087