### PR TITLE
Stabilize the `stdarch_neon_dotprod` feature

### DIFF
--- a/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -9597,7 +9597,7 @@ pub fn vcvtq_u32_f32(a: float32x4_t) -> uint32x4_t {
 #[rustc_legacy_const_generics(3)]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9622,7 +9622,7 @@ pub fn vdot_lane_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8x8_t) ->
 #[rustc_legacy_const_generics(3)]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9647,7 +9647,7 @@ pub fn vdotq_lane_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: int8x8_t) 
 #[rustc_legacy_const_generics(3)]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9672,7 +9672,7 @@ pub fn vdot_lane_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: uint8x8_t)
 #[rustc_legacy_const_generics(3)]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9695,7 +9695,14 @@ pub fn vdotq_lane_u32<const LANE: i32>(a: uint32x4_t, b: uint8x16_t, c: uint8x8_
     assert_instr(sdot, LANE = 0)
 )]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_dotprod", issue = "117224")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub fn vdot_laneq_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8x16_t) -> int32x2_t {
     static_assert_uimm_bits!(LANE, 2);
     let c = vreinterpretq_s32_s8(c);
@@ -9713,7 +9720,14 @@ pub fn vdot_laneq_s32<const LANE: i32>(a: int32x2_t, b: int8x8_t, c: int8x16_t) 
     assert_instr(sdot, LANE = 0)
 )]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_dotprod", issue = "117224")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub fn vdotq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: int8x16_t) -> int32x4_t {
     static_assert_uimm_bits!(LANE, 2);
     let c = vreinterpretq_s32_s8(c);
@@ -9731,7 +9745,14 @@ pub fn vdotq_laneq_s32<const LANE: i32>(a: int32x4_t, b: int8x16_t, c: int8x16_t
     assert_instr(udot, LANE = 0)
 )]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_dotprod", issue = "117224")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub fn vdot_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: uint8x16_t) -> uint32x2_t {
     static_assert_uimm_bits!(LANE, 2);
     let c = vreinterpretq_u32_u8(c);
@@ -9749,7 +9770,14 @@ pub fn vdot_laneq_u32<const LANE: i32>(a: uint32x2_t, b: uint8x8_t, c: uint8x16_
     assert_instr(udot, LANE = 0)
 )]
 #[rustc_legacy_const_generics(3)]
-#[unstable(feature = "stdarch_neon_dotprod", issue = "117224")]
+#[cfg_attr(
+    not(target_arch = "arm"),
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
+)]
+#[cfg_attr(
+    target_arch = "arm",
+    unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
+)]
 pub fn vdotq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint8x16_t, c: uint8x16_t) -> uint32x4_t {
     static_assert_uimm_bits!(LANE, 2);
     let c = vreinterpretq_u32_u8(c);
@@ -9769,7 +9797,7 @@ pub fn vdotq_laneq_u32<const LANE: i32>(a: uint32x4_t, b: uint8x16_t, c: uint8x1
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9799,7 +9827,7 @@ pub fn vdot_s32(a: int32x2_t, b: int8x8_t, c: int8x8_t) -> int32x2_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9835,7 +9863,7 @@ pub fn vdot_s32(a: int32x2_t, b: int8x8_t, c: int8x8_t) -> int32x2_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9865,7 +9893,7 @@ pub fn vdotq_s32(a: int32x4_t, b: int8x16_t, c: int8x16_t) -> int32x4_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9903,7 +9931,7 @@ pub fn vdotq_s32(a: int32x4_t, b: int8x16_t, c: int8x16_t) -> int32x4_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9933,7 +9961,7 @@ pub fn vdot_u32(a: uint32x2_t, b: uint8x8_t, c: uint8x8_t) -> uint32x2_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9969,7 +9997,7 @@ pub fn vdot_u32(a: uint32x2_t, b: uint8x8_t, c: uint8x8_t) -> uint32x2_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",
@@ -9999,7 +10027,7 @@ pub fn vdotq_u32(a: uint32x4_t, b: uint8x16_t, c: uint8x16_t) -> uint32x4_t {
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
-    unstable(feature = "stdarch_neon_dotprod", issue = "117224")
+    stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")
 )]
 #[cfg_attr(
     target_arch = "arm",

--- a/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -14,6 +14,10 @@ neon-stable: &neon-stable
 neon-stable-fp16: &neon-stable-fp16
   FnCall: [stable, ['feature = "stdarch_neon_fp16"', 'since = "1.94.0"']]
 
+# #[stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION")]
+neon-stable-dotprod: &neon-stable-dotprod
+  FnCall: [stable, ['feature = "stdarch_neon_dotprod"', 'since = "CURRENT_RUSTC_VERSION"']]
+
 # #[cfg_attr(target_arch = "arm", unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800"))]
 neon-cfg-arm-unstable: &neon-cfg-arm-unstable
   FnCall: ['cfg_attr', ['target_arch = "arm"', {FnCall: ['unstable', ['feature = "stdarch_arm_neon_intrinsics"', 'issue = "111800"']]}]]
@@ -58,6 +62,10 @@ neon-not-arm-stable: &neon-not-arm-stable
 # #[cfg_attr(not(target_arch = "arm"), stable(feature = "stdarch_neon_fp16", since = "1.94.0"))]
 neon-not-arm-stable-fp16: &neon-not-arm-stable-fp16
   FnCall: [cfg_attr, [{ FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [stable, ['feature = "stdarch_neon_fp16"', 'since = "1.94.0"']]}]]
+
+# #[cfg_attr(not(target_arch = "arm"), stable(feature = "stdarch_neon_dotprod", since = "CURRENT_RUSTC_VERSION"))]
+neon-not-arm-stable-dotprod: &neon-not-arm-stable-dotprod
+  FnCall: [cfg_attr, [{ FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [stable, ['feature = "stdarch_neon_dotprod"', 'since = "CURRENT_RUSTC_VERSION"']]}]]
 
 # #[cfg_attr(all(test, not(target_env = "msvc"))]
 msvc-disabled: &msvc-disabled
@@ -7033,7 +7041,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vsdot, 'LANE = 0']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [sdot, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - FnCall: [unstable, ['feature = "stdarch_neon_dotprod"', 'issue = "117224"']]
+      - *neon-not-arm-stable-dotprod
+      - *neon-cfg-arm-unstable
     safety: safe
     types:
       - [int32x2_t, int8x8_t, int8x16_t, '']
@@ -7063,7 +7072,8 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vudot, 'LANE = 0']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [udot, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - FnCall: [unstable, ['feature = "stdarch_neon_dotprod"', 'issue = "117224"']]
+      - *neon-not-arm-stable-dotprod
+      - *neon-cfg-arm-unstable
     safety: safe
     types:
       - [uint32x2_t, uint8x8_t, uint8x16_t, '']
@@ -7091,7 +7101,7 @@ intrinsics:
       - FnCall: [target_feature, ['enable = "neon,dotprod"']]
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vsdot]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [sdot]]}]]
-      - FnCall: [cfg_attr, [{FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [unstable, ['feature = "stdarch_neon_dotprod"', 'issue = "117224"']]}]]
+      - *neon-not-arm-stable-dotprod
       - *neon-cfg-arm-unstable
     safety: safe
     big_endian_inverse: true
@@ -7116,7 +7126,7 @@ intrinsics:
       - FnCall: [target_feature, ['enable = "neon,dotprod"']]
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vudot]]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [udot]]}]]
-      - FnCall: [cfg_attr, [{FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [unstable, ['feature = "stdarch_neon_dotprod"', 'issue = "117224"']]}]]
+      - *neon-not-arm-stable-dotprod
       - *neon-cfg-arm-unstable
     safety: safe
     big_endian_inverse: true
@@ -7143,7 +7153,7 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vsdot, 'LANE = 0']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [sdot, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - FnCall: [cfg_attr, [{FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [unstable, ['feature = "stdarch_neon_dotprod"', 'issue = "117224"']]}]]
+      - *neon-not-arm-stable-dotprod
       - *neon-cfg-arm-unstable
     safety: safe
     types:
@@ -7174,7 +7184,7 @@ intrinsics:
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vudot, 'LANE = 0']]}]]
       - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [udot, 'LANE = 0']]}]]
       - FnCall: [rustc_legacy_const_generics, ['3']]
-      - FnCall: [cfg_attr, [{FnCall: [not, ['target_arch = "arm"']]}, {FnCall: [unstable, ['feature = "stdarch_neon_dotprod"', 'issue = "117224"']]}]]
+      - *neon-not-arm-stable-dotprod
       - *neon-cfg-arm-unstable
     safety: safe
     types:


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/117224

Stabilizes the NEON dot product intrinsics (vdot*), tracking issue rust-lang/rust#117224.

Gated behind stdarch_neon_dotprod since 2023. The dotprod target feature and is_aarch64_feature_detected!("dotprod") are already stable, so this is an attribute-only change, same pattern as the fp16 stabilization in 0f9516b2. 

The vdot*_laneq* blocks had a plain unstable with no arch split.
I gave them the not(arm) split like the others for consistency.

Regenerated with stdarch-gen-arm, the diff is the stability attribute only. 

Needs an FCP.