### PR TITLE
Adds `cfg` to ensure little endian for SVE

### DIFF
--- a/crates/core_arch/src/aarch64/mod.rs
+++ b/crates/core_arch/src/aarch64/mod.rs
@@ -26,16 +26,16 @@ mod neon;
 pub use self::neon::*;
 
 // The rest of `core_arch::aarch64` is available on `arm64ec` but SVE is not supported on `arm64ec`.
-#[cfg(any(target_arch = "aarch64", doc))]
+#[cfg(any(all(target_arch = "aarch64", target_endian = "little"), doc))]
 mod sve;
-#[cfg(any(target_arch = "aarch64", doc))]
+#[cfg(any(all(target_arch = "aarch64", target_endian = "little"), doc))]
 #[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
 pub use self::sve::*;
 
 // The rest of `core_arch::aarch64` is available on `arm64ec` but SVE is not supported on `arm64ec`.
-#[cfg(any(target_arch = "aarch64", doc))]
+#[cfg(any(all(target_arch = "aarch64", target_endian = "little"), doc))]
 mod sve2;
-#[cfg(any(target_arch = "aarch64", doc))]
+#[cfg(any(all(target_arch = "aarch64", target_endian = "little"), doc))]
 #[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
 pub use self::sve2::*;
 


### PR DESCRIPTION
SVE is only compatible with Little Endian architectures.