### PR TITLE
document differences from pure hardware behavior

### DIFF
--- a/crates/core_arch/src/core_arch_docs.md
+++ b/crates/core_arch/src/core_arch_docs.md
@@ -31,11 +31,12 @@ ensure at least a few guarantees are upheld:
   typically done by ensuring that `#[cfg]` is used appropriately when using
   this module.
 * The CPU the program is currently running on supports the function being
-  called. For example it is unsafe to call an AVX2 function on a CPU that
+  called. For example, it is unsafe to call an AVX2 function on a CPU that
   doesn't actually support AVX2.
 
 As a result of the latter of these guarantees all intrinsics in this module
-are `unsafe` and extra care needs to be taken when calling them!
+are `unsafe` to call unless the caller enables the required target features,
+and extra care needs to be taken when calling them!
 
 # CPU Feature Detection
 
@@ -163,6 +164,25 @@ detail!
 And with all that we should have a working program! This program will run
 across all machines and it'll use the optimized AVX2 implementation on
 machines where support is detected.
+
+# Differences from pure hardware behavior
+
+While the intrinsics in this module exist to expose particular instructions of the underlying
+hardware, not all of them behave *exactly* like their corresponding instructions.
+
+* Floating-point operations are subject to the usual [Rust semantics for NaN
+  values][nan].
+* Operations that read or write the floating-point status register generally cannot be meaningfully
+  used because Rust makes no guarantee about when and where floating-point operations can be
+  executed. In particular, it is generally undefined behavior to change the default rounding or
+  exception behavior.
+* Some operations have special memory-model effects that are incompatible with the Rust Abstract
+  Machine, which means they are subject to more strict requirements than they would be in an
+  assembly program. Most notably, this applies to [non-temporal ("streaming") stores on
+  x86][non-temporal].
+
+[nan]: ../../core/primitive.f32.html#nan-bit-patterns
+[non-temporal]: ../../core/arch/x86/fn._mm_sfence.html#safety-of-non-temporal-stores
 
 # Ergonomics
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/153990 by documenting that the NaN rules also apply to stdarch intrinsics.

Rust does *not* have a general rule of "signaling NaN may be treated like quiet NaN"; that only affects a few operations (pow, powi, max, min) which just then state this caveat in their respective docs. My understanding is that stdarch wants to properly reflect hardware behavior here. That means however stdarch must be careful not to use the normal LLMV intrinsics for such operations. I think nvptx currently may be getting this wrong, which is already tracked at https://github.com/rust-lang/stdarch/issues/2056.

@Amanieu also mentioned that for subnormals, the intent is that stdarch matches the hardware. I suspect this may be tricky since LLVM will probably reserve the right to perform constant propagation with full subnormal precision, i.e., "guaranteed subnormal flushing" is probably not going to work. But right now the ARM32 NEON intrinsics are unsound and can cause UB (https://github.com/rust-lang/rust/issues/129880) so we can't really even have that discussion yet until that is fixed.