### PR TITLE
zeroall/zeroupper *are* supported by Miri

### DIFF
--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -789,7 +789,7 @@ mod tests {
     macro_rules! wide_store_load_roundtrip_fp16 {
         ($( $name:ident $args:tt);* $(;)?) => {
             $(
-                #[cfg_attr(miri, ignore)]
+                #[cfg_attr(miri, ignore)] // uses unsupported vendor intrinsics
                 #[simd_test(enable = "neon,fp16")]
                 #[cfg(not(target_arch = "arm64ec"))]
                 unsafe fn $name() {
@@ -1060,7 +1060,7 @@ mod tests {
     macro_rules! lane_wide_store_load_roundtrip_neon {
         ($( $name:ident $args:tt);* $(;)?) => {
             $(
-                #[cfg_attr(miri, ignore)]
+                #[cfg_attr(miri, ignore)] // uses unsupported vendor intrinsics
                 #[simd_test(enable = "neon")]
                 unsafe fn $name() {
                     lane_wide_store_load_roundtrip! $args;

--- a/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -5248,11 +5248,10 @@ mod tests {
         };
     }
 
-    // Most of these are implemented with builtins, which miri can't handle
     macro_rules! lane_wide_store_load_roundtrip_neon {
         ($( $name:ident $args:tt);* $(;)?) => {
             $(
-                #[cfg_attr(miri, ignore)]
+                #[cfg_attr(miri, ignore)] // uses unsupported vendor intrinsics
                 #[simd_test(enable = "neon")]
                 unsafe fn $name() {
                     lane_wide_store_load_roundtrip! $args;
@@ -5264,7 +5263,7 @@ mod tests {
     macro_rules! lane_wide_store_load_roundtrip_fp16 {
         ($( $name:ident $args:tt);* $(;)?) => {
             $(
-                #[cfg_attr(miri, ignore)]
+                #[cfg_attr(miri, ignore)] // uses unsupported vendor intrinsics
                 #[simd_test(enable = "neon,fp16")]
                 #[cfg(not(target_arch = "arm64ec"))]
                 unsafe fn $name() {

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -4488,7 +4488,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    #[cfg_attr(miri, ignore)] // Non-temporal store, which is not supported by Miri
+    #[cfg_attr(miri, ignore)] // Inline asm (for non-temporal store), which is not supported by Miri
     fn test_mm256_stream_si256() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let mut r = _mm256_undefined_si256();
@@ -4500,7 +4500,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    #[cfg_attr(miri, ignore)] // Non-temporal store, which is not supported by Miri
+    #[cfg_attr(miri, ignore)] // Inline asm (for non-temporal store), which is not supported by Miri
     fn test_mm256_stream_pd() {
         #[repr(align(32))]
         struct Memory {
@@ -4519,7 +4519,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    #[cfg_attr(miri, ignore)] // Non-temporal store, which is not supported by Miri
+    #[cfg_attr(miri, ignore)] // Inline asm (for non-temporal store), which is not supported by Miri
     fn test_mm256_stream_ps() {
         #[repr(align(32))]
         struct Memory {

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -1097,6 +1097,9 @@ pub const fn _mm256_cvtsi256_si32(a: __m256i) -> i32 {
 
 /// Zeroes the contents of all XMM or YMM registers.
 ///
+/// This operation is purely a performance hint for the CPU and has no effect on the Abstract
+/// Machine state.
+///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_zeroall)
 #[inline]
 #[target_feature(enable = "avx")]
@@ -1108,6 +1111,9 @@ pub fn _mm256_zeroall() {
 
 /// Zeroes the upper 128 bits of all YMM registers;
 /// the lower 128-bits of the registers are unmodified.
+///
+/// This operation is purely a performance hint for the CPU and has no effect on the Abstract
+/// Machine state.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_zeroupper)
 #[inline]
@@ -4007,13 +4013,11 @@ mod tests {
     }
 
     #[simd_test(enable = "avx")]
-    #[cfg_attr(miri, ignore)] // Register-level operation not supported by Miri
     fn test_mm256_zeroall() {
         _mm256_zeroall();
     }
 
     #[simd_test(enable = "avx")]
-    #[cfg_attr(miri, ignore)] // Register-level operation not supported by Miri
     fn test_mm256_zeroupper() {
         _mm256_zeroupper();
     }

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -58246,7 +58246,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Inline asm (for non-temporal store), which is not supported by Miri
     fn test_mm512_stream_ps() {
         #[repr(align(64))]
         struct Memory {
@@ -58265,7 +58265,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Inline asm (for non-temporal store), which is not supported by Miri
     fn test_mm512_stream_pd() {
         #[repr(align(64))]
         struct Memory {
@@ -58284,7 +58284,7 @@ mod tests {
     }
 
     #[simd_test(enable = "avx512f")]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Inline asm (for non-temporal store), which is not supported by Miri
     fn test_mm512_stream_si512() {
         #[repr(align(64))]
         struct Memory {


### PR DESCRIPTION
also update/add comments for some miri-ignored tests