### PR TITLE
loongarch: Rename SIMD helper intrinsics to avoid macro path issues

### DIFF
--- a/crates/core_arch/src/loongarch64/lasx/portable.rs
+++ b/crates/core_arch/src/loongarch64/lasx/portable.rs
@@ -1,13 +1,13 @@
 //! LoongArch64 LASX intrinsics - intrinsics::simd implementation
 
-use super::super::{simd as ls, simd::*, *};
-use crate::core_arch::simd::{self as cs, *};
-use crate::intrinsics::simd as is;
+use super::super::{simd::*, *};
+use crate::core_arch::simd::*;
+use crate::intrinsics::simd::*;
 use crate::mem::transmute;
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(
         b,
         a,
@@ -20,25 +20,25 @@ const unsafe fn simd_pickev_b<T: Copy>(a: T, b: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_d<T: Copy>(a: T, b: T) -> T {
-    simd_shuffle!(b, a, [0, 4, 2, 6])
-}
-
-#[inline(always)]
-#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_w<T: Copy>(a: T, b: T) -> T {
-    simd_shuffle!(b, a, [0, 2, 8, 10, 4, 6, 12, 14])
-}
-
-#[inline(always)]
-#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2, 4, 6, 16, 18, 20, 22, 8, 10, 12, 14, 24, 26, 28, 30])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_w<T: Copy>(a: T, b: T) -> T {
+    simd_shuffle!(b, a, [0, 2, 8, 10, 4, 6, 12, 14])
+}
+
+#[inline(always)]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+const unsafe fn simd_ext_pickev_d<T: Copy>(a: T, b: T) -> T {
+    simd_shuffle!(b, a, [0, 4, 2, 6])
+}
+
+#[inline(always)]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+const unsafe fn simd_ext_pickod_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(
         b,
         a,
@@ -51,25 +51,25 @@ const unsafe fn simd_pickod_b<T: Copy>(a: T, b: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_d<T: Copy>(a: T, b: T) -> T {
-    simd_shuffle!(b, a, [1, 5, 3, 7])
-}
-
-#[inline(always)]
-#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_w<T: Copy>(a: T, b: T) -> T {
-    simd_shuffle!(b, a, [1, 3, 9, 11, 5, 7, 13, 15])
-}
-
-#[inline(always)]
-#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickod_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3, 5, 7, 17, 19, 21, 23, 9, 11, 13, 15, 25, 27, 29, 31])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickod_w<T: Copy>(a: T, b: T) -> T {
+    simd_shuffle!(b, a, [1, 3, 9, 11, 5, 7, 13, 15])
+}
+
+#[inline(always)]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+const unsafe fn simd_ext_pickod_d<T: Copy>(a: T, b: T) -> T {
+    simd_shuffle!(b, a, [1, 5, 3, 7])
+}
+
+#[inline(always)]
+#[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
+const unsafe fn simd_ext_ilvh_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(
         b,
         a,
@@ -82,25 +82,25 @@ const unsafe fn simd_ilvh_b<T: Copy>(a: T, b: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [4, 20, 5, 21, 6, 22, 7, 23, 12, 28, 13, 29, 14, 30, 15, 31])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [2, 10, 3, 11, 6, 14, 7, 15])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 5, 3, 7])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(
         b,
         a,
@@ -113,25 +113,25 @@ const unsafe fn simd_ilvl_b<T: Copy>(a: T, b: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 16, 1, 17, 2, 18, 3, 19, 8, 24, 9, 25, 10, 26, 11, 27])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 8, 1, 9, 4, 12, 5, 13])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 4, 2, 6])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_b<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_b<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -145,7 +145,7 @@ const unsafe fn simd_replvei_b<const I: u32, T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_h<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_h<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -158,19 +158,19 @@ const unsafe fn simd_replvei_h<const I: u32, T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_w<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_w<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [I, I, I, I, I + 4, I + 4, I + 4, I + 4])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_d<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_d<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [I, I, I + 2, I + 2])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replve0_b<T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replve0_b<T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -183,31 +183,31 @@ const unsafe fn simd_replve0_b<T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replve0_h<T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replve0_h<T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replve0_w<T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replve0_w<T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [0, 0, 0, 0, 0, 0, 0, 0])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replve0_d<T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replve0_d<T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [0, 0, 0, 0])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replve0_q<T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replve0_q<T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [0, 1, 0, 1])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(
         b,
         a,
@@ -220,25 +220,25 @@ const unsafe fn simd_packev_b<T: Copy>(a: T, b: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 4, 2, 6])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(
         b,
         a,
@@ -251,25 +251,25 @@ const unsafe fn simd_packod_b<T: Copy>(a: T, b: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 5, 3, 7])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_b<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_shuf4i_b<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -288,7 +288,7 @@ const unsafe fn simd_shuf4i_b<const I: u32, T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_h<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_shuf4i_h<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -303,7 +303,7 @@ const unsafe fn simd_shuf4i_h<const I: u32, T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_w<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_shuf4i_w<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -314,307 +314,307 @@ const unsafe fn simd_shuf4i_w<const I: u32, T: Copy>(a: T) -> T {
     )
 }
 
-impl_vv!("lasx", lasx_xvpcnt_b, is::simd_ctpop, m256i, i8x32);
-impl_vv!("lasx", lasx_xvpcnt_h, is::simd_ctpop, m256i, i16x16);
-impl_vv!("lasx", lasx_xvpcnt_w, is::simd_ctpop, m256i, i32x8);
-impl_vv!("lasx", lasx_xvpcnt_d, is::simd_ctpop, m256i, i64x4);
-impl_vv!("lasx", lasx_xvclz_b, is::simd_ctlz, m256i, i8x32);
-impl_vv!("lasx", lasx_xvclz_h, is::simd_ctlz, m256i, i16x16);
-impl_vv!("lasx", lasx_xvclz_w, is::simd_ctlz, m256i, i32x8);
-impl_vv!("lasx", lasx_xvclz_d, is::simd_ctlz, m256i, i64x4);
-impl_vv!("lasx", lasx_xvneg_b, is::simd_neg, m256i, i8x32);
-impl_vv!("lasx", lasx_xvneg_h, is::simd_neg, m256i, i16x16);
-impl_vv!("lasx", lasx_xvneg_w, is::simd_neg, m256i, i32x8);
-impl_vv!("lasx", lasx_xvneg_d, is::simd_neg, m256i, i64x4);
-impl_vv!("lasx", lasx_xvfsqrt_s, is::simd_fsqrt, m256, f32x8);
-impl_vv!("lasx", lasx_xvfsqrt_d, is::simd_fsqrt, m256d, f64x4);
-impl_vv!("lasx", lasx_xvfrsqrt_s, ls::simd_frsqrt_s, m256, f32x8);
-impl_vv!("lasx", lasx_xvfrsqrt_d, ls::simd_frsqrt_d, m256d, f64x4);
-impl_vv!("lasx", lasx_xvfrecip_s, ls::simd_frecip_s, m256, f32x8);
-impl_vv!("lasx", lasx_xvfrecip_d, ls::simd_frecip_d, m256d, f64x4);
-impl_vv!("lasx", lasx_xvfrintrp_s, is::simd_ceil, m256, f32x8);
-impl_vv!("lasx", lasx_xvfrintrp_d, is::simd_ceil, m256d, f64x4);
-impl_vv!("lasx", lasx_xvfrintrm_s, is::simd_floor, m256, f32x8);
-impl_vv!("lasx", lasx_xvfrintrm_d, is::simd_floor, m256d, f64x4);
-impl_vv!("lasx", lasx_xvfrintrz_s, is::simd_trunc, m256, f32x8);
-impl_vv!("lasx", lasx_xvfrintrz_d, is::simd_trunc, m256d, f64x4);
-impl_vv!("lasx", lasx_xvreplve0_b, simd_replve0_b, m256i, i8x32);
-impl_vv!("lasx", lasx_xvreplve0_h, simd_replve0_h, m256i, i16x16);
-impl_vv!("lasx", lasx_xvreplve0_w, simd_replve0_w, m256i, i32x8);
-impl_vv!("lasx", lasx_xvreplve0_d, simd_replve0_d, m256i, i64x4);
-impl_vv!("lasx", lasx_xvreplve0_q, simd_replve0_q, m256i, i64x4);
+impl_vv!("lasx", lasx_xvpcnt_b, simd_ctpop, m256i, i8x32);
+impl_vv!("lasx", lasx_xvpcnt_h, simd_ctpop, m256i, i16x16);
+impl_vv!("lasx", lasx_xvpcnt_w, simd_ctpop, m256i, i32x8);
+impl_vv!("lasx", lasx_xvpcnt_d, simd_ctpop, m256i, i64x4);
+impl_vv!("lasx", lasx_xvclz_b, simd_ctlz, m256i, i8x32);
+impl_vv!("lasx", lasx_xvclz_h, simd_ctlz, m256i, i16x16);
+impl_vv!("lasx", lasx_xvclz_w, simd_ctlz, m256i, i32x8);
+impl_vv!("lasx", lasx_xvclz_d, simd_ctlz, m256i, i64x4);
+impl_vv!("lasx", lasx_xvneg_b, simd_neg, m256i, i8x32);
+impl_vv!("lasx", lasx_xvneg_h, simd_neg, m256i, i16x16);
+impl_vv!("lasx", lasx_xvneg_w, simd_neg, m256i, i32x8);
+impl_vv!("lasx", lasx_xvneg_d, simd_neg, m256i, i64x4);
+impl_vv!("lasx", lasx_xvfsqrt_s, simd_fsqrt, m256, f32x8);
+impl_vv!("lasx", lasx_xvfsqrt_d, simd_fsqrt, m256d, f64x4);
+impl_vv!("lasx", lasx_xvfrsqrt_s, simd_ext_frsqrt_s, m256, f32x8);
+impl_vv!("lasx", lasx_xvfrsqrt_d, simd_ext_frsqrt_d, m256d, f64x4);
+impl_vv!("lasx", lasx_xvfrecip_s, simd_ext_frecip_s, m256, f32x8);
+impl_vv!("lasx", lasx_xvfrecip_d, simd_ext_frecip_d, m256d, f64x4);
+impl_vv!("lasx", lasx_xvfrintrp_s, simd_ceil, m256, f32x8);
+impl_vv!("lasx", lasx_xvfrintrp_d, simd_ceil, m256d, f64x4);
+impl_vv!("lasx", lasx_xvfrintrm_s, simd_floor, m256, f32x8);
+impl_vv!("lasx", lasx_xvfrintrm_d, simd_floor, m256d, f64x4);
+impl_vv!("lasx", lasx_xvfrintrz_s, simd_trunc, m256, f32x8);
+impl_vv!("lasx", lasx_xvfrintrz_d, simd_trunc, m256d, f64x4);
+impl_vv!("lasx", lasx_xvreplve0_b, simd_ext_replve0_b, m256i, i8x32);
+impl_vv!("lasx", lasx_xvreplve0_h, simd_ext_replve0_h, m256i, i16x16);
+impl_vv!("lasx", lasx_xvreplve0_w, simd_ext_replve0_w, m256i, i32x8);
+impl_vv!("lasx", lasx_xvreplve0_d, simd_ext_replve0_d, m256i, i64x4);
+impl_vv!("lasx", lasx_xvreplve0_q, simd_ext_replve0_q, m256i, i64x4);
 
-impl_gv!("lasx", lasx_xvreplgr2vr_b, ls::simd_splat, m256i, i8x32, i32);
-impl_gv!("lasx", lasx_xvreplgr2vr_h, ls::simd_splat, m256i, i16x16, i32);
-impl_gv!("lasx", lasx_xvreplgr2vr_w, ls::simd_splat, m256i, i32x8, i32);
-impl_gv!("lasx", lasx_xvreplgr2vr_d, ls::simd_splat, m256i, i64x4, i64);
+impl_gv!("lasx", lasx_xvreplgr2vr_b, simd_ext_splat, m256i, i8x32, i32);
+impl_gv!("lasx", lasx_xvreplgr2vr_h, simd_ext_splat, m256i, i16x16, i32);
+impl_gv!("lasx", lasx_xvreplgr2vr_w, simd_ext_splat, m256i, i32x8, i32);
+impl_gv!("lasx", lasx_xvreplgr2vr_d, simd_ext_splat, m256i, i64x4, i64);
 
-impl_ggv!("lasx", lasx_xvldx, simd_ldx, m256i, i8x32, *const i8, i64, unsafe);
+impl_ggv!("lasx", lasx_xvldx, simd_ext_ldx, m256i, i8x32, *const i8, i64, unsafe);
 
-impl_gsv!("lasx", lasx_xvld, simd_ld, m256i, i8x32, *const i8, 12, const, unsafe);
+impl_gsv!("lasx", lasx_xvld, simd_ext_ld, m256i, i8x32, *const i8, 12, const, unsafe);
 
-impl_sv!("lasx", lasx_xvrepli_b, ls::simd_splat, m256i, i8x32, 10);
-impl_sv!("lasx", lasx_xvrepli_h, ls::simd_splat, m256i, i16x16, 10);
-impl_sv!("lasx", lasx_xvrepli_w, ls::simd_splat, m256i, i32x8, 10);
-impl_sv!("lasx", lasx_xvrepli_d, ls::simd_splat, m256i, i64x4, 10);
+impl_sv!("lasx", lasx_xvrepli_b, simd_ext_splat, m256i, i8x32, 10);
+impl_sv!("lasx", lasx_xvrepli_h, simd_ext_splat, m256i, i16x16, 10);
+impl_sv!("lasx", lasx_xvrepli_w, simd_ext_splat, m256i, i32x8, 10);
+impl_sv!("lasx", lasx_xvrepli_d, simd_ext_splat, m256i, i64x4, 10);
 
-impl_vvv!("lasx", lasx_xvadd_b, is::simd_add, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvadd_h, is::simd_add, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvadd_w, is::simd_add, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvadd_d, is::simd_add, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvsub_b, is::simd_sub, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvsub_h, is::simd_sub, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvsub_w, is::simd_sub, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvsub_d, is::simd_sub, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvmax_b, cs::simd_imax, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvmax_h, cs::simd_imax, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvmax_w, cs::simd_imax, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvmax_d, cs::simd_imax, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvmax_bu, cs::simd_imax, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvmax_hu, cs::simd_imax, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvmax_wu, cs::simd_imax, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvmax_du, cs::simd_imax, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvmin_b, cs::simd_imin, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvmin_h, cs::simd_imin, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvmin_w, cs::simd_imin, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvmin_d, cs::simd_imin, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvmin_bu, cs::simd_imin, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvmin_hu, cs::simd_imin, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvmin_wu, cs::simd_imin, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvmin_du, cs::simd_imin, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvseq_b, is::simd_eq, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvseq_h, is::simd_eq, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvseq_w, is::simd_eq, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvseq_d, is::simd_eq, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvslt_b, is::simd_lt, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvslt_h, is::simd_lt, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvslt_w, is::simd_lt, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvslt_d, is::simd_lt, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvslt_bu, is::simd_lt, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvslt_hu, is::simd_lt, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvslt_wu, is::simd_lt, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvslt_du, is::simd_lt, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvsle_b, is::simd_le, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvsle_h, is::simd_le, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvsle_w, is::simd_le, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvsle_d, is::simd_le, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvsle_bu, is::simd_le, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvsle_hu, is::simd_le, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvsle_wu, is::simd_le, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvsle_du, is::simd_le, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvmul_b, is::simd_mul, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvmul_h, is::simd_mul, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvmul_w, is::simd_mul, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvmul_d, is::simd_mul, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvdiv_b, is::simd_div, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvdiv_h, is::simd_div, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvdiv_w, is::simd_div, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvdiv_d, is::simd_div, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvdiv_bu, is::simd_div, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvdiv_hu, is::simd_div, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvdiv_wu, is::simd_div, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvdiv_du, is::simd_div, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvmod_b, is::simd_rem, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvmod_h, is::simd_rem, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvmod_w, is::simd_rem, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvmod_d, is::simd_rem, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvmod_bu, is::simd_rem, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvmod_hu, is::simd_rem, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvmod_wu, is::simd_rem, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvmod_du, is::simd_rem, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvand_v, is::simd_and, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvandn_v, ls::simd_andn, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvor_v, is::simd_or, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvorn_v, ls::simd_orn, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvnor_v, ls::simd_nor, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvxor_v, is::simd_xor, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvfadd_s, is::simd_add, m256, f32x8);
-impl_vvv!("lasx", lasx_xvfadd_d, is::simd_add, m256d, f64x4);
-impl_vvv!("lasx", lasx_xvfsub_s, is::simd_sub, m256, f32x8);
-impl_vvv!("lasx", lasx_xvfsub_d, is::simd_sub, m256d, f64x4);
-impl_vvv!("lasx", lasx_xvfmul_s, is::simd_mul, m256, f32x8);
-impl_vvv!("lasx", lasx_xvfmul_d, is::simd_mul, m256d, f64x4);
-impl_vvv!("lasx", lasx_xvfdiv_s, is::simd_div, m256, f32x8);
-impl_vvv!("lasx", lasx_xvfdiv_d, is::simd_div, m256d, f64x4);
-impl_vvv!("lasx", lasx_xvsll_b, ls::simd_shl, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvsll_h, ls::simd_shl, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvsll_w, ls::simd_shl, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvsll_d, ls::simd_shl, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvsra_b, ls::simd_shr, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvsra_h, ls::simd_shr, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvsra_w, ls::simd_shr, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvsra_d, ls::simd_shr, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvsrl_b, ls::simd_shr, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvsrl_h, ls::simd_shr, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvsrl_w, ls::simd_shr, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvsrl_d, ls::simd_shr, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvrotr_b, ls::simd_rotr, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvrotr_h, ls::simd_rotr, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvrotr_w, ls::simd_rotr, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvrotr_d, ls::simd_rotr, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvbitclr_b, ls::simd_bitclr, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvbitclr_h, ls::simd_bitclr, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvbitclr_w, ls::simd_bitclr, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvbitclr_d, ls::simd_bitclr, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvbitset_b, ls::simd_bitset, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvbitset_h, ls::simd_bitset, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvbitset_w, ls::simd_bitset, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvbitset_d, ls::simd_bitset, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvbitrev_b, ls::simd_bitrev, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvbitrev_h, ls::simd_bitrev, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvbitrev_w, ls::simd_bitrev, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvbitrev_d, ls::simd_bitrev, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvsadd_b, is::simd_saturating_add, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvsadd_h, is::simd_saturating_add, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvsadd_w, is::simd_saturating_add, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvsadd_d, is::simd_saturating_add, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvsadd_bu, is::simd_saturating_add, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvsadd_hu, is::simd_saturating_add, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvsadd_wu, is::simd_saturating_add, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvsadd_du, is::simd_saturating_add, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvssub_b, is::simd_saturating_sub, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvssub_h, is::simd_saturating_sub, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvssub_w, is::simd_saturating_sub, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvssub_d, is::simd_saturating_sub, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvssub_bu, is::simd_saturating_sub, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvssub_hu, is::simd_saturating_sub, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvssub_wu, is::simd_saturating_sub, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvssub_du, is::simd_saturating_sub, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvadda_b, ls::simd_adda, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvadda_h, ls::simd_adda, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvadda_w, ls::simd_adda, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvadda_d, ls::simd_adda, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvabsd_b, ls::simd_absd, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvabsd_h, ls::simd_absd, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvabsd_w, ls::simd_absd, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvabsd_d, ls::simd_absd, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvabsd_bu, ls::simd_absd, m256i, u8x32);
-impl_vvv!("lasx", lasx_xvabsd_hu, ls::simd_absd, m256i, u16x16);
-impl_vvv!("lasx", lasx_xvabsd_wu, ls::simd_absd, m256i, u32x8);
-impl_vvv!("lasx", lasx_xvabsd_du, ls::simd_absd, m256i, u64x4);
-impl_vvv!("lasx", lasx_xvmuh_b, simd_muh, m256i, i8x32, i16x32);
-impl_vvv!("lasx", lasx_xvmuh_h, simd_muh, m256i, i16x16, i32x16);
-impl_vvv!("lasx", lasx_xvmuh_w, simd_muh, m256i, i32x8, i64x8);
-impl_vvv!("lasx", lasx_xvmuh_d, simd_muh, m256i, i64x4, i128x4);
-impl_vvv!("lasx", lasx_xvmuh_bu, simd_muh, m256i, u8x32, u16x32);
-impl_vvv!("lasx", lasx_xvmuh_hu, simd_muh, m256i, u16x16, u32x16);
-impl_vvv!("lasx", lasx_xvmuh_wu, simd_muh, m256i, u32x8, u64x8);
-impl_vvv!("lasx", lasx_xvmuh_du, simd_muh, m256i, u64x4, u128x4);
-impl_vvv!("lasx", lasx_xvpickev_b, simd_pickev_b, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvpickev_h, simd_pickev_h, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvpickev_w, simd_pickev_w, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvpickev_d, simd_pickev_d, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvpickod_b, simd_pickod_b, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvpickod_h, simd_pickod_h, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvpickod_w, simd_pickod_w, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvpickod_d, simd_pickod_d, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvilvh_b, simd_ilvh_b, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvilvh_h, simd_ilvh_h, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvilvh_w, simd_ilvh_w, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvilvh_d, simd_ilvh_d, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvilvl_b, simd_ilvl_b, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvilvl_h, simd_ilvl_h, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvilvl_w, simd_ilvl_w, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvilvl_d, simd_ilvl_d, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvpackev_b, simd_packev_b, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvpackev_h, simd_packev_h, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvpackev_w, simd_packev_w, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvpackev_d, simd_packev_d, m256i, i64x4);
-impl_vvv!("lasx", lasx_xvpackod_b, simd_packod_b, m256i, i8x32);
-impl_vvv!("lasx", lasx_xvpackod_h, simd_packod_h, m256i, i16x16);
-impl_vvv!("lasx", lasx_xvpackod_w, simd_packod_w, m256i, i32x8);
-impl_vvv!("lasx", lasx_xvpackod_d, simd_packod_d, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvadd_b, simd_add, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvadd_h, simd_add, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvadd_w, simd_add, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvadd_d, simd_add, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvsub_b, simd_sub, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvsub_h, simd_sub, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvsub_w, simd_sub, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvsub_d, simd_sub, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvmax_b, simd_imax, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvmax_h, simd_imax, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvmax_w, simd_imax, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvmax_d, simd_imax, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvmax_bu, simd_imax, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvmax_hu, simd_imax, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvmax_wu, simd_imax, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvmax_du, simd_imax, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvmin_b, simd_imin, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvmin_h, simd_imin, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvmin_w, simd_imin, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvmin_d, simd_imin, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvmin_bu, simd_imin, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvmin_hu, simd_imin, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvmin_wu, simd_imin, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvmin_du, simd_imin, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvseq_b, simd_eq, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvseq_h, simd_eq, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvseq_w, simd_eq, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvseq_d, simd_eq, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvslt_b, simd_lt, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvslt_h, simd_lt, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvslt_w, simd_lt, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvslt_d, simd_lt, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvslt_bu, simd_lt, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvslt_hu, simd_lt, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvslt_wu, simd_lt, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvslt_du, simd_lt, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvsle_b, simd_le, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvsle_h, simd_le, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvsle_w, simd_le, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvsle_d, simd_le, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvsle_bu, simd_le, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvsle_hu, simd_le, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvsle_wu, simd_le, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvsle_du, simd_le, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvmul_b, simd_mul, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvmul_h, simd_mul, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvmul_w, simd_mul, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvmul_d, simd_mul, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvdiv_b, simd_div, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvdiv_h, simd_div, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvdiv_w, simd_div, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvdiv_d, simd_div, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvdiv_bu, simd_div, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvdiv_hu, simd_div, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvdiv_wu, simd_div, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvdiv_du, simd_div, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvmod_b, simd_rem, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvmod_h, simd_rem, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvmod_w, simd_rem, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvmod_d, simd_rem, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvmod_bu, simd_rem, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvmod_hu, simd_rem, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvmod_wu, simd_rem, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvmod_du, simd_rem, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvand_v, simd_and, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvandn_v, simd_ext_andn, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvor_v, simd_or, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvorn_v, simd_ext_orn, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvnor_v, simd_ext_nor, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvxor_v, simd_xor, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvfadd_s, simd_add, m256, f32x8);
+impl_vvv!("lasx", lasx_xvfadd_d, simd_add, m256d, f64x4);
+impl_vvv!("lasx", lasx_xvfsub_s, simd_sub, m256, f32x8);
+impl_vvv!("lasx", lasx_xvfsub_d, simd_sub, m256d, f64x4);
+impl_vvv!("lasx", lasx_xvfmul_s, simd_mul, m256, f32x8);
+impl_vvv!("lasx", lasx_xvfmul_d, simd_mul, m256d, f64x4);
+impl_vvv!("lasx", lasx_xvfdiv_s, simd_div, m256, f32x8);
+impl_vvv!("lasx", lasx_xvfdiv_d, simd_div, m256d, f64x4);
+impl_vvv!("lasx", lasx_xvsll_b, simd_ext_shl, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvsll_h, simd_ext_shl, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvsll_w, simd_ext_shl, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvsll_d, simd_ext_shl, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvsra_b, simd_ext_shr, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvsra_h, simd_ext_shr, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvsra_w, simd_ext_shr, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvsra_d, simd_ext_shr, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvsrl_b, simd_ext_shr, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvsrl_h, simd_ext_shr, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvsrl_w, simd_ext_shr, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvsrl_d, simd_ext_shr, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvrotr_b, simd_ext_rotr, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvrotr_h, simd_ext_rotr, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvrotr_w, simd_ext_rotr, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvrotr_d, simd_ext_rotr, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvbitclr_b, simd_ext_bitclr, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvbitclr_h, simd_ext_bitclr, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvbitclr_w, simd_ext_bitclr, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvbitclr_d, simd_ext_bitclr, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvbitset_b, simd_ext_bitset, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvbitset_h, simd_ext_bitset, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvbitset_w, simd_ext_bitset, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvbitset_d, simd_ext_bitset, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvbitrev_b, simd_ext_bitrev, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvbitrev_h, simd_ext_bitrev, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvbitrev_w, simd_ext_bitrev, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvbitrev_d, simd_ext_bitrev, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvsadd_b, simd_saturating_add, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvsadd_h, simd_saturating_add, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvsadd_w, simd_saturating_add, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvsadd_d, simd_saturating_add, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvsadd_bu, simd_saturating_add, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvsadd_hu, simd_saturating_add, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvsadd_wu, simd_saturating_add, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvsadd_du, simd_saturating_add, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvssub_b, simd_saturating_sub, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvssub_h, simd_saturating_sub, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvssub_w, simd_saturating_sub, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvssub_d, simd_saturating_sub, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvssub_bu, simd_saturating_sub, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvssub_hu, simd_saturating_sub, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvssub_wu, simd_saturating_sub, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvssub_du, simd_saturating_sub, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvadda_b, simd_ext_adda, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvadda_h, simd_ext_adda, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvadda_w, simd_ext_adda, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvadda_d, simd_ext_adda, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvabsd_b, simd_ext_absd, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvabsd_h, simd_ext_absd, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvabsd_w, simd_ext_absd, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvabsd_d, simd_ext_absd, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvabsd_bu, simd_ext_absd, m256i, u8x32);
+impl_vvv!("lasx", lasx_xvabsd_hu, simd_ext_absd, m256i, u16x16);
+impl_vvv!("lasx", lasx_xvabsd_wu, simd_ext_absd, m256i, u32x8);
+impl_vvv!("lasx", lasx_xvabsd_du, simd_ext_absd, m256i, u64x4);
+impl_vvv!("lasx", lasx_xvmuh_b, simd_ext_muh, m256i, i8x32, i16x32);
+impl_vvv!("lasx", lasx_xvmuh_h, simd_ext_muh, m256i, i16x16, i32x16);
+impl_vvv!("lasx", lasx_xvmuh_w, simd_ext_muh, m256i, i32x8, i64x8);
+impl_vvv!("lasx", lasx_xvmuh_d, simd_ext_muh, m256i, i64x4, i128x4);
+impl_vvv!("lasx", lasx_xvmuh_bu, simd_ext_muh, m256i, u8x32, u16x32);
+impl_vvv!("lasx", lasx_xvmuh_hu, simd_ext_muh, m256i, u16x16, u32x16);
+impl_vvv!("lasx", lasx_xvmuh_wu, simd_ext_muh, m256i, u32x8, u64x8);
+impl_vvv!("lasx", lasx_xvmuh_du, simd_ext_muh, m256i, u64x4, u128x4);
+impl_vvv!("lasx", lasx_xvpickev_b, simd_ext_pickev_b, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvpickev_h, simd_ext_pickev_h, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvpickev_w, simd_ext_pickev_w, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvpickev_d, simd_ext_pickev_d, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvpickod_b, simd_ext_pickod_b, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvpickod_h, simd_ext_pickod_h, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvpickod_w, simd_ext_pickod_w, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvpickod_d, simd_ext_pickod_d, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvilvh_b, simd_ext_ilvh_b, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvilvh_h, simd_ext_ilvh_h, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvilvh_w, simd_ext_ilvh_w, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvilvh_d, simd_ext_ilvh_d, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvilvl_b, simd_ext_ilvl_b, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvilvl_h, simd_ext_ilvl_h, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvilvl_w, simd_ext_ilvl_w, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvilvl_d, simd_ext_ilvl_d, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvpackev_b, simd_ext_packev_b, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvpackev_h, simd_ext_packev_h, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvpackev_w, simd_ext_packev_w, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvpackev_d, simd_ext_packev_d, m256i, i64x4);
+impl_vvv!("lasx", lasx_xvpackod_b, simd_ext_packod_b, m256i, i8x32);
+impl_vvv!("lasx", lasx_xvpackod_h, simd_ext_packod_h, m256i, i16x16);
+impl_vvv!("lasx", lasx_xvpackod_w, simd_ext_packod_w, m256i, i32x8);
+impl_vvv!("lasx", lasx_xvpackod_d, simd_ext_packod_d, m256i, i64x4);
 
-impl_vgg!("lasx", lasx_xvstx, simd_stx, m256i, i8x32, *mut i8, i64, unsafe);
+impl_vgg!("lasx", lasx_xvstx, simd_ext_stx, m256i, i8x32, *mut i8, i64, unsafe);
 
-impl_vgs!("lasx", lasx_xvst, simd_st, m256i, i8x32, *mut i8, 12, const, unsafe);
+impl_vgs!("lasx", lasx_xvst, simd_ext_st, m256i, i8x32, *mut i8, 12, const, unsafe);
 
-impl_vuv!("lasx", lasx_xvslli_b, is::simd_shl, m256i, i8x32);
-impl_vuv!("lasx", lasx_xvslli_h, is::simd_shl, m256i, i16x16);
-impl_vuv!("lasx", lasx_xvslli_w, is::simd_shl, m256i, i32x8);
-impl_vuv!("lasx", lasx_xvslli_d, is::simd_shl, m256i, i64x4);
-impl_vuv!("lasx", lasx_xvsrai_b, is::simd_shr, m256i, i8x32);
-impl_vuv!("lasx", lasx_xvsrai_h, is::simd_shr, m256i, i16x16);
-impl_vuv!("lasx", lasx_xvsrai_w, is::simd_shr, m256i, i32x8);
-impl_vuv!("lasx", lasx_xvsrai_d, is::simd_shr, m256i, i64x4);
-impl_vuv!("lasx", lasx_xvsrli_b, is::simd_shr, m256i, u8x32);
-impl_vuv!("lasx", lasx_xvsrli_h, is::simd_shr, m256i, u16x16);
-impl_vuv!("lasx", lasx_xvsrli_w, is::simd_shr, m256i, u32x8);
-impl_vuv!("lasx", lasx_xvsrli_d, is::simd_shr, m256i, u64x4);
-impl_vuv!("lasx", lasx_xvrotri_b, ls::simd_rotr, m256i, u8x32);
-impl_vuv!("lasx", lasx_xvrotri_h, ls::simd_rotr, m256i, u16x16);
-impl_vuv!("lasx", lasx_xvrotri_w, ls::simd_rotr, m256i, u32x8);
-impl_vuv!("lasx", lasx_xvrotri_d, ls::simd_rotr, m256i, u64x4);
-impl_vuv!("lasx", lasx_xvaddi_bu, is::simd_add, m256i, u8x32, 5);
-impl_vuv!("lasx", lasx_xvaddi_hu, is::simd_add, m256i, u16x16, 5);
-impl_vuv!("lasx", lasx_xvaddi_wu, is::simd_add, m256i, u32x8, 5);
-impl_vuv!("lasx", lasx_xvaddi_du, is::simd_add, m256i, u64x4, 5);
-impl_vuv!("lasx", lasx_xvslti_bu, is::simd_lt, m256i, u8x32, 5);
-impl_vuv!("lasx", lasx_xvslti_hu, is::simd_lt, m256i, u16x16, 5);
-impl_vuv!("lasx", lasx_xvslti_wu, is::simd_lt, m256i, u32x8, 5);
-impl_vuv!("lasx", lasx_xvslti_du, is::simd_lt, m256i, u64x4, 5);
-impl_vuv!("lasx", lasx_xvslei_bu, is::simd_le, m256i, u8x32, 5);
-impl_vuv!("lasx", lasx_xvslei_hu, is::simd_le, m256i, u16x16, 5);
-impl_vuv!("lasx", lasx_xvslei_wu, is::simd_le, m256i, u32x8, 5);
-impl_vuv!("lasx", lasx_xvslei_du, is::simd_le, m256i, u64x4, 5);
-impl_vuv!("lasx", lasx_xvmaxi_bu, cs::simd_imax, m256i, u8x32, 5);
-impl_vuv!("lasx", lasx_xvmaxi_hu, cs::simd_imax, m256i, u16x16, 5);
-impl_vuv!("lasx", lasx_xvmaxi_wu, cs::simd_imax, m256i, u32x8, 5);
-impl_vuv!("lasx", lasx_xvmaxi_du, cs::simd_imax, m256i, u64x4, 5);
-impl_vuv!("lasx", lasx_xvmini_bu, cs::simd_imin, m256i, u8x32, 5);
-impl_vuv!("lasx", lasx_xvmini_hu, cs::simd_imin, m256i, u16x16, 5);
-impl_vuv!("lasx", lasx_xvmini_wu, cs::simd_imin, m256i, u32x8, 5);
-impl_vuv!("lasx", lasx_xvmini_du, cs::simd_imin, m256i, u64x4, 5);
-impl_vuv!("lasx", lasx_xvrepl128vei_b, simd_replvei_b, m256i, i8x32, 4, const);
-impl_vuv!("lasx", lasx_xvrepl128vei_h, simd_replvei_h, m256i, i16x16, 3, const);
-impl_vuv!("lasx", lasx_xvrepl128vei_w, simd_replvei_w, m256i, i32x8, 2, const);
-impl_vuv!("lasx", lasx_xvrepl128vei_d, simd_replvei_d, m256i, i64x4, 1, const);
-impl_vuv!("lasx", lasx_xvshuf4i_b, simd_shuf4i_b, m256i, i8x32, 8, const);
-impl_vuv!("lasx", lasx_xvshuf4i_h, simd_shuf4i_h, m256i, i16x16, 8, const);
-impl_vuv!("lasx", lasx_xvshuf4i_w, simd_shuf4i_w, m256i, i32x8, 8, const);
+impl_vuv!("lasx", lasx_xvslli_b, simd_shl, m256i, i8x32);
+impl_vuv!("lasx", lasx_xvslli_h, simd_shl, m256i, i16x16);
+impl_vuv!("lasx", lasx_xvslli_w, simd_shl, m256i, i32x8);
+impl_vuv!("lasx", lasx_xvslli_d, simd_shl, m256i, i64x4);
+impl_vuv!("lasx", lasx_xvsrai_b, simd_shr, m256i, i8x32);
+impl_vuv!("lasx", lasx_xvsrai_h, simd_shr, m256i, i16x16);
+impl_vuv!("lasx", lasx_xvsrai_w, simd_shr, m256i, i32x8);
+impl_vuv!("lasx", lasx_xvsrai_d, simd_shr, m256i, i64x4);
+impl_vuv!("lasx", lasx_xvsrli_b, simd_shr, m256i, u8x32);
+impl_vuv!("lasx", lasx_xvsrli_h, simd_shr, m256i, u16x16);
+impl_vuv!("lasx", lasx_xvsrli_w, simd_shr, m256i, u32x8);
+impl_vuv!("lasx", lasx_xvsrli_d, simd_shr, m256i, u64x4);
+impl_vuv!("lasx", lasx_xvrotri_b, simd_ext_rotr, m256i, u8x32);
+impl_vuv!("lasx", lasx_xvrotri_h, simd_ext_rotr, m256i, u16x16);
+impl_vuv!("lasx", lasx_xvrotri_w, simd_ext_rotr, m256i, u32x8);
+impl_vuv!("lasx", lasx_xvrotri_d, simd_ext_rotr, m256i, u64x4);
+impl_vuv!("lasx", lasx_xvaddi_bu, simd_add, m256i, u8x32, 5);
+impl_vuv!("lasx", lasx_xvaddi_hu, simd_add, m256i, u16x16, 5);
+impl_vuv!("lasx", lasx_xvaddi_wu, simd_add, m256i, u32x8, 5);
+impl_vuv!("lasx", lasx_xvaddi_du, simd_add, m256i, u64x4, 5);
+impl_vuv!("lasx", lasx_xvslti_bu, simd_lt, m256i, u8x32, 5);
+impl_vuv!("lasx", lasx_xvslti_hu, simd_lt, m256i, u16x16, 5);
+impl_vuv!("lasx", lasx_xvslti_wu, simd_lt, m256i, u32x8, 5);
+impl_vuv!("lasx", lasx_xvslti_du, simd_lt, m256i, u64x4, 5);
+impl_vuv!("lasx", lasx_xvslei_bu, simd_le, m256i, u8x32, 5);
+impl_vuv!("lasx", lasx_xvslei_hu, simd_le, m256i, u16x16, 5);
+impl_vuv!("lasx", lasx_xvslei_wu, simd_le, m256i, u32x8, 5);
+impl_vuv!("lasx", lasx_xvslei_du, simd_le, m256i, u64x4, 5);
+impl_vuv!("lasx", lasx_xvmaxi_bu, simd_imax, m256i, u8x32, 5);
+impl_vuv!("lasx", lasx_xvmaxi_hu, simd_imax, m256i, u16x16, 5);
+impl_vuv!("lasx", lasx_xvmaxi_wu, simd_imax, m256i, u32x8, 5);
+impl_vuv!("lasx", lasx_xvmaxi_du, simd_imax, m256i, u64x4, 5);
+impl_vuv!("lasx", lasx_xvmini_bu, simd_imin, m256i, u8x32, 5);
+impl_vuv!("lasx", lasx_xvmini_hu, simd_imin, m256i, u16x16, 5);
+impl_vuv!("lasx", lasx_xvmini_wu, simd_imin, m256i, u32x8, 5);
+impl_vuv!("lasx", lasx_xvmini_du, simd_imin, m256i, u64x4, 5);
+impl_vuv!("lasx", lasx_xvrepl128vei_b, simd_ext_replvei_b, m256i, i8x32, 4, const);
+impl_vuv!("lasx", lasx_xvrepl128vei_h, simd_ext_replvei_h, m256i, i16x16, 3, const);
+impl_vuv!("lasx", lasx_xvrepl128vei_w, simd_ext_replvei_w, m256i, i32x8, 2, const);
+impl_vuv!("lasx", lasx_xvrepl128vei_d, simd_ext_replvei_d, m256i, i64x4, 1, const);
+impl_vuv!("lasx", lasx_xvshuf4i_b, simd_ext_shuf4i_b, m256i, i8x32, 8, const);
+impl_vuv!("lasx", lasx_xvshuf4i_h, simd_ext_shuf4i_h, m256i, i16x16, 8, const);
+impl_vuv!("lasx", lasx_xvshuf4i_w, simd_ext_shuf4i_w, m256i, i32x8, 8, const);
 
-impl_vug!("lasx", lasx_xvpickve2gr_w, is::simd_extract, m256i, i32x8, i32, 3);
-impl_vug!("lasx", lasx_xvpickve2gr_d, is::simd_extract, m256i, i64x4, i64, 2);
-impl_vug!("lasx", lasx_xvpickve2gr_wu, is::simd_extract, m256i, u32x8, u32, 3);
-impl_vug!("lasx", lasx_xvpickve2gr_du, is::simd_extract, m256i, u64x4, u64, 2);
+impl_vug!("lasx", lasx_xvpickve2gr_w, simd_extract, m256i, i32x8, i32, 3);
+impl_vug!("lasx", lasx_xvpickve2gr_d, simd_extract, m256i, i64x4, i64, 2);
+impl_vug!("lasx", lasx_xvpickve2gr_wu, simd_extract, m256i, u32x8, u32, 3);
+impl_vug!("lasx", lasx_xvpickve2gr_du, simd_extract, m256i, u64x4, u64, 2);
 
-impl_vsv!("lasx", lasx_xvseqi_b, is::simd_eq, m256i, i8x32, 5);
-impl_vsv!("lasx", lasx_xvseqi_h, is::simd_eq, m256i, i16x16, 5);
-impl_vsv!("lasx", lasx_xvseqi_w, is::simd_eq, m256i, i32x8, 5);
-impl_vsv!("lasx", lasx_xvseqi_d, is::simd_eq, m256i, i64x4, 5);
-impl_vsv!("lasx", lasx_xvslti_b, is::simd_lt, m256i, i8x32, 5);
-impl_vsv!("lasx", lasx_xvslti_h, is::simd_lt, m256i, i16x16, 5);
-impl_vsv!("lasx", lasx_xvslti_w, is::simd_lt, m256i, i32x8, 5);
-impl_vsv!("lasx", lasx_xvslti_d, is::simd_lt, m256i, i64x4, 5);
-impl_vsv!("lasx", lasx_xvslei_b, is::simd_le, m256i, i8x32, 5);
-impl_vsv!("lasx", lasx_xvslei_h, is::simd_le, m256i, i16x16, 5);
-impl_vsv!("lasx", lasx_xvslei_w, is::simd_le, m256i, i32x8, 5);
-impl_vsv!("lasx", lasx_xvslei_d, is::simd_le, m256i, i64x4, 5);
-impl_vsv!("lasx", lasx_xvmaxi_b, cs::simd_imax, m256i, i8x32, 5);
-impl_vsv!("lasx", lasx_xvmaxi_h, cs::simd_imax, m256i, i16x16, 5);
-impl_vsv!("lasx", lasx_xvmaxi_w, cs::simd_imax, m256i, i32x8, 5);
-impl_vsv!("lasx", lasx_xvmaxi_d, cs::simd_imax, m256i, i64x4, 5);
-impl_vsv!("lasx", lasx_xvmini_b, cs::simd_imin, m256i, i8x32, 5);
-impl_vsv!("lasx", lasx_xvmini_h, cs::simd_imin, m256i, i16x16, 5);
-impl_vsv!("lasx", lasx_xvmini_w, cs::simd_imin, m256i, i32x8, 5);
-impl_vsv!("lasx", lasx_xvmini_d, cs::simd_imin, m256i, i64x4, 5);
+impl_vsv!("lasx", lasx_xvseqi_b, simd_eq, m256i, i8x32, 5);
+impl_vsv!("lasx", lasx_xvseqi_h, simd_eq, m256i, i16x16, 5);
+impl_vsv!("lasx", lasx_xvseqi_w, simd_eq, m256i, i32x8, 5);
+impl_vsv!("lasx", lasx_xvseqi_d, simd_eq, m256i, i64x4, 5);
+impl_vsv!("lasx", lasx_xvslti_b, simd_lt, m256i, i8x32, 5);
+impl_vsv!("lasx", lasx_xvslti_h, simd_lt, m256i, i16x16, 5);
+impl_vsv!("lasx", lasx_xvslti_w, simd_lt, m256i, i32x8, 5);
+impl_vsv!("lasx", lasx_xvslti_d, simd_lt, m256i, i64x4, 5);
+impl_vsv!("lasx", lasx_xvslei_b, simd_le, m256i, i8x32, 5);
+impl_vsv!("lasx", lasx_xvslei_h, simd_le, m256i, i16x16, 5);
+impl_vsv!("lasx", lasx_xvslei_w, simd_le, m256i, i32x8, 5);
+impl_vsv!("lasx", lasx_xvslei_d, simd_le, m256i, i64x4, 5);
+impl_vsv!("lasx", lasx_xvmaxi_b, simd_imax, m256i, i8x32, 5);
+impl_vsv!("lasx", lasx_xvmaxi_h, simd_imax, m256i, i16x16, 5);
+impl_vsv!("lasx", lasx_xvmaxi_w, simd_imax, m256i, i32x8, 5);
+impl_vsv!("lasx", lasx_xvmaxi_d, simd_imax, m256i, i64x4, 5);
+impl_vsv!("lasx", lasx_xvmini_b, simd_imin, m256i, i8x32, 5);
+impl_vsv!("lasx", lasx_xvmini_h, simd_imin, m256i, i16x16, 5);
+impl_vsv!("lasx", lasx_xvmini_w, simd_imin, m256i, i32x8, 5);
+impl_vsv!("lasx", lasx_xvmini_d, simd_imin, m256i, i64x4, 5);
 
-impl_vvvv!("lasx", lasx_xvmadd_b, ls::simd_madd, m256i, i8x32);
-impl_vvvv!("lasx", lasx_xvmadd_h, ls::simd_madd, m256i, i16x16);
-impl_vvvv!("lasx", lasx_xvmadd_w, ls::simd_madd, m256i, i32x8);
-impl_vvvv!("lasx", lasx_xvmadd_d, ls::simd_madd, m256i, i64x4);
-impl_vvvv!("lasx", lasx_xvmsub_b, ls::simd_msub, m256i, i8x32);
-impl_vvvv!("lasx", lasx_xvmsub_h, ls::simd_msub, m256i, i16x16);
-impl_vvvv!("lasx", lasx_xvmsub_w, ls::simd_msub, m256i, i32x8);
-impl_vvvv!("lasx", lasx_xvmsub_d, ls::simd_msub, m256i, i64x4);
-impl_vvvv!("lasx", lasx_xvfmadd_s, is::simd_fma, m256, f32x8);
-impl_vvvv!("lasx", lasx_xvfmadd_d, is::simd_fma, m256d, f64x4);
-impl_vvvv!("lasx", lasx_xvfmsub_s, ls::simd_fmsub, m256, f32x8);
-impl_vvvv!("lasx", lasx_xvfmsub_d, ls::simd_fmsub, m256d, f64x4);
-impl_vvvv!("lasx", lasx_xvfnmadd_s, ls::simd_fnmadd, m256, f32x8);
-impl_vvvv!("lasx", lasx_xvfnmadd_d, ls::simd_fnmadd, m256d, f64x4);
-impl_vvvv!("lasx", lasx_xvfnmsub_s, ls::simd_fnmsub, m256, f32x8);
-impl_vvvv!("lasx", lasx_xvfnmsub_d, ls::simd_fnmsub, m256d, f64x4);
+impl_vvvv!("lasx", lasx_xvmadd_b, simd_ext_madd, m256i, i8x32);
+impl_vvvv!("lasx", lasx_xvmadd_h, simd_ext_madd, m256i, i16x16);
+impl_vvvv!("lasx", lasx_xvmadd_w, simd_ext_madd, m256i, i32x8);
+impl_vvvv!("lasx", lasx_xvmadd_d, simd_ext_madd, m256i, i64x4);
+impl_vvvv!("lasx", lasx_xvmsub_b, simd_ext_msub, m256i, i8x32);
+impl_vvvv!("lasx", lasx_xvmsub_h, simd_ext_msub, m256i, i16x16);
+impl_vvvv!("lasx", lasx_xvmsub_w, simd_ext_msub, m256i, i32x8);
+impl_vvvv!("lasx", lasx_xvmsub_d, simd_ext_msub, m256i, i64x4);
+impl_vvvv!("lasx", lasx_xvfmadd_s, simd_fma, m256, f32x8);
+impl_vvvv!("lasx", lasx_xvfmadd_d, simd_fma, m256d, f64x4);
+impl_vvvv!("lasx", lasx_xvfmsub_s, simd_ext_fmsub, m256, f32x8);
+impl_vvvv!("lasx", lasx_xvfmsub_d, simd_ext_fmsub, m256d, f64x4);
+impl_vvvv!("lasx", lasx_xvfnmadd_s, simd_ext_fnmadd, m256, f32x8);
+impl_vvvv!("lasx", lasx_xvfnmadd_d, simd_ext_fnmadd, m256d, f64x4);
+impl_vvvv!("lasx", lasx_xvfnmsub_s, simd_ext_fnmsub, m256, f32x8);
+impl_vvvv!("lasx", lasx_xvfnmsub_d, simd_ext_fnmsub, m256d, f64x4);
 
-impl_vugv!("lasx", lasx_xvinsgr2vr_w, is::simd_insert, m256i, i32x8, i32, 3);
-impl_vugv!("lasx", lasx_xvinsgr2vr_d, is::simd_insert, m256i, i64x4, i64, 2);
+impl_vugv!("lasx", lasx_xvinsgr2vr_w, simd_insert, m256i, i32x8, i32, 3);
+impl_vugv!("lasx", lasx_xvinsgr2vr_d, simd_insert, m256i, i64x4, i64, 2);

--- a/crates/core_arch/src/loongarch64/lsx/portable.rs
+++ b/crates/core_arch/src/loongarch64/lsx/portable.rs
@@ -1,181 +1,181 @@
 //! LoongArch64 LSX intrinsics - intrinsics::simd implementation
 
-use super::super::{simd as ls, simd::*, *};
-use crate::core_arch::simd::{self as cs, *};
-use crate::intrinsics::simd as is;
+use super::super::{simd::*, *};
+use crate::core_arch::simd::*;
+use crate::intrinsics::simd::*;
 use crate::mem::transmute;
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2, 4, 6, 8, 10, 12, 14])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2, 4, 6])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickev_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickev_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickod_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickod_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3, 5, 7, 9, 11, 13, 15])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickod_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3, 5, 7])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_pickod_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_pickod_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [4, 12, 5, 13, 6, 14, 7, 15])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [2, 6, 3, 7])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvh_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvh_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 8, 1, 9, 2, 10, 3, 11])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 4, 1, 5])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_ilvl_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_ilvl_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_b<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_b<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_h<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_h<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [I, I, I, I, I, I, I, I])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_w<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_w<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [I, I, I, I])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_replvei_d<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_replvei_d<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [I, I])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 8, 2, 10, 4, 12, 6, 14])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 4, 2, 6])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packev_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packev_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [0, 2])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_b<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_b<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_h<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_h<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 9, 3, 11, 5, 13, 7, 15])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_w<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_w<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 5, 3, 7])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_packod_d<T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_packod_d<T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(b, a, [1, 3])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_b<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_shuf4i_b<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -190,7 +190,7 @@ const unsafe fn simd_shuf4i_b<const I: u32, T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_h<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_shuf4i_h<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(
         a,
         a,
@@ -203,320 +203,320 @@ const unsafe fn simd_shuf4i_h<const I: u32, T: Copy>(a: T) -> T {
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_w<const I: u32, T: Copy>(a: T) -> T {
+const unsafe fn simd_ext_shuf4i_w<const I: u32, T: Copy>(a: T) -> T {
     simd_shuffle!(a, a, [((I >> 0) & 3), ((I >> 2) & 3), ((I >> 4) & 3), ((I >> 6) & 3)])
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-const unsafe fn simd_shuf4i_d<const I: u32, T: Copy>(a: T, b: T) -> T {
+const unsafe fn simd_ext_shuf4i_d<const I: u32, T: Copy>(a: T, b: T) -> T {
     simd_shuffle!(a, b, [((I >> 0) & 3), ((I >> 2) & 3)])
 }
 
-impl_vv!("lsx", lsx_vpcnt_b, is::simd_ctpop, m128i, i8x16);
-impl_vv!("lsx", lsx_vpcnt_h, is::simd_ctpop, m128i, i16x8);
-impl_vv!("lsx", lsx_vpcnt_w, is::simd_ctpop, m128i, i32x4);
-impl_vv!("lsx", lsx_vpcnt_d, is::simd_ctpop, m128i, i64x2);
-impl_vv!("lsx", lsx_vclz_b, is::simd_ctlz, m128i, i8x16);
-impl_vv!("lsx", lsx_vclz_h, is::simd_ctlz, m128i, i16x8);
-impl_vv!("lsx", lsx_vclz_w, is::simd_ctlz, m128i, i32x4);
-impl_vv!("lsx", lsx_vclz_d, is::simd_ctlz, m128i, i64x2);
-impl_vv!("lsx", lsx_vneg_b, is::simd_neg, m128i, i8x16);
-impl_vv!("lsx", lsx_vneg_h, is::simd_neg, m128i, i16x8);
-impl_vv!("lsx", lsx_vneg_w, is::simd_neg, m128i, i32x4);
-impl_vv!("lsx", lsx_vneg_d, is::simd_neg, m128i, i64x2);
-impl_vv!("lsx", lsx_vfsqrt_s, is::simd_fsqrt, m128, f32x4);
-impl_vv!("lsx", lsx_vfsqrt_d, is::simd_fsqrt, m128d, f64x2);
-impl_vv!("lsx", lsx_vfrsqrt_s, ls::simd_frsqrt_s, m128, f32x4);
-impl_vv!("lsx", lsx_vfrsqrt_d, ls::simd_frsqrt_d, m128d, f64x2);
-impl_vv!("lsx", lsx_vfrecip_s, ls::simd_frecip_s, m128, f32x4);
-impl_vv!("lsx", lsx_vfrecip_d, ls::simd_frecip_d, m128d, f64x2);
-impl_vv!("lsx", lsx_vfrintrp_s, is::simd_ceil, m128, f32x4);
-impl_vv!("lsx", lsx_vfrintrp_d, is::simd_ceil, m128d, f64x2);
-impl_vv!("lsx", lsx_vfrintrm_s, is::simd_floor, m128, f32x4);
-impl_vv!("lsx", lsx_vfrintrm_d, is::simd_floor, m128d, f64x2);
-impl_vv!("lsx", lsx_vfrintrz_s, is::simd_trunc, m128, f32x4);
-impl_vv!("lsx", lsx_vfrintrz_d, is::simd_trunc, m128d, f64x2);
+impl_vv!("lsx", lsx_vpcnt_b, simd_ctpop, m128i, i8x16);
+impl_vv!("lsx", lsx_vpcnt_h, simd_ctpop, m128i, i16x8);
+impl_vv!("lsx", lsx_vpcnt_w, simd_ctpop, m128i, i32x4);
+impl_vv!("lsx", lsx_vpcnt_d, simd_ctpop, m128i, i64x2);
+impl_vv!("lsx", lsx_vclz_b, simd_ctlz, m128i, i8x16);
+impl_vv!("lsx", lsx_vclz_h, simd_ctlz, m128i, i16x8);
+impl_vv!("lsx", lsx_vclz_w, simd_ctlz, m128i, i32x4);
+impl_vv!("lsx", lsx_vclz_d, simd_ctlz, m128i, i64x2);
+impl_vv!("lsx", lsx_vneg_b, simd_neg, m128i, i8x16);
+impl_vv!("lsx", lsx_vneg_h, simd_neg, m128i, i16x8);
+impl_vv!("lsx", lsx_vneg_w, simd_neg, m128i, i32x4);
+impl_vv!("lsx", lsx_vneg_d, simd_neg, m128i, i64x2);
+impl_vv!("lsx", lsx_vfsqrt_s, simd_fsqrt, m128, f32x4);
+impl_vv!("lsx", lsx_vfsqrt_d, simd_fsqrt, m128d, f64x2);
+impl_vv!("lsx", lsx_vfrsqrt_s, simd_ext_frsqrt_s, m128, f32x4);
+impl_vv!("lsx", lsx_vfrsqrt_d, simd_ext_frsqrt_d, m128d, f64x2);
+impl_vv!("lsx", lsx_vfrecip_s, simd_ext_frecip_s, m128, f32x4);
+impl_vv!("lsx", lsx_vfrecip_d, simd_ext_frecip_d, m128d, f64x2);
+impl_vv!("lsx", lsx_vfrintrp_s, simd_ceil, m128, f32x4);
+impl_vv!("lsx", lsx_vfrintrp_d, simd_ceil, m128d, f64x2);
+impl_vv!("lsx", lsx_vfrintrm_s, simd_floor, m128, f32x4);
+impl_vv!("lsx", lsx_vfrintrm_d, simd_floor, m128d, f64x2);
+impl_vv!("lsx", lsx_vfrintrz_s, simd_trunc, m128, f32x4);
+impl_vv!("lsx", lsx_vfrintrz_d, simd_trunc, m128d, f64x2);
 
-impl_gv!("lsx", lsx_vreplgr2vr_b, ls::simd_splat, m128i, i8x16, i32);
-impl_gv!("lsx", lsx_vreplgr2vr_h, ls::simd_splat, m128i, i16x8, i32);
-impl_gv!("lsx", lsx_vreplgr2vr_w, ls::simd_splat, m128i, i32x4, i32);
-impl_gv!("lsx", lsx_vreplgr2vr_d, ls::simd_splat, m128i, i64x2, i64);
+impl_gv!("lsx", lsx_vreplgr2vr_b, simd_ext_splat, m128i, i8x16, i32);
+impl_gv!("lsx", lsx_vreplgr2vr_h, simd_ext_splat, m128i, i16x8, i32);
+impl_gv!("lsx", lsx_vreplgr2vr_w, simd_ext_splat, m128i, i32x4, i32);
+impl_gv!("lsx", lsx_vreplgr2vr_d, simd_ext_splat, m128i, i64x2, i64);
 
-impl_ggv!("lsx", lsx_vldx, simd_ldx, m128i, i8x16, *const i8, i64, unsafe);
+impl_ggv!("lsx", lsx_vldx, simd_ext_ldx, m128i, i8x16, *const i8, i64, unsafe);
 
-impl_gsv!("lsx", lsx_vld, simd_ld, m128i, i8x16, *const i8, 12, const, unsafe);
+impl_gsv!("lsx", lsx_vld, simd_ext_ld, m128i, i8x16, *const i8, 12, const, unsafe);
 
-impl_sv!("lsx", lsx_vrepli_b, ls::simd_splat, m128i, i8x16, 10);
-impl_sv!("lsx", lsx_vrepli_h, ls::simd_splat, m128i, i16x8, 10);
-impl_sv!("lsx", lsx_vrepli_w, ls::simd_splat, m128i, i32x4, 10);
-impl_sv!("lsx", lsx_vrepli_d, ls::simd_splat, m128i, i64x2, 10);
+impl_sv!("lsx", lsx_vrepli_b, simd_ext_splat, m128i, i8x16, 10);
+impl_sv!("lsx", lsx_vrepli_h, simd_ext_splat, m128i, i16x8, 10);
+impl_sv!("lsx", lsx_vrepli_w, simd_ext_splat, m128i, i32x4, 10);
+impl_sv!("lsx", lsx_vrepli_d, simd_ext_splat, m128i, i64x2, 10);
 
-impl_vvv!("lsx", lsx_vadd_b, is::simd_add, m128i, i8x16);
-impl_vvv!("lsx", lsx_vadd_h, is::simd_add, m128i, i16x8);
-impl_vvv!("lsx", lsx_vadd_w, is::simd_add, m128i, i32x4);
-impl_vvv!("lsx", lsx_vadd_d, is::simd_add, m128i, i64x2);
-impl_vvv!("lsx", lsx_vsub_b, is::simd_sub, m128i, i8x16);
-impl_vvv!("lsx", lsx_vsub_h, is::simd_sub, m128i, i16x8);
-impl_vvv!("lsx", lsx_vsub_w, is::simd_sub, m128i, i32x4);
-impl_vvv!("lsx", lsx_vsub_d, is::simd_sub, m128i, i64x2);
-impl_vvv!("lsx", lsx_vmax_b, cs::simd_imax, m128i, i8x16);
-impl_vvv!("lsx", lsx_vmax_h, cs::simd_imax, m128i, i16x8);
-impl_vvv!("lsx", lsx_vmax_w, cs::simd_imax, m128i, i32x4);
-impl_vvv!("lsx", lsx_vmax_d, cs::simd_imax, m128i, i64x2);
-impl_vvv!("lsx", lsx_vmax_bu, cs::simd_imax, m128i, u8x16);
-impl_vvv!("lsx", lsx_vmax_hu, cs::simd_imax, m128i, u16x8);
-impl_vvv!("lsx", lsx_vmax_wu, cs::simd_imax, m128i, u32x4);
-impl_vvv!("lsx", lsx_vmax_du, cs::simd_imax, m128i, u64x2);
-impl_vvv!("lsx", lsx_vmin_b, cs::simd_imin, m128i, i8x16);
-impl_vvv!("lsx", lsx_vmin_h, cs::simd_imin, m128i, i16x8);
-impl_vvv!("lsx", lsx_vmin_w, cs::simd_imin, m128i, i32x4);
-impl_vvv!("lsx", lsx_vmin_d, cs::simd_imin, m128i, i64x2);
-impl_vvv!("lsx", lsx_vmin_bu, cs::simd_imin, m128i, u8x16);
-impl_vvv!("lsx", lsx_vmin_hu, cs::simd_imin, m128i, u16x8);
-impl_vvv!("lsx", lsx_vmin_wu, cs::simd_imin, m128i, u32x4);
-impl_vvv!("lsx", lsx_vmin_du, cs::simd_imin, m128i, u64x2);
-impl_vvv!("lsx", lsx_vseq_b, is::simd_eq, m128i, i8x16);
-impl_vvv!("lsx", lsx_vseq_h, is::simd_eq, m128i, i16x8);
-impl_vvv!("lsx", lsx_vseq_w, is::simd_eq, m128i, i32x4);
-impl_vvv!("lsx", lsx_vseq_d, is::simd_eq, m128i, i64x2);
-impl_vvv!("lsx", lsx_vslt_b, is::simd_lt, m128i, i8x16);
-impl_vvv!("lsx", lsx_vslt_h, is::simd_lt, m128i, i16x8);
-impl_vvv!("lsx", lsx_vslt_w, is::simd_lt, m128i, i32x4);
-impl_vvv!("lsx", lsx_vslt_d, is::simd_lt, m128i, i64x2);
-impl_vvv!("lsx", lsx_vslt_bu, is::simd_lt, m128i, u8x16);
-impl_vvv!("lsx", lsx_vslt_hu, is::simd_lt, m128i, u16x8);
-impl_vvv!("lsx", lsx_vslt_wu, is::simd_lt, m128i, u32x4);
-impl_vvv!("lsx", lsx_vslt_du, is::simd_lt, m128i, u64x2);
-impl_vvv!("lsx", lsx_vsle_b, is::simd_le, m128i, i8x16);
-impl_vvv!("lsx", lsx_vsle_h, is::simd_le, m128i, i16x8);
-impl_vvv!("lsx", lsx_vsle_w, is::simd_le, m128i, i32x4);
-impl_vvv!("lsx", lsx_vsle_d, is::simd_le, m128i, i64x2);
-impl_vvv!("lsx", lsx_vsle_bu, is::simd_le, m128i, u8x16);
-impl_vvv!("lsx", lsx_vsle_hu, is::simd_le, m128i, u16x8);
-impl_vvv!("lsx", lsx_vsle_wu, is::simd_le, m128i, u32x4);
-impl_vvv!("lsx", lsx_vsle_du, is::simd_le, m128i, u64x2);
-impl_vvv!("lsx", lsx_vmul_b, is::simd_mul, m128i, i8x16);
-impl_vvv!("lsx", lsx_vmul_h, is::simd_mul, m128i, i16x8);
-impl_vvv!("lsx", lsx_vmul_w, is::simd_mul, m128i, i32x4);
-impl_vvv!("lsx", lsx_vmul_d, is::simd_mul, m128i, i64x2);
-impl_vvv!("lsx", lsx_vdiv_b, is::simd_div, m128i, i8x16);
-impl_vvv!("lsx", lsx_vdiv_h, is::simd_div, m128i, i16x8);
-impl_vvv!("lsx", lsx_vdiv_w, is::simd_div, m128i, i32x4);
-impl_vvv!("lsx", lsx_vdiv_d, is::simd_div, m128i, i64x2);
-impl_vvv!("lsx", lsx_vdiv_bu, is::simd_div, m128i, u8x16);
-impl_vvv!("lsx", lsx_vdiv_hu, is::simd_div, m128i, u16x8);
-impl_vvv!("lsx", lsx_vdiv_wu, is::simd_div, m128i, u32x4);
-impl_vvv!("lsx", lsx_vdiv_du, is::simd_div, m128i, u64x2);
-impl_vvv!("lsx", lsx_vmod_b, is::simd_rem, m128i, i8x16);
-impl_vvv!("lsx", lsx_vmod_h, is::simd_rem, m128i, i16x8);
-impl_vvv!("lsx", lsx_vmod_w, is::simd_rem, m128i, i32x4);
-impl_vvv!("lsx", lsx_vmod_d, is::simd_rem, m128i, i64x2);
-impl_vvv!("lsx", lsx_vmod_bu, is::simd_rem, m128i, u8x16);
-impl_vvv!("lsx", lsx_vmod_hu, is::simd_rem, m128i, u16x8);
-impl_vvv!("lsx", lsx_vmod_wu, is::simd_rem, m128i, u32x4);
-impl_vvv!("lsx", lsx_vmod_du, is::simd_rem, m128i, u64x2);
-impl_vvv!("lsx", lsx_vand_v, is::simd_and, m128i, u8x16);
-impl_vvv!("lsx", lsx_vandn_v, ls::simd_andn, m128i, u8x16);
-impl_vvv!("lsx", lsx_vor_v, is::simd_or, m128i, u8x16);
-impl_vvv!("lsx", lsx_vorn_v, ls::simd_orn, m128i, u8x16);
-impl_vvv!("lsx", lsx_vnor_v, ls::simd_nor, m128i, u8x16);
-impl_vvv!("lsx", lsx_vxor_v, is::simd_xor, m128i, u8x16);
-impl_vvv!("lsx", lsx_vfadd_s, is::simd_add, m128, f32x4);
-impl_vvv!("lsx", lsx_vfadd_d, is::simd_add, m128d, f64x2);
-impl_vvv!("lsx", lsx_vfsub_s, is::simd_sub, m128, f32x4);
-impl_vvv!("lsx", lsx_vfsub_d, is::simd_sub, m128d, f64x2);
-impl_vvv!("lsx", lsx_vfmul_s, is::simd_mul, m128, f32x4);
-impl_vvv!("lsx", lsx_vfmul_d, is::simd_mul, m128d, f64x2);
-impl_vvv!("lsx", lsx_vfdiv_s, is::simd_div, m128, f32x4);
-impl_vvv!("lsx", lsx_vfdiv_d, is::simd_div, m128d, f64x2);
-impl_vvv!("lsx", lsx_vsll_b, ls::simd_shl, m128i, i8x16);
-impl_vvv!("lsx", lsx_vsll_h, ls::simd_shl, m128i, i16x8);
-impl_vvv!("lsx", lsx_vsll_w, ls::simd_shl, m128i, i32x4);
-impl_vvv!("lsx", lsx_vsll_d, ls::simd_shl, m128i, i64x2);
-impl_vvv!("lsx", lsx_vsra_b, ls::simd_shr, m128i, i8x16);
-impl_vvv!("lsx", lsx_vsra_h, ls::simd_shr, m128i, i16x8);
-impl_vvv!("lsx", lsx_vsra_w, ls::simd_shr, m128i, i32x4);
-impl_vvv!("lsx", lsx_vsra_d, ls::simd_shr, m128i, i64x2);
-impl_vvv!("lsx", lsx_vsrl_b, ls::simd_shr, m128i, u8x16);
-impl_vvv!("lsx", lsx_vsrl_h, ls::simd_shr, m128i, u16x8);
-impl_vvv!("lsx", lsx_vsrl_w, ls::simd_shr, m128i, u32x4);
-impl_vvv!("lsx", lsx_vsrl_d, ls::simd_shr, m128i, u64x2);
-impl_vvv!("lsx", lsx_vrotr_b, ls::simd_rotr, m128i, u8x16);
-impl_vvv!("lsx", lsx_vrotr_h, ls::simd_rotr, m128i, u16x8);
-impl_vvv!("lsx", lsx_vrotr_w, ls::simd_rotr, m128i, u32x4);
-impl_vvv!("lsx", lsx_vrotr_d, ls::simd_rotr, m128i, u64x2);
-impl_vvv!("lsx", lsx_vbitclr_b, ls::simd_bitclr, m128i, u8x16);
-impl_vvv!("lsx", lsx_vbitclr_h, ls::simd_bitclr, m128i, u16x8);
-impl_vvv!("lsx", lsx_vbitclr_w, ls::simd_bitclr, m128i, u32x4);
-impl_vvv!("lsx", lsx_vbitclr_d, ls::simd_bitclr, m128i, u64x2);
-impl_vvv!("lsx", lsx_vbitset_b, ls::simd_bitset, m128i, u8x16);
-impl_vvv!("lsx", lsx_vbitset_h, ls::simd_bitset, m128i, u16x8);
-impl_vvv!("lsx", lsx_vbitset_w, ls::simd_bitset, m128i, u32x4);
-impl_vvv!("lsx", lsx_vbitset_d, ls::simd_bitset, m128i, u64x2);
-impl_vvv!("lsx", lsx_vbitrev_b, ls::simd_bitrev, m128i, u8x16);
-impl_vvv!("lsx", lsx_vbitrev_h, ls::simd_bitrev, m128i, u16x8);
-impl_vvv!("lsx", lsx_vbitrev_w, ls::simd_bitrev, m128i, u32x4);
-impl_vvv!("lsx", lsx_vbitrev_d, ls::simd_bitrev, m128i, u64x2);
-impl_vvv!("lsx", lsx_vsadd_b, is::simd_saturating_add, m128i, i8x16);
-impl_vvv!("lsx", lsx_vsadd_h, is::simd_saturating_add, m128i, i16x8);
-impl_vvv!("lsx", lsx_vsadd_w, is::simd_saturating_add, m128i, i32x4);
-impl_vvv!("lsx", lsx_vsadd_d, is::simd_saturating_add, m128i, i64x2);
-impl_vvv!("lsx", lsx_vsadd_bu, is::simd_saturating_add, m128i, u8x16);
-impl_vvv!("lsx", lsx_vsadd_hu, is::simd_saturating_add, m128i, u16x8);
-impl_vvv!("lsx", lsx_vsadd_wu, is::simd_saturating_add, m128i, u32x4);
-impl_vvv!("lsx", lsx_vsadd_du, is::simd_saturating_add, m128i, u64x2);
-impl_vvv!("lsx", lsx_vssub_b, is::simd_saturating_sub, m128i, i8x16);
-impl_vvv!("lsx", lsx_vssub_h, is::simd_saturating_sub, m128i, i16x8);
-impl_vvv!("lsx", lsx_vssub_w, is::simd_saturating_sub, m128i, i32x4);
-impl_vvv!("lsx", lsx_vssub_d, is::simd_saturating_sub, m128i, i64x2);
-impl_vvv!("lsx", lsx_vssub_bu, is::simd_saturating_sub, m128i, u8x16);
-impl_vvv!("lsx", lsx_vssub_hu, is::simd_saturating_sub, m128i, u16x8);
-impl_vvv!("lsx", lsx_vssub_wu, is::simd_saturating_sub, m128i, u32x4);
-impl_vvv!("lsx", lsx_vssub_du, is::simd_saturating_sub, m128i, u64x2);
-impl_vvv!("lsx", lsx_vadda_b, ls::simd_adda, m128i, i8x16);
-impl_vvv!("lsx", lsx_vadda_h, ls::simd_adda, m128i, i16x8);
-impl_vvv!("lsx", lsx_vadda_w, ls::simd_adda, m128i, i32x4);
-impl_vvv!("lsx", lsx_vadda_d, ls::simd_adda, m128i, i64x2);
-impl_vvv!("lsx", lsx_vabsd_b, ls::simd_absd, m128i, i8x16);
-impl_vvv!("lsx", lsx_vabsd_h, ls::simd_absd, m128i, i16x8);
-impl_vvv!("lsx", lsx_vabsd_w, ls::simd_absd, m128i, i32x4);
-impl_vvv!("lsx", lsx_vabsd_d, ls::simd_absd, m128i, i64x2);
-impl_vvv!("lsx", lsx_vabsd_bu, ls::simd_absd, m128i, u8x16);
-impl_vvv!("lsx", lsx_vabsd_hu, ls::simd_absd, m128i, u16x8);
-impl_vvv!("lsx", lsx_vabsd_wu, ls::simd_absd, m128i, u32x4);
-impl_vvv!("lsx", lsx_vabsd_du, ls::simd_absd, m128i, u64x2);
-impl_vvv!("lsx", lsx_vmuh_b, simd_muh, m128i, i8x16, i16x16);
-impl_vvv!("lsx", lsx_vmuh_h, simd_muh, m128i, i16x8, i32x8);
-impl_vvv!("lsx", lsx_vmuh_w, simd_muh, m128i, i32x4, i64x4);
-impl_vvv!("lsx", lsx_vmuh_d, simd_muh, m128i, i64x2, i128x2);
-impl_vvv!("lsx", lsx_vmuh_bu, simd_muh, m128i, u8x16, u16x16);
-impl_vvv!("lsx", lsx_vmuh_hu, simd_muh, m128i, u16x8, u32x8);
-impl_vvv!("lsx", lsx_vmuh_wu, simd_muh, m128i, u32x4, u64x4);
-impl_vvv!("lsx", lsx_vmuh_du, simd_muh, m128i, u64x2, u128x2);
-impl_vvv!("lsx", lsx_vpickev_b, simd_pickev_b, m128i, i8x16);
-impl_vvv!("lsx", lsx_vpickev_h, simd_pickev_h, m128i, i16x8);
-impl_vvv!("lsx", lsx_vpickev_w, simd_pickev_w, m128i, i32x4);
-impl_vvv!("lsx", lsx_vpickev_d, simd_pickev_d, m128i, i64x2);
-impl_vvv!("lsx", lsx_vpickod_b, simd_pickod_b, m128i, i8x16);
-impl_vvv!("lsx", lsx_vpickod_h, simd_pickod_h, m128i, i16x8);
-impl_vvv!("lsx", lsx_vpickod_w, simd_pickod_w, m128i, i32x4);
-impl_vvv!("lsx", lsx_vpickod_d, simd_pickod_d, m128i, i64x2);
-impl_vvv!("lsx", lsx_vilvh_b, simd_ilvh_b, m128i, i8x16);
-impl_vvv!("lsx", lsx_vilvh_h, simd_ilvh_h, m128i, i16x8);
-impl_vvv!("lsx", lsx_vilvh_w, simd_ilvh_w, m128i, i32x4);
-impl_vvv!("lsx", lsx_vilvh_d, simd_ilvh_d, m128i, i64x2);
-impl_vvv!("lsx", lsx_vilvl_b, simd_ilvl_b, m128i, i8x16);
-impl_vvv!("lsx", lsx_vilvl_h, simd_ilvl_h, m128i, i16x8);
-impl_vvv!("lsx", lsx_vilvl_w, simd_ilvl_w, m128i, i32x4);
-impl_vvv!("lsx", lsx_vilvl_d, simd_ilvl_d, m128i, i64x2);
-impl_vvv!("lsx", lsx_vpackev_b, simd_packev_b, m128i, i8x16);
-impl_vvv!("lsx", lsx_vpackev_h, simd_packev_h, m128i, i16x8);
-impl_vvv!("lsx", lsx_vpackev_w, simd_packev_w, m128i, i32x4);
-impl_vvv!("lsx", lsx_vpackev_d, simd_packev_d, m128i, i64x2);
-impl_vvv!("lsx", lsx_vpackod_b, simd_packod_b, m128i, i8x16);
-impl_vvv!("lsx", lsx_vpackod_h, simd_packod_h, m128i, i16x8);
-impl_vvv!("lsx", lsx_vpackod_w, simd_packod_w, m128i, i32x4);
-impl_vvv!("lsx", lsx_vpackod_d, simd_packod_d, m128i, i64x2);
+impl_vvv!("lsx", lsx_vadd_b, simd_add, m128i, i8x16);
+impl_vvv!("lsx", lsx_vadd_h, simd_add, m128i, i16x8);
+impl_vvv!("lsx", lsx_vadd_w, simd_add, m128i, i32x4);
+impl_vvv!("lsx", lsx_vadd_d, simd_add, m128i, i64x2);
+impl_vvv!("lsx", lsx_vsub_b, simd_sub, m128i, i8x16);
+impl_vvv!("lsx", lsx_vsub_h, simd_sub, m128i, i16x8);
+impl_vvv!("lsx", lsx_vsub_w, simd_sub, m128i, i32x4);
+impl_vvv!("lsx", lsx_vsub_d, simd_sub, m128i, i64x2);
+impl_vvv!("lsx", lsx_vmax_b, simd_imax, m128i, i8x16);
+impl_vvv!("lsx", lsx_vmax_h, simd_imax, m128i, i16x8);
+impl_vvv!("lsx", lsx_vmax_w, simd_imax, m128i, i32x4);
+impl_vvv!("lsx", lsx_vmax_d, simd_imax, m128i, i64x2);
+impl_vvv!("lsx", lsx_vmax_bu, simd_imax, m128i, u8x16);
+impl_vvv!("lsx", lsx_vmax_hu, simd_imax, m128i, u16x8);
+impl_vvv!("lsx", lsx_vmax_wu, simd_imax, m128i, u32x4);
+impl_vvv!("lsx", lsx_vmax_du, simd_imax, m128i, u64x2);
+impl_vvv!("lsx", lsx_vmin_b, simd_imin, m128i, i8x16);
+impl_vvv!("lsx", lsx_vmin_h, simd_imin, m128i, i16x8);
+impl_vvv!("lsx", lsx_vmin_w, simd_imin, m128i, i32x4);
+impl_vvv!("lsx", lsx_vmin_d, simd_imin, m128i, i64x2);
+impl_vvv!("lsx", lsx_vmin_bu, simd_imin, m128i, u8x16);
+impl_vvv!("lsx", lsx_vmin_hu, simd_imin, m128i, u16x8);
+impl_vvv!("lsx", lsx_vmin_wu, simd_imin, m128i, u32x4);
+impl_vvv!("lsx", lsx_vmin_du, simd_imin, m128i, u64x2);
+impl_vvv!("lsx", lsx_vseq_b, simd_eq, m128i, i8x16);
+impl_vvv!("lsx", lsx_vseq_h, simd_eq, m128i, i16x8);
+impl_vvv!("lsx", lsx_vseq_w, simd_eq, m128i, i32x4);
+impl_vvv!("lsx", lsx_vseq_d, simd_eq, m128i, i64x2);
+impl_vvv!("lsx", lsx_vslt_b, simd_lt, m128i, i8x16);
+impl_vvv!("lsx", lsx_vslt_h, simd_lt, m128i, i16x8);
+impl_vvv!("lsx", lsx_vslt_w, simd_lt, m128i, i32x4);
+impl_vvv!("lsx", lsx_vslt_d, simd_lt, m128i, i64x2);
+impl_vvv!("lsx", lsx_vslt_bu, simd_lt, m128i, u8x16);
+impl_vvv!("lsx", lsx_vslt_hu, simd_lt, m128i, u16x8);
+impl_vvv!("lsx", lsx_vslt_wu, simd_lt, m128i, u32x4);
+impl_vvv!("lsx", lsx_vslt_du, simd_lt, m128i, u64x2);
+impl_vvv!("lsx", lsx_vsle_b, simd_le, m128i, i8x16);
+impl_vvv!("lsx", lsx_vsle_h, simd_le, m128i, i16x8);
+impl_vvv!("lsx", lsx_vsle_w, simd_le, m128i, i32x4);
+impl_vvv!("lsx", lsx_vsle_d, simd_le, m128i, i64x2);
+impl_vvv!("lsx", lsx_vsle_bu, simd_le, m128i, u8x16);
+impl_vvv!("lsx", lsx_vsle_hu, simd_le, m128i, u16x8);
+impl_vvv!("lsx", lsx_vsle_wu, simd_le, m128i, u32x4);
+impl_vvv!("lsx", lsx_vsle_du, simd_le, m128i, u64x2);
+impl_vvv!("lsx", lsx_vmul_b, simd_mul, m128i, i8x16);
+impl_vvv!("lsx", lsx_vmul_h, simd_mul, m128i, i16x8);
+impl_vvv!("lsx", lsx_vmul_w, simd_mul, m128i, i32x4);
+impl_vvv!("lsx", lsx_vmul_d, simd_mul, m128i, i64x2);
+impl_vvv!("lsx", lsx_vdiv_b, simd_div, m128i, i8x16);
+impl_vvv!("lsx", lsx_vdiv_h, simd_div, m128i, i16x8);
+impl_vvv!("lsx", lsx_vdiv_w, simd_div, m128i, i32x4);
+impl_vvv!("lsx", lsx_vdiv_d, simd_div, m128i, i64x2);
+impl_vvv!("lsx", lsx_vdiv_bu, simd_div, m128i, u8x16);
+impl_vvv!("lsx", lsx_vdiv_hu, simd_div, m128i, u16x8);
+impl_vvv!("lsx", lsx_vdiv_wu, simd_div, m128i, u32x4);
+impl_vvv!("lsx", lsx_vdiv_du, simd_div, m128i, u64x2);
+impl_vvv!("lsx", lsx_vmod_b, simd_rem, m128i, i8x16);
+impl_vvv!("lsx", lsx_vmod_h, simd_rem, m128i, i16x8);
+impl_vvv!("lsx", lsx_vmod_w, simd_rem, m128i, i32x4);
+impl_vvv!("lsx", lsx_vmod_d, simd_rem, m128i, i64x2);
+impl_vvv!("lsx", lsx_vmod_bu, simd_rem, m128i, u8x16);
+impl_vvv!("lsx", lsx_vmod_hu, simd_rem, m128i, u16x8);
+impl_vvv!("lsx", lsx_vmod_wu, simd_rem, m128i, u32x4);
+impl_vvv!("lsx", lsx_vmod_du, simd_rem, m128i, u64x2);
+impl_vvv!("lsx", lsx_vand_v, simd_and, m128i, u8x16);
+impl_vvv!("lsx", lsx_vandn_v, simd_ext_andn, m128i, u8x16);
+impl_vvv!("lsx", lsx_vor_v, simd_or, m128i, u8x16);
+impl_vvv!("lsx", lsx_vorn_v, simd_ext_orn, m128i, u8x16);
+impl_vvv!("lsx", lsx_vnor_v, simd_ext_nor, m128i, u8x16);
+impl_vvv!("lsx", lsx_vxor_v, simd_xor, m128i, u8x16);
+impl_vvv!("lsx", lsx_vfadd_s, simd_add, m128, f32x4);
+impl_vvv!("lsx", lsx_vfadd_d, simd_add, m128d, f64x2);
+impl_vvv!("lsx", lsx_vfsub_s, simd_sub, m128, f32x4);
+impl_vvv!("lsx", lsx_vfsub_d, simd_sub, m128d, f64x2);
+impl_vvv!("lsx", lsx_vfmul_s, simd_mul, m128, f32x4);
+impl_vvv!("lsx", lsx_vfmul_d, simd_mul, m128d, f64x2);
+impl_vvv!("lsx", lsx_vfdiv_s, simd_div, m128, f32x4);
+impl_vvv!("lsx", lsx_vfdiv_d, simd_div, m128d, f64x2);
+impl_vvv!("lsx", lsx_vsll_b, simd_ext_shl, m128i, i8x16);
+impl_vvv!("lsx", lsx_vsll_h, simd_ext_shl, m128i, i16x8);
+impl_vvv!("lsx", lsx_vsll_w, simd_ext_shl, m128i, i32x4);
+impl_vvv!("lsx", lsx_vsll_d, simd_ext_shl, m128i, i64x2);
+impl_vvv!("lsx", lsx_vsra_b, simd_ext_shr, m128i, i8x16);
+impl_vvv!("lsx", lsx_vsra_h, simd_ext_shr, m128i, i16x8);
+impl_vvv!("lsx", lsx_vsra_w, simd_ext_shr, m128i, i32x4);
+impl_vvv!("lsx", lsx_vsra_d, simd_ext_shr, m128i, i64x2);
+impl_vvv!("lsx", lsx_vsrl_b, simd_ext_shr, m128i, u8x16);
+impl_vvv!("lsx", lsx_vsrl_h, simd_ext_shr, m128i, u16x8);
+impl_vvv!("lsx", lsx_vsrl_w, simd_ext_shr, m128i, u32x4);
+impl_vvv!("lsx", lsx_vsrl_d, simd_ext_shr, m128i, u64x2);
+impl_vvv!("lsx", lsx_vrotr_b, simd_ext_rotr, m128i, u8x16);
+impl_vvv!("lsx", lsx_vrotr_h, simd_ext_rotr, m128i, u16x8);
+impl_vvv!("lsx", lsx_vrotr_w, simd_ext_rotr, m128i, u32x4);
+impl_vvv!("lsx", lsx_vrotr_d, simd_ext_rotr, m128i, u64x2);
+impl_vvv!("lsx", lsx_vbitclr_b, simd_ext_bitclr, m128i, u8x16);
+impl_vvv!("lsx", lsx_vbitclr_h, simd_ext_bitclr, m128i, u16x8);
+impl_vvv!("lsx", lsx_vbitclr_w, simd_ext_bitclr, m128i, u32x4);
+impl_vvv!("lsx", lsx_vbitclr_d, simd_ext_bitclr, m128i, u64x2);
+impl_vvv!("lsx", lsx_vbitset_b, simd_ext_bitset, m128i, u8x16);
+impl_vvv!("lsx", lsx_vbitset_h, simd_ext_bitset, m128i, u16x8);
+impl_vvv!("lsx", lsx_vbitset_w, simd_ext_bitset, m128i, u32x4);
+impl_vvv!("lsx", lsx_vbitset_d, simd_ext_bitset, m128i, u64x2);
+impl_vvv!("lsx", lsx_vbitrev_b, simd_ext_bitrev, m128i, u8x16);
+impl_vvv!("lsx", lsx_vbitrev_h, simd_ext_bitrev, m128i, u16x8);
+impl_vvv!("lsx", lsx_vbitrev_w, simd_ext_bitrev, m128i, u32x4);
+impl_vvv!("lsx", lsx_vbitrev_d, simd_ext_bitrev, m128i, u64x2);
+impl_vvv!("lsx", lsx_vsadd_b, simd_saturating_add, m128i, i8x16);
+impl_vvv!("lsx", lsx_vsadd_h, simd_saturating_add, m128i, i16x8);
+impl_vvv!("lsx", lsx_vsadd_w, simd_saturating_add, m128i, i32x4);
+impl_vvv!("lsx", lsx_vsadd_d, simd_saturating_add, m128i, i64x2);
+impl_vvv!("lsx", lsx_vsadd_bu, simd_saturating_add, m128i, u8x16);
+impl_vvv!("lsx", lsx_vsadd_hu, simd_saturating_add, m128i, u16x8);
+impl_vvv!("lsx", lsx_vsadd_wu, simd_saturating_add, m128i, u32x4);
+impl_vvv!("lsx", lsx_vsadd_du, simd_saturating_add, m128i, u64x2);
+impl_vvv!("lsx", lsx_vssub_b, simd_saturating_sub, m128i, i8x16);
+impl_vvv!("lsx", lsx_vssub_h, simd_saturating_sub, m128i, i16x8);
+impl_vvv!("lsx", lsx_vssub_w, simd_saturating_sub, m128i, i32x4);
+impl_vvv!("lsx", lsx_vssub_d, simd_saturating_sub, m128i, i64x2);
+impl_vvv!("lsx", lsx_vssub_bu, simd_saturating_sub, m128i, u8x16);
+impl_vvv!("lsx", lsx_vssub_hu, simd_saturating_sub, m128i, u16x8);
+impl_vvv!("lsx", lsx_vssub_wu, simd_saturating_sub, m128i, u32x4);
+impl_vvv!("lsx", lsx_vssub_du, simd_saturating_sub, m128i, u64x2);
+impl_vvv!("lsx", lsx_vadda_b, simd_ext_adda, m128i, i8x16);
+impl_vvv!("lsx", lsx_vadda_h, simd_ext_adda, m128i, i16x8);
+impl_vvv!("lsx", lsx_vadda_w, simd_ext_adda, m128i, i32x4);
+impl_vvv!("lsx", lsx_vadda_d, simd_ext_adda, m128i, i64x2);
+impl_vvv!("lsx", lsx_vabsd_b, simd_ext_absd, m128i, i8x16);
+impl_vvv!("lsx", lsx_vabsd_h, simd_ext_absd, m128i, i16x8);
+impl_vvv!("lsx", lsx_vabsd_w, simd_ext_absd, m128i, i32x4);
+impl_vvv!("lsx", lsx_vabsd_d, simd_ext_absd, m128i, i64x2);
+impl_vvv!("lsx", lsx_vabsd_bu, simd_ext_absd, m128i, u8x16);
+impl_vvv!("lsx", lsx_vabsd_hu, simd_ext_absd, m128i, u16x8);
+impl_vvv!("lsx", lsx_vabsd_wu, simd_ext_absd, m128i, u32x4);
+impl_vvv!("lsx", lsx_vabsd_du, simd_ext_absd, m128i, u64x2);
+impl_vvv!("lsx", lsx_vmuh_b, simd_ext_muh, m128i, i8x16, i16x16);
+impl_vvv!("lsx", lsx_vmuh_h, simd_ext_muh, m128i, i16x8, i32x8);
+impl_vvv!("lsx", lsx_vmuh_w, simd_ext_muh, m128i, i32x4, i64x4);
+impl_vvv!("lsx", lsx_vmuh_d, simd_ext_muh, m128i, i64x2, i128x2);
+impl_vvv!("lsx", lsx_vmuh_bu, simd_ext_muh, m128i, u8x16, u16x16);
+impl_vvv!("lsx", lsx_vmuh_hu, simd_ext_muh, m128i, u16x8, u32x8);
+impl_vvv!("lsx", lsx_vmuh_wu, simd_ext_muh, m128i, u32x4, u64x4);
+impl_vvv!("lsx", lsx_vmuh_du, simd_ext_muh, m128i, u64x2, u128x2);
+impl_vvv!("lsx", lsx_vpickev_b, simd_ext_pickev_b, m128i, i8x16);
+impl_vvv!("lsx", lsx_vpickev_h, simd_ext_pickev_h, m128i, i16x8);
+impl_vvv!("lsx", lsx_vpickev_w, simd_ext_pickev_w, m128i, i32x4);
+impl_vvv!("lsx", lsx_vpickev_d, simd_ext_pickev_d, m128i, i64x2);
+impl_vvv!("lsx", lsx_vpickod_b, simd_ext_pickod_b, m128i, i8x16);
+impl_vvv!("lsx", lsx_vpickod_h, simd_ext_pickod_h, m128i, i16x8);
+impl_vvv!("lsx", lsx_vpickod_w, simd_ext_pickod_w, m128i, i32x4);
+impl_vvv!("lsx", lsx_vpickod_d, simd_ext_pickod_d, m128i, i64x2);
+impl_vvv!("lsx", lsx_vilvh_b, simd_ext_ilvh_b, m128i, i8x16);
+impl_vvv!("lsx", lsx_vilvh_h, simd_ext_ilvh_h, m128i, i16x8);
+impl_vvv!("lsx", lsx_vilvh_w, simd_ext_ilvh_w, m128i, i32x4);
+impl_vvv!("lsx", lsx_vilvh_d, simd_ext_ilvh_d, m128i, i64x2);
+impl_vvv!("lsx", lsx_vilvl_b, simd_ext_ilvl_b, m128i, i8x16);
+impl_vvv!("lsx", lsx_vilvl_h, simd_ext_ilvl_h, m128i, i16x8);
+impl_vvv!("lsx", lsx_vilvl_w, simd_ext_ilvl_w, m128i, i32x4);
+impl_vvv!("lsx", lsx_vilvl_d, simd_ext_ilvl_d, m128i, i64x2);
+impl_vvv!("lsx", lsx_vpackev_b, simd_ext_packev_b, m128i, i8x16);
+impl_vvv!("lsx", lsx_vpackev_h, simd_ext_packev_h, m128i, i16x8);
+impl_vvv!("lsx", lsx_vpackev_w, simd_ext_packev_w, m128i, i32x4);
+impl_vvv!("lsx", lsx_vpackev_d, simd_ext_packev_d, m128i, i64x2);
+impl_vvv!("lsx", lsx_vpackod_b, simd_ext_packod_b, m128i, i8x16);
+impl_vvv!("lsx", lsx_vpackod_h, simd_ext_packod_h, m128i, i16x8);
+impl_vvv!("lsx", lsx_vpackod_w, simd_ext_packod_w, m128i, i32x4);
+impl_vvv!("lsx", lsx_vpackod_d, simd_ext_packod_d, m128i, i64x2);
 
-impl_vgg!("lsx", lsx_vstx, simd_stx, m128i, i8x16, *mut i8, i64, unsafe);
+impl_vgg!("lsx", lsx_vstx, simd_ext_stx, m128i, i8x16, *mut i8, i64, unsafe);
 
-impl_vgs!("lsx", lsx_vst, simd_st, m128i, i8x16, *mut i8, 12, const, unsafe);
+impl_vgs!("lsx", lsx_vst, simd_ext_st, m128i, i8x16, *mut i8, 12, const, unsafe);
 
-impl_vuv!("lsx", lsx_vslli_b, is::simd_shl, m128i, i8x16);
-impl_vuv!("lsx", lsx_vslli_h, is::simd_shl, m128i, i16x8);
-impl_vuv!("lsx", lsx_vslli_w, is::simd_shl, m128i, i32x4);
-impl_vuv!("lsx", lsx_vslli_d, is::simd_shl, m128i, i64x2);
-impl_vuv!("lsx", lsx_vsrai_b, is::simd_shr, m128i, i8x16);
-impl_vuv!("lsx", lsx_vsrai_h, is::simd_shr, m128i, i16x8);
-impl_vuv!("lsx", lsx_vsrai_w, is::simd_shr, m128i, i32x4);
-impl_vuv!("lsx", lsx_vsrai_d, is::simd_shr, m128i, i64x2);
-impl_vuv!("lsx", lsx_vsrli_b, is::simd_shr, m128i, u8x16);
-impl_vuv!("lsx", lsx_vsrli_h, is::simd_shr, m128i, u16x8);
-impl_vuv!("lsx", lsx_vsrli_w, is::simd_shr, m128i, u32x4);
-impl_vuv!("lsx", lsx_vsrli_d, is::simd_shr, m128i, u64x2);
-impl_vuv!("lsx", lsx_vrotri_b, ls::simd_rotr, m128i, u8x16);
-impl_vuv!("lsx", lsx_vrotri_h, ls::simd_rotr, m128i, u16x8);
-impl_vuv!("lsx", lsx_vrotri_w, ls::simd_rotr, m128i, u32x4);
-impl_vuv!("lsx", lsx_vrotri_d, ls::simd_rotr, m128i, u64x2);
-impl_vuv!("lsx", lsx_vaddi_bu, is::simd_add, m128i, u8x16, 5);
-impl_vuv!("lsx", lsx_vaddi_hu, is::simd_add, m128i, u16x8, 5);
-impl_vuv!("lsx", lsx_vaddi_wu, is::simd_add, m128i, u32x4, 5);
-impl_vuv!("lsx", lsx_vaddi_du, is::simd_add, m128i, u64x2, 5);
-impl_vuv!("lsx", lsx_vslti_bu, is::simd_lt, m128i, u8x16, 5);
-impl_vuv!("lsx", lsx_vslti_hu, is::simd_lt, m128i, u16x8, 5);
-impl_vuv!("lsx", lsx_vslti_wu, is::simd_lt, m128i, u32x4, 5);
-impl_vuv!("lsx", lsx_vslti_du, is::simd_lt, m128i, u64x2, 5);
-impl_vuv!("lsx", lsx_vslei_bu, is::simd_le, m128i, u8x16, 5);
-impl_vuv!("lsx", lsx_vslei_hu, is::simd_le, m128i, u16x8, 5);
-impl_vuv!("lsx", lsx_vslei_wu, is::simd_le, m128i, u32x4, 5);
-impl_vuv!("lsx", lsx_vslei_du, is::simd_le, m128i, u64x2, 5);
-impl_vuv!("lsx", lsx_vmaxi_bu, cs::simd_imax, m128i, u8x16, 5);
-impl_vuv!("lsx", lsx_vmaxi_hu, cs::simd_imax, m128i, u16x8, 5);
-impl_vuv!("lsx", lsx_vmaxi_wu, cs::simd_imax, m128i, u32x4, 5);
-impl_vuv!("lsx", lsx_vmaxi_du, cs::simd_imax, m128i, u64x2, 5);
-impl_vuv!("lsx", lsx_vmini_bu, cs::simd_imin, m128i, u8x16, 5);
-impl_vuv!("lsx", lsx_vmini_hu, cs::simd_imin, m128i, u16x8, 5);
-impl_vuv!("lsx", lsx_vmini_wu, cs::simd_imin, m128i, u32x4, 5);
-impl_vuv!("lsx", lsx_vmini_du, cs::simd_imin, m128i, u64x2, 5);
-impl_vuv!("lsx", lsx_vreplvei_b, simd_replvei_b, m128i, i8x16, 4, const);
-impl_vuv!("lsx", lsx_vreplvei_h, simd_replvei_h, m128i, i16x8, 3, const);
-impl_vuv!("lsx", lsx_vreplvei_w, simd_replvei_w, m128i, i32x4, 2, const);
-impl_vuv!("lsx", lsx_vreplvei_d, simd_replvei_d, m128i, i64x2, 1, const);
-impl_vuv!("lsx", lsx_vshuf4i_b, simd_shuf4i_b, m128i, i8x16, 8, const);
-impl_vuv!("lsx", lsx_vshuf4i_h, simd_shuf4i_h, m128i, i16x8, 8, const);
-impl_vuv!("lsx", lsx_vshuf4i_w, simd_shuf4i_w, m128i, i32x4, 8, const);
+impl_vuv!("lsx", lsx_vslli_b, simd_shl, m128i, i8x16);
+impl_vuv!("lsx", lsx_vslli_h, simd_shl, m128i, i16x8);
+impl_vuv!("lsx", lsx_vslli_w, simd_shl, m128i, i32x4);
+impl_vuv!("lsx", lsx_vslli_d, simd_shl, m128i, i64x2);
+impl_vuv!("lsx", lsx_vsrai_b, simd_shr, m128i, i8x16);
+impl_vuv!("lsx", lsx_vsrai_h, simd_shr, m128i, i16x8);
+impl_vuv!("lsx", lsx_vsrai_w, simd_shr, m128i, i32x4);
+impl_vuv!("lsx", lsx_vsrai_d, simd_shr, m128i, i64x2);
+impl_vuv!("lsx", lsx_vsrli_b, simd_shr, m128i, u8x16);
+impl_vuv!("lsx", lsx_vsrli_h, simd_shr, m128i, u16x8);
+impl_vuv!("lsx", lsx_vsrli_w, simd_shr, m128i, u32x4);
+impl_vuv!("lsx", lsx_vsrli_d, simd_shr, m128i, u64x2);
+impl_vuv!("lsx", lsx_vrotri_b, simd_ext_rotr, m128i, u8x16);
+impl_vuv!("lsx", lsx_vrotri_h, simd_ext_rotr, m128i, u16x8);
+impl_vuv!("lsx", lsx_vrotri_w, simd_ext_rotr, m128i, u32x4);
+impl_vuv!("lsx", lsx_vrotri_d, simd_ext_rotr, m128i, u64x2);
+impl_vuv!("lsx", lsx_vaddi_bu, simd_add, m128i, u8x16, 5);
+impl_vuv!("lsx", lsx_vaddi_hu, simd_add, m128i, u16x8, 5);
+impl_vuv!("lsx", lsx_vaddi_wu, simd_add, m128i, u32x4, 5);
+impl_vuv!("lsx", lsx_vaddi_du, simd_add, m128i, u64x2, 5);
+impl_vuv!("lsx", lsx_vslti_bu, simd_lt, m128i, u8x16, 5);
+impl_vuv!("lsx", lsx_vslti_hu, simd_lt, m128i, u16x8, 5);
+impl_vuv!("lsx", lsx_vslti_wu, simd_lt, m128i, u32x4, 5);
+impl_vuv!("lsx", lsx_vslti_du, simd_lt, m128i, u64x2, 5);
+impl_vuv!("lsx", lsx_vslei_bu, simd_le, m128i, u8x16, 5);
+impl_vuv!("lsx", lsx_vslei_hu, simd_le, m128i, u16x8, 5);
+impl_vuv!("lsx", lsx_vslei_wu, simd_le, m128i, u32x4, 5);
+impl_vuv!("lsx", lsx_vslei_du, simd_le, m128i, u64x2, 5);
+impl_vuv!("lsx", lsx_vmaxi_bu, simd_imax, m128i, u8x16, 5);
+impl_vuv!("lsx", lsx_vmaxi_hu, simd_imax, m128i, u16x8, 5);
+impl_vuv!("lsx", lsx_vmaxi_wu, simd_imax, m128i, u32x4, 5);
+impl_vuv!("lsx", lsx_vmaxi_du, simd_imax, m128i, u64x2, 5);
+impl_vuv!("lsx", lsx_vmini_bu, simd_imin, m128i, u8x16, 5);
+impl_vuv!("lsx", lsx_vmini_hu, simd_imin, m128i, u16x8, 5);
+impl_vuv!("lsx", lsx_vmini_wu, simd_imin, m128i, u32x4, 5);
+impl_vuv!("lsx", lsx_vmini_du, simd_imin, m128i, u64x2, 5);
+impl_vuv!("lsx", lsx_vreplvei_b, simd_ext_replvei_b, m128i, i8x16, 4, const);
+impl_vuv!("lsx", lsx_vreplvei_h, simd_ext_replvei_h, m128i, i16x8, 3, const);
+impl_vuv!("lsx", lsx_vreplvei_w, simd_ext_replvei_w, m128i, i32x4, 2, const);
+impl_vuv!("lsx", lsx_vreplvei_d, simd_ext_replvei_d, m128i, i64x2, 1, const);
+impl_vuv!("lsx", lsx_vshuf4i_b, simd_ext_shuf4i_b, m128i, i8x16, 8, const);
+impl_vuv!("lsx", lsx_vshuf4i_h, simd_ext_shuf4i_h, m128i, i16x8, 8, const);
+impl_vuv!("lsx", lsx_vshuf4i_w, simd_ext_shuf4i_w, m128i, i32x4, 8, const);
 
-impl_vug!("lsx", lsx_vpickve2gr_b, is::simd_extract, m128i, i8x16, i32, 4);
-impl_vug!("lsx", lsx_vpickve2gr_h, is::simd_extract, m128i, i16x8, i32, 3);
-impl_vug!("lsx", lsx_vpickve2gr_w, is::simd_extract, m128i, i32x4, i32, 2);
-impl_vug!("lsx", lsx_vpickve2gr_d, is::simd_extract, m128i, i64x2, i64, 1);
-impl_vug!("lsx", lsx_vpickve2gr_bu, is::simd_extract, m128i, u8x16, u32, 4);
-impl_vug!("lsx", lsx_vpickve2gr_hu, is::simd_extract, m128i, u16x8, u32, 3);
-impl_vug!("lsx", lsx_vpickve2gr_wu, is::simd_extract, m128i, u32x4, u32, 2);
-impl_vug!("lsx", lsx_vpickve2gr_du, is::simd_extract, m128i, u64x2, u64, 1);
+impl_vug!("lsx", lsx_vpickve2gr_b, simd_extract, m128i, i8x16, i32, 4);
+impl_vug!("lsx", lsx_vpickve2gr_h, simd_extract, m128i, i16x8, i32, 3);
+impl_vug!("lsx", lsx_vpickve2gr_w, simd_extract, m128i, i32x4, i32, 2);
+impl_vug!("lsx", lsx_vpickve2gr_d, simd_extract, m128i, i64x2, i64, 1);
+impl_vug!("lsx", lsx_vpickve2gr_bu, simd_extract, m128i, u8x16, u32, 4);
+impl_vug!("lsx", lsx_vpickve2gr_hu, simd_extract, m128i, u16x8, u32, 3);
+impl_vug!("lsx", lsx_vpickve2gr_wu, simd_extract, m128i, u32x4, u32, 2);
+impl_vug!("lsx", lsx_vpickve2gr_du, simd_extract, m128i, u64x2, u64, 1);
 
-impl_vsv!("lsx", lsx_vseqi_b, is::simd_eq, m128i, i8x16, 5);
-impl_vsv!("lsx", lsx_vseqi_h, is::simd_eq, m128i, i16x8, 5);
-impl_vsv!("lsx", lsx_vseqi_w, is::simd_eq, m128i, i32x4, 5);
-impl_vsv!("lsx", lsx_vseqi_d, is::simd_eq, m128i, i64x2, 5);
-impl_vsv!("lsx", lsx_vslti_b, is::simd_lt, m128i, i8x16, 5);
-impl_vsv!("lsx", lsx_vslti_h, is::simd_lt, m128i, i16x8, 5);
-impl_vsv!("lsx", lsx_vslti_w, is::simd_lt, m128i, i32x4, 5);
-impl_vsv!("lsx", lsx_vslti_d, is::simd_lt, m128i, i64x2, 5);
-impl_vsv!("lsx", lsx_vslei_b, is::simd_le, m128i, i8x16, 5);
-impl_vsv!("lsx", lsx_vslei_h, is::simd_le, m128i, i16x8, 5);
-impl_vsv!("lsx", lsx_vslei_w, is::simd_le, m128i, i32x4, 5);
-impl_vsv!("lsx", lsx_vslei_d, is::simd_le, m128i, i64x2, 5);
-impl_vsv!("lsx", lsx_vmaxi_b, cs::simd_imax, m128i, i8x16, 5);
-impl_vsv!("lsx", lsx_vmaxi_h, cs::simd_imax, m128i, i16x8, 5);
-impl_vsv!("lsx", lsx_vmaxi_w, cs::simd_imax, m128i, i32x4, 5);
-impl_vsv!("lsx", lsx_vmaxi_d, cs::simd_imax, m128i, i64x2, 5);
-impl_vsv!("lsx", lsx_vmini_b, cs::simd_imin, m128i, i8x16, 5);
-impl_vsv!("lsx", lsx_vmini_h, cs::simd_imin, m128i, i16x8, 5);
-impl_vsv!("lsx", lsx_vmini_w, cs::simd_imin, m128i, i32x4, 5);
-impl_vsv!("lsx", lsx_vmini_d, cs::simd_imin, m128i, i64x2, 5);
+impl_vsv!("lsx", lsx_vseqi_b, simd_eq, m128i, i8x16, 5);
+impl_vsv!("lsx", lsx_vseqi_h, simd_eq, m128i, i16x8, 5);
+impl_vsv!("lsx", lsx_vseqi_w, simd_eq, m128i, i32x4, 5);
+impl_vsv!("lsx", lsx_vseqi_d, simd_eq, m128i, i64x2, 5);
+impl_vsv!("lsx", lsx_vslti_b, simd_lt, m128i, i8x16, 5);
+impl_vsv!("lsx", lsx_vslti_h, simd_lt, m128i, i16x8, 5);
+impl_vsv!("lsx", lsx_vslti_w, simd_lt, m128i, i32x4, 5);
+impl_vsv!("lsx", lsx_vslti_d, simd_lt, m128i, i64x2, 5);
+impl_vsv!("lsx", lsx_vslei_b, simd_le, m128i, i8x16, 5);
+impl_vsv!("lsx", lsx_vslei_h, simd_le, m128i, i16x8, 5);
+impl_vsv!("lsx", lsx_vslei_w, simd_le, m128i, i32x4, 5);
+impl_vsv!("lsx", lsx_vslei_d, simd_le, m128i, i64x2, 5);
+impl_vsv!("lsx", lsx_vmaxi_b, simd_imax, m128i, i8x16, 5);
+impl_vsv!("lsx", lsx_vmaxi_h, simd_imax, m128i, i16x8, 5);
+impl_vsv!("lsx", lsx_vmaxi_w, simd_imax, m128i, i32x4, 5);
+impl_vsv!("lsx", lsx_vmaxi_d, simd_imax, m128i, i64x2, 5);
+impl_vsv!("lsx", lsx_vmini_b, simd_imin, m128i, i8x16, 5);
+impl_vsv!("lsx", lsx_vmini_h, simd_imin, m128i, i16x8, 5);
+impl_vsv!("lsx", lsx_vmini_w, simd_imin, m128i, i32x4, 5);
+impl_vsv!("lsx", lsx_vmini_d, simd_imin, m128i, i64x2, 5);
 
-impl_vvvv!("lsx", lsx_vmadd_b, ls::simd_madd, m128i, i8x16);
-impl_vvvv!("lsx", lsx_vmadd_h, ls::simd_madd, m128i, i16x8);
-impl_vvvv!("lsx", lsx_vmadd_w, ls::simd_madd, m128i, i32x4);
-impl_vvvv!("lsx", lsx_vmadd_d, ls::simd_madd, m128i, i64x2);
-impl_vvvv!("lsx", lsx_vmsub_b, ls::simd_msub, m128i, i8x16);
-impl_vvvv!("lsx", lsx_vmsub_h, ls::simd_msub, m128i, i16x8);
-impl_vvvv!("lsx", lsx_vmsub_w, ls::simd_msub, m128i, i32x4);
-impl_vvvv!("lsx", lsx_vmsub_d, ls::simd_msub, m128i, i64x2);
-impl_vvvv!("lsx", lsx_vfmadd_s, is::simd_fma, m128, f32x4);
-impl_vvvv!("lsx", lsx_vfmadd_d, is::simd_fma, m128d, f64x2);
-impl_vvvv!("lsx", lsx_vfmsub_s, ls::simd_fmsub, m128, f32x4);
-impl_vvvv!("lsx", lsx_vfmsub_d, ls::simd_fmsub, m128d, f64x2);
-impl_vvvv!("lsx", lsx_vfnmadd_s, ls::simd_fnmadd, m128, f32x4);
-impl_vvvv!("lsx", lsx_vfnmadd_d, ls::simd_fnmadd, m128d, f64x2);
-impl_vvvv!("lsx", lsx_vfnmsub_s, ls::simd_fnmsub, m128, f32x4);
-impl_vvvv!("lsx", lsx_vfnmsub_d, ls::simd_fnmsub, m128d, f64x2);
+impl_vvvv!("lsx", lsx_vmadd_b, simd_ext_madd, m128i, i8x16);
+impl_vvvv!("lsx", lsx_vmadd_h, simd_ext_madd, m128i, i16x8);
+impl_vvvv!("lsx", lsx_vmadd_w, simd_ext_madd, m128i, i32x4);
+impl_vvvv!("lsx", lsx_vmadd_d, simd_ext_madd, m128i, i64x2);
+impl_vvvv!("lsx", lsx_vmsub_b, simd_ext_msub, m128i, i8x16);
+impl_vvvv!("lsx", lsx_vmsub_h, simd_ext_msub, m128i, i16x8);
+impl_vvvv!("lsx", lsx_vmsub_w, simd_ext_msub, m128i, i32x4);
+impl_vvvv!("lsx", lsx_vmsub_d, simd_ext_msub, m128i, i64x2);
+impl_vvvv!("lsx", lsx_vfmadd_s, simd_fma, m128, f32x4);
+impl_vvvv!("lsx", lsx_vfmadd_d, simd_fma, m128d, f64x2);
+impl_vvvv!("lsx", lsx_vfmsub_s, simd_ext_fmsub, m128, f32x4);
+impl_vvvv!("lsx", lsx_vfmsub_d, simd_ext_fmsub, m128d, f64x2);
+impl_vvvv!("lsx", lsx_vfnmadd_s, simd_ext_fnmadd, m128, f32x4);
+impl_vvvv!("lsx", lsx_vfnmadd_d, simd_ext_fnmadd, m128d, f64x2);
+impl_vvvv!("lsx", lsx_vfnmsub_s, simd_ext_fnmsub, m128, f32x4);
+impl_vvvv!("lsx", lsx_vfnmsub_d, simd_ext_fnmsub, m128d, f64x2);
 
-impl_vvuv!("lsx", lsx_vshuf4i_d, simd_shuf4i_d, m128i, i64x2, 8, const);
+impl_vvuv!("lsx", lsx_vshuf4i_d, simd_ext_shuf4i_d, m128i, i64x2, 8, const);
 
-impl_vugv!("lsx", lsx_vinsgr2vr_b, is::simd_insert, m128i, i8x16, i32, 4);
-impl_vugv!("lsx", lsx_vinsgr2vr_h, is::simd_insert, m128i, i16x8, i32, 3);
-impl_vugv!("lsx", lsx_vinsgr2vr_w, is::simd_insert, m128i, i32x4, i32, 2);
-impl_vugv!("lsx", lsx_vinsgr2vr_d, is::simd_insert, m128i, i64x2, i64, 1);
+impl_vugv!("lsx", lsx_vinsgr2vr_b, simd_insert, m128i, i8x16, i32, 4);
+impl_vugv!("lsx", lsx_vinsgr2vr_h, simd_insert, m128i, i16x8, i32, 3);
+impl_vugv!("lsx", lsx_vinsgr2vr_w, simd_insert, m128i, i32x4, i32, 2);
+impl_vugv!("lsx", lsx_vinsgr2vr_d, simd_insert, m128i, i64x2, i64, 1);

--- a/crates/core_arch/src/loongarch64/simd.rs
+++ b/crates/core_arch/src/loongarch64/simd.rs
@@ -1,7 +1,6 @@
 //! LoongArch64 SIMD helpers
 
-use self as ls;
-use crate::intrinsics::simd as is;
+use crate::intrinsics::simd::*;
 
 // Internal extension trait for concrete `Simd<T, N>` types.
 //
@@ -23,7 +22,7 @@ macro_rules! impl_simd_ext {
 
             #[inline(always)]
             unsafe fn splat(v: i64) -> Self {
-                is::simd_splat(v as Self::Elem)
+                simd_splat(v as Self::Elem)
             }
         }
     };
@@ -58,189 +57,189 @@ impl_simd_ext!(u128x4, u128);
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_abs<T: Copy + const SimdExt>(a: T) -> T {
-    let m: T = is::simd_lt(a, ls::simd_splat(0));
-    is::simd_select(m, is::simd_neg(a), a)
+pub(super) const unsafe fn simd_ext_abs<T: Copy + const SimdExt>(a: T) -> T {
+    let m: T = simd_lt(a, simd_ext_splat(0));
+    simd_select(m, simd_neg(a), a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_absd<T: Copy>(a: T, b: T) -> T {
-    let m: T = is::simd_gt(a, b);
-    is::simd_select(m, is::simd_sub(a, b), is::simd_sub(b, a))
+pub(super) const unsafe fn simd_ext_absd<T: Copy>(a: T, b: T) -> T {
+    let m: T = simd_gt(a, b);
+    simd_select(m, simd_sub(a, b), simd_sub(b, a))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_adda<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    is::simd_add(ls::simd_abs(a), ls::simd_abs(b))
+pub(super) const unsafe fn simd_ext_adda<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_add(simd_ext_abs(a), simd_ext_abs(b))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_andn<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    is::simd_and(ls::simd_not(a), b)
+pub(super) const unsafe fn simd_ext_andn<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_and(simd_ext_not(a), b)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_bitclr<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    ls::simd_andn(ls::simd_shl(ls::simd_splat(1), b), a)
+pub(super) const unsafe fn simd_ext_bitclr<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_ext_andn(simd_ext_shl(simd_ext_splat(1), b), a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_bitrev<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    is::simd_xor(ls::simd_shl(ls::simd_splat(1), b), a)
+pub(super) const unsafe fn simd_ext_bitrev<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_xor(simd_ext_shl(simd_ext_splat(1), b), a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_bitset<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    is::simd_or(ls::simd_shl(ls::simd_splat(1), b), a)
+pub(super) const unsafe fn simd_ext_bitset<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_or(simd_ext_shl(simd_ext_splat(1), b), a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_fmsub<T: Copy>(a: T, b: T, c: T) -> T {
-    is::simd_fma(a, b, is::simd_neg(c))
+pub(super) const unsafe fn simd_ext_fmsub<T: Copy>(a: T, b: T, c: T) -> T {
+    simd_fma(a, b, simd_neg(c))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_fnmadd<T: Copy>(a: T, b: T, c: T) -> T {
-    is::simd_neg(is::simd_fma(a, b, c))
+pub(super) const unsafe fn simd_ext_fnmadd<T: Copy>(a: T, b: T, c: T) -> T {
+    simd_neg(simd_fma(a, b, c))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_fnmsub<T: Copy>(a: T, b: T, c: T) -> T {
-    is::simd_neg(ls::simd_fmsub(a, b, c))
+pub(super) const unsafe fn simd_ext_fnmsub<T: Copy>(a: T, b: T, c: T) -> T {
+    simd_neg(simd_ext_fmsub(a, b, c))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_frecip_s<T: Copy>(a: T) -> T {
-    is::simd_div(is::simd_splat(1.0f32), a)
+pub(super) const unsafe fn simd_ext_frecip_s<T: Copy>(a: T) -> T {
+    simd_div(simd_splat(1.0f32), a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_frecip_d<T: Copy>(a: T) -> T {
-    is::simd_div(is::simd_splat(1.0f64), a)
+pub(super) const unsafe fn simd_ext_frecip_d<T: Copy>(a: T) -> T {
+    simd_div(simd_splat(1.0f64), a)
 }
 
 #[inline(always)]
-pub(super) unsafe fn simd_frsqrt_s<T: Copy>(a: T) -> T {
-    ls::simd_frecip_s(is::simd_fsqrt(a))
+pub(super) unsafe fn simd_ext_frsqrt_s<T: Copy>(a: T) -> T {
+    simd_ext_frecip_s(simd_fsqrt(a))
 }
 
 #[inline(always)]
-pub(super) unsafe fn simd_frsqrt_d<T: Copy>(a: T) -> T {
-    ls::simd_frecip_d(is::simd_fsqrt(a))
+pub(super) unsafe fn simd_ext_frsqrt_d<T: Copy>(a: T) -> T {
+    simd_ext_frecip_d(simd_fsqrt(a))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_ld<const I: i32, T: Copy>(a: *const i8) -> T {
+pub(super) const unsafe fn simd_ext_ld<const I: i32, T: Copy>(a: *const i8) -> T {
     let a = a.offset(I as isize) as *const T;
     core::ptr::read_unaligned(a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_ldx<T: Copy>(a: *const i8, b: i64) -> T {
+pub(super) const unsafe fn simd_ext_ldx<T: Copy>(a: *const i8, b: i64) -> T {
     let a = a.offset(b as isize) as *const T;
     core::ptr::read_unaligned(a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_madd<T: Copy>(a: T, b: T, c: T) -> T {
-    is::simd_add(a, is::simd_mul(b, c))
+pub(super) const unsafe fn simd_ext_madd<T: Copy>(a: T, b: T, c: T) -> T {
+    simd_add(a, simd_mul(b, c))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_msub<T: Copy>(a: T, b: T, c: T) -> T {
-    is::simd_sub(a, is::simd_mul(b, c))
+pub(super) const unsafe fn simd_ext_msub<T: Copy>(a: T, b: T, c: T) -> T {
+    simd_sub(a, simd_mul(b, c))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_muh<T: Copy, W: Copy + const SimdExt>(a: T, b: T) -> T {
-    let a: W = is::simd_cast(a);
-    let b: W = is::simd_cast(b);
-    let p = is::simd_mul(a, b);
-    is::simd_cast(is::simd_shr(
+pub(super) const unsafe fn simd_ext_muh<T: Copy, W: Copy + const SimdExt>(a: T, b: T) -> T {
+    let a: W = simd_cast(a);
+    let b: W = simd_cast(b);
+    let p = simd_mul(a, b);
+    simd_cast(simd_shr(
         p,
-        ls::simd_splat((size_of::<W::Elem>() * 8 / 2) as i64),
+        simd_ext_splat((size_of::<W::Elem>() * 8 / 2) as i64),
     ))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_nor<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    ls::simd_not(is::simd_or(a, b))
+pub(super) const unsafe fn simd_ext_nor<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_ext_not(simd_or(a, b))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_not<T: Copy + const SimdExt>(a: T) -> T {
-    is::simd_xor(a, ls::simd_splat(!0))
+pub(super) const unsafe fn simd_ext_not<T: Copy + const SimdExt>(a: T) -> T {
+    simd_xor(a, simd_ext_splat(!0))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_orn<T: Copy + const SimdExt>(a: T, b: T) -> T {
-    is::simd_or(a, ls::simd_not(b))
+pub(super) const unsafe fn simd_ext_orn<T: Copy + const SimdExt>(a: T, b: T) -> T {
+    simd_or(a, simd_ext_not(b))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_rotr<T: Copy + const SimdExt>(a: T, b: T) -> T {
+pub(super) const unsafe fn simd_ext_rotr<T: Copy + const SimdExt>(a: T, b: T) -> T {
     let m = (size_of::<T::Elem>() * 8 - 1) as i64;
-    let r = is::simd_and(b, ls::simd_splat(m));
-    let l = is::simd_and(is::simd_sub(ls::simd_splat(m + 1), r), ls::simd_splat(m));
-    is::simd_or(is::simd_shr(a, r), is::simd_shl(a, l))
+    let r = simd_and(b, simd_ext_splat(m));
+    let l = simd_and(simd_sub(simd_ext_splat(m + 1), r), simd_ext_splat(m));
+    simd_or(simd_shr(a, r), simd_shl(a, l))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_shl<T: Copy + const SimdExt>(a: T, b: T) -> T {
+pub(super) const unsafe fn simd_ext_shl<T: Copy + const SimdExt>(a: T, b: T) -> T {
     let m = (size_of::<T::Elem>() * 8 - 1) as i64;
-    is::simd_shl(a, is::simd_and(b, ls::simd_splat(m)))
+    simd_shl(a, simd_and(b, simd_ext_splat(m)))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_shr<T: Copy + const SimdExt>(a: T, b: T) -> T {
+pub(super) const unsafe fn simd_ext_shr<T: Copy + const SimdExt>(a: T, b: T) -> T {
     let m = (size_of::<T::Elem>() * 8 - 1) as i64;
-    is::simd_shr(a, is::simd_and(b, ls::simd_splat(m)))
+    simd_shr(a, simd_and(b, simd_ext_splat(m)))
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_splat<T: Copy + const SimdExt>(a: i64) -> T {
+pub(super) const unsafe fn simd_ext_splat<T: Copy + const SimdExt>(a: i64) -> T {
     T::splat(a)
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_st<const I: i32, T: Copy>(a: T, b: *mut i8) {
+pub(super) const unsafe fn simd_ext_st<const I: i32, T: Copy>(a: T, b: *mut i8) {
     let b = b.offset(I as isize) as *mut T;
     core::ptr::write_unaligned(b, a);
 }
 
 #[inline(always)]
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-pub(super) const unsafe fn simd_stx<T: Copy>(a: T, b: *mut i8, c: i64) {
+pub(super) const unsafe fn simd_ext_stx<T: Copy>(a: T, b: *mut i8, c: i64) {
     let b = b.offset(c as isize) as *mut T;
     core::ptr::write_unaligned(b, a);
 }
 
 macro_rules! impl_vv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ty) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ty) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -257,7 +256,7 @@ macro_rules! impl_vv {
 pub(super) use impl_vv;
 
 macro_rules! impl_gv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $gty:ty) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $gty:ty) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -273,7 +272,7 @@ macro_rules! impl_gv {
 pub(super) use impl_gv;
 
 macro_rules! impl_ggv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $gty:ty, $xty:ty, unsafe) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $gty:ty, $xty:ty, unsafe) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -303,7 +302,7 @@ macro_rules! impl_gsv {
 pub(super) use impl_gsv;
 
 macro_rules! impl_sv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $ibs:expr) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $ibs:expr) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[rustc_legacy_const_generics(0)]
@@ -321,7 +320,7 @@ macro_rules! impl_sv {
 pub(super) use impl_sv;
 
 macro_rules! impl_vvv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ty) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ty) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -352,7 +351,7 @@ macro_rules! impl_vvv {
 pub(super) use impl_vvv;
 
 macro_rules! impl_vgg {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $gty:ty, $xty:ty, unsafe) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $gty:ty, $xty:ty, unsafe) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -380,7 +379,7 @@ macro_rules! impl_vgs {
 pub(super) use impl_vgs;
 
 macro_rules! impl_vuv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[rustc_legacy_const_generics(1)]
@@ -389,13 +388,13 @@ macro_rules! impl_vuv {
             static_assert_uimm_bits!(IMM, (size_of::<<$ity as SimdExt>::Elem>() * 8).ilog2());
             unsafe {
                 let a: $ity = transmute(a);
-                let b: $ity = ls::simd_splat(IMM.into());
+                let b: $ity = simd_ext_splat(IMM.into());
                 let r: $ity = $op(a, b);
                 transmute(r)
             }
         }
     };
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $ibs:expr) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $ibs:expr) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[rustc_legacy_const_generics(1)]
@@ -404,7 +403,7 @@ macro_rules! impl_vuv {
             static_assert_uimm_bits!(IMM, $ibs);
             unsafe {
                 let a: $ity = transmute(a);
-                let b: $ity = ls::simd_splat(IMM.into());
+                let b: $ity = simd_ext_splat(IMM.into());
                 let r: $ity = $op(a, b);
                 transmute(r)
             }
@@ -429,7 +428,7 @@ macro_rules! impl_vuv {
 pub(super) use impl_vuv;
 
 macro_rules! impl_vug {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $gty:ty, $ibs:expr) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $gty:ty, $ibs:expr) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[rustc_legacy_const_generics(1)]
@@ -448,7 +447,7 @@ macro_rules! impl_vug {
 pub(super) use impl_vug;
 
 macro_rules! impl_vsv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $ibs:expr) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $ibs:expr) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[rustc_legacy_const_generics(1)]
@@ -457,7 +456,7 @@ macro_rules! impl_vsv {
             static_assert_simm_bits!(IMM, $ibs);
             unsafe {
                 let a: $ity = transmute(a);
-                let b: $ity = ls::simd_splat(IMM.into());
+                let b: $ity = simd_ext_splat(IMM.into());
                 let r: $ity = $op(a, b);
                 transmute(r)
             }
@@ -468,7 +467,7 @@ macro_rules! impl_vsv {
 pub(super) use impl_vsv;
 
 macro_rules! impl_vvvv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ty) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ty) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -507,7 +506,7 @@ macro_rules! impl_vvuv {
 pub(super) use impl_vvuv;
 
 macro_rules! impl_vugv {
-    ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident, $gty:ty, $ibs:expr) => {
+    ($ft:literal, $name:ident, $op:ident, $oty:ty, $ity:ident, $gty:ty, $ibs:expr) => {
         #[inline]
         #[target_feature(enable = $ft)]
         #[rustc_legacy_const_generics(2)]


### PR DESCRIPTION
The `is::`, `cs::`, and `ls::` prefixes were originally used to clearly distinguish helper intrinsics from different namespaces at call sites.

However, due to limitations in Rust macro expansion, `impl_xxx!(..., prefix::simd_xxx, ...);` cannot always be used. Some macro expansions only accept an identifier, causing errors such as:

```
  ($ft:literal, $name:ident, $op:path, $oty:ty, $ity:ident) => {
      let r: $ity = $op::<IMM, _>(a);
                       ^^ expected one of `.`, `;`, `?`, `else`, or an operator
```

Instead of relying on namespace prefixes, rename the LoongArch-specific `simd_xxx` helpers to `simd_ext_xxx` and remove the `is::`, `cs::`, and `ls::` prefixes from macro invocations. This preserves the distinction between helper intrinsics while avoiding the macro expansion limitation.

r? @folkertdev