### PR TITLE
core_arch: redefine `svrev`, `svzip` and `svuzp`

### DIFF
--- a/crates/core_arch/src/aarch64/sve/generated.rs
+++ b/crates/core_arch/src/aarch64/sve/generated.rs
@@ -35226,19 +35226,6 @@ pub fn svreinterpret_u64_u64(op: svuint64_t) -> svuint64_t {
     unsafe { crate::intrinsics::transmute_unchecked(op) }
 }
 #[doc = "Reverse all elements"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrev_b8)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(rev))]
-pub fn svrev_b8(op: svbool_t) -> svbool_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.vector.reverse.nxv16i1")]
-        fn _svrev_b8(op: svbool_t) -> svbool_t;
-    }
-    unsafe { _svrev_b8(op) }
-}
-#[doc = "Reverse all elements"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrev_b16)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -35246,10 +35233,10 @@ pub fn svrev_b8(op: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(rev))]
 pub fn svrev_b16(op: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.vector.reverse.nxv8i1")]
-        fn _svrev_b16(op: svbool8_t) -> svbool8_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.rev.b16")]
+        fn _svrev_b16(op: svbool_t) -> svbool_t;
     }
-    unsafe { _svrev_b16(op.sve_into()).sve_into() }
+    unsafe { _svrev_b16(op.sve_into()) }
 }
 #[doc = "Reverse all elements"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrev_b32)"]
@@ -35259,10 +35246,10 @@ pub fn svrev_b16(op: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(rev))]
 pub fn svrev_b32(op: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.vector.reverse.nxv4i1")]
-        fn _svrev_b32(op: svbool4_t) -> svbool4_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.rev.b32")]
+        fn _svrev_b32(op: svbool_t) -> svbool_t;
     }
-    unsafe { _svrev_b32(op.sve_into()).sve_into() }
+    unsafe { _svrev_b32(op.sve_into()) }
 }
 #[doc = "Reverse all elements"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrev_b64)"]
@@ -35272,10 +35259,10 @@ pub fn svrev_b32(op: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(rev))]
 pub fn svrev_b64(op: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.vector.reverse.nxv2i1")]
-        fn _svrev_b64(op: svbool2_t) -> svbool2_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.rev.b64")]
+        fn _svrev_b64(op: svbool_t) -> svbool_t;
     }
-    unsafe { _svrev_b64(op.sve_into()).sve_into() }
+    unsafe { _svrev_b64(op.sve_into()) }
 }
 #[doc = "Reverse all elements"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrev[_f32])"]
@@ -35390,6 +35377,19 @@ pub fn svrev_u32(op: svuint32_t) -> svuint32_t {
 #[cfg_attr(test, assert_instr(rev))]
 pub fn svrev_u64(op: svuint64_t) -> svuint64_t {
     unsafe { svrev_s64(op.as_signed()).as_unsigned() }
+}
+#[doc = "Reverse all elements"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrev[_b8])"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(rev))]
+pub fn svrev_b8(op: svbool_t) -> svbool_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.vector.reverse.nxv16i1")]
+        fn _svrev_b8(op: svbool_t) -> svbool_t;
+    }
+    unsafe { _svrev_b8(op) }
 }
 #[doc = "Reverse bytes within elements"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svrevb[_s16]_m)"]

--- a/crates/core_arch/src/aarch64/sve/generated.rs
+++ b/crates/core_arch/src/aarch64/sve/generated.rs
@@ -43336,19 +43336,6 @@ pub fn svusmmla_s32(op1: svint32_t, op2: svuint8_t, op3: svint8_t) -> svint32_t 
     unsafe { _svusmmla_s32(op1, op2.as_signed(), op3) }
 }
 #[doc = "Concatenate even elements from two inputs"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1_b8)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(uzp1))]
-pub fn svuzp1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.nxv16i1")]
-        fn _svuzp1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
-    }
-    unsafe { _svuzp1_b8(op1, op2) }
-}
-#[doc = "Concatenate even elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1_b16)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -43356,10 +43343,10 @@ pub fn svuzp1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 pub fn svuzp1_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.nxv8i1")]
-        fn _svuzp1_b16(op1: svbool8_t, op2: svbool8_t) -> svbool8_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.b16")]
+        fn _svuzp1_b16(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svuzp1_b16(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svuzp1_b16(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Concatenate even elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1_b32)"]
@@ -43369,10 +43356,10 @@ pub fn svuzp1_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 pub fn svuzp1_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.nxv4i1")]
-        fn _svuzp1_b32(op1: svbool4_t, op2: svbool4_t) -> svbool4_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.b32")]
+        fn _svuzp1_b32(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svuzp1_b32(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svuzp1_b32(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Concatenate even elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1_b64)"]
@@ -43382,10 +43369,10 @@ pub fn svuzp1_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 pub fn svuzp1_b64(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.nxv2i1")]
-        fn _svuzp1_b64(op1: svbool2_t, op2: svbool2_t) -> svbool2_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.b64")]
+        fn _svuzp1_b64(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svuzp1_b64(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svuzp1_b64(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Concatenate even elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1[_f32])"]
@@ -43500,6 +43487,19 @@ pub fn svuzp1_u32(op1: svuint32_t, op2: svuint32_t) -> svuint32_t {
 #[cfg_attr(test, assert_instr(uzp1))]
 pub fn svuzp1_u64(op1: svuint64_t, op2: svuint64_t) -> svuint64_t {
     unsafe { svuzp1_s64(op1.as_signed(), op2.as_signed()).as_unsigned() }
+}
+#[doc = "Concatenate even elements from two inputs"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1[_b8])"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(uzp1))]
+pub fn svuzp1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp1.nxv16i1")]
+        fn _svuzp1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
+    }
+    unsafe { _svuzp1_b8(op1, op2) }
 }
 #[doc = "Concatenate even quadwords from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp1q[_f32])"]
@@ -43616,19 +43616,6 @@ pub fn svuzp1q_u64(op1: svuint64_t, op2: svuint64_t) -> svuint64_t {
     unsafe { svuzp1q_s64(op1.as_signed(), op2.as_signed()).as_unsigned() }
 }
 #[doc = "Concatenate odd elements from two inputs"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2_b8)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(uzp2))]
-pub fn svuzp2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.nxv16i1")]
-        fn _svuzp2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
-    }
-    unsafe { _svuzp2_b8(op1, op2) }
-}
-#[doc = "Concatenate odd elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2_b16)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -43636,10 +43623,10 @@ pub fn svuzp2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 pub fn svuzp2_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.nxv8i1")]
-        fn _svuzp2_b16(op1: svbool8_t, op2: svbool8_t) -> svbool8_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.b16")]
+        fn _svuzp2_b16(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svuzp2_b16(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svuzp2_b16(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Concatenate odd elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2_b32)"]
@@ -43649,10 +43636,10 @@ pub fn svuzp2_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 pub fn svuzp2_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.nxv4i1")]
-        fn _svuzp2_b32(op1: svbool4_t, op2: svbool4_t) -> svbool4_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.b32")]
+        fn _svuzp2_b32(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svuzp2_b32(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svuzp2_b32(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Concatenate odd elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2_b64)"]
@@ -43662,10 +43649,10 @@ pub fn svuzp2_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 pub fn svuzp2_b64(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.nxv2i1")]
-        fn _svuzp2_b64(op1: svbool2_t, op2: svbool2_t) -> svbool2_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.b64")]
+        fn _svuzp2_b64(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svuzp2_b64(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svuzp2_b64(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Concatenate odd elements from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2[_f32])"]
@@ -43780,6 +43767,19 @@ pub fn svuzp2_u32(op1: svuint32_t, op2: svuint32_t) -> svuint32_t {
 #[cfg_attr(test, assert_instr(uzp2))]
 pub fn svuzp2_u64(op1: svuint64_t, op2: svuint64_t) -> svuint64_t {
     unsafe { svuzp2_s64(op1.as_signed(), op2.as_signed()).as_unsigned() }
+}
+#[doc = "Concatenate odd elements from two inputs"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2[_b8])"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(uzp2))]
+pub fn svuzp2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.uzp2.nxv16i1")]
+        fn _svuzp2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
+    }
+    unsafe { _svuzp2_b8(op1, op2) }
 }
 #[doc = "Concatenate odd quadwords from two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svuzp2q[_f32])"]
@@ -44421,19 +44421,6 @@ pub fn svwrffr(op: svbool_t) {
     unsafe { _svwrffr(op) }
 }
 #[doc = "Interleave elements from low halves of two inputs"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1_b8)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(zip1))]
-pub fn svzip1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.nxv16i1")]
-        fn _svzip1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
-    }
-    unsafe { _svzip1_b8(op1, op2) }
-}
-#[doc = "Interleave elements from low halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1_b16)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -44441,10 +44428,10 @@ pub fn svzip1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(zip1))]
 pub fn svzip1_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.nxv8i1")]
-        fn _svzip1_b16(op1: svbool8_t, op2: svbool8_t) -> svbool8_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.b16")]
+        fn _svzip1_b16(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svzip1_b16(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svzip1_b16(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Interleave elements from low halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1_b32)"]
@@ -44454,10 +44441,10 @@ pub fn svzip1_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(zip1))]
 pub fn svzip1_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.nxv4i1")]
-        fn _svzip1_b32(op1: svbool4_t, op2: svbool4_t) -> svbool4_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.b32")]
+        fn _svzip1_b32(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svzip1_b32(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svzip1_b32(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Interleave elements from low halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1_b64)"]
@@ -44467,10 +44454,10 @@ pub fn svzip1_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(zip1))]
 pub fn svzip1_b64(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.nxv2i1")]
-        fn _svzip1_b64(op1: svbool2_t, op2: svbool2_t) -> svbool2_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.b64")]
+        fn _svzip1_b64(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svzip1_b64(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svzip1_b64(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Interleave elements from low halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1[_f32])"]
@@ -44585,6 +44572,19 @@ pub fn svzip1_u32(op1: svuint32_t, op2: svuint32_t) -> svuint32_t {
 #[cfg_attr(test, assert_instr(zip1))]
 pub fn svzip1_u64(op1: svuint64_t, op2: svuint64_t) -> svuint64_t {
     unsafe { svzip1_s64(op1.as_signed(), op2.as_signed()).as_unsigned() }
+}
+#[doc = "Interleave elements from low halves of two inputs"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1[_b8])"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(zip1))]
+pub fn svzip1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip1.nxv16i1")]
+        fn _svzip1_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
+    }
+    unsafe { _svzip1_b8(op1, op2) }
 }
 #[doc = "Interleave quadwords from low halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip1q[_f32])"]
@@ -44701,19 +44701,6 @@ pub fn svzip1q_u64(op1: svuint64_t, op2: svuint64_t) -> svuint64_t {
     unsafe { svzip1q_s64(op1.as_signed(), op2.as_signed()).as_unsigned() }
 }
 #[doc = "Interleave elements from high halves of two inputs"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2_b8)"]
-#[inline]
-#[target_feature(enable = "sve")]
-#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
-#[cfg_attr(test, assert_instr(zip2))]
-pub fn svzip2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.nxv16i1")]
-        fn _svzip2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
-    }
-    unsafe { _svzip2_b8(op1, op2) }
-}
-#[doc = "Interleave elements from high halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2_b16)"]
 #[inline]
 #[target_feature(enable = "sve")]
@@ -44721,10 +44708,10 @@ pub fn svzip2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(zip2))]
 pub fn svzip2_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.nxv8i1")]
-        fn _svzip2_b16(op1: svbool8_t, op2: svbool8_t) -> svbool8_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.b16")]
+        fn _svzip2_b16(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svzip2_b16(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svzip2_b16(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Interleave elements from high halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2_b32)"]
@@ -44734,10 +44721,10 @@ pub fn svzip2_b16(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(zip2))]
 pub fn svzip2_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.nxv4i1")]
-        fn _svzip2_b32(op1: svbool4_t, op2: svbool4_t) -> svbool4_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.b32")]
+        fn _svzip2_b32(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svzip2_b32(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svzip2_b32(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Interleave elements from high halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2_b64)"]
@@ -44747,10 +44734,10 @@ pub fn svzip2_b32(op1: svbool_t, op2: svbool_t) -> svbool_t {
 #[cfg_attr(test, assert_instr(zip2))]
 pub fn svzip2_b64(op1: svbool_t, op2: svbool_t) -> svbool_t {
     unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.nxv2i1")]
-        fn _svzip2_b64(op1: svbool2_t, op2: svbool2_t) -> svbool2_t;
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.b64")]
+        fn _svzip2_b64(op1: svbool_t, op2: svbool_t) -> svbool_t;
     }
-    unsafe { _svzip2_b64(op1.sve_into(), op2.sve_into()).sve_into() }
+    unsafe { _svzip2_b64(op1.sve_into(), op2.sve_into()) }
 }
 #[doc = "Interleave elements from high halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2[_f32])"]
@@ -44865,6 +44852,19 @@ pub fn svzip2_u32(op1: svuint32_t, op2: svuint32_t) -> svuint32_t {
 #[cfg_attr(test, assert_instr(zip2))]
 pub fn svzip2_u64(op1: svuint64_t, op2: svuint64_t) -> svuint64_t {
     unsafe { svzip2_s64(op1.as_signed(), op2.as_signed()).as_unsigned() }
+}
+#[doc = "Interleave elements from high halves of two inputs"]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2[_b8])"]
+#[inline]
+#[target_feature(enable = "sve")]
+#[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
+#[cfg_attr(test, assert_instr(zip2))]
+pub fn svzip2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t {
+    unsafe extern "unadjusted" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.zip2.nxv16i1")]
+        fn _svzip2_b8(op1: svbool_t, op2: svbool_t) -> svbool_t;
+    }
+    unsafe { _svzip2_b8(op1, op2) }
 }
 #[doc = "Interleave quadwords from high halves of two inputs"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/svzip2q[_f32])"]

--- a/crates/core_arch/src/aarch64/sve/mod.rs
+++ b/crates/core_arch/src/aarch64/sve/mod.rs
@@ -28,6 +28,14 @@ pub(super) trait SveInto<T>: Sized {
     unsafe fn sve_into(self) -> T;
 }
 
+impl<T> SveInto<T> for T {
+    #[inline]
+    #[target_feature(enable = "sve")]
+    unsafe fn sve_into(self) -> T {
+        self
+    }
+}
+
 macro_rules! impl_sve_type {
     ($(($v:vis, $elem_type:ty, $name:ident, $elt:literal))*) => ($(
         #[doc = concat!("Scalable vector of type ", stringify!($elem_type))]

--- a/crates/stdarch-gen-arm/spec/sve/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/sve/aarch64.spec.yml
@@ -1021,7 +1021,7 @@ intrinsics:
     doc: Interleave elements from low halves of two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
+    types: [b8, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
     assert_instr: [zip1]
     compose:
       - LLVMLink: { name: "zip1.{sve_type}" }
@@ -1031,10 +1031,13 @@ intrinsics:
     doc: Interleave elements from low halves of two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [b8, b16, b32, b64]
+    types: [b16, b32, b64]
     assert_instr: [zip1]
     compose:
-      - LLVMLink: { name: "zip1.{sve_type}" }
+      - LLVMLink:
+          name: "llvm.aarch64.sve.zip1.b{size}"
+          arguments: ["op1: svbool_t", "op2: svbool_t"]
+          return_type: "svbool_t"
 
   - name: svzip1q[_{type}]
     attr: [*sve-unstable]
@@ -1052,7 +1055,7 @@ intrinsics:
     doc: Interleave elements from high halves of two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
+    types: [b8, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
     assert_instr: [zip2]
     compose:
       - LLVMLink: { name: "zip2.{sve_type}" }
@@ -1062,10 +1065,13 @@ intrinsics:
     doc: Interleave elements from high halves of two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [b8, b16, b32, b64]
+    types: [b16, b32, b64]
     assert_instr: [zip2]
     compose:
-      - LLVMLink: { name: "zip2.{sve_type}" }
+      - LLVMLink:
+          name: "llvm.aarch64.sve.zip2.b{size}"
+          arguments: ["op1: svbool_t", "op2: svbool_t"]
+          return_type: "svbool_t"
 
   - name: svzip2q[_{type}]
     attr: [*sve-unstable]
@@ -1083,7 +1089,7 @@ intrinsics:
     doc: Concatenate even elements from two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
+    types: [b8, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
     assert_instr: [uzp1]
     compose:
       - LLVMLink: { name: "uzp1.{sve_type}" }
@@ -1093,10 +1099,13 @@ intrinsics:
     doc: Concatenate even elements from two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [b8, b16, b32, b64]
+    types: [b16, b32, b64]
     assert_instr: [uzp1]
     compose:
-      - LLVMLink: { name: "uzp1.{sve_type}" }
+      - LLVMLink:
+          name: "llvm.aarch64.sve.uzp1.b{size}"
+          arguments: ["op1: svbool_t", "op2: svbool_t"]
+          return_type: "svbool_t"
 
   - name: svuzp1q[_{type}]
     attr: [*sve-unstable]
@@ -1114,7 +1123,7 @@ intrinsics:
     doc: Concatenate odd elements from two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
+    types: [b8, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
     assert_instr: [uzp2]
     compose:
       - LLVMLink: { name: "uzp2.{sve_type}" }
@@ -1124,10 +1133,13 @@ intrinsics:
     doc: Concatenate odd elements from two inputs
     arguments: ["op1: {sve_type}", "op2: {sve_type}"]
     return_type: "{sve_type}"
-    types: [b8, b16, b32, b64]
+    types: [b16, b32, b64]
     assert_instr: [uzp2]
     compose:
-      - LLVMLink: { name: "uzp2.{sve_type}" }
+      - LLVMLink:
+          name: "llvm.aarch64.sve.uzp2.b{size}"
+          arguments: ["op1: svbool_t", "op2: svbool_t"]
+          return_type: "svbool_t"
 
   - name: svuzp2q[_{type}]
     attr: [*sve-unstable]

--- a/crates/stdarch-gen-arm/spec/sve/aarch64.spec.yml
+++ b/crates/stdarch-gen-arm/spec/sve/aarch64.spec.yml
@@ -1207,7 +1207,7 @@ intrinsics:
     doc: Reverse all elements
     arguments: ["op: {sve_type}"]
     return_type: "{sve_type}"
-    types: [f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
+    types: [b8, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64]
     assert_instr: [rev]
     compose:
       - LLVMLink: { name: "llvm.vector.reverse.{sve_type}" }
@@ -1217,10 +1217,13 @@ intrinsics:
     doc: Reverse all elements
     arguments: ["op: {sve_type}"]
     return_type: "{sve_type}"
-    types: [b8, b16, b32, b64]
+    types: [b16, b32, b64]
     assert_instr: [rev]
     compose:
-      - LLVMLink: { name: "llvm.vector.reverse.{sve_type}" }
+      - LLVMLink:
+          name: "llvm.aarch64.sve.rev.b{size}"
+          arguments: ["op: svbool_t"]
+          return_type: "svbool_t"
 
   - name: svrevb[_{type}]{_mxz}
     attr: [*sve-unstable]

--- a/crates/stdarch-gen-arm/src/intrinsic.rs
+++ b/crates/stdarch-gen-arm/src/intrinsic.rs
@@ -1604,6 +1604,7 @@ impl Intrinsic {
                             (Some(BaseTypeKind::Float), Some(BaseTypeKind::Float)) => ex,
                             (Some(BaseTypeKind::UInt), Some(BaseTypeKind::UInt)) => ex,
                             (Some(BaseTypeKind::Poly), Some(BaseTypeKind::Poly)) => ex,
+                            (Some(BaseTypeKind::Bool), Some(BaseTypeKind::Bool)) => ex,
 
                             (None, None) => ex,
                             _ => unreachable!(


### PR DESCRIPTION
Split out from rust-lang/stdarch#2160.

Clang uses the `llvm.aarch64.sve.rev.bN` intrinsic for `svrev` with `b16`, `b32` and `b64`. Likewise with `llvm.aarch64.sve.zip.bN` for `svzip` and `llvm.aarch64.sve.uzp.bN` for `svuzp`. This required small generator changes so it knew a bool-to-bool conversion was a no-op and a new blanket identity impl of `SveInto` so the calls generated compile. These intrinsics were just returning the wrong value prior to this change, but obviously this isn't tested until rust-lang/stdarch#2160 lands.

r? @adamgemmell 