### PR TITLE
Add `_mm_clflushopt` intrinsic

### DIFF
--- a/crates/core_arch/missing-x86.md
+++ b/crates/core_arch/missing-x86.md
@@ -70,12 +70,6 @@
 </p></details>
 
 
-<details><summary>["CLFLUSHOPT"]</summary><p>
-
-  * [x] [`_mm_clflushopt`](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_clflushopt)
-</p></details>
-
-
 <details><summary>["CLWB"]</summary><p>
 
   * [ ] [`_mm_clwb`](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_clwb)

--- a/crates/core_arch/missing-x86.md
+++ b/crates/core_arch/missing-x86.md
@@ -72,7 +72,7 @@
 
 <details><summary>["CLFLUSHOPT"]</summary><p>
 
-  * [ ] [`_mm_clflushopt`](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_clflushopt)
+  * [x] [`_mm_clflushopt`](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_clflushopt)
 </p></details>
 
 

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -40,6 +40,7 @@
     const_eval_select,
     maybe_uninit_as_bytes,
     movrs_target_feature,
+    clflushopt_target_feature,
     min_adt_const_params
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, stdarch_internal))]

--- a/crates/core_arch/src/x86/clflushopt.rs
+++ b/crates/core_arch/src/x86/clflushopt.rs
@@ -4,7 +4,7 @@
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.clflushopt"]
     fn clflushopt(p: *const u8);
 }
@@ -26,6 +26,10 @@ unsafe extern "C" {
 /// Unlike the prefetch intrinsics, `CLFLUSHOPT` is subject to all the
 /// permission checking and faults associated with a byte load, so `p` must
 /// point to a byte that is valid for reads.
+///
+/// [`_mm_clflush`]: crate::arch::x86::_mm_clflush
+/// [`_mm_sfence`]: crate::arch::x86::_mm_sfence
+/// [`_mm_mfence`]: crate::arch::x86::_mm_mfence
 #[inline]
 #[target_feature(enable = "clflushopt")]
 #[cfg_attr(test, assert_instr(clflushopt))]

--- a/crates/core_arch/src/x86/clflushopt.rs
+++ b/crates/core_arch/src/x86/clflushopt.rs
@@ -26,10 +26,6 @@ unsafe extern "C" {
 /// Unlike the prefetch intrinsics, `CLFLUSHOPT` is subject to all the
 /// permission checking and faults associated with a byte load, so `p` must
 /// point to a byte that is valid for reads.
-///
-/// [`_mm_clflush`]: crate::arch::x86_64::_mm_clflush
-/// [`_mm_sfence`]: crate::arch::x86_64::_mm_sfence
-/// [`_mm_mfence`]: crate::arch::x86_64::_mm_mfence
 #[inline]
 #[target_feature(enable = "clflushopt")]
 #[cfg_attr(test, assert_instr(clflushopt))]

--- a/crates/core_arch/src/x86/clflushopt.rs
+++ b/crates/core_arch/src/x86/clflushopt.rs
@@ -6,7 +6,7 @@ use stdarch_test::assert_instr;
 #[allow(improper_ctypes)]
 unsafe extern "C" {
     #[link_name = "llvm.x86.clflushopt"]
-    fn clflushopt(p: *mut i8);
+    fn clflushopt(p: *const u8);
 }
 
 /// Invalidates from every level of the cache hierarchy the cache line that
@@ -21,6 +21,12 @@ unsafe extern "C" {
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_clflushopt)
 ///
+/// # Safety
+///
+/// Unlike the prefetch intrinsics, `CLFLUSHOPT` is subject to all the
+/// permission checking and faults associated with a byte load, so `p` must
+/// point to a byte that is valid for reads.
+///
 /// [`_mm_clflush`]: crate::arch::x86_64::_mm_clflush
 /// [`_mm_sfence`]: crate::arch::x86_64::_mm_sfence
 /// [`_mm_mfence`]: crate::arch::x86_64::_mm_mfence
@@ -29,7 +35,7 @@ unsafe extern "C" {
 #[cfg_attr(test, assert_instr(clflushopt))]
 #[unstable(feature = "simd_x86_clflushopt", issue = "157096")]
 pub unsafe fn _mm_clflushopt(p: *const u8) {
-    clflushopt(p as *mut i8);
+    clflushopt(p);
 }
 
 #[cfg(test)]

--- a/crates/core_arch/src/x86/clflushopt.rs
+++ b/crates/core_arch/src/x86/clflushopt.rs
@@ -1,0 +1,45 @@
+//! `CLFLUSHOPT` cache-line flush.
+
+#[cfg(test)]
+use stdarch_test::assert_instr;
+
+#[allow(improper_ctypes)]
+unsafe extern "C" {
+    #[link_name = "llvm.x86.clflushopt"]
+    fn clflushopt(p: *mut i8);
+}
+
+/// Invalidates from every level of the cache hierarchy the cache line that
+/// contains `p`.
+///
+/// Unlike [`_mm_clflush`], `CLFLUSHOPT` is only ordered with respect to older
+/// writes to the flushed cache line and with respect to fence/locked
+/// operations; it is *not* serialized against other `CLFLUSHOPT`/`CLFLUSH`
+/// instructions or unrelated stores. This makes flushing a range of lines
+/// substantially faster, but a fence (e.g. [`_mm_sfence`] or [`_mm_mfence`]) is
+/// required afterward to order the flushes against subsequent operations.
+///
+/// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_clflushopt)
+///
+/// [`_mm_clflush`]: crate::arch::x86_64::_mm_clflush
+/// [`_mm_sfence`]: crate::arch::x86_64::_mm_sfence
+/// [`_mm_mfence`]: crate::arch::x86_64::_mm_mfence
+#[inline]
+#[target_feature(enable = "clflushopt")]
+#[cfg_attr(test, assert_instr(clflushopt))]
+#[unstable(feature = "simd_x86_clflushopt", issue = "157096")]
+pub unsafe fn _mm_clflushopt(p: *const u8) {
+    clflushopt(p as *mut i8);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core_arch::x86::*;
+    use stdarch_test::simd_test;
+
+    #[simd_test(enable = "clflushopt")]
+    unsafe fn test_mm_clflushopt() {
+        let x = 0_u8;
+        _mm_clflushopt(core::ptr::addr_of!(x));
+    }
+}

--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -692,6 +692,10 @@ mod adx;
 #[stable(feature = "simd_x86_adx", since = "1.33.0")]
 pub use self::adx::*;
 
+mod clflushopt;
+#[unstable(feature = "simd_x86_clflushopt", issue = "157096")]
+pub use self::clflushopt::*;
+
 #[cfg(test)]
 use stdarch_test::assert_instr;
 

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -29,6 +29,12 @@ pub fn _mm_pause() {
 /// the cache hierarchy.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_clflush)
+///
+/// # Safety
+///
+/// Unlike the prefetch intrinsics, `CLFLUSH` is subject to all the permission
+/// checking and faults associated with a byte load, so `p` must point to a
+/// byte that is valid for reads.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(clflush))]

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -661,14 +661,16 @@ fn matches(rust: &Function, intel: &Intrinsic) -> Result<(), String> {
 fn pointed_type(intrinsic: &Intrinsic) -> Result<Type, String> {
     Ok(
         if intrinsic.tech == "AMX"
-            || intrinsic
-                .cpuid
-                .iter()
-                .any(|cpuid| matches!(&**cpuid, "KEYLOCKER" | "KEYLOCKER_WIDE" | "XSAVE" | "FXSR"))
+            || intrinsic.cpuid.iter().any(|cpuid| {
+                matches!(
+                    &**cpuid,
+                    "KEYLOCKER" | "KEYLOCKER_WIDE" | "XSAVE" | "FXSR" | "CLFLUSHOPT"
+                )
+            })
         {
-            // AMX, KEYLOCKER and XSAVE intrinsics should take `*u8`
+            // AMX, KEYLOCKER, XSAVE and CLFLUSHOPT intrinsics should take `*u8`
             U8
-        } else if intrinsic.name == "_mm_clflush" || intrinsic.name == "_mm_clflushopt" {
+        } else if intrinsic.name == "_mm_clflush" {
             // Just a false match in the following logic
             U8
         } else if ["_mm_storeu_si", "_mm_loadu_si"]

--- a/crates/stdarch-verify/tests/x86-intel.rs
+++ b/crates/stdarch-verify/tests/x86-intel.rs
@@ -668,7 +668,7 @@ fn pointed_type(intrinsic: &Intrinsic) -> Result<Type, String> {
         {
             // AMX, KEYLOCKER and XSAVE intrinsics should take `*u8`
             U8
-        } else if intrinsic.name == "_mm_clflush" {
+        } else if intrinsic.name == "_mm_clflush" || intrinsic.name == "_mm_clflushopt" {
             // Just a false match in the following logic
             U8
         } else if ["_mm_storeu_si", "_mm_loadu_si"]


### PR DESCRIPTION
Fixes rust-lang/stdarch#1456

adds the `_mm_clflushopt` intrinsic for the
`CLFLUSHOPT` instruction (weakly-ordered cache-line flush). Until now stdarch
exposed only the SSE2 `_mm_clflush`, so there was no way to emit `clflushopt`
from an intrinsic.

Gated on the `clflushopt` target feature added in rust-lang/rust#157098
(tracking issue rust-lang/rust#157096). **CI will be red until that compiler
change merges and syncs into the pinned toolchain here** — the
`#[target_feature(enable = "clflushopt")]` won't be recognized before then.

Modeled on the existing `_mm_clflush` / `adx` intrinsics: links
`llvm.x86.clflushopt`, `assert_instr(clflushopt)` codegen test, and a
`simd_test` runtime test. The Intel-verification false-match exemption for
`_mm_clflush` is extended to cover `_mm_clflushopt` (both take `*const u8`).