### PR TITLE
intrinsic-test fixes for low intrinsic, high core counts

### DIFF
--- a/ci/intrinsic-test.sh
+++ b/ci/intrinsic-test.sh
@@ -57,4 +57,4 @@ case "${TARGET}" in
         ;;
 esac
 
-cargo test --manifest-path=rust_programs/Cargo.toml --target "${TARGET}" --profile "${PROFILE}"
+cargo test --manifest-path=rust_programs/Cargo.toml --target "${TARGET}" --profile "${PROFILE}" --tests

--- a/crates/intrinsic-test/src/common/mod.rs
+++ b/crates/intrinsic-test/src/common/mod.rs
@@ -42,11 +42,11 @@ pub trait SupportedArchitectureTest {
     fn arch_flags(&self) -> Vec<&str>;
 
     fn generate_c_file(&self) {
-        let (chunk_size, _chunk_count) = manual_chunk(self.intrinsics().len());
+        let (max_chunk_size, _chunk_count) = manual_chunk(self.intrinsics().len());
 
         std::fs::create_dir_all("c_programs").unwrap();
         self.intrinsics()
-            .par_chunks(chunk_size)
+            .par_chunks(max_chunk_size)
             .enumerate()
             .map(|(i, chunk)| {
                 let c_filename = format!("c_programs/wrapper_{i}.c");
@@ -62,13 +62,13 @@ pub trait SupportedArchitectureTest {
 
         std::fs::create_dir_all("rust_programs").unwrap();
 
-        let (chunk_size, chunk_count) = manual_chunk(self.intrinsics().len());
+        let (max_chunk_size, chunk_count) = manual_chunk(self.intrinsics().len());
 
         let mut cargo = File::create("rust_programs/Cargo.toml").unwrap();
         write_bin_cargo_toml(&mut cargo, chunk_count).unwrap();
 
         self.intrinsics()
-            .chunks(chunk_size)
+            .chunks(max_chunk_size)
             .enumerate()
             .map(|(i, chunk)| {
                 std::fs::create_dir_all(format!("rust_programs/mod_{i}/src"))?;
@@ -109,5 +109,7 @@ pub trait SupportedArchitectureTest {
 
 pub fn manual_chunk(intrinsic_count: usize) -> (usize, usize) {
     let ncores = std::thread::available_parallelism().unwrap().into();
-    (intrinsic_count.div_ceil(ncores), ncores)
+    let max_intrinsics_per_chunk = intrinsic_count.div_ceil(ncores);
+    let number_of_chunks = intrinsic_count.div_ceil(max_intrinsics_per_chunk);
+    (max_intrinsics_per_chunk, number_of_chunks)
 }


### PR DESCRIPTION
When the intrinsic count is low (such as when adding filtering for debugging) and the core count is high, sometimes the chunk count returned by `manual_chunk()` didn't match the number of modules created, which meant that the `rust_programs/Cargo.toml` referred to modules that didn't exist.

e.g. 100 intrinsics and 80 cores:
chunk_size = 100.div_ceil(80) = 2,
chunk count = 80

However, in practice, with a chunk_size of 2 `Iter::chunks` will only return 50 chunks. The fix is to calculate the real number of chunks with another div ceil, such as `100.div_ceil(2) = 50`. There shouldn't be any difference when the intrinsic count is high enough for this to not matter.

In addition, this patch also adds the `--tests` argument to `cargo test` in order to not attempt running doc tests, which is a slowdown more noticeable with low intrinsic count and higher core count.