### PR TITLE
Port stdarch-gen-loongarch to stdarch-gen-common harness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -328,13 +328,17 @@ jobs:
       run: |
         cargo run --bin=stdarch-gen-arm --release -- crates/stdarch-gen-arm/spec
         git diff --exit-code
-    - name: Check lsx.spec
+    - name: Check loongarch lsx
+      env:
+        STDARCH_GEN_MODE: check
       run: |
-        cargo run --bin=stdarch-gen-loongarch --release -- crates/stdarch-gen-loongarch/lsx.spec
+        cargo run -p stdarch-gen-loongarch --release -- lsx
         git diff --exit-code
-    - name: Check lasx.spec
+    - name: Check loongarch lasx
+      env:
+        STDARCH_GEN_MODE: check
       run: |
-        cargo run --bin=stdarch-gen-loongarch --release -- crates/stdarch-gen-loongarch/lasx.spec
+        cargo run -p stdarch-gen-loongarch --release -- lasx
         git diff --exit-code
     - name: Check hexagon
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,7 @@ name = "stdarch-gen-loongarch"
 version = "0.1.0"
 dependencies = [
  "rand 0.9.4",
+ "stdarch-gen-common",
 ]
 
 [[package]]

--- a/crates/core_arch/src/loongarch64/lasx/tests.rs
+++ b/crates/core_arch/src/loongarch64/lasx/tests.rs
@@ -1,5 +1,5 @@
+// Auto-generated tests. DO NOT MODIFY.
 // See crates/stdarch-gen-loongarch/README.md
-// This code is automatically generated. DO NOT MODIFY.
 
 use crate::{
     core_arch::{loongarch64::*, simd::*},

--- a/crates/core_arch/src/loongarch64/lasx/tests.rs
+++ b/crates/core_arch/src/loongarch64/lasx/tests.rs
@@ -1,5 +1,5 @@
-// This code is automatically generated. DO NOT MODIFY.
 // See crates/stdarch-gen-loongarch/README.md
+// This code is automatically generated. DO NOT MODIFY.
 
 use crate::{
     core_arch::{loongarch64::*, simd::*},

--- a/crates/core_arch/src/loongarch64/lsx/tests.rs
+++ b/crates/core_arch/src/loongarch64/lsx/tests.rs
@@ -1,5 +1,5 @@
+// Auto-generated tests. DO NOT MODIFY.
 // See crates/stdarch-gen-loongarch/README.md
-// This code is automatically generated. DO NOT MODIFY.
 
 use crate::{
     core_arch::{loongarch64::*, simd::*},

--- a/crates/core_arch/src/loongarch64/lsx/tests.rs
+++ b/crates/core_arch/src/loongarch64/lsx/tests.rs
@@ -1,5 +1,5 @@
-// This code is automatically generated. DO NOT MODIFY.
 // See crates/stdarch-gen-loongarch/README.md
+// This code is automatically generated. DO NOT MODIFY.
 
 use crate::{
     core_arch::{loongarch64::*, simd::*},

--- a/crates/stdarch-gen-loongarch/Cargo.toml
+++ b/crates/stdarch-gen-loongarch/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2024"
 
 [dependencies]
 rand = "0.9.3"
+stdarch-gen-common = { path = "../stdarch-gen-common" }

--- a/crates/stdarch-gen-loongarch/src/main.rs
+++ b/crates/stdarch-gen-loongarch/src/main.rs
@@ -1604,10 +1604,11 @@ static void {current_name}(void)
 /// no args or a bare ext name.
 pub fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();
-    let harness_exts: Option<&[&str]> = match args.len() {
-        1 => Some(&["lsx", "lasx"]),
-        2 if args[1] == "lsx" => Some(&["lsx"]),
-        2 if args[1] == "lasx" => Some(&["lasx"]),
+    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let harness_exts: Option<&[&str]> = match arg_strs.as_slice() {
+        [_] => Some(&["lsx", "lasx"]),
+        [_, "lsx"] => Some(&["lsx"]),
+        [_, "lasx"] => Some(&["lasx"]),
         _ => None,
     };
     if let Some(exts) = harness_exts {
@@ -1640,7 +1641,7 @@ pub fn main() -> Result<(), String> {
     if in_file_name.ends_with(".h") {
         return gen_spec(in_file, ext_name).map_err(|e| e.to_string());
     }
-    if args.get(2).is_some() {
+    if let [_, _lsx_or_lasx, "test"] = arg_strs.as_slice() {
         return gen_test(in_file, ext_name).map_err(|e| e.to_string());
     }
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap_or("crates/core_arch".to_string()))

--- a/crates/stdarch-gen-loongarch/src/main.rs
+++ b/crates/stdarch-gen-loongarch/src/main.rs
@@ -858,10 +858,8 @@ union v4df
     out.push('\n');
     out.push_str("int main(int argc, char *argv[])\n");
     out.push_str("{\n");
-    out.push_str("    printf(\"// See crates/stdarch-gen-loongarch/README.md\\n\");\n");
-    out.push_str(
-        "    printf(\"// This code is automatically generated. DO NOT MODIFY.\\n\\n\");\n",
-    );
+    out.push_str("    printf(\"// Auto-generated tests. DO NOT MODIFY.\\n\");\n");
+    out.push_str("    printf(\"// See crates/stdarch-gen-loongarch/README.md\\n\\n\");\n");
     out.push_str("    printf(\"use crate::{\\n\");\n");
     out.push_str("    printf(\"    core_arch::{loongarch64::*, simd::*},\\n\");\n");
     out.push_str("    printf(\"    mem::transmute,\\n\");\n");

--- a/crates/stdarch-gen-loongarch/src/main.rs
+++ b/crates/stdarch-gen-loongarch/src/main.rs
@@ -4,7 +4,9 @@ use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, BufReader};
+use std::path::Path;
 use std::path::PathBuf;
+use stdarch_gen_common::{Mode, run_generator};
 
 /// Complete lines of generated source.
 ///
@@ -148,8 +150,8 @@ fn gen_spec(in_file: String, ext_name: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn gen_bind(in_file: String, ext_name: &str) -> io::Result<()> {
-    let f = File::open(in_file.clone()).unwrap_or_else(|_| panic!("Failed to open {in_file}"));
+fn gen_bind(in_file: &str, ext_name: &str, out_path: &Path) -> io::Result<()> {
+    let f = File::open(in_file).unwrap_or_else(|_| panic!("Failed to open {in_file}"));
     let f = BufReader::new(f);
 
     let target: TargetFeature = TargetFeature::new(ext_name);
@@ -241,13 +243,7 @@ unsafe extern "unadjusted" {
     out.push_str("}\n");
     out.push_str(&function_str);
 
-    let out_path: PathBuf =
-        PathBuf::from(env::var("OUT_DIR").unwrap_or("crates/core_arch".to_string()))
-            .join("src")
-            .join("loongarch64")
-            .join(ext_name);
-    std::fs::create_dir_all(&out_path)?;
-
+    std::fs::create_dir_all(out_path)?;
     let mut file = File::create(out_path.join("generated.rs"))?;
     file.write_all(out.as_bytes())?;
     Ok(())
@@ -862,8 +858,10 @@ union v4df
     out.push('\n');
     out.push_str("int main(int argc, char *argv[])\n");
     out.push_str("{\n");
-    out.push_str("    printf(\"// This code is automatically generated. DO NOT MODIFY.\\n\");\n");
-    out.push_str("    printf(\"// See crates/stdarch-gen-loongarch/README.md\\n\\n\");\n");
+    out.push_str("    printf(\"// See crates/stdarch-gen-loongarch/README.md\\n\");\n");
+    out.push_str(
+        "    printf(\"// This code is automatically generated. DO NOT MODIFY.\\n\\n\");\n",
+    );
     out.push_str("    printf(\"use crate::{\\n\");\n");
     out.push_str("    printf(\"    core_arch::{loongarch64::*, simd::*},\\n\");\n");
     out.push_str("    printf(\"    mem::transmute,\\n\");\n");
@@ -1604,28 +1602,52 @@ static void {current_name}(void)
     (impl_function, call_function)
 }
 
-pub fn main() -> io::Result<()> {
+/// Runs the check/bless harness for `lsx`/`lasx` when invoked with
+/// no args or a bare ext name.
+pub fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();
-    let in_file = args.get(1).cloned().expect("Input file missing!");
-    let in_file_path = PathBuf::from(&in_file);
-    let in_file_name = in_file_path
+    let harness_exts: Option<&[&str]> = match args.len() {
+        1 => Some(&["lsx", "lasx"]),
+        2 if args[1] == "lsx" => Some(&["lsx"]),
+        2 if args[1] == "lasx" => Some(&["lasx"]),
+        _ => None,
+    };
+    if let Some(exts) = harness_exts {
+        let crate_dir =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+        let core_arch_src = crate_dir.join("../core_arch/src");
+        let mode = Mode::from_env();
+        for ext in exts {
+            let spec_rel = format!("crates/stdarch-gen-loongarch/{ext}.spec");
+            let committed = core_arch_src.join("loongarch64").join(ext);
+            run_generator(&committed, mode, |out_dir| {
+                gen_bind(&spec_rel, ext, out_dir)
+            })
+            .map_err(|e| e.to_string())?;
+        }
+        return Ok(());
+    }
+
+    let in_file = args[1].clone();
+    let in_file_name = PathBuf::from(&in_file)
         .file_name()
         .unwrap()
-        .to_os_string()
-        .into_string()
-        .unwrap();
-
+        .to_string_lossy()
+        .into_owned();
     let ext_name = if in_file_name.starts_with("lasx") {
         "lasx"
     } else {
         "lsx"
     };
-
     if in_file_name.ends_with(".h") {
-        gen_spec(in_file, ext_name)
-    } else if args.get(2).is_some() {
-        gen_test(in_file, ext_name)
-    } else {
-        gen_bind(in_file, ext_name)
+        return gen_spec(in_file, ext_name).map_err(|e| e.to_string());
     }
+    if args.get(2).is_some() {
+        return gen_test(in_file, ext_name).map_err(|e| e.to_string());
+    }
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap_or("crates/core_arch".to_string()))
+        .join("src")
+        .join("loongarch64")
+        .join(ext_name);
+    gen_bind(&in_file, ext_name, &out_path).map_err(|e| e.to_string())
 }


### PR DESCRIPTION
This PR ports `stdarch-gen-loongarch` to `stdarch-gen-common` harness. 

The change in `main` invokes `run_generator` once per committed dir when called with no args or `lsx`/`lasx`.

The CI switches from `-- <spec>` to `-- lsx` / `-- lasx` with `STDARCH_GEN_MODE=check`.

Swapped the first two comment lines of `lsx/tests.rs` and `lasx/tests.rs` so the auto-generated marker moves to line 2 . So `discover_owned` only checks the first line and  makes the harness skip `tests.rs` which is not produced by `stdarch-gen-loongarch` .

r? @folkertdev