### PR TITLE
Several fixes to the loongarch CRC intrinsics

### DIFF
--- a/crates/core_arch/src/loongarch64/mod.rs
+++ b/crates/core_arch/src/loongarch64/mod.rs
@@ -22,8 +22,20 @@ pub fn rdtime_d() -> (i64, isize) {
 
 #[allow(improper_ctypes)]
 unsafe extern "unadjusted" {
+    #[link_name = "llvm.loongarch.crc.w.b.w"]
+    fn __crc_w_b_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crc.w.h.w"]
+    fn __crc_w_h_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crc.w.w.w"]
+    fn __crc_w_w_w(a: i32, b: i32) -> i32;
     #[link_name = "llvm.loongarch.crc.w.d.w"]
     fn __crc_w_d_w(a: i64, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.b.w"]
+    fn __crcc_w_b_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.h.w"]
+    fn __crcc_w_h_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.w.w"]
+    fn __crcc_w_w_w(a: i32, b: i32) -> i32;
     #[link_name = "llvm.loongarch.crcc.w.d.w"]
     fn __crcc_w_d_w(a: i64, b: i32) -> i32;
     #[link_name = "llvm.loongarch.cacop.d"]
@@ -51,8 +63,50 @@ unsafe extern "unadjusted" {
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn crc_w_b_w(a: i32, b: i32) -> i32 {
+    unsafe { __crc_w_b_w(a, b) }
+}
+
+/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
+#[inline(always)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn crc_w_h_w(a: i32, b: i32) -> i32 {
+    unsafe { __crc_w_h_w(a, b) }
+}
+
+/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
+#[inline(always)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn crc_w_w_w(a: i32, b: i32) -> i32 {
+    unsafe { __crc_w_w_w(a, b) }
+}
+
+/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
+#[inline(always)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn crc_w_d_w(a: i64, b: i32) -> i32 {
     unsafe { __crc_w_d_w(a, b) }
+}
+
+/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
+#[inline(always)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn crcc_w_b_w(a: i32, b: i32) -> i32 {
+    unsafe { __crcc_w_b_w(a, b) }
+}
+
+/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
+#[inline(always)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn crcc_w_h_w(a: i32, b: i32) -> i32 {
+    unsafe { __crcc_w_h_w(a, b) }
+}
+
+/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
+#[inline(always)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn crcc_w_w_w(a: i32, b: i32) -> i32 {
+    unsafe { __crcc_w_w_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)

--- a/crates/core_arch/src/loongarch64/mod.rs
+++ b/crates/core_arch/src/loongarch64/mod.rs
@@ -63,15 +63,15 @@ unsafe extern "unadjusted" {
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crc_w_b_w(a: i32, b: i32) -> i32 {
-    unsafe { __crc_w_b_w(a, b) }
+pub fn crc_w_b_w(a: i8, b: i32) -> i32 {
+    unsafe { __crc_w_b_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crc_w_h_w(a: i32, b: i32) -> i32 {
-    unsafe { __crc_w_h_w(a, b) }
+pub fn crc_w_h_w(a: i16, b: i32) -> i32 {
+    unsafe { __crc_w_h_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
@@ -91,15 +91,15 @@ pub fn crc_w_d_w(a: i64, b: i32) -> i32 {
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crcc_w_b_w(a: i32, b: i32) -> i32 {
-    unsafe { __crcc_w_b_w(a, b) }
+pub fn crcc_w_b_w(a: i8, b: i32) -> i32 {
+    unsafe { __crcc_w_b_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crcc_w_h_w(a: i32, b: i32) -> i32 {
-    unsafe { __crcc_w_h_w(a, b) }
+pub fn crcc_w_h_w(a: i16, b: i32) -> i32 {
+    unsafe { __crcc_w_h_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)

--- a/crates/core_arch/src/loongarch_shared/mod.rs
+++ b/crates/core_arch/src/loongarch_shared/mod.rs
@@ -22,18 +22,6 @@ pub fn rdtimeh_w() -> (i32, isize) {
 
 #[allow(improper_ctypes)]
 unsafe extern "unadjusted" {
-    #[link_name = "llvm.loongarch.crc.w.b.w"]
-    fn __crc_w_b_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crc.w.h.w"]
-    fn __crc_w_h_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crc.w.w.w"]
-    fn __crc_w_w_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crcc.w.b.w"]
-    fn __crcc_w_b_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crcc.w.h.w"]
-    fn __crcc_w_h_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crcc.w.w.w"]
-    fn __crcc_w_w_w(a: i32, b: i32) -> i32;
     #[link_name = "llvm.loongarch.dbar"]
     fn __dbar(a: i32);
     #[link_name = "llvm.loongarch.ibar"]
@@ -68,48 +56,6 @@ unsafe extern "unadjusted" {
     fn __frsqrte_s(a: f32) -> f32;
     #[link_name = "llvm.loongarch.frsqrte.d"]
     fn __frsqrte_d(a: f64) -> f64;
-}
-
-/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
-#[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crc_w_b_w(a: i32, b: i32) -> i32 {
-    unsafe { __crc_w_b_w(a, b) }
-}
-
-/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
-#[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crc_w_h_w(a: i32, b: i32) -> i32 {
-    unsafe { __crc_w_h_w(a, b) }
-}
-
-/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
-#[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crc_w_w_w(a: i32, b: i32) -> i32 {
-    unsafe { __crc_w_w_w(a, b) }
-}
-
-/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
-#[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crcc_w_b_w(a: i32, b: i32) -> i32 {
-    unsafe { __crcc_w_b_w(a, b) }
-}
-
-/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
-#[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crcc_w_h_w(a: i32, b: i32) -> i32 {
-    unsafe { __crcc_w_h_w(a, b) }
-}
-
-/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
-#[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub fn crcc_w_w_w(a: i32, b: i32) -> i32 {
-    unsafe { __crcc_w_w_w(a, b) }
 }
 
 /// Generates the memory barrier instruction


### PR DESCRIPTION
The first commit makes the CRC intrinsics exclusive to 64-bit LoongArch, since they are exclusive to LA64 in Clang and GCC (see https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp#L4797).

The second commit aligns the CRC intrinsic definitions for 8 and 16-bit wide data with Clang and GCC, which both use `char` and `short` rather than `int` for the data parameter (see https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/larchintrin.h#L60 and https://github.com/gcc-mirror/gcc/blob/master/gcc/config/loongarch/larchintrin.h#L152). The ARM CRC intrinsics are handled identically in stdarch already: there, the LLVM intrinsic also takes an `i32` but we cast from `u8` or `u16`  (https://doc.rust-lang.org/stable/src/core/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs.html#63).