### PR TITLE
Use mirrored llvm artifacts

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   wget
 
-RUN wget https://mirrors.edge.kernel.org/pub/tools/llvm/files/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
+RUN wget https://ci-mirrors.rust-lang.org/llvm/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
 RUN mkdir llvm
 RUN tar -xvf llvm.tar.xz --strip-components=1 -C llvm
 

--- a/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/bin
 RUN tar -xvf "${TOOLCHAIN}.tar.xz"
 RUN mkdir /toolchains && mv "./${TOOLCHAIN}" /toolchains
 
-RUN wget https://mirrors.edge.kernel.org/pub/tools/llvm/files/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
+RUN wget https://ci-mirrors.rust-lang.org/llvm/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
 RUN mkdir llvm
 RUN tar -xvf llvm.tar.xz --strip-components=1 -C llvm
 

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   file \
   wget
 
-RUN wget https://mirrors.edge.kernel.org/pub/tools/llvm/files/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
+RUN wget https://ci-mirrors.rust-lang.org/llvm/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
 RUN mkdir llvm
 RUN tar -xvf llvm.tar.xz --strip-components=1 -C llvm
 

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -13,7 +13,7 @@ RUN wget http://ci-mirrors.rust-lang.org/sde-external-10.8.0-2026-03-15-lin.tar.
 RUN mkdir intel-sde
 RUN tar -xJf sde.tar.xz --strip-components=1 -C intel-sde
 
-RUN wget https://mirrors.edge.kernel.org/pub/tools/llvm/files/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
+RUN wget https://ci-mirrors.rust-lang.org/llvm/llvm-22.1.4-x86_64.tar.gz -O llvm.tar.xz
 RUN mkdir llvm
 RUN tar -xvf llvm.tar.xz --strip-components=1 -C llvm
 


### PR DESCRIPTION
## Summary

Use llvm artifacts mirrored under `ci-mirrors` instead of going to kernel.org (which presumably is under stress following the outage from a few days ago).

- Needs https://github.com/rust-lang/ci-mirrors/pull/49 (already merged).

Reported in [#t-infra > kernel.org is borked (stdarch variant)](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/kernel.2Eorg.20is.20borked.20.28stdarch.20variant.29/with/608988032)