### PR TITLE
Stabilize LoongArch CRC Intrinsics

### DIFF
--- a/crates/core_arch/src/loongarch64/mod.rs
+++ b/crates/core_arch/src/loongarch64/mod.rs
@@ -62,56 +62,56 @@ unsafe extern "unadjusted" {
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crc_w_b_w(a: i8, b: i32) -> i32 {
     unsafe { __crc_w_b_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crc_w_h_w(a: i16, b: i32) -> i32 {
     unsafe { __crc_w_h_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crc_w_w_w(a: i32, b: i32) -> i32 {
     unsafe { __crc_w_w_w(a, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crc_w_d_w(a: i64, b: i32) -> i32 {
     unsafe { __crc_w_d_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crcc_w_b_w(a: i8, b: i32) -> i32 {
     unsafe { __crcc_w_b_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crcc_w_h_w(a: i16, b: i32) -> i32 {
     unsafe { __crcc_w_h_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crcc_w_w_w(a: i32, b: i32) -> i32 {
     unsafe { __crcc_w_w_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+#[stable(feature = "stdarch_loongarch_crc", since = "CURRENT_RUSTC_VERSION")]
 pub fn crcc_w_d_w(a: i64, b: i32) -> i32 {
     unsafe { __crcc_w_d_w(a, b) }
 }


### PR DESCRIPTION
implementation: https://github.com/rust-lang/stdarch/pull/1688
tracking issue: https://github.com/rust-lang/rust/issues/156908

Following a proposal from @folkertdev and downstream interest from zlib-rs (https://github.com/trifectatechfoundation/zlib-rs/pull/511), this PR proposes stabilizing the LoongArch CRC intrinsics.

Since the API only operates on scalar integer types, there are no major ABI concerns around stabilization.

## API surface

The `stdarch_loongarch_crc` feature exposes 8 functions:

```rust
/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
pub fn crc_w_b_w(a: i8, b: i32) -> i32

/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
pub fn crc_w_h_w(a: i16, b: i32) -> i32

/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
pub fn crc_w_w_w(a: i32, b: i32) -> i32

/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
pub fn crc_w_d_w(a: i64, b: i32) -> i32 

/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
pub fn crcc_w_b_w(a: i8, b: i32) -> i32

/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
pub fn crcc_w_h_w(a: i16, b: i32) -> i32

/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
pub fn crcc_w_w_w(a: i32, b: i32) -> i32

/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
pub fn crcc_w_d_w(a: i64, b: i32) -> i32
```