### PR TITLE
hexagon-gen: add optional output-dir argument

### DIFF
--- a/crates/stdarch-gen-hexagon-scalar/src/main.rs
+++ b/crates/stdarch-gen-hexagon-scalar/src/main.rs
@@ -664,7 +664,11 @@ fn main() -> Result<(), String> {
     let intrinsics = parse_header(&header_content);
     println!("Parsed {} scalar intrinsics", intrinsics.len());
 
-    let hexagon_dir = crate_dir.join("../core_arch/src/hexagon");
+    let hexagon_dir = std::env::args()
+        .nth(1)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| crate_dir.join("../core_arch/src/hexagon"));
+    std::fs::create_dir_all(&hexagon_dir).map_err(|e| e.to_string())?;
     let scalar_path = hexagon_dir.join("scalar.rs");
 
     generate_scalar_file(&intrinsics, &scalar_path)?;

--- a/crates/stdarch-gen-hexagon/src/main.rs
+++ b/crates/stdarch-gen-hexagon/src/main.rs
@@ -1691,7 +1691,11 @@ fn main() -> Result<(), String> {
     }
 
     // Generate output files
-    let hexagon_dir = crate_dir.join("../core_arch/src/hexagon");
+    let hexagon_dir = std::env::args()
+        .nth(1)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| crate_dir.join("../core_arch/src/hexagon"));
+    std::fs::create_dir_all(&hexagon_dir).map_err(|e| e.to_string())?;
 
     // Generate v64.rs (64-byte vector mode)
     let v64_path = hexagon_dir.join("v64.rs");


### PR DESCRIPTION
This PR adds an optional output-directory argument to `stdarch-gen-hexagon` and `stdarch-gen-hexagon-scalar` while preserving the default current behaviour .

r? folkertdev