### PR TITLE
fix:set newline_style=Unix

### DIFF
--- a/crates/stdarch-gen-arm/src/main.rs
+++ b/crates/stdarch-gen-arm/src/main.rs
@@ -180,6 +180,8 @@ pub fn format_code(
     input: impl std::fmt::Display,
 ) -> std::io::Result<()> {
     let proc = Command::new("rustfmt")
+        .arg("--config")
+        .arg("newline_style=Unix")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;

--- a/crates/stdarch-gen-arm/src/main.rs
+++ b/crates/stdarch-gen-arm/src/main.rs
@@ -180,6 +180,7 @@ pub fn format_code(
     input: impl std::fmt::Display,
 ) -> std::io::Result<()> {
     let proc = Command::new("rustfmt")
+        // Ensure that we generate the same file contents on both Linux and Windows.
         .arg("--config")
         .arg("newline_style=Unix")
         .stdin(Stdio::piped())


### PR DESCRIPTION
This PR fix line ending mismatch by setting newline_style=Unix 


r? @folkertdev