### PR TITLE
Correct some wrong uses of LLVM intrinsics

### DIFF
--- a/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/crates/core_arch/src/aarch64/neon/generated.rs
@@ -11903,7 +11903,7 @@ pub unsafe fn vluti4q_lane_s8<const LANE: i32>(a: int8x16_t, b: uint8x8_t) -> in
     unsafe extern "unadjusted" {
         #[cfg_attr(
             any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.vluti4q.lane.v8i8"
+            link_name = "llvm.aarch64.neon.vluti4q.lane.v16i8"
         )]
         fn _vluti4q_lane_s8(a: int8x16_t, b: uint8x8_t, n: i32) -> int8x16_t;
     }

--- a/crates/core_arch/src/aarch64/prefetch.rs
+++ b/crates/core_arch/src/aarch64/prefetch.rs
@@ -2,7 +2,7 @@
 use stdarch_test::assert_instr;
 
 unsafe extern "unadjusted" {
-    #[link_name = "llvm.prefetch"]
+    #[link_name = "llvm.prefetch.p0"]
     fn prefetch(p: *const i8, rw: i32, loc: i32, ty: i32);
 }
 

--- a/crates/core_arch/src/aarch64/sve/generated.rs
+++ b/crates/core_arch/src/aarch64/sve/generated.rs
@@ -1843,7 +1843,7 @@ pub fn svadrd_u64base_u64index(bases: svuint64_t, indices: svuint64_t) -> svuint
 #[cfg_attr(test, assert_instr(and))]
 pub fn svand_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.and.z.nvx16i1")]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.and.z.nxv16i1")]
         fn _svand_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
     unsafe { _svand_b_z(pg, op1, op2) }
@@ -2935,7 +2935,7 @@ pub fn svasrd_n_s64_z<const IMM2: i32>(pg: svbool_t, op1: svint64_t) -> svint64_
 #[cfg_attr(test, assert_instr(bic))]
 pub fn svbic_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.bic.z.nvx16i1")]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.bic.z.nxv16i1")]
         fn _svbic_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
     unsafe { _svbic_b_z(pg, op1, op2) }
@@ -4559,7 +4559,7 @@ pub fn svcmla_lane_f32<const IMM_INDEX: i32, const IMM_ROTATION: i32>(
     unsafe extern "unadjusted" {
         #[cfg_attr(
             target_arch = "aarch64",
-            link_name = "llvm.aarch64.sve.fcmla.lane.x.nxv4f32"
+            link_name = "llvm.aarch64.sve.fcmla.lane.nxv4f32"
         )]
         fn _svcmla_lane_f32(
             op1: svfloat32_t,
@@ -7657,7 +7657,10 @@ pub fn svcvt_f64_f32_z(pg: svbool_t, op: svfloat32_t) -> svfloat64_t {
 #[cfg_attr(test, assert_instr(scvtf))]
 pub fn svcvt_f32_s32_m(inactive: svfloat32_t, pg: svbool_t, op: svint32_t) -> svfloat32_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.scvtf.f32i32")]
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.scvtf.nxv4f32.nxv4i32"
+        )]
         fn _svcvt_f32_s32_m(inactive: svfloat32_t, pg: svbool4_t, op: svint32_t) -> svfloat32_t;
     }
     unsafe { _svcvt_f32_s32_m(inactive, pg.sve_into(), op) }
@@ -7679,6 +7682,108 @@ pub fn svcvt_f32_s32_x(pg: svbool_t, op: svint32_t) -> svfloat32_t {
 #[cfg_attr(test, assert_instr(scvtf))]
 pub fn svcvt_f32_s32_z(pg: svbool_t, op: svint32_t) -> svfloat32_t {
     svcvt_f32_s32_m(svdup_n_f32(0.0), pg, op)
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u32]_m)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(ucvtf))]
+pub fn svcvt_f32_u32_m(inactive: svfloat32_t, pg: svbool_t, op: svuint32_t) -> svfloat32_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.ucvtf.nxv4f32.nxv4i32"
+        )]
+        fn _svcvt_f32_u32_m(inactive: svfloat32_t, pg: svbool4_t, op: svint32_t) -> svfloat32_t;
+    }
+    unsafe { _svcvt_f32_u32_m(inactive, pg.sve_into(), op.as_signed()) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u32]_x)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(ucvtf))]
+pub fn svcvt_f32_u32_x(pg: svbool_t, op: svuint32_t) -> svfloat32_t {
+    unsafe { svcvt_f32_u32_m(transmute_unchecked(op), pg, op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u32]_z)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(ucvtf))]
+pub fn svcvt_f32_u32_z(pg: svbool_t, op: svuint32_t) -> svfloat32_t {
+    svcvt_f32_u32_m(svdup_n_f32(0.0), pg, op)
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_s64]_m)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(scvtf))]
+pub fn svcvt_f64_s64_m(inactive: svfloat64_t, pg: svbool_t, op: svint64_t) -> svfloat64_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.scvtf.nxv2f64.nxv2i64"
+        )]
+        fn _svcvt_f64_s64_m(inactive: svfloat64_t, pg: svbool2_t, op: svint64_t) -> svfloat64_t;
+    }
+    unsafe { _svcvt_f64_s64_m(inactive, pg.sve_into(), op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_s64]_x)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(scvtf))]
+pub fn svcvt_f64_s64_x(pg: svbool_t, op: svint64_t) -> svfloat64_t {
+    unsafe { svcvt_f64_s64_m(transmute_unchecked(op), pg, op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_s64]_z)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(scvtf))]
+pub fn svcvt_f64_s64_z(pg: svbool_t, op: svint64_t) -> svfloat64_t {
+    svcvt_f64_s64_m(svdup_n_f64(0.0), pg, op)
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u64]_m)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(ucvtf))]
+pub fn svcvt_f64_u64_m(inactive: svfloat64_t, pg: svbool_t, op: svuint64_t) -> svfloat64_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.ucvtf.nxv2f64.nxv2i64"
+        )]
+        fn _svcvt_f64_u64_m(inactive: svfloat64_t, pg: svbool2_t, op: svint64_t) -> svfloat64_t;
+    }
+    unsafe { _svcvt_f64_u64_m(inactive, pg.sve_into(), op.as_signed()) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u64]_x)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(ucvtf))]
+pub fn svcvt_f64_u64_x(pg: svbool_t, op: svuint64_t) -> svfloat64_t {
+    unsafe { svcvt_f64_u64_m(transmute_unchecked(op), pg, op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u64]_z)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(ucvtf))]
+pub fn svcvt_f64_u64_z(pg: svbool_t, op: svuint64_t) -> svfloat64_t {
+    svcvt_f64_u64_m(svdup_n_f64(0.0), pg, op)
 }
 #[doc = "Floating-point convert"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_s64]_m)"]
@@ -7710,37 +7815,6 @@ pub fn svcvt_f32_s64_x(pg: svbool_t, op: svint64_t) -> svfloat32_t {
 #[cfg_attr(test, assert_instr(scvtf))]
 pub fn svcvt_f32_s64_z(pg: svbool_t, op: svint64_t) -> svfloat32_t {
     svcvt_f32_s64_m(svdup_n_f32(0.0), pg, op)
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u32]_m)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(ucvtf))]
-pub fn svcvt_f32_u32_m(inactive: svfloat32_t, pg: svbool_t, op: svuint32_t) -> svfloat32_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.ucvtf.f32i32")]
-        fn _svcvt_f32_u32_m(inactive: svfloat32_t, pg: svbool4_t, op: svint32_t) -> svfloat32_t;
-    }
-    unsafe { _svcvt_f32_u32_m(inactive, pg.sve_into(), op.as_signed()) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u32]_x)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(ucvtf))]
-pub fn svcvt_f32_u32_x(pg: svbool_t, op: svuint32_t) -> svfloat32_t {
-    unsafe { svcvt_f32_u32_m(transmute_unchecked(op), pg, op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u32]_z)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(ucvtf))]
-pub fn svcvt_f32_u32_z(pg: svbool_t, op: svuint32_t) -> svfloat32_t {
-    svcvt_f32_u32_m(svdup_n_f32(0.0), pg, op)
 }
 #[doc = "Floating-point convert"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f32[_u64]_m)"]
@@ -7805,37 +7879,6 @@ pub fn svcvt_f64_s32_z(pg: svbool_t, op: svint32_t) -> svfloat64_t {
     svcvt_f64_s32_m(svdup_n_f64(0.0), pg, op)
 }
 #[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_s64]_m)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(scvtf))]
-pub fn svcvt_f64_s64_m(inactive: svfloat64_t, pg: svbool_t, op: svint64_t) -> svfloat64_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.scvtf.f64i64")]
-        fn _svcvt_f64_s64_m(inactive: svfloat64_t, pg: svbool2_t, op: svint64_t) -> svfloat64_t;
-    }
-    unsafe { _svcvt_f64_s64_m(inactive, pg.sve_into(), op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_s64]_x)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(scvtf))]
-pub fn svcvt_f64_s64_x(pg: svbool_t, op: svint64_t) -> svfloat64_t {
-    unsafe { svcvt_f64_s64_m(transmute_unchecked(op), pg, op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_s64]_z)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(scvtf))]
-pub fn svcvt_f64_s64_z(pg: svbool_t, op: svint64_t) -> svfloat64_t {
-    svcvt_f64_s64_m(svdup_n_f64(0.0), pg, op)
-}
-#[doc = "Floating-point convert"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u32]_m)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -7867,37 +7910,6 @@ pub fn svcvt_f64_u32_z(pg: svbool_t, op: svuint32_t) -> svfloat64_t {
     svcvt_f64_u32_m(svdup_n_f64(0.0), pg, op)
 }
 #[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u64]_m)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(ucvtf))]
-pub fn svcvt_f64_u64_m(inactive: svfloat64_t, pg: svbool_t, op: svuint64_t) -> svfloat64_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.ucvtf.f64i64")]
-        fn _svcvt_f64_u64_m(inactive: svfloat64_t, pg: svbool2_t, op: svint64_t) -> svfloat64_t;
-    }
-    unsafe { _svcvt_f64_u64_m(inactive, pg.sve_into(), op.as_signed()) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u64]_x)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(ucvtf))]
-pub fn svcvt_f64_u64_x(pg: svbool_t, op: svuint64_t) -> svfloat64_t {
-    unsafe { svcvt_f64_u64_m(transmute_unchecked(op), pg, op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_f64[_u64]_z)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(ucvtf))]
-pub fn svcvt_f64_u64_z(pg: svbool_t, op: svuint64_t) -> svfloat64_t {
-    svcvt_f64_u64_m(svdup_n_f64(0.0), pg, op)
-}
-#[doc = "Floating-point convert"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s32[_f32]_m)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -7905,7 +7917,10 @@ pub fn svcvt_f64_u64_z(pg: svbool_t, op: svuint64_t) -> svfloat64_t {
 #[cfg_attr(test, assert_instr(fcvtzs))]
 pub fn svcvt_s32_f32_m(inactive: svint32_t, pg: svbool_t, op: svfloat32_t) -> svint32_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.fcvtzs.i32f32")]
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.fcvtzs.nxv4i32.nxv4f32"
+        )]
         fn _svcvt_s32_f32_m(inactive: svint32_t, pg: svbool4_t, op: svfloat32_t) -> svint32_t;
     }
     unsafe { _svcvt_s32_f32_m(inactive, pg.sve_into(), op) }
@@ -7927,6 +7942,108 @@ pub fn svcvt_s32_f32_x(pg: svbool_t, op: svfloat32_t) -> svint32_t {
 #[cfg_attr(test, assert_instr(fcvtzs))]
 pub fn svcvt_s32_f32_z(pg: svbool_t, op: svfloat32_t) -> svint32_t {
     svcvt_s32_f32_m(svdup_n_s32(0), pg, op)
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s64[_f64]_m)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzs))]
+pub fn svcvt_s64_f64_m(inactive: svint64_t, pg: svbool_t, op: svfloat64_t) -> svint64_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.fcvtzs.nxv2i64.nxv2f64"
+        )]
+        fn _svcvt_s64_f64_m(inactive: svint64_t, pg: svbool2_t, op: svfloat64_t) -> svint64_t;
+    }
+    unsafe { _svcvt_s64_f64_m(inactive, pg.sve_into(), op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s64[_f64]_x)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzs))]
+pub fn svcvt_s64_f64_x(pg: svbool_t, op: svfloat64_t) -> svint64_t {
+    unsafe { svcvt_s64_f64_m(transmute_unchecked(op), pg, op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s64[_f64]_z)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzs))]
+pub fn svcvt_s64_f64_z(pg: svbool_t, op: svfloat64_t) -> svint64_t {
+    svcvt_s64_f64_m(svdup_n_s64(0), pg, op)
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f32]_m)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub fn svcvt_u32_f32_m(inactive: svuint32_t, pg: svbool_t, op: svfloat32_t) -> svuint32_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.fcvtzu.nxv4i32.nxv4f32"
+        )]
+        fn _svcvt_u32_f32_m(inactive: svint32_t, pg: svbool4_t, op: svfloat32_t) -> svint32_t;
+    }
+    unsafe { _svcvt_u32_f32_m(inactive.as_signed(), pg.sve_into(), op).as_unsigned() }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f32]_x)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub fn svcvt_u32_f32_x(pg: svbool_t, op: svfloat32_t) -> svuint32_t {
+    unsafe { svcvt_u32_f32_m(transmute_unchecked(op), pg, op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f32]_z)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub fn svcvt_u32_f32_z(pg: svbool_t, op: svfloat32_t) -> svuint32_t {
+    svcvt_u32_f32_m(svdup_n_u32(0), pg, op)
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u64[_f64]_m)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub fn svcvt_u64_f64_m(inactive: svuint64_t, pg: svbool_t, op: svfloat64_t) -> svuint64_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.fcvtzu.nxv2i64.nxv2f64"
+        )]
+        fn _svcvt_u64_f64_m(inactive: svint64_t, pg: svbool2_t, op: svfloat64_t) -> svint64_t;
+    }
+    unsafe { _svcvt_u64_f64_m(inactive.as_signed(), pg.sve_into(), op).as_unsigned() }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u64[_f64]_x)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub fn svcvt_u64_f64_x(pg: svbool_t, op: svfloat64_t) -> svuint64_t {
+    unsafe { svcvt_u64_f64_m(transmute_unchecked(op), pg, op) }
+}
+#[doc = "Floating-point convert"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u64[_f64]_z)"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(fcvtzu))]
+pub fn svcvt_u64_f64_z(pg: svbool_t, op: svfloat64_t) -> svuint64_t {
+    svcvt_u64_f64_m(svdup_n_u64(0), pg, op)
 }
 #[doc = "Floating-point convert"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s32[_f64]_m)"]
@@ -7991,68 +8108,6 @@ pub fn svcvt_s64_f32_z(pg: svbool_t, op: svfloat32_t) -> svint64_t {
     svcvt_s64_f32_m(svdup_n_s64(0), pg, op)
 }
 #[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s64[_f64]_m)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzs))]
-pub fn svcvt_s64_f64_m(inactive: svint64_t, pg: svbool_t, op: svfloat64_t) -> svint64_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.fcvtzs.i64f64")]
-        fn _svcvt_s64_f64_m(inactive: svint64_t, pg: svbool2_t, op: svfloat64_t) -> svint64_t;
-    }
-    unsafe { _svcvt_s64_f64_m(inactive, pg.sve_into(), op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s64[_f64]_x)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzs))]
-pub fn svcvt_s64_f64_x(pg: svbool_t, op: svfloat64_t) -> svint64_t {
-    unsafe { svcvt_s64_f64_m(transmute_unchecked(op), pg, op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_s64[_f64]_z)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzs))]
-pub fn svcvt_s64_f64_z(pg: svbool_t, op: svfloat64_t) -> svint64_t {
-    svcvt_s64_f64_m(svdup_n_s64(0), pg, op)
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f32]_m)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzu))]
-pub fn svcvt_u32_f32_m(inactive: svuint32_t, pg: svbool_t, op: svfloat32_t) -> svuint32_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.fcvtzu.i32f32")]
-        fn _svcvt_u32_f32_m(inactive: svint32_t, pg: svbool4_t, op: svfloat32_t) -> svint32_t;
-    }
-    unsafe { _svcvt_u32_f32_m(inactive.as_signed(), pg.sve_into(), op).as_unsigned() }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f32]_x)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzu))]
-pub fn svcvt_u32_f32_x(pg: svbool_t, op: svfloat32_t) -> svuint32_t {
-    unsafe { svcvt_u32_f32_m(transmute_unchecked(op), pg, op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f32]_z)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzu))]
-pub fn svcvt_u32_f32_z(pg: svbool_t, op: svfloat32_t) -> svuint32_t {
-    svcvt_u32_f32_m(svdup_n_u32(0), pg, op)
-}
-#[doc = "Floating-point convert"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u32[_f64]_m)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -8113,37 +8168,6 @@ pub fn svcvt_u64_f32_x(pg: svbool_t, op: svfloat32_t) -> svuint64_t {
 #[cfg_attr(test, assert_instr(fcvtzu))]
 pub fn svcvt_u64_f32_z(pg: svbool_t, op: svfloat32_t) -> svuint64_t {
     svcvt_u64_f32_m(svdup_n_u64(0), pg, op)
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u64[_f64]_m)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzu))]
-pub fn svcvt_u64_f64_m(inactive: svuint64_t, pg: svbool_t, op: svfloat64_t) -> svuint64_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.fcvtzu.i64f64")]
-        fn _svcvt_u64_f64_m(inactive: svint64_t, pg: svbool2_t, op: svfloat64_t) -> svint64_t;
-    }
-    unsafe { _svcvt_u64_f64_m(inactive.as_signed(), pg.sve_into(), op).as_unsigned() }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u64[_f64]_x)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzu))]
-pub fn svcvt_u64_f64_x(pg: svbool_t, op: svfloat64_t) -> svuint64_t {
-    unsafe { svcvt_u64_f64_m(transmute_unchecked(op), pg, op) }
-}
-#[doc = "Floating-point convert"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svcvt_u64[_f64]_z)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(fcvtzu))]
-pub fn svcvt_u64_f64_z(pg: svbool_t, op: svfloat64_t) -> svuint64_t {
-    svcvt_u64_f64_m(svdup_n_u64(0), pg, op)
 }
 #[doc = "Divide"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svdiv[_f32]_m)"]
@@ -10040,7 +10064,7 @@ pub fn svdupq_n_u8(
 #[cfg_attr(test, assert_instr(eor))]
 pub fn sveor_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.eor.z.nvx16i1")]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.eor.z.nxv16i1")]
         fn _sveor_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
     unsafe { _sveor_b_z(pg, op1, op2) }
@@ -10591,7 +10615,7 @@ pub fn svexpa_f32(op: svuint32_t) -> svfloat32_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             target_arch = "aarch64",
-            link_name = "llvm.aarch64.sve.fexpa.x.nxv4f32 "
+            link_name = "llvm.aarch64.sve.fexpa.x.nxv4f32"
         )]
         fn _svexpa_f32(op: svint32_t) -> svfloat32_t;
     }
@@ -10607,7 +10631,7 @@ pub fn svexpa_f64(op: svuint64_t) -> svfloat64_t {
     unsafe extern "unadjusted" {
         #[cfg_attr(
             target_arch = "aarch64",
-            link_name = "llvm.aarch64.sve.fexpa.x.nxv2f64 "
+            link_name = "llvm.aarch64.sve.fexpa.x.nxv2f64"
         )]
         fn _svexpa_f64(op: svint64_t) -> svfloat64_t;
     }
@@ -27371,7 +27395,10 @@ pub fn svmls_lane_f64<const IMM_INDEX: i32>(
 #[cfg_attr(test, assert_instr(fmmla))]
 pub fn svmmla_f32(op1: svfloat32_t, op2: svfloat32_t, op3: svfloat32_t) -> svfloat32_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.fmmla.nxv4f32")]
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.fmmla.nxv4f32.nxv4f32"
+        )]
         fn _svmmla_f32(op1: svfloat32_t, op2: svfloat32_t, op3: svfloat32_t) -> svfloat32_t;
     }
     unsafe { _svmmla_f32(op1, op2, op3) }
@@ -27384,7 +27411,10 @@ pub fn svmmla_f32(op1: svfloat32_t, op2: svfloat32_t, op3: svfloat32_t) -> svflo
 #[cfg_attr(test, assert_instr(fmmla))]
 pub fn svmmla_f64(op1: svfloat64_t, op2: svfloat64_t, op3: svfloat64_t) -> svfloat64_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.fmmla.nxv2f64")]
+        #[cfg_attr(
+            target_arch = "aarch64",
+            link_name = "llvm.aarch64.sve.fmmla.nxv2f64.nxv2f64"
+        )]
         fn _svmmla_f64(op1: svfloat64_t, op2: svfloat64_t, op3: svfloat64_t) -> svfloat64_t;
     }
     unsafe { _svmmla_f64(op1, op2, op3) }
@@ -30260,7 +30290,7 @@ pub fn svnot_u64_z(pg: svbool_t, op: svuint64_t) -> svuint64_t {
 #[cfg_attr(test, assert_instr(orn))]
 pub fn svorn_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.orn.z.nvx16i1")]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.orn.z.nxv16i1")]
         fn _svorn_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
     unsafe { _svorn_b_z(pg, op1, op2) }
@@ -30273,7 +30303,7 @@ pub fn svorn_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(orr))]
 pub fn svorr_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.orr.z.nvx16i1")]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.orr.z.nxv16i1")]
         fn _svorr_b_z(pg: svbool_t, op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
     unsafe { _svorr_b_z(pg, op1, op2) }
@@ -34340,10 +34370,7 @@ pub fn svrecps_f64(op1: svfloat64_t, op2: svfloat64_t) -> svfloat64_t {
 #[cfg_attr(test, assert_instr(frecpx))]
 pub fn svrecpx_f32_m(inactive: svfloat32_t, pg: svbool_t, op: svfloat32_t) -> svfloat32_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(
-            target_arch = "aarch64",
-            link_name = "llvm.aarch64.sve.frecpx.x.nxv4f32"
-        )]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.frecpx.nxv4f32")]
         fn _svrecpx_f32_m(inactive: svfloat32_t, pg: svbool4_t, op: svfloat32_t) -> svfloat32_t;
     }
     unsafe { _svrecpx_f32_m(inactive, pg.sve_into(), op) }
@@ -34374,10 +34401,7 @@ pub fn svrecpx_f32_z(pg: svbool_t, op: svfloat32_t) -> svfloat32_t {
 #[cfg_attr(test, assert_instr(frecpx))]
 pub fn svrecpx_f64_m(inactive: svfloat64_t, pg: svbool_t, op: svfloat64_t) -> svfloat64_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(
-            target_arch = "aarch64",
-            link_name = "llvm.aarch64.sve.frecpx.x.nxv2f64"
-        )]
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.frecpx.nxv2f64")]
         fn _svrecpx_f64_m(inactive: svfloat64_t, pg: svbool2_t, op: svfloat64_t) -> svfloat64_t;
     }
     unsafe { _svrecpx_f64_m(inactive, pg.sve_into(), op) }

--- a/crates/core_arch/src/aarch64/sve/mod.rs
+++ b/crates/core_arch/src/aarch64/sve/mod.rs
@@ -130,7 +130,7 @@ macro_rules! impl_internal_sve_predicate {
             #[target_feature(enable = "sve")]
             unsafe fn sve_into(self) -> svbool_t {
                 #[allow(improper_ctypes)]
-                unsafe extern "C" {
+                unsafe extern "unadjusted" {
                     #[cfg_attr(
                         target_arch = "aarch64",
                         link_name = concat!("llvm.aarch64.sve.convert.to.svbool.nxv", $elt, "i1")
@@ -147,7 +147,7 @@ macro_rules! impl_internal_sve_predicate {
             #[target_feature(enable = "sve")]
             unsafe fn sve_into(self) -> $name {
                 #[allow(improper_ctypes)]
-                unsafe extern "C" {
+                unsafe extern "unadjusted" {
                     #[cfg_attr(
                         target_arch = "aarch64",
                         link_name = concat!("llvm.aarch64.sve.convert.from.svbool.nxv", $elt, "i1")

--- a/crates/core_arch/src/mips/msa.rs
+++ b/crates/core_arch/src/mips/msa.rs
@@ -45,7 +45,7 @@ types! {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.mips.add.a.b"]
     fn msa_add_a_b(a: v16i8, b: v16i8) -> v16i8;
     #[link_name = "llvm.mips.add.a.h"]

--- a/crates/core_arch/src/nvptx/mod.rs
+++ b/crates/core_arch/src/nvptx/mod.rs
@@ -19,7 +19,7 @@ mod packed;
 pub use packed::*;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.nvvm.barrier.cta.sync.aligned.all"]
     fn syncthreads(a: u32) -> ();
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.x"]

--- a/crates/core_arch/src/nvptx/mod.rs
+++ b/crates/core_arch/src/nvptx/mod.rs
@@ -20,8 +20,8 @@ pub use packed::*;
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
-    #[link_name = "llvm.nvvm.barrier0"]
-    fn syncthreads() -> ();
+    #[link_name = "llvm.nvvm.barrier.cta.sync.aligned.all"]
+    fn syncthreads(a: u32) -> ();
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.x"]
     fn block_dim_x() -> u32;
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.y"]
@@ -54,7 +54,7 @@ unsafe extern "C" {
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
 pub unsafe fn _syncthreads() -> () {
-    syncthreads()
+    syncthreads(0)
 }
 
 /// x-th thread-block dimension.

--- a/crates/core_arch/src/nvptx/packed.rs
+++ b/crates/core_arch/src/nvptx/packed.rs
@@ -7,7 +7,7 @@
 use crate::intrinsics::simd::*;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.minimum.v2f16"]
     fn llvm_f16x2_minimum(a: f16x2, b: f16x2) -> f16x2;
     #[link_name = "llvm.maximum.v2f16"]

--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -96,7 +96,7 @@ impl From<vector_bool_int> for m32x4 {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.ppc.altivec.lvx"]
     fn lvx(p: *const i8) -> vector_unsigned_int;
 

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -52,7 +52,7 @@ impl From<vector_bool_long> for m64x2 {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.ppc.altivec.vperm"]
     fn vperm(
         a: vector_signed_int,

--- a/crates/core_arch/src/powerpc64/vsx.rs
+++ b/crates/core_arch/src/powerpc64/vsx.rs
@@ -17,7 +17,7 @@ use stdarch_test::assert_instr;
 use crate::mem::transmute;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.ppc.vsx.lxvl"]
     fn lxvl(a: *const u8, l: usize) -> vector_signed_int;
 

--- a/crates/core_arch/src/wasm32/memory.rs
+++ b/crates/core_arch/src/wasm32/memory.rs
@@ -2,9 +2,11 @@
 use stdarch_test::assert_instr;
 
 unsafe extern "unadjusted" {
-    #[link_name = "llvm.wasm.memory.grow"]
+    #[cfg_attr(target_pointer_width = "32", link_name = "llvm.wasm.memory.grow.i32")]
+    #[cfg_attr(target_pointer_width = "64", link_name = "llvm.wasm.memory.grow.i64")]
     fn llvm_memory_grow(mem: u32, pages: usize) -> usize;
-    #[link_name = "llvm.wasm.memory.size"]
+    #[cfg_attr(target_pointer_width = "32", link_name = "llvm.wasm.memory.size.i32")]
+    #[cfg_attr(target_pointer_width = "64", link_name = "llvm.wasm.memory.size.i64")]
     fn llvm_memory_size(mem: u32) -> usize;
 }
 

--- a/crates/core_arch/src/x86/aes.rs
+++ b/crates/core_arch/src/x86/aes.rs
@@ -13,7 +13,7 @@ use crate::core_arch::x86::__m128i;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.aesni.aesdec"]
     fn aesdec(a: __m128i, round_key: __m128i) -> __m128i;
     #[link_name = "llvm.x86.aesni.aesdeclast"]

--- a/crates/core_arch/src/x86/avx.rs
+++ b/crates/core_arch/src/x86/avx.rs
@@ -3292,7 +3292,7 @@ pub const fn _mm256_cvtss_f32(a: __m256) -> f32 {
 
 // LLVM intrinsics used in the above functions
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx.round.pd.256"]
     fn roundpd256(a: __m256d, b: i32) -> __m256d;
     #[link_name = "llvm.x86.avx.round.ps.256"]

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -3906,7 +3906,7 @@ pub const fn _mm256_extract_epi16<const INDEX: i32>(a: __m256i) -> i32 {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx2.pmadd.wd"]
     fn pmaddwd(a: i16x16, b: i16x16) -> i32x8;
     #[link_name = "llvm.x86.avx2.pmadd.ub.sw"]

--- a/crates/core_arch/src/x86/avx512bf16.rs
+++ b/crates/core_arch/src/x86/avx512bf16.rs
@@ -9,7 +9,7 @@ use crate::intrinsics::simd::*;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512bf16.cvtne2ps2bf16.128"]
     fn cvtne2ps2bf16(a: f32x4, b: f32x4) -> i16x8;
     #[link_name = "llvm.x86.avx512bf16.cvtne2ps2bf16.256"]

--- a/crates/core_arch/src/x86/avx512bitalg.rs
+++ b/crates/core_arch/src/x86/avx512bitalg.rs
@@ -27,7 +27,7 @@ use crate::mem::transmute;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.vpshufbitqmb.512"]
     fn bitshuffle_512(data: i8x64, indices: i8x64) -> __mmask64;
     #[link_name = "llvm.x86.avx512.vpshufbitqmb.256"]

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -12764,7 +12764,7 @@ pub unsafe fn _mm_mask_cvtusepi16_storeu_epi8(mem_addr: *mut i8, k: __mmask8, a:
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.pmul.hr.sw.512"]
     fn vpmulhrsw(a: i16x32, b: i16x32) -> i16x32;
 

--- a/crates/core_arch/src/x86/avx512cd.rs
+++ b/crates/core_arch/src/x86/avx512cd.rs
@@ -563,7 +563,7 @@ pub const fn _mm_maskz_lzcnt_epi64(k: __mmask8, a: __m128i) -> __m128i {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.conflict.d.512"]
     fn vpconflictd(a: i32x16) -> i32x16;
     #[link_name = "llvm.x86.avx512.conflict.d.256"]

--- a/crates/core_arch/src/x86/avx512dq.rs
+++ b/crates/core_arch/src/x86/avx512dq.rs
@@ -7235,7 +7235,7 @@ pub fn _mm_mask_fpclass_ss_mask<const IMM8: i32>(k1: __mmask8, a: __m128) -> __m
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.sitofp.round.v2f64.v2i64"]
     fn vcvtqq2pd_128(a: i64x2, rounding: i32) -> f64x2;
     #[link_name = "llvm.x86.avx512.sitofp.round.v4f64.v4i64"]

--- a/crates/core_arch/src/x86/avx512f.rs
+++ b/crates/core_arch/src/x86/avx512f.rs
@@ -44215,7 +44215,7 @@ pub const _MM_PERM_DDDC: _MM_PERM_ENUM = 0xFE;
 pub const _MM_PERM_DDDD: _MM_PERM_ENUM = 0xFF;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.sqrt.ps.512"]
     fn vsqrtps(a: f32x16, rounding: i32) -> f32x16;
     #[link_name = "llvm.x86.avx512.sqrt.pd.512"]

--- a/crates/core_arch/src/x86/avx512ifma.rs
+++ b/crates/core_arch/src/x86/avx512ifma.rs
@@ -347,7 +347,7 @@ pub fn _mm_maskz_madd52lo_epu64(k: __mmask8, a: __m128i, b: __m128i, c: __m128i)
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.vpmadd52l.uq.128"]
     fn vpmadd52luq_128(z: __m128i, x: __m128i, y: __m128i) -> __m128i;
     #[link_name = "llvm.x86.avx512.vpmadd52h.uq.128"]

--- a/crates/core_arch/src/x86/avx512vbmi.rs
+++ b/crates/core_arch/src/x86/avx512vbmi.rs
@@ -453,7 +453,7 @@ pub fn _mm_maskz_multishift_epi64_epi8(k: __mmask16, a: __m128i, b: __m128i) -> 
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.vpermi2var.qi.512"]
     fn vpermi2b(a: i8x64, idx: i8x64, b: i8x64) -> i8x64;
     #[link_name = "llvm.x86.avx512.vpermi2var.qi.256"]

--- a/crates/core_arch/src/x86/avx512vbmi2.rs
+++ b/crates/core_arch/src/x86/avx512vbmi2.rs
@@ -2383,7 +2383,7 @@ pub const fn _mm_maskz_shrdi_epi16<const IMM8: i32>(
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.mask.compress.store.w.512"]
     fn vcompressstorew(mem: *mut i8, data: i16x32, mask: u32);
     #[link_name = "llvm.x86.avx512.mask.compress.store.w.256"]

--- a/crates/core_arch/src/x86/avx512vnni.rs
+++ b/crates/core_arch/src/x86/avx512vnni.rs
@@ -873,7 +873,7 @@ pub fn _mm256_dpwuuds_epi32(src: __m256i, a: __m256i, b: __m256i) -> __m256i {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.vpdpwssd.512"]
     fn vpdpwssd(src: i32x16, a: i16x32, b: i16x32) -> i32x16;
     #[link_name = "llvm.x86.avx512.vpdpwssd.256"]

--- a/crates/core_arch/src/x86/avx512vp2intersect.rs
+++ b/crates/core_arch/src/x86/avx512vp2intersect.rs
@@ -110,7 +110,7 @@ pub unsafe fn _mm512_2intersect_epi64(
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.vp2intersect.d.128"]
     fn vp2intersectd_128(a: i32x4, b: i32x4) -> (u8, u8);
     #[link_name = "llvm.x86.avx512.vp2intersect.q.128"]

--- a/crates/core_arch/src/x86/avxneconvert.rs
+++ b/crates/core_arch/src/x86/avxneconvert.rs
@@ -176,7 +176,7 @@ pub fn _mm256_cvtneps_avx_pbh(a: __m256) -> __m128bh {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.vbcstnebf162ps128"]
     fn bcstnebf162ps_128(a: *const bf16) -> __m128;
     #[link_name = "llvm.x86.vbcstnebf162ps256"]

--- a/crates/core_arch/src/x86/bmi1.rs
+++ b/crates/core_arch/src/x86/bmi1.rs
@@ -131,7 +131,7 @@ pub const fn _mm_tzcnt_32(x: u32) -> i32 {
     x.trailing_zeros() as i32
 }
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.bmi.bextr.32"]
     fn x86_bmi_bextr_32(x: u32, y: u32) -> u32;
 }

--- a/crates/core_arch/src/x86/bmi2.rs
+++ b/crates/core_arch/src/x86/bmi2.rs
@@ -67,7 +67,7 @@ pub fn _pext_u32(a: u32, mask: u32) -> u32 {
     unsafe { x86_bmi2_pext_32(a, mask) }
 }
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.bmi.bzhi.32"]
     fn x86_bmi2_bzhi_32(x: u32, y: u32) -> u32;
     #[link_name = "llvm.x86.bmi.pdep.32"]

--- a/crates/core_arch/src/x86/fxsr.rs
+++ b/crates/core_arch/src/x86/fxsr.rs
@@ -4,7 +4,7 @@
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.fxsave"]
     fn fxsave(p: *mut u8);
     #[link_name = "llvm.x86.fxrstor"]

--- a/crates/core_arch/src/x86/gfni.rs
+++ b/crates/core_arch/src/x86/gfni.rs
@@ -23,7 +23,7 @@ use crate::mem::transmute;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.vgf2p8affineinvqb.512"]
     fn vgf2p8affineinvqb_512(x: i8x64, a: i8x64, imm8: u8) -> i8x64;
     #[link_name = "llvm.x86.vgf2p8affineinvqb.256"]

--- a/crates/core_arch/src/x86/pclmulqdq.rs
+++ b/crates/core_arch/src/x86/pclmulqdq.rs
@@ -11,7 +11,7 @@ use crate::core_arch::x86::__m128i;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.pclmulqdq"]
     fn pclmulqdq(a: __m128i, round_key: __m128i, imm8: u8) -> __m128i;
 }

--- a/crates/core_arch/src/x86/rtm.rs
+++ b/crates/core_arch/src/x86/rtm.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.xbegin"]
     fn x86_xbegin() -> i32;
     #[link_name = "llvm.x86.xend"]

--- a/crates/core_arch/src/x86/sha.rs
+++ b/crates/core_arch/src/x86/sha.rs
@@ -1,7 +1,7 @@
 use crate::core_arch::{simd::*, x86::*};
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sha1msg1"]
     fn sha1msg1(a: i32x4, b: i32x4) -> i32x4;
     #[link_name = "llvm.x86.sha1msg2"]

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -2040,7 +2040,7 @@ unsafe extern "C" {
     fn stmxcsr(p: *mut i8);
     #[link_name = "llvm.x86.sse.ldmxcsr"]
     fn ldmxcsr(p: *const i8);
-    #[link_name = "llvm.prefetch"]
+    #[link_name = "llvm.prefetch.p0"]
     fn prefetch(p: *const i8, rw: i32, loc: i32, ty: i32);
     #[link_name = "llvm.x86.sse.cmp.ss"]
     fn cmpss(a: __m128, b: __m128, imm8: i8) -> __m128;

--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -1987,7 +1987,7 @@ pub const fn _MM_TRANSPOSE4_PS(
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse.rcp.ss"]
     fn rcpss(a: __m128) -> __m128;
     #[link_name = "llvm.x86.sse.rcp.ps"]

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -3236,7 +3236,7 @@ pub const fn _mm_unpacklo_pd(a: __m128d, b: __m128d) -> __m128d {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse2.pause"]
     fn pause();
     #[link_name = "llvm.x86.sse2.clflush"]

--- a/crates/core_arch/src/x86/sse3.rs
+++ b/crates/core_arch/src/x86/sse3.rs
@@ -178,7 +178,7 @@ pub const fn _mm_moveldup_ps(a: __m128) -> __m128 {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse3.ldu.dq"]
     fn lddqu(mem_addr: *const i8) -> i8x16;
 }

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -1181,7 +1181,7 @@ pub unsafe fn _mm_stream_load_si128(mem_addr: *const __m128i) -> __m128i {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse41.insertps"]
     fn insertps(a: __m128, b: __m128, imm8: u8) -> __m128;
     #[link_name = "llvm.x86.sse41.dppd"]

--- a/crates/core_arch/src/x86/sse42.rs
+++ b/crates/core_arch/src/x86/sse42.rs
@@ -569,7 +569,7 @@ pub const fn _mm_cmpgt_epi64(a: __m128i, b: __m128i) -> __m128i {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     // SSE 4.2 string and text comparison ops
     #[link_name = "llvm.x86.sse42.pcmpestrm128"]
     fn pcmpestrm128(a: i8x16, la: i32, b: i8x16, lb: i32, imm8: i8) -> u8x16;

--- a/crates/core_arch/src/x86/sse4a.rs
+++ b/crates/core_arch/src/x86/sse4a.rs
@@ -6,7 +6,7 @@ use crate::core_arch::{simd::*, x86::*};
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse4a.extrq"]
     fn extrq(x: i64x2, y: i8x16) -> i64x2;
     #[link_name = "llvm.x86.sse4a.extrqi"]

--- a/crates/core_arch/src/x86/ssse3.rs
+++ b/crates/core_arch/src/x86/ssse3.rs
@@ -345,7 +345,7 @@ pub fn _mm_sign_epi32(a: __m128i, b: __m128i) -> __m128i {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.ssse3.pshuf.b.128"]
     fn pshufb128(a: u8x16, b: u8x16) -> u8x16;
 

--- a/crates/core_arch/src/x86/tbm.rs
+++ b/crates/core_arch/src/x86/tbm.rs
@@ -13,7 +13,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.tbm.bextri.u32"]
     fn bextri_u32(a: u32, control: u32) -> u32;
 }

--- a/crates/core_arch/src/x86/vaes.rs
+++ b/crates/core_arch/src/x86/vaes.rs
@@ -14,7 +14,7 @@ use crate::core_arch::x86::__m512i;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.aesni.aesenc.256"]
     fn aesenc_256(a: __m256i, round_key: __m256i) -> __m256i;
     #[link_name = "llvm.x86.aesni.aesenclast.256"]

--- a/crates/core_arch/src/x86/vpclmulqdq.rs
+++ b/crates/core_arch/src/x86/vpclmulqdq.rs
@@ -12,7 +12,7 @@ use crate::core_arch::x86::__m512i;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.pclmulqdq.256"]
     fn pclmulqdq_256(a: __m256i, round_key: __m256i, imm8: u8) -> __m256i;
     #[link_name = "llvm.x86.pclmulqdq.512"]

--- a/crates/core_arch/src/x86/xsave.rs
+++ b/crates/core_arch/src/x86/xsave.rs
@@ -5,7 +5,7 @@
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.xsave"]
     fn xsave(p: *mut u8, hi: u32, lo: u32);
     #[link_name = "llvm.x86.xrstor"]

--- a/crates/core_arch/src/x86_64/amx.rs
+++ b/crates/core_arch/src/x86_64/amx.rs
@@ -595,7 +595,7 @@ pub unsafe fn _tile_movrowi<const TILE: i32, const ROW: i32>() -> __m512i {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.ldtilecfg"]
     fn ldtilecfg(mem_addr: *const u8);
     #[link_name = "llvm.x86.sttilecfg"]

--- a/crates/core_arch/src/x86_64/avx512f.rs
+++ b/crates/core_arch/src/x86_64/avx512f.rs
@@ -527,7 +527,7 @@ pub fn _mm_cvtt_roundss_u64<const SAE: i32>(a: __m128) -> u64 {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512.vcvtss2si64"]
     fn vcvtss2si64(a: f32x4, rounding: i32) -> i64;
     #[link_name = "llvm.x86.avx512.vcvtss2usi64"]

--- a/crates/core_arch/src/x86_64/avx512fp16.rs
+++ b/crates/core_arch/src/x86_64/avx512fp16.rs
@@ -211,7 +211,7 @@ pub fn _mm_cvtt_roundsh_u64<const SAE: i32>(a: __m128h) -> u64 {
 }
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.avx512fp16.vcvtsi642sh"]
     fn vcvtsi642sh(a: __m128h, b: i64, rounding: i32) -> __m128h;
     #[link_name = "llvm.x86.avx512fp16.vcvtusi642sh"]

--- a/crates/core_arch/src/x86_64/bmi.rs
+++ b/crates/core_arch/src/x86_64/bmi.rs
@@ -122,7 +122,7 @@ pub const fn _mm_tzcnt_64(x: u64) -> i64 {
     x.trailing_zeros() as i64
 }
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.bmi.bextr.64"]
     fn x86_bmi_bextr_64(x: u64, y: u64) -> u64;
 }

--- a/crates/core_arch/src/x86_64/bmi2.rs
+++ b/crates/core_arch/src/x86_64/bmi2.rs
@@ -69,7 +69,7 @@ pub fn _pext_u64(a: u64, mask: u64) -> u64 {
     unsafe { x86_bmi2_pext_64(a, mask) }
 }
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.bmi.bzhi.64"]
     fn x86_bmi2_bzhi_64(x: u64, y: u64) -> u64;
     #[link_name = "llvm.x86.bmi.pdep.64"]

--- a/crates/core_arch/src/x86_64/fxsr.rs
+++ b/crates/core_arch/src/x86_64/fxsr.rs
@@ -4,7 +4,7 @@
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.fxsave64"]
     fn fxsave64(p: *mut u8);
     #[link_name = "llvm.x86.fxrstor64"]

--- a/crates/core_arch/src/x86_64/sse.rs
+++ b/crates/core_arch/src/x86_64/sse.rs
@@ -6,7 +6,7 @@ use crate::core_arch::x86::*;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse.cvtss2si64"]
     fn cvtss2si64(a: __m128) -> i64;
     #[link_name = "llvm.x86.sse.cvttss2si64"]

--- a/crates/core_arch/src/x86_64/sse2.rs
+++ b/crates/core_arch/src/x86_64/sse2.rs
@@ -6,7 +6,7 @@ use crate::core_arch::x86::*;
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse2.cvtsd2si64"]
     fn cvtsd2si64(a: __m128d) -> i64;
     #[link_name = "llvm.x86.sse2.cvttsd2si64"]

--- a/crates/core_arch/src/x86_64/sse42.rs
+++ b/crates/core_arch/src/x86_64/sse42.rs
@@ -4,7 +4,7 @@
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.sse42.crc32.64.64"]
     fn crc32_64_64(crc: u64, v: u64) -> u64;
 }

--- a/crates/core_arch/src/x86_64/tbm.rs
+++ b/crates/core_arch/src/x86_64/tbm.rs
@@ -13,7 +13,7 @@
 #[cfg(test)]
 use stdarch_test::assert_instr;
 
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.tbm.bextri.u64"]
     fn bextri_u64(a: u64, control: u64) -> u64;
 }

--- a/crates/core_arch/src/x86_64/xsave.rs
+++ b/crates/core_arch/src/x86_64/xsave.rs
@@ -6,7 +6,7 @@
 use stdarch_test::assert_instr;
 
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "unadjusted" {
     #[link_name = "llvm.x86.xsave64"]
     fn xsave64(p: *mut u8, hi: u32, lo: u32);
     #[link_name = "llvm.x86.xrstor64"]

--- a/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13951,7 +13951,7 @@ intrinsics:
             - 'b: {neon_type[1]}'
             - 'n: i32'
           links:
-            - link: "llvm.aarch64.neon.vluti4q.lane.{neon_type[1]}"
+            - link: "llvm.aarch64.neon.vluti4q.lane.{neon_type[0]}"
               arch: aarch64,arm64ec
       - FnCall: ['_vluti4{neon_type[0].lane_nox}', [a, b, LANE]]
 
@@ -14002,7 +14002,7 @@ intrinsics:
             - 'b: {neon_type[1]}'
             - 'n: i32'
           links:
-            - link: "llvm.aarch64.neon.vluti4q.laneq.{neon_type[1]}"
+            - link: "llvm.aarch64.neon.vluti4q.laneq.{neon_type[0]}"
               arch: aarch64,arm64ec
       - FnCall: ['_vluti4{neon_type[0].laneq_nox}', [a, b, LANE]]
 

--- a/crates/stdarch-gen-arm/spec/sve/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/sve/aarch64.spec.yml
@@ -115,7 +115,7 @@ intrinsics:
     assert_instr: [[fcmla, "IMM_INDEX = 0, IMM_ROTATION = 90"]]
     compose:
       - LLVMLink:
-          name: fcmla.lane.x.{sve_type}
+          name: fcmla.lane.{sve_type}
           arguments:
             - "op1: {sve_type}"
             - "op2: {sve_type}"
@@ -4179,7 +4179,8 @@ intrinsics:
       ["inactive: {sve_type[0]}", "pg: {max_predicate}", "op: {sve_type[1]}"]
     return_type: "{sve_type[0]}"
     types:
-      - [[f32, f64], [i32, u32, i64, u64]]
+      - [f32, [i64, u64]]
+      - [f64, [i32, u32]]
     zeroing_method: { drop: inactive }
     substitutions:
       convert_from: { match_kind: "{type[1]}", default: s, unsigned: u }
@@ -4187,6 +4188,23 @@ intrinsics:
     compose:
       - LLVMLink:
           name: "{convert_from}cvtf.{type[0]}{type[1]}"
+  
+  - name: svcvt_{type[0]}[_{type[1]}]{_mxz}
+    attr: [*sve-unstable]
+    doc: Floating-point convert
+    arguments:
+      ["inactive: {sve_type[0]}", "pg: {max_predicate}", "op: {sve_type[1]}"]
+    return_type: "{sve_type[0]}"
+    types:
+      - [f32, [i32, u32]]
+      - [f64, [i64, u64]]
+    zeroing_method: { drop: inactive }
+    substitutions:
+      convert_from: { match_kind: "{type[1]}", default: s, unsigned: u }
+    assert_instr: ["{convert_from}cvtf"]
+    compose:
+      - LLVMLink:
+          name: "{convert_from}cvtf.{sve_type[0]}.{sve_type[1]}"
 
   - name: svcvt_{type[0]}[_{type[1]}]{_mxz}
     attr: [*sve-unstable]
@@ -4195,13 +4213,30 @@ intrinsics:
       ["inactive: {sve_type[0]}", "pg: {max_predicate}", "op: {sve_type[1]}"]
     return_type: "{sve_type[0]}"
     types:
-      - [[i32, u32, i64, u64], [f32, f64]]
+      - [[i32, u32], f64]
+      - [[i64, u64], f32]
     zeroing_method: { drop: inactive }
     substitutions:
       convert_to: { match_kind: "{type[0]}", default: s, unsigned: u }
     assert_instr: ["fcvtz{convert_to}"]
     compose:
       - LLVMLink: { name: "fcvtz{convert_to}.{type[0]}{type[1]}" }
+  
+  - name: svcvt_{type[0]}[_{type[1]}]{_mxz}
+    attr: [*sve-unstable]
+    doc: Floating-point convert
+    arguments:
+      ["inactive: {sve_type[0]}", "pg: {max_predicate}", "op: {sve_type[1]}"]
+    return_type: "{sve_type[0]}"
+    types:
+      - [[i32, u32], f32]
+      - [[i64, u64], f64]
+    zeroing_method: { drop: inactive }
+    substitutions:
+      convert_to: { match_kind: "{type[0]}", default: s, unsigned: u }
+    assert_instr: ["fcvtz{convert_to}"]
+    compose:
+      - LLVMLink: { name: "fcvtz{convert_to}.{sve_type[0]}.{sve_type[1]}" }
 
   - name: svcvt_{type[0]}[_{type[1]}]{_mxz}
     attr: [*sve-unstable]
@@ -4356,7 +4391,7 @@ intrinsics:
     return_type: svbool_t
     assert_instr: [and]
     compose:
-      - LLVMLink: { name: "and.z.nvx16i1" }
+      - LLVMLink: { name: "and.z.nxv16i1" }
 
   - name: svmov[_b]_z
     attr: [*sve-unstable]
@@ -4386,7 +4421,7 @@ intrinsics:
     return_type: svbool_t
     assert_instr: [bic]
     compose:
-      - LLVMLink: { name: "bic.z.nvx16i1" }
+      - LLVMLink: { name: "bic.z.nxv16i1" }
 
   - name: sveor[{_n}_{type}]{_mxz}
     attr: [*sve-unstable]
@@ -4417,7 +4452,7 @@ intrinsics:
     return_type: svbool_t
     assert_instr: [eor]
     compose:
-      - LLVMLink: { name: "eor.z.nvx16i1" }
+      - LLVMLink: { name: "eor.z.nxv16i1" }
 
   - name: svnot[_{type}]{_mxz}
     attr: [*sve-unstable]
@@ -4497,7 +4532,7 @@ intrinsics:
     return_type: svbool_t
     assert_instr: [orr]
     compose:
-      - LLVMLink: { name: "orr.z.nvx16i1" }
+      - LLVMLink: { name: "orr.z.nxv16i1" }
 
   - name: svorn[_b]_z
     attr: [*sve-unstable]
@@ -4506,7 +4541,7 @@ intrinsics:
     return_type: svbool_t
     assert_instr: [orn]
     compose:
-      - LLVMLink: { name: "orn.z.nvx16i1" }
+      - LLVMLink: { name: "orn.z.nxv16i1" }
 
   - name: svlsl[{_n}_{type[0]}]{_mxz}
     attr: [*sve-unstable]
@@ -4749,7 +4784,7 @@ intrinsics:
     assert_instr: [frecpx]
     zeroing_method: { drop: inactive }
     compose:
-      - LLVMLink: { name: "frecpx.x.{sve_type}" }
+      - LLVMLink: { name: "frecpx.{sve_type}" }
 
   - name: svrsqrte[_{type}]
     attr: [*sve-unstable]
@@ -5115,7 +5150,7 @@ intrinsics:
     types: [[f32, u32], [f64, u64]]
     assert_instr: [fexpa]
     compose:
-      - LLVMLink: { name: "fexpa.x.{sve_type[0]} " }
+      - LLVMLink: { name: "fexpa.x.{sve_type[0]}" }
 
   - name: svscale[{_n}_{type[0]}]{_mxz}
     attr: [*sve-unstable]
@@ -5139,7 +5174,7 @@ intrinsics:
     types: [f32]
     assert_instr: [fmmla]
     compose:
-      - LLVMLink: { name: "fmmla.{sve_type}" }
+      - LLVMLink: { name: "fmmla.{sve_type}.{sve_type}" }
 
   - name: svmmla[_{type}]
     attr: [*sve-unstable]
@@ -5150,7 +5185,7 @@ intrinsics:
     types: [f64]
     assert_instr: [fmmla]
     compose:
-      - LLVMLink: { name: "fmmla.{sve_type}" }
+      - LLVMLink: { name: "fmmla.{sve_type}.{sve_type}" }
 
   - name: svmmla[_{type[0]}]
     attr: [*sve-unstable]


### PR DESCRIPTION
There were some small mistakes in the LLVM intrinsics, these were autoupgraded by LLVM so the builds passed. Also replaces all `extern "C"` LLVM intrinsics blocks with `extern "unadjusted"`

## AArch64
cc @adamgemmell

 - wrong type parameter in `neon.vluti4q.lane`
 - missing type parameter in `prefetch`
 - typo in `sve.{and,bic,eor,orr,orn}.z`
 - extra `.x` in `sve.fcmla.lane` and `sve.frecpx`
 - trailing whitespace in `sve.expa.x`
 - one missing type parameter in `sve.fmmla`
 - splitting `svcvt` in two parts, because same size operands need a different intrinsic

## x86

 - missing type parameter in `prefetch`

## NVPTX
I don't know who to cc here, the file was last modified by @gnzlbg but he doesn't seem active here anymore

 - deprecated intrinsic `llvm.nvvm.barrier0` used

## WASM32
cc @alexcrichton

 - missing type parameter in `llvm.wasm.memory.{grow,size}`

r? @folkertdev