### PR TITLE
PowerPC: Add vec_add/vec_sub/vec_mul intrinsics support for vector_double

### DIFF
--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -411,7 +411,7 @@ unsafe extern "unadjusted" {
 }
 
 #[macro_use]
-mod sealed {
+pub(crate) mod sealed {
     use super::*;
 
     #[unstable(feature = "stdarch_powerpc", issue = "111145")]

--- a/crates/core_arch/src/powerpc/altivec.rs
+++ b/crates/core_arch/src/powerpc/altivec.rs
@@ -837,7 +837,6 @@ pub(crate) mod sealed {
     impl_vec_cmp! { [VectorCmpGt vec_cmpgt] ( vec_vcmpgtub, vec_vcmpgtsb, vec_vcmpgtuh, vec_vcmpgtsh, vec_vcmpgtuw, vec_vcmpgtsw ) }
 
     test_impl! { vec_vcmpgefp(a: vector_float, b: vector_float) -> vector_bool_int [ vcmpgefp, vcmpgefp ] }
-
     test_impl! { vec_vcmpequb(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_bool_char [ vcmpequb, vcmpequb ] }
     test_impl! { vec_vcmpequh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_bool_short [ vcmpequh, vcmpequh ] }
     test_impl! { vec_vcmpequw(a: vector_unsigned_int, b: vector_unsigned_int) -> vector_bool_int [ vcmpequw, vcmpequw ] }
@@ -2416,7 +2415,8 @@ pub(crate) mod sealed {
 
     #[inline]
     #[target_feature(enable = "altivec")]
-    #[cfg_attr(test, assert_instr(xvaddsp))]
+    #[cfg_attr(all(test, not(target_feature = "vsx")), assert_instr(vaddfp))]
+    #[cfg_attr(all(test, target_feature = "vsx"), assert_instr(xvaddsp))]
     pub unsafe fn vec_add_float_float(a: vector_float, b: vector_float) -> vector_float {
         simd_add(a, b)
     }

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -10,6 +10,7 @@
 
 use crate::core_arch::powerpc::*;
 use crate::core_arch::simd::*;
+use crate::intrinsics::simd::simd_add;
 
 #[cfg(test)]
 use stdarch_test::assert_instr;
@@ -171,6 +172,27 @@ mod sealed {
     vec_mergeeo! { vector_unsigned_int, mergee, mergeo }
     vec_mergeeo! { vector_bool_int, mergee, mergeo }
     vec_mergeeo! { vector_float, mergee, mergeo }
+
+    #[inline]
+    #[target_feature(enable = "vsx")]
+    #[cfg_attr(test, assert_instr(xvadddp))]
+    pub(crate) unsafe fn vec_add_double_double(
+        a: vector_double,
+        b: vector_double,
+    ) -> vector_double {
+        simd_add(a, b)
+    }
+}
+
+// Implement AltiVec's VectorAdd trait for vector_double to enable vec_add support
+#[unstable(feature = "stdarch_powerpc", issue = "111145")]
+impl crate::core_arch::powerpc::altivec::sealed::VectorAdd<vector_double> for vector_double {
+    type Result = vector_double;
+    #[inline]
+    #[target_feature(enable = "vsx")]
+    unsafe fn vec_add(self, other: vector_double) -> Self::Result {
+        sealed::vec_add_double_double(self, other)
+    }
 }
 
 /// Vector permute.
@@ -255,4 +277,15 @@ mod tests {
     test_vec_xxpermdi! {test_vec_xxpermdi_i64x2, i64x2, vector_signed_long, [0], [-1], [2], [-3]}
     test_vec_xxpermdi! {test_vec_xxpermdi_m64x2, m64x2, vector_bool_long, [false], [true], [false], [true]}
     test_vec_xxpermdi! {test_vec_xxpermdi_f64x2, f64x2, vector_double, [0.0], [1.0], [2.0], [3.0]}
+
+    #[simd_test(enable = "vsx")]
+    fn test_vec_add_f64x2_f64x2() {
+        let a = vector_double::from(f64x2::from_array([1.0, 2.0]));
+        let b = vector_double::from(f64x2::from_array([3.0, 4.0]));
+        let expected = vector_double::from(f64x2::from_array([4.0, 6.0]));
+
+        unsafe {
+            assert_eq!(f64x2::from(vec_add(a, b)), f64x2::from(expected));
+        }
+    }
 }

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -10,7 +10,7 @@
 
 use crate::core_arch::powerpc::*;
 use crate::core_arch::simd::*;
-use crate::intrinsics::simd::simd_add;
+use crate::intrinsics::simd::{simd_add, simd_sub};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;
@@ -182,6 +182,16 @@ mod sealed {
     ) -> vector_double {
         simd_add(a, b)
     }
+
+    #[inline]
+    #[target_feature(enable = "vsx")]
+    #[cfg_attr(test, assert_instr(xvsubdp))]
+    pub(crate) unsafe fn vec_sub_double_double(
+        a: vector_double,
+        b: vector_double,
+    ) -> vector_double {
+        simd_sub(a, b)
+    }
 }
 
 // Implement AltiVec's VectorAdd trait for vector_double to enable vec_add support
@@ -192,6 +202,17 @@ impl crate::core_arch::powerpc::altivec::sealed::VectorAdd<vector_double> for ve
     #[target_feature(enable = "vsx")]
     unsafe fn vec_add(self, other: vector_double) -> Self::Result {
         sealed::vec_add_double_double(self, other)
+    }
+}
+
+// Implement AltiVec's VectorSub trait for vector_double to enable vec_sub support
+#[unstable(feature = "stdarch_powerpc", issue = "111145")]
+impl crate::core_arch::powerpc::altivec::sealed::VectorSub<vector_double> for vector_double {
+    type Result = vector_double;
+    #[inline]
+    #[target_feature(enable = "vsx")]
+    unsafe fn vec_sub(self, other: vector_double) -> Self::Result {
+        sealed::vec_sub_double_double(self, other)
     }
 }
 
@@ -286,6 +307,16 @@ mod tests {
 
         unsafe {
             assert_eq!(f64x2::from(vec_add(a, b)), f64x2::from(expected));
+        }
+    }
+    #[simd_test(enable = "vsx")]
+    fn test_vec_sub_f64x2_f64x2() {
+        let a = vector_double::from(f64x2::from_array([5.0, 8.0]));
+        let b = vector_double::from(f64x2::from_array([3.0, 4.0]));
+        let expected = vector_double::from(f64x2::from_array([2.0, 4.0]));
+
+        unsafe {
+            assert_eq!(f64x2::from(vec_sub(a, b)), f64x2::from(expected));
         }
     }
 }

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -10,7 +10,7 @@
 
 use crate::core_arch::powerpc::*;
 use crate::core_arch::simd::*;
-use crate::intrinsics::simd::{simd_add, simd_sub};
+use crate::intrinsics::simd::{simd_add, simd_mul, simd_sub};
 
 #[cfg(test)]
 use stdarch_test::assert_instr;
@@ -192,6 +192,16 @@ mod sealed {
     ) -> vector_double {
         simd_sub(a, b)
     }
+
+    #[inline]
+    #[target_feature(enable = "vsx")]
+    #[cfg_attr(test, assert_instr(xvmuldp))]
+    pub(crate) unsafe fn vec_mul_double_double(
+        a: vector_double,
+        b: vector_double,
+    ) -> vector_double {
+        simd_mul(a, b)
+    }
 }
 
 // Implement AltiVec's VectorAdd trait for vector_double to enable vec_add support
@@ -213,6 +223,16 @@ impl crate::core_arch::powerpc::altivec::sealed::VectorSub<vector_double> for ve
     #[target_feature(enable = "vsx")]
     unsafe fn vec_sub(self, other: vector_double) -> Self::Result {
         sealed::vec_sub_double_double(self, other)
+    }
+}
+
+// Implement AltiVec's VectorMul trait for vector_double to enable vec_mul support.
+#[unstable(feature = "stdarch_powerpc", issue = "111145")]
+impl crate::core_arch::powerpc::altivec::sealed::VectorMul for vector_double {
+    #[inline]
+    #[target_feature(enable = "vsx")]
+    unsafe fn vec_mul(self, b: Self) -> Self {
+        sealed::vec_mul_double_double(self, b)
     }
 }
 
@@ -317,6 +337,17 @@ mod tests {
 
         unsafe {
             assert_eq!(f64x2::from(vec_sub(a, b)), f64x2::from(expected));
+        }
+    }
+
+    #[simd_test(enable = "vsx")]
+    fn test_vec_mul_f64x2_f64x2() {
+        let a = vector_double::from(f64x2::from_array([2.0, 3.0]));
+        let b = vector_double::from(f64x2::from_array([4.0, 5.0]));
+        let expected = vector_double::from(f64x2::from_array([8.0, 15.0]));
+
+        unsafe {
+            assert_eq!(f64x2::from(vec_mul(a, b)), f64x2::from(expected));
         }
     }
 }

--- a/crates/core_arch/src/powerpc/vsx.rs
+++ b/crates/core_arch/src/powerpc/vsx.rs
@@ -183,6 +183,17 @@ mod sealed {
         simd_add(a, b)
     }
 
+    // Implement AltiVec's VectorAdd trait for vector_double to enable vec_add support
+    #[unstable(feature = "stdarch_powerpc", issue = "111145")]
+    impl crate::core_arch::powerpc::altivec::sealed::VectorAdd<vector_double> for vector_double {
+        type Result = vector_double;
+        #[inline]
+        #[target_feature(enable = "vsx")]
+        unsafe fn vec_add(self, other: vector_double) -> Self::Result {
+            vec_add_double_double(self, other)
+        }
+    }
+
     #[inline]
     #[target_feature(enable = "vsx")]
     #[cfg_attr(test, assert_instr(xvsubdp))]
@@ -191,6 +202,17 @@ mod sealed {
         b: vector_double,
     ) -> vector_double {
         simd_sub(a, b)
+    }
+
+    // Implement AltiVec's VectorSub trait for vector_double to enable vec_sub support
+    #[unstable(feature = "stdarch_powerpc", issue = "111145")]
+    impl crate::core_arch::powerpc::altivec::sealed::VectorSub<vector_double> for vector_double {
+        type Result = vector_double;
+        #[inline]
+        #[target_feature(enable = "vsx")]
+        unsafe fn vec_sub(self, other: vector_double) -> Self::Result {
+            vec_sub_double_double(self, other)
+        }
     }
 
     #[inline]
@@ -202,37 +224,15 @@ mod sealed {
     ) -> vector_double {
         simd_mul(a, b)
     }
-}
 
-// Implement AltiVec's VectorAdd trait for vector_double to enable vec_add support
-#[unstable(feature = "stdarch_powerpc", issue = "111145")]
-impl crate::core_arch::powerpc::altivec::sealed::VectorAdd<vector_double> for vector_double {
-    type Result = vector_double;
-    #[inline]
-    #[target_feature(enable = "vsx")]
-    unsafe fn vec_add(self, other: vector_double) -> Self::Result {
-        sealed::vec_add_double_double(self, other)
-    }
-}
-
-// Implement AltiVec's VectorSub trait for vector_double to enable vec_sub support
-#[unstable(feature = "stdarch_powerpc", issue = "111145")]
-impl crate::core_arch::powerpc::altivec::sealed::VectorSub<vector_double> for vector_double {
-    type Result = vector_double;
-    #[inline]
-    #[target_feature(enable = "vsx")]
-    unsafe fn vec_sub(self, other: vector_double) -> Self::Result {
-        sealed::vec_sub_double_double(self, other)
-    }
-}
-
-// Implement AltiVec's VectorMul trait for vector_double to enable vec_mul support.
-#[unstable(feature = "stdarch_powerpc", issue = "111145")]
-impl crate::core_arch::powerpc::altivec::sealed::VectorMul for vector_double {
-    #[inline]
-    #[target_feature(enable = "vsx")]
-    unsafe fn vec_mul(self, b: Self) -> Self {
-        sealed::vec_mul_double_double(self, b)
+    // Implement AltiVec's VectorMul trait for vector_double to enable vec_mul support.
+    #[unstable(feature = "stdarch_powerpc", issue = "111145")]
+    impl crate::core_arch::powerpc::altivec::sealed::VectorMul for vector_double {
+        #[inline]
+        #[target_feature(enable = "vsx")]
+        unsafe fn vec_mul(self, b: Self) -> Self {
+            vec_mul_double_double(self, b)
+        }
     }
 }
 


### PR DESCRIPTION
Add intrinsics support on Linux on Power for:
* vec_add(vector_double, vector_double)
* vec_sub(vector_double, vector_double)
* vec_mul(vector_double, vector_double)

AI Assissted.