### PR TITLE
loongarch: Remove explicit zero-extension from CRC[C].W.{B,H}.W

### DIFF
--- a/crates/core_arch/src/loongarch64/mod.rs
+++ b/crates/core_arch/src/loongarch64/mod.rs
@@ -64,14 +64,14 @@ unsafe extern "unadjusted" {
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn crc_w_b_w(a: i8, b: i32) -> i32 {
-    unsafe { __crc_w_b_w(a.cast_unsigned() as i32, b) }
+    unsafe { __crc_w_b_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn crc_w_h_w(a: i16, b: i32) -> i32 {
-    unsafe { __crc_w_h_w(a.cast_unsigned() as i32, b) }
+    unsafe { __crc_w_h_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
@@ -92,14 +92,14 @@ pub fn crc_w_d_w(a: i64, b: i32) -> i32 {
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn crcc_w_b_w(a: i8, b: i32) -> i32 {
-    unsafe { __crcc_w_b_w(a.cast_unsigned() as i32, b) }
+    unsafe { __crcc_w_b_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline(always)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub fn crcc_w_h_w(a: i16, b: i32) -> i32 {
-    unsafe { __crcc_w_h_w(a.cast_unsigned() as i32, b) }
+    unsafe { __crcc_w_h_w(a as i32, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)


### PR DESCRIPTION
The `CRC[C].W.{B,H}.W` only consume the low 8/16 bits of the input operand. The previous unsigned cast was a workaround for Miri's software implementation.

Miri now masks the inputs to match hardware semantics, and LLVM will learn the demanded-bits property of CRC intrinsics, so the explicit zero-extension is no longer required.