### PR TITLE
Update itertools to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,9 +431,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/crates/intrinsic-test/Cargo.toml
+++ b/crates/intrinsic-test/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.11"
 pretty_env_logger = "0.5.0"
 rayon = "1.5.0"
 diff = "0.1.12"
-itertools = "0.14.0"
+itertools = "0.15.0"
 quick-xml = { version = "0.37.5", features = ["serialize", "overlapped-lists"] }
 serde-xml-rs = "0.8.0"
 regex = "1.11.1"

--- a/crates/stdarch-gen-arm/Cargo.toml
+++ b/crates/stdarch-gen-arm/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-itertools = "0.14.0"
+itertools = "0.15.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.5"

--- a/crates/stdarch-gen-arm/src/intrinsic.rs
+++ b/crates/stdarch-gen-arm/src/intrinsic.rs
@@ -1802,9 +1802,8 @@ fn create_tokens(intrinsic: &Intrinsic, endianness: Endianness, tokens: &mut Tok
             body_current = &mut body_unsafe;
         }
         ex.to_tokens(body_current);
-        let is_last = matches!(pos, itertools::Position::Last | itertools::Position::Only);
         let is_llvm_link = matches!(ex, Expression::LLVMLink(_));
-        if !is_last && !is_llvm_link {
+        if !pos.is_last && !is_llvm_link {
             body_current.append(Punct::new(';', Spacing::Alone));
         }
     }


### PR DESCRIPTION
Update the version of the dependency and make the necessary changes related to the breaking API changes.