### PR TITLE
Fix or allow clippy lints in `core_arch`

### DIFF
--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -60,7 +60,9 @@
     clippy::shadow_reuse,
     clippy::similar_names,
     clippy::unusual_byte_groupings,
-    clippy::wrong_self_convention
+    clippy::wrong_self_convention,
+    clippy::zero_prefixed_literal,
+    clippy::tabs_in_doc_comments
 )]
 #![cfg_attr(test, allow(unused_imports))]
 #![no_std]

--- a/crates/core_arch/src/x86/bmi1.rs
+++ b/crates/core_arch/src/x86/bmi1.rs
@@ -60,7 +60,7 @@ pub const fn _andn_u32(a: u32, b: u32) -> u32 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _blsi_u32(x: u32) -> u32 {
-    x & x.wrapping_neg()
+    x.isolate_lowest_one()
 }
 
 /// Gets mask up to lowest set bit.

--- a/crates/core_arch/src/x86_64/bmi.rs
+++ b/crates/core_arch/src/x86_64/bmi.rs
@@ -63,7 +63,7 @@ pub const fn _andn_u64(a: u64, b: u64) -> u64 {
 #[stable(feature = "simd_x86", since = "1.27.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _blsi_u64(x: u64) -> u64 {
-    x & x.wrapping_neg()
+    x.isolate_lowest_one()
 }
 
 /// Gets mask up to lowest set bit.


### PR DESCRIPTION
I'm trying to enable more clippy lints in the standard library so fixing them here is useful.