### PR TITLE
Revert "Change implementation of `vld1_dup`"

### DIFF
--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -14614,8 +14614,8 @@ pub fn vhsubq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub unsafe fn vld1_dup_f16(ptr: *const f16) -> float16x4_t {
-    let x = vld1_lane_f16::<0>(ptr, transmute(f16x4::splat(0.0)));
-    vdup_lane_f16::<0>(x)
+    let x: float16x4_t = vld1_lane_f16::<0>(ptr, transmute(f16x4::splat(0.0)));
+    simd_shuffle!(x, x, [0, 0, 0, 0])
 }
 #[doc = "Load one single-element structure and replicate to all lanes of one register"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_f16)"]
@@ -14633,8 +14633,8 @@ pub unsafe fn vld1_dup_f16(ptr: *const f16) -> float16x4_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg(not(target_arch = "arm64ec"))]
 pub unsafe fn vld1q_dup_f16(ptr: *const f16) -> float16x8_t {
-    let x = vld1q_lane_f16::<0>(ptr, transmute(f16x8::splat(0.0)));
-    vdupq_laneq_f16::<0>(x)
+    let x: float16x8_t = vld1q_lane_f16::<0>(ptr, transmute(f16x8::splat(0.0)));
+    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_f32)"]

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -2835,7 +2835,7 @@ intrinsics:
       - FnCall: [static_assert_uimm_bits!, [LANE, '{type[3]}']]
       - FnCall: [simd_insert!, [src, "LANE as u32", "*ptr"]]
 
-  - name: "vld1{neon_type[1].dup_nox}"
+  - name: "vld1{type[2]}_{neon_type[1]}"
     doc: "Load one single-element structure and replicate to all lanes of one register"
     arguments: ["ptr: {type[0]}"]
     return_type: "{neon_type[1]}"
@@ -2849,11 +2849,11 @@ intrinsics:
     safety:
       unsafe: [neon]
     types:
-      - ["*const f16", float16x4_t, '_lane', 'f16x4']
-      - ["*const f16", float16x8_t, 'q_laneq', 'f16x8']
+      - ["*const f16", float16x4_t, '_dup', 'f16x4', "[0, 0, 0, 0]"]
+      - ["*const f16", float16x8_t, 'q_dup', 'f16x8', "[0, 0, 0, 0, 0, 0, 0, 0]"]
     compose:
-      - Let: [x, {FnCall: ["vld1{neon_type[1].lane_nox}", [ptr, {FnCall: [transmute, ["{type[3]}::splat(0.0)"]]}], [0]]}]
-      - FnCall: ['vdup{type[2]}_{neon_type[1]}', [x], [0]]
+      - Let: [x, "{neon_type[1]}", "vld1{neon_type[1].lane_nox}::<0>(ptr, transmute({type[3]}::splat(0.0)))"]
+      - FnCall: [simd_shuffle!, [x, x, "{type[4]}"]]
 
 
   - name: "vld2{neon_type[1].nox}"


### PR DESCRIPTION
This reverts commit 5f676a53f584e6304985345791525fa06bb9130e.

This is a partial revert of rust-lang/stdarch#2108, this commit creates a little bit of problem in rust-lang/stdarch#2063. Sorry for the inconvenience

r? @folkertdev