### PR TITLE
Add align requirement in _mm_stream_si32 and _mm_stream_si64

### DIFF
--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1445,7 +1445,7 @@ pub unsafe fn _mm_stream_si128(mem_addr: *mut __m128i, a: __m128i) {
     );
 }
 
-/// Stores a 32-bit integer value in the specified memory location.
+/// Stores a 32-bit integer value in a 4-byte aligned memory location.
 /// To minimize caching, the data is flagged as non-temporal (unlikely to be
 /// used again soon).
 ///

--- a/crates/core_arch/src/x86_64/sse2.rs
+++ b/crates/core_arch/src/x86_64/sse2.rs
@@ -59,7 +59,7 @@ pub fn _mm_cvttsd_si64x(a: __m128d) -> i64 {
     _mm_cvttsd_si64(a)
 }
 
-/// Stores a 64-bit integer value in the specified memory location.
+/// Stores a 64-bit integer value in an 8-byte aligned memory location.
 /// To minimize caching, the data is flagged as non-temporal (unlikely to be
 /// used again soon).
 ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Update alignment documentation for `_mm_stream_si32` and `_mm_stream_si64`

The documentation for `_mm_stream_si32` and `_mm_stream_si64` previously described the target as a generic memory location, but did not mention the required alignment of the memory address.

These intrinsics imply that the destination memory should be naturally aligned: 4 bytes for `_mm_stream_si32` and 8 bytes for `_mm_stream_si64`.

Similar store intrinsics([_mm_stream_si128](https://doc.rust-lang.org/beta/core/arch/x86/fn._mm_stream_si128.html), [_mm_stream_si256](https://doc.rust-lang.org/beta/core/arch/x86/fn._mm256_stream_si256.html), [_mm512_stream_si512](https://doc.rust-lang.org/beta/core/arch/x86/fn._mm512_stream_si512.html)) already document their alignment requirements, and the existing tests for these APIs also use properly aligned memory. This PR updates the documentation to make the alignment requirements explicit and consistent with the surrounding APIs.

This is a documentation-only change.