### PR TITLE
endianness shuffles on loads/stores on `aarch64_be`

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -9924,6 +9924,7 @@ pub fn vgetq_lane_f64<const IMM5: i32>(a: float64x2_t) -> f64 {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -9932,10 +9933,25 @@ pub unsafe fn vld1_f16(ptr: *const f16) -> float16x4_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_f16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon,fp16")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg(not(target_arch = "arm64ec"))]
+pub unsafe fn vld1_f16(ptr: *const f16) -> float16x4_t {
+    let ret_val: float16x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_f16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -9944,10 +9960,25 @@ pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_f16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon,fp16")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg(not(target_arch = "arm64ec"))]
+pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t {
+    let ret_val: float16x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_f32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -9955,15 +9986,42 @@ pub unsafe fn vld1_f32(ptr: *const f32) -> float32x2_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_f32(ptr: *const f32) -> float32x2_t {
+    let ret_val: float32x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_f32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vld1q_f32(ptr: *const f32) -> float32x4_t {
     crate::ptr::read_unaligned(ptr.cast())
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_f32(ptr: *const f32) -> float32x4_t {
+    let ret_val: float32x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_f64)"]
@@ -9981,6 +10039,7 @@ pub unsafe fn vld1_f64(ptr: *const f64) -> float64x1_t {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -9988,10 +10047,24 @@ pub unsafe fn vld1q_f64(ptr: *const f64) -> float64x2_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_f64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_f64(ptr: *const f64) -> float64x2_t {
+    let ret_val: float64x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -9999,10 +10072,24 @@ pub unsafe fn vld1_s8(ptr: *const i8) -> int8x8_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_s8(ptr: *const i8) -> int8x8_t {
+    let ret_val: int8x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10010,10 +10097,28 @@ pub unsafe fn vld1q_s8(ptr: *const i8) -> int8x16_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_s8(ptr: *const i8) -> int8x16_t {
+    let ret_val: int8x16_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(
+        ret_val,
+        ret_val,
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    )
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10021,10 +10126,24 @@ pub unsafe fn vld1_s16(ptr: *const i16) -> int16x4_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_s16(ptr: *const i16) -> int16x4_t {
+    let ret_val: int16x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10032,10 +10151,24 @@ pub unsafe fn vld1q_s16(ptr: *const i16) -> int16x8_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_s16(ptr: *const i16) -> int16x8_t {
+    let ret_val: int16x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10043,15 +10176,42 @@ pub unsafe fn vld1_s32(ptr: *const i32) -> int32x2_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_s32(ptr: *const i32) -> int32x2_t {
+    let ret_val: int32x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vld1q_s32(ptr: *const i32) -> int32x4_t {
     crate::ptr::read_unaligned(ptr.cast())
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_s32(ptr: *const i32) -> int32x4_t {
+    let ret_val: int32x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_s64)"]
@@ -10069,6 +10229,7 @@ pub unsafe fn vld1_s64(ptr: *const i64) -> int64x1_t {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10076,10 +10237,24 @@ pub unsafe fn vld1q_s64(ptr: *const i64) -> int64x2_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_s64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_s64(ptr: *const i64) -> int64x2_t {
+    let ret_val: int64x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10087,10 +10262,24 @@ pub unsafe fn vld1_u8(ptr: *const u8) -> uint8x8_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_u8(ptr: *const u8) -> uint8x8_t {
+    let ret_val: uint8x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10098,10 +10287,28 @@ pub unsafe fn vld1q_u8(ptr: *const u8) -> uint8x16_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_u8(ptr: *const u8) -> uint8x16_t {
+    let ret_val: uint8x16_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(
+        ret_val,
+        ret_val,
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    )
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10109,10 +10316,24 @@ pub unsafe fn vld1_u16(ptr: *const u16) -> uint16x4_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_u16(ptr: *const u16) -> uint16x4_t {
+    let ret_val: uint16x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10120,10 +10341,24 @@ pub unsafe fn vld1q_u16(ptr: *const u16) -> uint16x8_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_u16(ptr: *const u16) -> uint16x8_t {
+    let ret_val: uint16x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10131,15 +10366,42 @@ pub unsafe fn vld1_u32(ptr: *const u32) -> uint32x2_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_u32(ptr: *const u32) -> uint32x2_t {
+    let ret_val: uint32x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vld1q_u32(ptr: *const u32) -> uint32x4_t {
     crate::ptr::read_unaligned(ptr.cast())
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_u32(ptr: *const u32) -> uint32x4_t {
+    let ret_val: uint32x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_u64)"]
@@ -10157,6 +10419,7 @@ pub unsafe fn vld1_u64(ptr: *const u64) -> uint64x1_t {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10164,10 +10427,24 @@ pub unsafe fn vld1q_u64(ptr: *const u64) -> uint64x2_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_u64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_u64(ptr: *const u64) -> uint64x2_t {
+    let ret_val: uint64x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10175,10 +10452,24 @@ pub unsafe fn vld1_p8(ptr: *const p8) -> poly8x8_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_p8(ptr: *const p8) -> poly8x8_t {
+    let ret_val: poly8x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10186,10 +10477,28 @@ pub unsafe fn vld1q_p8(ptr: *const p8) -> poly8x16_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_p8(ptr: *const p8) -> poly8x16_t {
+    let ret_val: poly8x16_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(
+        ret_val,
+        ret_val,
+        [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    )
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
@@ -10197,15 +10506,42 @@ pub unsafe fn vld1_p16(ptr: *const p16) -> poly16x4_t {
     crate::ptr::read_unaligned(ptr.cast())
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1_p16(ptr: *const p16) -> poly16x4_t {
+    let ret_val: poly16x4_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [3, 2, 1, 0])
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vld1q_p16(ptr: *const p16) -> poly16x8_t {
     crate::ptr::read_unaligned(ptr.cast())
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_p16(ptr: *const p16) -> poly16x8_t {
+    let ret_val: poly16x8_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [7, 6, 5, 4, 3, 2, 1, 0])
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_p64)"]
@@ -10223,11 +10559,25 @@ pub unsafe fn vld1_p64(ptr: *const p64) -> poly64x1_t {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(ldr))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vld1q_p64(ptr: *const p64) -> poly64x2_t {
     crate::ptr::read_unaligned(ptr.cast())
+}
+#[doc = "Load multiple single-element structures to one, two, three, or four registers"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_p64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon,aes")]
+#[cfg_attr(test, assert_instr(ldr))]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vld1q_p64(ptr: *const p64) -> poly64x2_t {
+    let ret_val: poly64x2_t = crate::ptr::read_unaligned(ptr.cast());
+    simd_shuffle!(ret_val, ret_val, [1, 0])
 }
 #[doc = "Load multiple single-element structures to one, two, three, or four registers"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_f64_x2)"]
@@ -24617,6 +24967,7 @@ pub fn vsrid_n_u64<const N: i32>(a: u64, b: u64) -> u64 {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24626,10 +24977,26 @@ pub unsafe fn vst1_f16(ptr: *mut f16, a: float16x4_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_f16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon,fp16")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg(not(target_arch = "arm64ec"))]
+pub unsafe fn vst1_f16(ptr: *mut f16, a: float16x4_t) {
+    let a: float16x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_f16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,fp16")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24639,10 +25006,26 @@ pub unsafe fn vst1q_f16(ptr: *mut f16, a: float16x8_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_f16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon,fp16")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[unstable(feature = "stdarch_neon_f16", issue = "136306")]
+#[cfg(not(target_arch = "arm64ec"))]
+pub unsafe fn vst1q_f16(ptr: *mut f16, a: float16x8_t) {
+    let a: float16x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_f32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24651,15 +25034,44 @@ pub unsafe fn vst1_f32(ptr: *mut f32, a: float32x2_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_f32(ptr: *mut f32, a: float32x2_t) {
+    let a: float32x2_t = simd_shuffle!(a, a, [1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_f32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vst1q_f32(ptr: *mut f32, a: float32x4_t) {
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_f32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_f32(ptr: *mut f32, a: float32x4_t) {
+    let a: float32x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
@@ -24679,6 +25091,7 @@ pub unsafe fn vst1_f64(ptr: *mut f64, a: float64x1_t) {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24687,10 +25100,25 @@ pub unsafe fn vst1q_f64(ptr: *mut f64, a: float64x2_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_f64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_f64(ptr: *mut f64, a: float64x2_t) {
+    let a: float64x2_t = simd_shuffle!(a, a, [1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_s8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24699,10 +25127,25 @@ pub unsafe fn vst1_s8(ptr: *mut i8, a: int8x8_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_s8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_s8(ptr: *mut i8, a: int8x8_t) {
+    let a: int8x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24711,10 +25154,25 @@ pub unsafe fn vst1q_s8(ptr: *mut i8, a: int8x16_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_s8(ptr: *mut i8, a: int8x16_t) {
+    let a: int8x16_t = simd_shuffle!(a, a, [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_s16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24723,10 +25181,25 @@ pub unsafe fn vst1_s16(ptr: *mut i16, a: int16x4_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_s16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_s16(ptr: *mut i16, a: int16x4_t) {
+    let a: int16x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24735,10 +25208,25 @@ pub unsafe fn vst1q_s16(ptr: *mut i16, a: int16x8_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_s16(ptr: *mut i16, a: int16x8_t) {
+    let a: int16x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_s32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24747,15 +25235,44 @@ pub unsafe fn vst1_s32(ptr: *mut i32, a: int32x2_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_s32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_s32(ptr: *mut i32, a: int32x2_t) {
+    let a: int32x2_t = simd_shuffle!(a, a, [1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vst1q_s32(ptr: *mut i32, a: int32x4_t) {
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_s32(ptr: *mut i32, a: int32x4_t) {
+    let a: int32x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
@@ -24775,6 +25292,7 @@ pub unsafe fn vst1_s64(ptr: *mut i64, a: int64x1_t) {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24783,10 +25301,25 @@ pub unsafe fn vst1q_s64(ptr: *mut i64, a: int64x2_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_s64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_s64(ptr: *mut i64, a: int64x2_t) {
+    let a: int64x2_t = simd_shuffle!(a, a, [1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_u8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24795,10 +25328,25 @@ pub unsafe fn vst1_u8(ptr: *mut u8, a: uint8x8_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_u8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_u8(ptr: *mut u8, a: uint8x8_t) {
+    let a: uint8x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24807,10 +25355,25 @@ pub unsafe fn vst1q_u8(ptr: *mut u8, a: uint8x16_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_u8(ptr: *mut u8, a: uint8x16_t) {
+    let a: uint8x16_t = simd_shuffle!(a, a, [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_u16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24819,10 +25382,25 @@ pub unsafe fn vst1_u16(ptr: *mut u16, a: uint16x4_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_u16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_u16(ptr: *mut u16, a: uint16x4_t) {
+    let a: uint16x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24831,10 +25409,25 @@ pub unsafe fn vst1q_u16(ptr: *mut u16, a: uint16x8_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_u16(ptr: *mut u16, a: uint16x8_t) {
+    let a: uint16x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_u32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24843,15 +25436,44 @@ pub unsafe fn vst1_u32(ptr: *mut u32, a: uint32x2_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_u32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_u32(ptr: *mut u32, a: uint32x2_t) {
+    let a: uint32x2_t = simd_shuffle!(a, a, [1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u32)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vst1q_u32(ptr: *mut u32, a: uint32x4_t) {
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u32)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_u32(ptr: *mut u32, a: uint32x4_t) {
+    let a: uint32x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
@@ -24871,6 +25493,7 @@ pub unsafe fn vst1_u64(ptr: *mut u64, a: uint64x1_t) {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24879,10 +25502,25 @@ pub unsafe fn vst1q_u64(ptr: *mut u64, a: uint64x2_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_u64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_u64(ptr: *mut u64, a: uint64x2_t) {
+    let a: uint64x2_t = simd_shuffle!(a, a, [1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24891,10 +25529,25 @@ pub unsafe fn vst1_p8(ptr: *mut p8, a: poly8x8_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_p8(ptr: *mut p8, a: poly8x8_t) {
+    let a: poly8x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p8)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24903,10 +25556,25 @@ pub unsafe fn vst1q_p8(ptr: *mut p8, a: poly8x16_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p8)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_p8(ptr: *mut p8, a: poly8x16_t) {
+    let a: poly8x16_t = simd_shuffle!(a, a, [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -24915,15 +25583,44 @@ pub unsafe fn vst1_p16(ptr: *mut p16, a: poly16x4_t) {
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1_p16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1_p16(ptr: *mut p16, a: poly16x4_t) {
+    let a: poly16x4_t = simd_shuffle!(a, a, [3, 2, 1, 0]);
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p16)"]
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vst1q_p16(ptr: *mut p16, a: poly16x8_t) {
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p16)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_p16(ptr: *mut p16, a: poly16x8_t) {
+    let a: poly16x8_t = simd_shuffle!(a, a, [7, 6, 5, 4, 3, 2, 1, 0]);
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures from one, two, three, or four registers."]
@@ -24943,11 +25640,26 @@ pub unsafe fn vst1_p64(ptr: *mut p64, a: poly64x1_t) {
 #[doc = "## Safety"]
 #[doc = "  * Neon intrinsic unsafe"]
 #[inline]
+#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,aes")]
 #[cfg_attr(test, assert_instr(str))]
 #[allow(clippy::cast_ptr_alignment)]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub unsafe fn vst1q_p64(ptr: *mut p64, a: poly64x2_t) {
+    crate::ptr::write_unaligned(ptr.cast(), a)
+}
+#[doc = "Store multiple single-element structures from one, two, three, or four registers."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vst1q_p64)"]
+#[doc = "## Safety"]
+#[doc = "  * Neon intrinsic unsafe"]
+#[inline]
+#[cfg(target_endian = "big")]
+#[target_feature(enable = "neon,aes")]
+#[cfg_attr(test, assert_instr(str))]
+#[allow(clippy::cast_ptr_alignment)]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+pub unsafe fn vst1q_p64(ptr: *mut p64, a: poly64x2_t) {
+    let a: poly64x2_t = simd_shuffle!(a, a, [1, 0]);
     crate::ptr::write_unaligned(ptr.cast(), a)
 }
 #[doc = "Store multiple single-element structures to one, two, three, or four registers"]

--- a/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/crates/core_arch/src/aarch64/neon/mod.rs
@@ -424,6 +424,17 @@ mod tests {
     use crate::core_arch::{aarch64::neon::*, aarch64::*, simd::*};
     use stdarch_test::simd_test;
 
+    fn reverse_on_be<T, const N: usize>(arr: [T; N]) -> [T; N] {
+        cfg_select! {
+            target_endian = "big" => {
+                let mut arr = arr;
+                arr.reverse();
+                arr
+            }
+            target_endian = "little" => arr,
+        }
+    }
+
     #[simd_test(enable = "neon")]
     fn test_vadd_f64() {
         let a = f64x1::from_array([1.]);
@@ -704,7 +715,7 @@ mod tests {
     #[simd_test(enable = "neon")]
     fn test_vld1q_f64() {
         let a: [f64; 3] = [0., 1., 2.];
-        let e = f64x2::new(1., 2.);
+        let e = f64x2::from_array(reverse_on_be([1., 2.]));
         let r = unsafe { f64x2::from(vld1q_f64(a[1..].as_ptr())) };
         assert_eq!(r, e)
     }
@@ -759,7 +770,7 @@ mod tests {
     #[simd_test(enable = "neon")]
     fn test_vst1q_f64() {
         let mut vals = [0_f64; 3];
-        let a = f64x2::new(1., 2.);
+        let a = f64x2::from_array(reverse_on_be([1., 2.]));
 
         unsafe {
             vst1q_f64(vals[1..].as_mut_ptr(), a.into());
@@ -768,6 +779,32 @@ mod tests {
         assert_eq!(vals[0], 0.);
         assert_eq!(vals[1], 1.);
         assert_eq!(vals[2], 2.);
+    }
+
+    #[simd_test(enable = "neon")]
+    fn test_vpminq_u8() {
+        unsafe {
+            let a = vld1q_u8([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8].as_ptr());
+            let b = vld1q_u8([0, 3, 2, 5, 4, 7, 6, 9, 0, 3, 2, 5, 4, 7, 6, 9].as_ptr());
+            let e = [1, 3, 5, 7, 1, 3, 5, 7, 0, 2, 4, 6, 0, 2, 4, 6];
+            let mut r = [0; 16];
+            let res = vpminq_u8(a, b);
+            vst1q_u8(r.as_mut_ptr(), res);
+            assert_eq!(r, e);
+        }
+    }
+
+    #[simd_test(enable = "neon")]
+    fn test_vpmaxq_u8() {
+        unsafe {
+            let a = vld1q_u8([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8].as_ptr());
+            let b = vld1q_u8([0, 3, 2, 5, 4, 7, 6, 9, 0, 3, 2, 5, 4, 7, 6, 9].as_ptr());
+            let e = [2, 4, 6, 8, 2, 4, 6, 8, 3, 5, 7, 9, 3, 5, 7, 9];
+            let mut r = [0; 16];
+            let res = vpmaxq_u8(a, b);
+            vst1q_u8(r.as_mut_ptr(), res);
+            assert_eq!(r, e);
+        }
     }
 
     macro_rules! wide_store_load_roundtrip {

--- a/crates/core_arch/src/arm_shared/neon/load_tests.rs
+++ b/crates/core_arch/src/arm_shared/neon/load_tests.rs
@@ -14,10 +14,20 @@ use crate::core_arch::simd::*;
 use std::mem;
 use stdarch_test::simd_test;
 
+fn reverse_on_be<T, const N: usize>(mut arr: [T; N]) -> [T; N] {
+    cfg_select! {
+        target_endian = "big" => {
+            arr.reverse();
+            arr
+        }
+        target_endian = "little" => arr,
+    }
+}
+
 #[simd_test(enable = "neon")]
 fn test_vld1_s8() {
     let a: [i8; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let e = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let e = i8x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
     let r = unsafe { i8x8::from(vld1_s8(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -25,7 +35,9 @@ fn test_vld1_s8() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_s8() {
     let a: [i8; 17] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    let e = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    let e = i8x16::from_array(reverse_on_be([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
     let r = unsafe { i8x16::from(vld1q_s8(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -33,7 +45,7 @@ fn test_vld1q_s8() {
 #[simd_test(enable = "neon")]
 fn test_vld1_s16() {
     let a: [i16; 5] = [0, 1, 2, 3, 4];
-    let e = i16x4::new(1, 2, 3, 4);
+    let e = i16x4::from_array(reverse_on_be([1, 2, 3, 4]));
     let r = unsafe { i16x4::from(vld1_s16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -41,7 +53,7 @@ fn test_vld1_s16() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_s16() {
     let a: [i16; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let e = i16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let e = i16x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
     let r = unsafe { i16x8::from(vld1q_s16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -49,7 +61,7 @@ fn test_vld1q_s16() {
 #[simd_test(enable = "neon")]
 fn test_vld1_s32() {
     let a: [i32; 3] = [0, 1, 2];
-    let e = i32x2::new(1, 2);
+    let e = i32x2::from_array(reverse_on_be([1, 2]));
     let r = unsafe { i32x2::from(vld1_s32(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -57,7 +69,7 @@ fn test_vld1_s32() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_s32() {
     let a: [i32; 5] = [0, 1, 2, 3, 4];
-    let e = i32x4::new(1, 2, 3, 4);
+    let e = i32x4::from_array(reverse_on_be([1, 2, 3, 4]));
     let r = unsafe { i32x4::from(vld1q_s32(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -65,7 +77,7 @@ fn test_vld1q_s32() {
 #[simd_test(enable = "neon")]
 fn test_vld1_s64() {
     let a: [i64; 2] = [0, 1];
-    let e = i64x1::new(1);
+    let e = i64x1::from_array(reverse_on_be([1]));
     let r = unsafe { i64x1::from(vld1_s64(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -73,7 +85,7 @@ fn test_vld1_s64() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_s64() {
     let a: [i64; 3] = [0, 1, 2];
-    let e = i64x2::new(1, 2);
+    let e = i64x2::from_array(reverse_on_be([1, 2]));
     let r = unsafe { i64x2::from(vld1q_s64(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -81,7 +93,7 @@ fn test_vld1q_s64() {
 #[simd_test(enable = "neon")]
 fn test_vld1_u8() {
     let a: [u8; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let e = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let e = u8x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
     let r = unsafe { u8x8::from(vld1_u8(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -89,7 +101,9 @@ fn test_vld1_u8() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_u8() {
     let a: [u8; 17] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    let e = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    let e = u8x16::from_array(reverse_on_be([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
     let r = unsafe { u8x16::from(vld1q_u8(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -97,7 +111,7 @@ fn test_vld1q_u8() {
 #[simd_test(enable = "neon")]
 fn test_vld1_u16() {
     let a: [u16; 5] = [0, 1, 2, 3, 4];
-    let e = u16x4::new(1, 2, 3, 4);
+    let e = u16x4::from_array(reverse_on_be([1, 2, 3, 4]));
     let r = unsafe { u16x4::from(vld1_u16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -105,7 +119,7 @@ fn test_vld1_u16() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_u16() {
     let a: [u16; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let e = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let e = u16x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
     let r = unsafe { u16x8::from(vld1q_u16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -113,7 +127,7 @@ fn test_vld1q_u16() {
 #[simd_test(enable = "neon")]
 fn test_vld1_u32() {
     let a: [u32; 3] = [0, 1, 2];
-    let e = u32x2::new(1, 2);
+    let e = u32x2::from_array(reverse_on_be([1, 2]));
     let r = unsafe { u32x2::from(vld1_u32(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -121,7 +135,7 @@ fn test_vld1_u32() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_u32() {
     let a: [u32; 5] = [0, 1, 2, 3, 4];
-    let e = u32x4::new(1, 2, 3, 4);
+    let e = u32x4::from_array(reverse_on_be([1, 2, 3, 4]));
     let r = unsafe { u32x4::from(vld1q_u32(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -129,7 +143,7 @@ fn test_vld1q_u32() {
 #[simd_test(enable = "neon")]
 fn test_vld1_u64() {
     let a: [u64; 2] = [0, 1];
-    let e = u64x1::new(1);
+    let e = u64x1::from_array(reverse_on_be([1]));
     let r = unsafe { u64x1::from(vld1_u64(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -137,7 +151,7 @@ fn test_vld1_u64() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_u64() {
     let a: [u64; 3] = [0, 1, 2];
-    let e = u64x2::new(1, 2);
+    let e = u64x2::from_array(reverse_on_be([1, 2]));
     let r = unsafe { u64x2::from(vld1q_u64(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -145,7 +159,7 @@ fn test_vld1q_u64() {
 #[simd_test(enable = "neon")]
 fn test_vld1_p8() {
     let a: [p8; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let e = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let e = u8x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
     let r = unsafe { u8x8::from(vld1_p8(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -153,7 +167,9 @@ fn test_vld1_p8() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_p8() {
     let a: [p8; 17] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    let e = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    let e = u8x16::from_array(reverse_on_be([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
     let r = unsafe { u8x16::from(vld1q_p8(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -161,7 +177,7 @@ fn test_vld1q_p8() {
 #[simd_test(enable = "neon")]
 fn test_vld1_p16() {
     let a: [p16; 5] = [0, 1, 2, 3, 4];
-    let e = u16x4::new(1, 2, 3, 4);
+    let e = u16x4::from_array(reverse_on_be([1, 2, 3, 4]));
     let r = unsafe { u16x4::from(vld1_p16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -169,7 +185,7 @@ fn test_vld1_p16() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_p16() {
     let a: [p16; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let e = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let e = u16x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
     let r = unsafe { u16x8::from(vld1q_p16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -177,7 +193,7 @@ fn test_vld1q_p16() {
 #[simd_test(enable = "neon,aes")]
 fn test_vld1_p64() {
     let a: [p64; 2] = [0, 1];
-    let e = u64x1::new(1);
+    let e = u64x1::from_array(reverse_on_be([1]));
     let r = unsafe { u64x1::from(vld1_p64(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -185,7 +201,7 @@ fn test_vld1_p64() {
 #[simd_test(enable = "neon,aes")]
 fn test_vld1q_p64() {
     let a: [p64; 3] = [0, 1, 2];
-    let e = u64x2::new(1, 2);
+    let e = u64x2::from_array(reverse_on_be([1, 2]));
     let r = unsafe { u64x2::from(vld1q_p64(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -194,7 +210,7 @@ fn test_vld1q_p64() {
 #[simd_test(enable = "neon,fp16")]
 fn test_vld1_f16() {
     let a: [f16; 5] = [0., 1., 2., 3., 4.];
-    let e = f16x4::new(1., 2., 3., 4.);
+    let e = f16x4::from_array(reverse_on_be([1., 2., 3., 4.]));
     let r = unsafe { f16x4::from(vld1_f16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -203,7 +219,7 @@ fn test_vld1_f16() {
 #[simd_test(enable = "neon,fp16")]
 fn test_vld1q_f16() {
     let a: [f16; 9] = [0., 1., 2., 3., 4., 5., 6., 7., 8.];
-    let e = f16x8::new(1., 2., 3., 4., 5., 6., 7., 8.);
+    let e = f16x8::from_array(reverse_on_be([1., 2., 3., 4., 5., 6., 7., 8.]));
     let r = unsafe { f16x8::from(vld1q_f16(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -211,7 +227,7 @@ fn test_vld1q_f16() {
 #[simd_test(enable = "neon")]
 fn test_vld1_f32() {
     let a: [f32; 3] = [0., 1., 2.];
-    let e = f32x2::new(1., 2.);
+    let e = f32x2::from_array(reverse_on_be([1., 2.]));
     let r = unsafe { f32x2::from(vld1_f32(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }
@@ -219,7 +235,7 @@ fn test_vld1_f32() {
 #[simd_test(enable = "neon")]
 fn test_vld1q_f32() {
     let a: [f32; 5] = [0., 1., 2., 3., 4.];
-    let e = f32x4::new(1., 2., 3., 4.);
+    let e = f32x4::from_array(reverse_on_be([1., 2., 3., 4.]));
     let r = unsafe { f32x4::from(vld1q_f32(a[1..].as_ptr())) };
     assert_eq!(r, e)
 }

--- a/crates/core_arch/src/arm_shared/neon/store_tests.rs
+++ b/crates/core_arch/src/arm_shared/neon/store_tests.rs
@@ -13,10 +13,21 @@ use crate::core_arch::aarch64::*;
 use crate::core_arch::simd::*;
 use stdarch_test::simd_test;
 
+fn reverse_on_be<T, const N: usize>(arr: [T; N]) -> [T; N] {
+    cfg_select! {
+        target_endian = "big" => {
+            let mut arr = arr;
+            arr.reverse();
+            arr
+        }
+        target_endian = "little" => arr,
+    }
+}
+
 #[simd_test(enable = "neon")]
 fn test_vst1_s8() {
     let mut vals = [0_i8; 9];
-    let a = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let a = i8x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
 
     unsafe {
         vst1_s8(vals[1..].as_mut_ptr(), a.into());
@@ -36,7 +47,9 @@ fn test_vst1_s8() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_s8() {
     let mut vals = [0_i8; 17];
-    let a = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    let a = i8x16::from_array(reverse_on_be([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
 
     unsafe {
         vst1q_s8(vals[1..].as_mut_ptr(), a.into());
@@ -64,7 +77,7 @@ fn test_vst1q_s8() {
 #[simd_test(enable = "neon")]
 fn test_vst1_s16() {
     let mut vals = [0_i16; 5];
-    let a = i16x4::new(1, 2, 3, 4);
+    let a = i16x4::from_array(reverse_on_be([1, 2, 3, 4]));
 
     unsafe {
         vst1_s16(vals[1..].as_mut_ptr(), a.into());
@@ -80,7 +93,7 @@ fn test_vst1_s16() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_s16() {
     let mut vals = [0_i16; 9];
-    let a = i16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let a = i16x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
 
     unsafe {
         vst1q_s16(vals[1..].as_mut_ptr(), a.into());
@@ -100,7 +113,7 @@ fn test_vst1q_s16() {
 #[simd_test(enable = "neon")]
 fn test_vst1_s32() {
     let mut vals = [0_i32; 3];
-    let a = i32x2::new(1, 2);
+    let a = i32x2::from_array(reverse_on_be([1, 2]));
 
     unsafe {
         vst1_s32(vals[1..].as_mut_ptr(), a.into());
@@ -114,7 +127,7 @@ fn test_vst1_s32() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_s32() {
     let mut vals = [0_i32; 5];
-    let a = i32x4::new(1, 2, 3, 4);
+    let a = i32x4::from_array(reverse_on_be([1, 2, 3, 4]));
 
     unsafe {
         vst1q_s32(vals[1..].as_mut_ptr(), a.into());
@@ -130,7 +143,7 @@ fn test_vst1q_s32() {
 #[simd_test(enable = "neon")]
 fn test_vst1_s64() {
     let mut vals = [0_i64; 2];
-    let a = i64x1::new(1);
+    let a = i64x1::from_array(reverse_on_be([1]));
 
     unsafe {
         vst1_s64(vals[1..].as_mut_ptr(), a.into());
@@ -143,7 +156,7 @@ fn test_vst1_s64() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_s64() {
     let mut vals = [0_i64; 3];
-    let a = i64x2::new(1, 2);
+    let a = i64x2::from_array(reverse_on_be([1, 2]));
 
     unsafe {
         vst1q_s64(vals[1..].as_mut_ptr(), a.into());
@@ -157,7 +170,7 @@ fn test_vst1q_s64() {
 #[simd_test(enable = "neon")]
 fn test_vst1_u8() {
     let mut vals = [0_u8; 9];
-    let a = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let a = u8x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
 
     unsafe {
         vst1_u8(vals[1..].as_mut_ptr(), a.into());
@@ -177,7 +190,9 @@ fn test_vst1_u8() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_u8() {
     let mut vals = [0_u8; 17];
-    let a = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    let a = u8x16::from_array(reverse_on_be([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
 
     unsafe {
         vst1q_u8(vals[1..].as_mut_ptr(), a.into());
@@ -205,7 +220,7 @@ fn test_vst1q_u8() {
 #[simd_test(enable = "neon")]
 fn test_vst1_u16() {
     let mut vals = [0_u16; 5];
-    let a = u16x4::new(1, 2, 3, 4);
+    let a = u16x4::from_array(reverse_on_be([1, 2, 3, 4]));
 
     unsafe {
         vst1_u16(vals[1..].as_mut_ptr(), a.into());
@@ -221,7 +236,7 @@ fn test_vst1_u16() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_u16() {
     let mut vals = [0_u16; 9];
-    let a = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let a = u16x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
 
     unsafe {
         vst1q_u16(vals[1..].as_mut_ptr(), a.into());
@@ -241,7 +256,7 @@ fn test_vst1q_u16() {
 #[simd_test(enable = "neon")]
 fn test_vst1_u32() {
     let mut vals = [0_u32; 3];
-    let a = u32x2::new(1, 2);
+    let a = u32x2::from_array(reverse_on_be([1, 2]));
 
     unsafe {
         vst1_u32(vals[1..].as_mut_ptr(), a.into());
@@ -255,7 +270,7 @@ fn test_vst1_u32() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_u32() {
     let mut vals = [0_u32; 5];
-    let a = u32x4::new(1, 2, 3, 4);
+    let a = u32x4::from_array(reverse_on_be([1, 2, 3, 4]));
 
     unsafe {
         vst1q_u32(vals[1..].as_mut_ptr(), a.into());
@@ -271,7 +286,7 @@ fn test_vst1q_u32() {
 #[simd_test(enable = "neon")]
 fn test_vst1_u64() {
     let mut vals = [0_u64; 2];
-    let a = u64x1::new(1);
+    let a = u64x1::from_array(reverse_on_be([1]));
 
     unsafe {
         vst1_u64(vals[1..].as_mut_ptr(), a.into());
@@ -284,7 +299,7 @@ fn test_vst1_u64() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_u64() {
     let mut vals = [0_u64; 3];
-    let a = u64x2::new(1, 2);
+    let a = u64x2::from_array(reverse_on_be([1, 2]));
 
     unsafe {
         vst1q_u64(vals[1..].as_mut_ptr(), a.into());
@@ -298,7 +313,7 @@ fn test_vst1q_u64() {
 #[simd_test(enable = "neon")]
 fn test_vst1_p8() {
     let mut vals = [0_u8; 9];
-    let a = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let a = u8x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
 
     unsafe {
         vst1_p8(vals[1..].as_mut_ptr(), a.into());
@@ -318,7 +333,9 @@ fn test_vst1_p8() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_p8() {
     let mut vals = [0_u8; 17];
-    let a = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+    let a = u8x16::from_array(reverse_on_be([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
 
     unsafe {
         vst1q_p8(vals[1..].as_mut_ptr(), a.into());
@@ -346,7 +363,7 @@ fn test_vst1q_p8() {
 #[simd_test(enable = "neon")]
 fn test_vst1_p16() {
     let mut vals = [0_u16; 5];
-    let a = u16x4::new(1, 2, 3, 4);
+    let a = u16x4::from_array(reverse_on_be([1, 2, 3, 4]));
 
     unsafe {
         vst1_p16(vals[1..].as_mut_ptr(), a.into());
@@ -362,7 +379,7 @@ fn test_vst1_p16() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_p16() {
     let mut vals = [0_u16; 9];
-    let a = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
+    let a = u16x8::from_array(reverse_on_be([1, 2, 3, 4, 5, 6, 7, 8]));
 
     unsafe {
         vst1q_p16(vals[1..].as_mut_ptr(), a.into());
@@ -382,7 +399,7 @@ fn test_vst1q_p16() {
 #[simd_test(enable = "neon,aes")]
 fn test_vst1_p64() {
     let mut vals = [0_u64; 2];
-    let a = u64x1::new(1);
+    let a = u64x1::from_array(reverse_on_be([1]));
 
     unsafe {
         vst1_p64(vals[1..].as_mut_ptr(), a.into());
@@ -395,7 +412,7 @@ fn test_vst1_p64() {
 #[simd_test(enable = "neon,aes")]
 fn test_vst1q_p64() {
     let mut vals = [0_u64; 3];
-    let a = u64x2::new(1, 2);
+    let a = u64x2::from_array(reverse_on_be([1, 2]));
 
     unsafe {
         vst1q_p64(vals[1..].as_mut_ptr(), a.into());
@@ -410,7 +427,7 @@ fn test_vst1q_p64() {
 #[simd_test(enable = "neon,fp16")]
 fn test_vst1_f16() {
     let mut vals = [0_f16; 5];
-    let a = f16x4::new(1., 2., 3., 4.);
+    let a = f16x4::from_array(reverse_on_be([1., 2., 3., 4.]));
 
     unsafe {
         vst1_f16(vals[1..].as_mut_ptr(), a.into());
@@ -427,7 +444,7 @@ fn test_vst1_f16() {
 #[simd_test(enable = "neon,fp16")]
 fn test_vst1q_f16() {
     let mut vals = [0_f16; 9];
-    let a = f16x8::new(1., 2., 3., 4., 5., 6., 7., 8.);
+    let a = f16x8::from_array(reverse_on_be([1., 2., 3., 4., 5., 6., 7., 8.]));
 
     unsafe {
         vst1q_f16(vals[1..].as_mut_ptr(), a.into());
@@ -447,7 +464,7 @@ fn test_vst1q_f16() {
 #[simd_test(enable = "neon")]
 fn test_vst1_f32() {
     let mut vals = [0_f32; 3];
-    let a = f32x2::new(1., 2.);
+    let a = f32x2::from_array(reverse_on_be([1., 2.]));
 
     unsafe {
         vst1_f32(vals[1..].as_mut_ptr(), a.into());
@@ -461,7 +478,7 @@ fn test_vst1_f32() {
 #[simd_test(enable = "neon")]
 fn test_vst1q_f32() {
     let mut vals = [0_f32; 5];
-    let a = f32x4::new(1., 2., 3., 4.);
+    let a = f32x4::from_array(reverse_on_be([1., 2., 3., 4.]));
 
     unsafe {
         vst1q_f32(vals[1..].as_mut_ptr(), a.into());

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -12767,6 +12767,7 @@ intrinsics:
       - *neon-stable
     safety:
       unsafe: [neon]
+    big_endian_inverse: true
     types:
       - ['*const i8', int8x8_t, "neon"]
       - ['*const i8', int8x16_t, "neon"]
@@ -12813,6 +12814,7 @@ intrinsics:
       - *target-not-arm64ec
     safety:
       unsafe: [neon]
+    big_endian_inverse: true
     types:
       - ['*const f16', float16x4_t, "neon,fp16"]
       - ['*const f16', float16x8_t, "neon,fp16"]
@@ -12834,6 +12836,7 @@ intrinsics:
       - *neon-stable
     safety:
       unsafe: [neon]
+    big_endian_inverse: true
     types:
       - ['*mut i8', int8x8_t, "neon"]
       - ['*mut i8', int8x16_t, "neon"]
@@ -12881,6 +12884,7 @@ intrinsics:
       - *target-not-arm64ec
     safety:
       unsafe: [neon]
+    big_endian_inverse: true
     types:
       - ['*mut f16', float16x4_t, "neon,fp16"]
       - ['*mut f16', float16x8_t, "neon,fp16"]


### PR DESCRIPTION
With clang I get 

https://godbolt.org/z/Mcvebd79G

```c
// test_vpmaxq_u8.c
#include <arm_neon.h>
#include <stdint.h>
#include <stdio.h>
#include <stdlib.h>

uint8x16_t wrapper(uint8x16_t a, uint8x16_t b) {
    return vpmaxq_u8(a, b);
}

void wrapper2(uint8_t *a, uint8_t *b, uint8_t *out) {
    uint8x16_t x = vld1q_u8(a);
    uint8x16_t y = vld1q_u8(b);
    
    uint8x16_t tmp = vpmaxq_u8(x, y);

    vst1q_u8(out, tmp);
}
```

gives 

```asm
wrapper:
        rev64   v1.16b, v1.16b
        rev64   v0.16b, v0.16b
        ext     v1.16b, v1.16b, v1.16b, #8
        ext     v0.16b, v0.16b, v0.16b, #8
        rev64   v0.16b, v0.16b
        rev64   v1.16b, v1.16b
        ext     v0.16b, v0.16b, v0.16b, #8
        ext     v1.16b, v1.16b, v1.16b, #8
        umaxp   v0.16b, v0.16b, v1.16b
        rev64   v0.16b, v0.16b
        ext     v0.16b, v0.16b, v0.16b, #8
        rev64   v0.16b, v0.16b
        ext     v0.16b, v0.16b, v0.16b, #8
        ret

wrapper2:
        ld1     { v0.16b }, [x0]
        ld1     { v1.16b }, [x1]
        umaxp   v0.16b, v0.16b, v1.16b
        st1     { v0.16b }, [x2]
        ret
```

while with `cargo 1.98.0-nightly (fbb61be30 2026-05-26)` this rust code 

```rust
use core::arch::aarch64::*;

#[target_feature(enable = "neon")]
#[unsafe(no_mangle)]
extern "C" fn wrapper(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
    unsafe {
        return vpmaxq_u8(a, b);
    }
}

#[target_feature(enable = "neon")]
#[unsafe(no_mangle)]
extern "C" fn wrapper2(a: *const u8, b: *const u8, out: *mut u8) {
    unsafe {
        let x: uint8x16_t = vld1q_u8(a);
        let y: uint8x16_t = vld1q_u8(b);

        let tmp = vpmaxq_u8(x, y);

        vst1q_u8(out, tmp);
    }
}
```

emits 

```asm
wrapper:
	rev64 v1.16b, v1.16b
	rev64 v0.16b, v0.16b
	ext v1.16b, v1.16b, v1.16b, #8
	ext v0.16b, v0.16b, v0.16b, #8
	rev64 v0.16b, v0.16b
	rev64 v1.16b, v1.16b
	ext v0.16b, v0.16b, v0.16b, #8
	ext v1.16b, v1.16b, v1.16b, #8
	umaxp v0.16b, v0.16b, v1.16b
	rev64 v0.16b, v0.16b
	ext v0.16b, v0.16b, v0.16b, #8
	rev64 v0.16b, v0.16b
	ext v0.16b, v0.16b, v0.16b, #8
	ret

wrapper2:
	ld1 { v0.16b }, [x0]
	ld1 { v1.16b }, [x1]
	rev64 v0.16b, v0.16b
	rev64 v1.16b, v1.16b
	ext v0.16b, v0.16b, v0.16b, #8
	ext v1.16b, v1.16b, v1.16b, #8
	umaxp v0.16b, v0.16b, v1.16b
	rev64 v0.16b, v0.16b
	ext v0.16b, v0.16b, v0.16b, #8
	st1 { v0.16b }, [x2]
	ret
```

So the `wrapper` is the same, but the loads and stores mess it up somehow.

---

So, this is pretty nasty. We also get instruction assertion errors like

```
---- core_arch::aarch64::neon::generated::assert_vst1q_u32_str stdout ----
disassembly for stdarch_test_shim_vst1q_u32_str: 
	 0: rev64 v0.4s, v0.4s
	 1: ext v0.16b, v0.16b, v0.16b, #8
	 2: rev64 v0.4s, v0.4s
	 3: ext v0.16b, v0.16b, v0.16b, #8
	 4: st1 {v0.4s}, [x0]
	 5: ret
```

So, I'm not sure what to do about that. We can just test for the `st*` prefix? Or drop the test altogether?

r? adamgemmell 