### PR TITLE
Re-enable ICX run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -285,13 +285,12 @@ jobs:
         include:
           - target: aarch64_be-unknown-linux-gnu
             build_std: true
-          # getting the icx compiler hits network failures.
-          # - target: x86_64-unknown-linux-gnu
-          #   cc: icx
-          #   profile: dev
-          # - target: x86_64-unknown-linux-gnu
-          #   cc: icx
-          #   profile: release
+          - target: x86_64-unknown-linux-gnu
+            cc: icx
+            profile: dev
+          - target: x86_64-unknown-linux-gnu
+            cc: icx
+            profile: release
         exclude:
           - target: armv7-unknown-linux-gnueabihf
             cc: gcc

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends intel-oneapi-co
 
 ENV CLANG_PATH="/llvm/bin/clang"
 ENV GCC_PATH="gcc"
-ENV ICX_PATH="/opt/intel/oneapi/compiler/2026.0/bin/icx"
+ENV ICX_PATH="/opt/intel/oneapi/compiler/2026.1/bin/icx"
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/intel-sde/sde64 \
             -cpuid-in /checkout/ci/docker/x86_64-unknown-linux-gnu/cpuid.def \


### PR DESCRIPTION
It was failing because Intel updated the version to 2026.1