### PR TITLE
assert_instr: add support for stricter tests

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -32,8 +32,14 @@ case ${TARGET} in
         ;;
     # Some x86_64 targets enable by default more features beyond SSE2,
     # which cause some instruction assertion checks to fail.
+    # (This does not disable tests that need more features, they get enabled based on
+    # what the host actually supports.)
     x86_64-*)
-        export RUSTFLAGS="${RUSTFLAGS} -C target-feature=-sse3"
+        # We want frame pointers to be consistent across targets. On the ios_macabi target
+        # we cannot turn them off, so let's turn them on everywhere.
+        # If we ever turn these off, a bunch of `limit(...)` clauses should be reduced to
+        # avoid tests becoming less strict!
+        export RUSTFLAGS="${RUSTFLAGS} -C target-feature=-sse3 -Cforce-frame-pointers=on"
         ;;
     #Unoptimized build uses fast-isel which breaks with msa
     mips-* | mipsel-*)

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -36,6 +36,11 @@ pub fn assert_instr(
 
     let instr = &invoc.instr;
     let not = invoc.not;
+    let limit = match invoc.limit {
+        None => quote! { None },
+        Some(l) => quote! { Some(#l) },
+    };
+
     let name = &func.sig.ident;
     let maybe_allow_deprecated = if func
         .attrs
@@ -180,7 +185,7 @@ pub fn assert_instr(
         fn #assert_name() {
             #to_test
 
-            ::stdarch_test::assert(#shim_name as usize, stringify!(#shim_name), #instr, &[#(#not),*]);
+            ::stdarch_test::assert(#shim_name as usize, stringify!(#shim_name), #instr, &[#(#not),*], #limit);
         }
     };
 
@@ -194,6 +199,7 @@ pub fn assert_instr(
 struct Invoc {
     instr: String,
     not: Vec<String>,
+    limit: Option<syn::LitInt>,
     args: Vec<(syn::Ident, syn::Expr)>,
 }
 
@@ -229,6 +235,7 @@ impl syn::parse::Parse for Invoc {
 
         let instr = parse_instr(input)?;
         let mut not = Vec::new();
+        let mut limit = None;
         let mut args = Vec::new();
 
         while !input.is_empty() {
@@ -236,9 +243,13 @@ impl syn::parse::Parse for Invoc {
             if input.parse::<Token![,]>().is_err() {
                 return Err(input.error("extra tokens at end"));
             }
+            // Handle trailing comma.
+            if input.is_empty() {
+                break;
+            }
 
-            // This is either `not(instr)` or `arg = val`.
-            // We treat `not` as a magic identifier here.
+            // This is either `not(instr)` or `limit(n)` or `arg = val`.
+            // We treat `not` and `limit` as a magic identifier here.
 
             let name = input.parse::<syn::Ident>()?;
 
@@ -252,12 +263,24 @@ impl syn::parse::Parse for Invoc {
                 not.push(not_instr);
                 continue;
             }
+            if name == "limit" {
+                let content;
+                parenthesized!(content in input);
+                let n = content.parse::<syn::LitInt>()?;
+                limit = Some(n);
+                continue;
+            }
 
             input.parse::<Token![=]>()?;
             let expr = input.parse::<syn::Expr>()?;
             args.push((name, expr));
         }
-        Ok(Self { instr, not, args })
+        Ok(Self {
+            instr,
+            not,
+            limit,
+            args,
+        })
     }
 }
 

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -35,6 +35,7 @@ pub fn assert_instr(
     };
 
     let instr = &invoc.instr;
+    let not = invoc.not;
     let name = &func.sig.ident;
     let maybe_allow_deprecated = if func
         .attrs
@@ -179,7 +180,7 @@ pub fn assert_instr(
         fn #assert_name() {
             #to_test
 
-            ::stdarch_test::assert(#shim_name as usize, stringify!(#shim_name), #instr);
+            ::stdarch_test::assert(#shim_name as usize, stringify!(#shim_name), #instr, &[#(#not),*]);
         }
     };
 
@@ -192,51 +193,71 @@ pub fn assert_instr(
 
 struct Invoc {
     instr: String,
+    not: Vec<String>,
     args: Vec<(syn::Ident, syn::Expr)>,
+}
+
+fn parse_instr(input: syn::parse::ParseStream<'_>) -> syn::Result<String> {
+    use syn::{Token, ext::IdentExt};
+
+    let mut instr = String::new();
+    while !input.is_empty() {
+        if let Ok(ident) = syn::Ident::parse_any(input) {
+            instr.push_str(&ident.to_string());
+            continue;
+        }
+        if input.parse::<Token![.]>().is_ok() {
+            instr.push('.');
+            continue;
+        }
+        if let Ok(s) = input.parse::<syn::LitStr>() {
+            instr.push_str(&s.value());
+            continue;
+        }
+        // Some other token, must be start of the next thing.
+        break;
+    }
+    if instr.is_empty() {
+        return Err(input.error("expected an instruction"));
+    }
+    Ok(instr)
 }
 
 impl syn::parse::Parse for Invoc {
     fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
-        use syn::{Token, ext::IdentExt};
+        use syn::{Token, parenthesized};
 
-        let mut instr = String::new();
-        while !input.is_empty() {
-            if input.parse::<Token![,]>().is_ok() {
-                break;
-            }
-            if let Ok(ident) = syn::Ident::parse_any(input) {
-                instr.push_str(&ident.to_string());
-                continue;
-            }
-            if input.parse::<Token![.]>().is_ok() {
-                instr.push('.');
-                continue;
-            }
-            if let Ok(s) = input.parse::<syn::LitStr>() {
-                instr.push_str(&s.value());
-                continue;
-            }
-            println!("{:?}", input.cursor().token_stream());
-            return Err(input.error("expected an instruction"));
-        }
-        if instr.is_empty() {
-            return Err(input.error("expected an instruction before comma"));
-        }
+        let instr = parse_instr(input)?;
+        let mut not = Vec::new();
         let mut args = Vec::new();
+
         while !input.is_empty() {
+            // Parse the comma after the previous thing
+            if input.parse::<Token![,]>().is_err() {
+                return Err(input.error("extra tokens at end"));
+            }
+
+            // This is either `not(instr)` or `arg = val`.
+            // We treat `not` as a magic identifier here.
+
             let name = input.parse::<syn::Ident>()?;
+
+            if name == "not" {
+                let content;
+                parenthesized!(content in input);
+                let not_instr = parse_instr(&content)?;
+                if !content.is_empty() {
+                    return Err(input.error("expected just an instruction in `not(...)`"));
+                }
+                not.push(not_instr);
+                continue;
+            }
+
             input.parse::<Token![=]>()?;
             let expr = input.parse::<syn::Expr>()?;
             args.push((name, expr));
-
-            if input.parse::<Token![,]>().is_err() {
-                if !input.is_empty() {
-                    return Err(input.error("extra tokens at end"));
-                }
-                break;
-            }
         }
-        Ok(Self { instr, args })
+        Ok(Self { instr, not, args })
     }
 }
 

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2321,7 +2321,7 @@ pub const fn _mm256_or_si256(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packs_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpacksswb, limit(2)))]
+#[cfg_attr(test, assert_instr(vpacksswb, limit(5)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packs_epi16(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packsswb(a.as_i16x16(), b.as_i16x16())) }
@@ -2333,7 +2333,7 @@ pub fn _mm256_packs_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packs_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackssdw, limit(2)))]
+#[cfg_attr(test, assert_instr(vpackssdw, limit(5)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packs_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packssdw(a.as_i32x8(), b.as_i32x8())) }
@@ -2345,7 +2345,7 @@ pub fn _mm256_packs_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packus_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackuswb, limit(2)))]
+#[cfg_attr(test, assert_instr(vpackuswb, limit(5)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packus_epi16(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packuswb(a.as_i16x16(), b.as_i16x16())) }
@@ -2357,7 +2357,7 @@ pub fn _mm256_packus_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packus_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackusdw, limit(2)))]
+#[cfg_attr(test, assert_instr(vpackusdw, limit(5)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packus_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packusdw(a.as_i32x8(), b.as_i32x8())) }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2321,7 +2321,7 @@ pub const fn _mm256_or_si256(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packs_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpacksswb))]
+#[cfg_attr(test, assert_instr(vpacksswb, limit(2)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packs_epi16(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packsswb(a.as_i16x16(), b.as_i16x16())) }
@@ -2333,7 +2333,7 @@ pub fn _mm256_packs_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packs_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackssdw))]
+#[cfg_attr(test, assert_instr(vpackssdw, limit(2)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packs_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packssdw(a.as_i32x8(), b.as_i32x8())) }
@@ -2345,7 +2345,7 @@ pub fn _mm256_packs_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packus_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackuswb))]
+#[cfg_attr(test, assert_instr(vpackuswb, limit(2)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packus_epi16(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packuswb(a.as_i16x16(), b.as_i16x16())) }
@@ -2357,7 +2357,7 @@ pub fn _mm256_packus_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packus_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackusdw))]
+#[cfg_attr(test, assert_instr(vpackusdw, limit(2)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packus_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packusdw(a.as_i32x8(), b.as_i32x8())) }

--- a/crates/core_arch/src/x86/avx2.rs
+++ b/crates/core_arch/src/x86/avx2.rs
@@ -2321,7 +2321,7 @@ pub const fn _mm256_or_si256(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packs_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpacksswb, limit(5)))]
+#[cfg_attr(test, assert_instr(vpacksswb, limit(5), not(vpmin), not(vpmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packs_epi16(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packsswb(a.as_i16x16(), b.as_i16x16())) }
@@ -2333,7 +2333,7 @@ pub fn _mm256_packs_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packs_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackssdw, limit(5)))]
+#[cfg_attr(test, assert_instr(vpackssdw, limit(5), not(vpmin), not(vpmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packs_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packssdw(a.as_i32x8(), b.as_i32x8())) }
@@ -2345,7 +2345,7 @@ pub fn _mm256_packs_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packus_epi16)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackuswb, limit(5)))]
+#[cfg_attr(test, assert_instr(vpackuswb, limit(5), not(vpmin), not(vpmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packus_epi16(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packuswb(a.as_i16x16(), b.as_i16x16())) }
@@ -2357,7 +2357,7 @@ pub fn _mm256_packus_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_packus_epi32)
 #[inline]
 #[target_feature(enable = "avx2")]
-#[cfg_attr(test, assert_instr(vpackusdw, limit(5)))]
+#[cfg_attr(test, assert_instr(vpackusdw, limit(5), not(vpmin), not(vpmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm256_packus_epi32(a: __m256i, b: __m256i) -> __m256i {
     unsafe { transmute(packusdw(a.as_i32x8(), b.as_i32x8())) }

--- a/crates/core_arch/src/x86/avx512bw.rs
+++ b/crates/core_arch/src/x86/avx512bw.rs
@@ -6522,7 +6522,7 @@ pub fn _mm_maskz_maddubs_epi16(k: __mmask8, a: __m128i, b: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "avx512bw")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
-#[cfg_attr(test, assert_instr(vpackssdw))]
+#[cfg_attr(test, assert_instr(vpackssdw, limit(5), not(vpmin), not(vpmax)))]
 pub fn _mm512_packs_epi32(a: __m512i, b: __m512i) -> __m512i {
     unsafe { transmute(vpackssdw(a.as_i32x16(), b.as_i32x16())) }
 }
@@ -6617,7 +6617,7 @@ pub fn _mm_maskz_packs_epi32(k: __mmask8, a: __m128i, b: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "avx512bw")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
-#[cfg_attr(test, assert_instr(vpacksswb))]
+#[cfg_attr(test, assert_instr(vpacksswb, limit(5), not(vpmin), not(vpmax)))]
 pub fn _mm512_packs_epi16(a: __m512i, b: __m512i) -> __m512i {
     unsafe { transmute(vpacksswb(a.as_i16x32(), b.as_i16x32())) }
 }
@@ -6712,7 +6712,7 @@ pub fn _mm_maskz_packs_epi16(k: __mmask16, a: __m128i, b: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "avx512bw")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
-#[cfg_attr(test, assert_instr(vpackusdw))]
+#[cfg_attr(test, assert_instr(vpackusdw, limit(5), not(vpmin), not(vpmax)))]
 pub fn _mm512_packus_epi32(a: __m512i, b: __m512i) -> __m512i {
     unsafe { transmute(vpackusdw(a.as_i32x16(), b.as_i32x16())) }
 }
@@ -6807,7 +6807,7 @@ pub fn _mm_maskz_packus_epi32(k: __mmask8, a: __m128i, b: __m128i) -> __m128i {
 #[inline]
 #[target_feature(enable = "avx512bw")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
-#[cfg_attr(test, assert_instr(vpackuswb))]
+#[cfg_attr(test, assert_instr(vpackuswb, limit(5), not(vpmin), not(vpmax)))]
 pub fn _mm512_packus_epi16(a: __m512i, b: __m512i) -> __m512i {
     unsafe { transmute(vpackuswb(a.as_i16x32(), b.as_i16x32())) }
 }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1497,7 +1497,7 @@ pub const fn _mm_move_epi64(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packsswb, limit(2), not(pminsw), not(pmaxsw)))]
+#[cfg_attr(test, assert_instr(packsswb, limit(5), not(pminsw), not(pmaxsw)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packsswb(a.as_i16x8(), b.as_i16x8())) }
@@ -1509,7 +1509,7 @@ pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packssdw, limit(2)))]
+#[cfg_attr(test, assert_instr(packssdw, limit(5)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packssdw(a.as_i32x4(), b.as_i32x4())) }
@@ -1521,7 +1521,7 @@ pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packuswb, limit(2), not(pminsw), not(pmaxsw)))]
+#[cfg_attr(test, assert_instr(packuswb, limit(5), not(pminsw), not(pmaxsw)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packuswb(a.as_i16x8(), b.as_i16x8())) }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1497,7 +1497,7 @@ pub const fn _mm_move_epi64(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packsswb, limit(5), not(pminsw), not(pmaxsw)))]
+#[cfg_attr(test, assert_instr(packsswb, limit(5), not(pmin), not(pmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packsswb(a.as_i16x8(), b.as_i16x8())) }
@@ -1509,7 +1509,7 @@ pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packssdw, limit(5)))]
+#[cfg_attr(test, assert_instr(packssdw, limit(5), not(pmin), not(pmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packssdw(a.as_i32x4(), b.as_i32x4())) }
@@ -1521,7 +1521,7 @@ pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packuswb, limit(5), not(pminsw), not(pmaxsw)))]
+#[cfg_attr(test, assert_instr(packuswb, limit(5), not(pmin), not(pmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packuswb(a.as_i16x8(), b.as_i16x8())) }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1497,7 +1497,7 @@ pub const fn _mm_move_epi64(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packsswb, not(pminsw), not(pmaxsw)))]
+#[cfg_attr(test, assert_instr(packsswb, limit(2), not(pminsw), not(pmaxsw)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packsswb(a.as_i16x8(), b.as_i16x8())) }
@@ -1509,7 +1509,7 @@ pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi32)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packssdw))]
+#[cfg_attr(test, assert_instr(packssdw, limit(2)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packssdw(a.as_i32x4(), b.as_i32x4())) }
@@ -1521,7 +1521,7 @@ pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packuswb, not(pminsw), not(pmaxsw)))]
+#[cfg_attr(test, assert_instr(packuswb, limit(2), not(pminsw), not(pmaxsw)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packuswb(a.as_i16x8(), b.as_i16x8())) }

--- a/crates/core_arch/src/x86/sse2.rs
+++ b/crates/core_arch/src/x86/sse2.rs
@@ -1497,7 +1497,7 @@ pub const fn _mm_move_epi64(a: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packs_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packsswb))]
+#[cfg_attr(test, assert_instr(packsswb, not(pminsw), not(pmaxsw)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packs_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packsswb(a.as_i16x8(), b.as_i16x8())) }
@@ -1521,7 +1521,7 @@ pub fn _mm_packs_epi32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi16)
 #[inline]
 #[target_feature(enable = "sse2")]
-#[cfg_attr(test, assert_instr(packuswb))]
+#[cfg_attr(test, assert_instr(packuswb, not(pminsw), not(pmaxsw)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packuswb(a.as_i16x8(), b.as_i16x8())) }

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -424,7 +424,7 @@ pub const fn _mm_min_epu32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi32)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(packusdw))]
+#[cfg_attr(test, assert_instr(packusdw, limit(2)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packusdw(a.as_i32x4(), b.as_i32x4())) }

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -424,7 +424,7 @@ pub const fn _mm_min_epu32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi32)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(packusdw, limit(2)))]
+#[cfg_attr(test, assert_instr(packusdw, limit(5)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packusdw(a.as_i32x4(), b.as_i32x4())) }

--- a/crates/core_arch/src/x86/sse41.rs
+++ b/crates/core_arch/src/x86/sse41.rs
@@ -424,7 +424,7 @@ pub const fn _mm_min_epu32(a: __m128i, b: __m128i) -> __m128i {
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_packus_epi32)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(test, assert_instr(packusdw, limit(5)))]
+#[cfg_attr(test, assert_instr(packusdw, limit(5), not(pmin), not(pmax)))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub fn _mm_packus_epi32(a: __m128i, b: __m128i) -> __m128i {
     unsafe { transmute(packusdw(a.as_i32x4(), b.as_i32x4())) }

--- a/crates/stdarch-gen-arm/README.md
+++ b/crates/stdarch-gen-arm/README.md
@@ -91,7 +91,7 @@ attribute:
 - `target_features` (_Optional_)
     - A sequence of target features to enable for this intrinsic (merged with any global `arch_cfgs` settings).
 - `assert_instr` (_Optional_)
-    - A sequence of strings expected to be found in the assembly. Required if `attr` is not set.
+    - A string expected to be found in the assembly, followed by value assignments for const generic arguments to be used for this test. Required if `attr` is not set.
 - `safety` (_Optional_)
     - Use `safe`, or map `unsafe:` to a sequence of unsafety comments:
         - `custom: "<string>"`

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -54,7 +54,7 @@ impl hash::Hash for Function {
 ///
 /// This asserts that the function at `fnptr` contains the instruction
 /// `expected` provided.
-pub fn assert(shim_addr: usize, fnname: &str, expected: &str, not: &[&str]) {
+pub fn assert(shim_addr: usize, fnname: &str, expected: &str, not: &[&str], limit: Option<usize>) {
     // Make sure that the shim is not removed
     black_box(shim_addr);
 
@@ -133,68 +133,67 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str, not: &[&str]) {
 
     let instruction_limit = std::env::var("STDARCH_ASSERT_INSTR_LIMIT")
         .ok()
-        .map_or_else(
-            || match expected {
-                // `cpuid` returns a pretty big aggregate structure, so exempt
-                // it from the slightly more restrictive 22 instructions below.
-                "cpuid" => 30,
+        .map(|v| v.parse().unwrap())
+        .or(limit.map(|n| n + 1)) // adjust for the `<` below: `limit = 2` means 2 instructions is okay
+        .unwrap_or_else(|| match expected {
+            // `cpuid` returns a pretty big aggregate structure, so exempt
+            // it from the slightly more restrictive 22 instructions below.
+            "cpuid" => 30,
 
-                // These require 8 loads and stores, so it _just_ overflows the limit
-                "aesencwide128kl" | "aesencwide256kl" | "aesdecwide128kl" | "aesdecwide256kl" => 24,
+            // These require 8 loads and stores, so it _just_ overflows the limit
+            "aesencwide128kl" | "aesencwide256kl" | "aesdecwide128kl" | "aesdecwide256kl" => 24,
 
-                // Apparently, on Windows, LLVM generates a bunch of
-                // saves/restores of xmm registers around these instructions,
-                // which exceeds the limit of 20 below. As it seems dictated by
-                // Windows's ABI (I believe?), we probably can't do much
-                // about it.
-                "vzeroall" | "vzeroupper" if cfg!(windows) => 30,
+            // Apparently, on Windows, LLVM generates a bunch of
+            // saves/restores of xmm registers around these instructions,
+            // which exceeds the limit of 20 below. As it seems dictated by
+            // Windows's ABI (I believe?), we probably can't do much
+            // about it.
+            "vzeroall" | "vzeroupper" if cfg!(windows) => 30,
 
-                // Intrinsics using `cvtpi2ps` are typically "composites" and
-                // in some cases exceed the limit.
-                "cvtpi2ps" => 25,
-                // core_arch/src/arm_shared/simd32
-                // vfmaq_n_f32_vfma : #instructions = 26 >= 22 (limit)
-                "usad8" | "vfma" | "vfms" => 27,
-                "qadd8" | "qsub8" | "sadd8" | "sel" | "shadd8" | "shsub8" | "usub8" | "ssub8" => 29,
-                // core_arch/src/arm_shared/simd32
-                // vst1q_s64_x4_vst1 : #instructions = 27 >= 22 (limit)
-                "vld3" => 28,
-                // core_arch/src/arm_shared/simd32
-                // vld4q_lane_u32_vld4 : #instructions = 36 >= 22 (limit)
-                "vld4" => 37,
-                // core_arch/src/arm_shared/simd32
-                // vst1q_s64_x4_vst1 : #instructions = 40 >= 22 (limit)
-                "vst1" => 41,
-                // core_arch/src/arm_shared/simd32
-                // vst3q_u32_vst3 : #instructions = 25 >= 22 (limit)
-                "vst3" => 26,
-                // core_arch/src/arm_shared/simd32
-                // vst4q_u32_vst4 : #instructions = 33 >= 22 (limit)
-                "vst4" => 34,
+            // Intrinsics using `cvtpi2ps` are typically "composites" and
+            // in some cases exceed the limit.
+            "cvtpi2ps" => 25,
+            // core_arch/src/arm_shared/simd32
+            // vfmaq_n_f32_vfma : #instructions = 26 >= 22 (limit)
+            "usad8" | "vfma" | "vfms" => 27,
+            "qadd8" | "qsub8" | "sadd8" | "sel" | "shadd8" | "shsub8" | "usub8" | "ssub8" => 29,
+            // core_arch/src/arm_shared/simd32
+            // vst1q_s64_x4_vst1 : #instructions = 27 >= 22 (limit)
+            "vld3" => 28,
+            // core_arch/src/arm_shared/simd32
+            // vld4q_lane_u32_vld4 : #instructions = 36 >= 22 (limit)
+            "vld4" => 37,
+            // core_arch/src/arm_shared/simd32
+            // vst1q_s64_x4_vst1 : #instructions = 40 >= 22 (limit)
+            "vst1" => 41,
+            // core_arch/src/arm_shared/simd32
+            // vst3q_u32_vst3 : #instructions = 25 >= 22 (limit)
+            "vst3" => 26,
+            // core_arch/src/arm_shared/simd32
+            // vst4q_u32_vst4 : #instructions = 33 >= 22 (limit)
+            "vst4" => 34,
 
-                // core_arch/src/arm_shared/simd32
-                // vst1q_p64_x4_nop : #instructions = 33 >= 22 (limit)
-                "nop" if fnname.contains("vst1q_p64") => 34,
+            // core_arch/src/arm_shared/simd32
+            // vst1q_p64_x4_nop : #instructions = 33 >= 22 (limit)
+            "nop" if fnname.contains("vst1q_p64") => 34,
 
-                // AMX intrinsics generate a lot of move instructions to load/store the tile registers
-                // due to Rust ABI
-                _ if fnname.contains("___tile") => 165,
+            // AMX intrinsics generate a lot of move instructions to load/store the tile registers
+            // due to Rust ABI
+            _ if fnname.contains("___tile") => 165,
 
-                // Original limit was 20 instructions, but ARM DSP Intrinsics
-                // are exactly 20 instructions long. So, bump the limit to 22
-                // instead of adding here a long list of exceptions.
-                _ => {
-                    // aarch64_be may add reverse instructions which increases
-                    // the number of instructions generated.
-                    if cfg!(all(target_endian = "big", target_arch = "aarch64")) {
-                        32
-                    } else {
-                        22
-                    }
+            // Original limit was 20 instructions, but ARM DSP Intrinsics
+            // are exactly 20 instructions long. So, bump the limit to 22
+            // instead of adding here a long list of exceptions.
+            _ => {
+                // aarch64_be may add reverse instructions which increases
+                // the number of instructions generated.
+                if cfg!(all(target_endian = "big", target_arch = "aarch64")) {
+                    32
+                } else {
+                    22
                 }
-            },
-            |v| v.parse().unwrap(),
-        );
+            }
+        });
     let probably_only_one_instruction = instrs.len() < instruction_limit;
 
     if found && found_bad.is_none() && probably_only_one_instruction && !inlining_failed {

--- a/crates/stdarch-test/src/lib.rs
+++ b/crates/stdarch-test/src/lib.rs
@@ -54,7 +54,7 @@ impl hash::Hash for Function {
 ///
 /// This asserts that the function at `fnptr` contains the instruction
 /// `expected` provided.
-pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
+pub fn assert(shim_addr: usize, fnname: &str, expected: &str, not: &[&str]) {
     // Make sure that the shim is not removed
     black_box(shim_addr);
 
@@ -99,6 +99,12 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
             // TODO: resolve the conflicts (x86_64 and aarch64 have a bunch, probably others)
             // && !instruction[expected.len()..].starts_with(|c: char| c.is_ascii_alphanumeric())
         });
+
+    let found_bad = not
+        .iter()
+        // We deliberately only check `sarts_with` here, so one can exclude a bunch of related
+        // instructions at once.
+        .find(|not| instrs.iter().any(|instr| instr.starts_with(**not)));
 
     // Look for subroutine call instructions in the disassembly to detect whether
     // inlining failed: all intrinsics are `#[inline(always)]`, so calling one
@@ -191,7 +197,7 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
         );
     let probably_only_one_instruction = instrs.len() < instruction_limit;
 
-    if found && probably_only_one_instruction && !inlining_failed {
+    if found && found_bad.is_none() && probably_only_one_instruction && !inlining_failed {
         return;
     }
 
@@ -204,6 +210,8 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
 
     if !found {
         panic!("failed to find instruction `{expected}` in the disassembly");
+    } else if let Some(bad) = found_bad {
+        panic!("instruction found, but the disassembly also contains the bad instructions `{bad}`");
     } else if !probably_only_one_instruction {
         panic!(
             "instruction found, but the disassembly contains too many \


### PR DESCRIPTION
Motivated by https://github.com/rust-lang/stdarch/issues/2208, this extends `assert_instr` with support for stricter tests:

- The first commit adds clauses of the form `not(instr)`; the macro will then ensure that the given instruction does *not* appear in the disassembly.
- The second commit adds clauses of the form `limit(n)`; the macro will ensure that overall there are no more than `n` instructions in the disassembly.

I verified that the problematic pack tests indeed fail before the revert of https://github.com/rust-lang/stdarch/pull/2033. I am not sure if the `not` part is even worth it, which is why the 2nd commit removes its uses -- one has to have very specific instructions in mind to exclude them, a general limit on how many instructions total there are seems better? So unless you think I should keep it I plan to remove the first commit from this again.

r? @folkertdev 