### PR TITLE
Run cargo fmt on JOSH syncs

### DIFF
--- a/josh-sync.toml
+++ b/josh-sync.toml
@@ -1,3 +1,7 @@
 org = "rust-lang"
 repo = "stdarch"
 path = "library/stdarch"
+
+[[post-pull]]
+cmd = ["cargo", "fmt"]
+commit-message = "Run `cargo fmt`"


### PR DESCRIPTION
This is what [rust-analyzer does on their syncs](https://github.com/rust-lang/rust-analyzer/blob/master/josh-sync.toml) and was recommended by Jakub on our Zulip.

In rust-lang/rust, stdarch is excluded from tidy because the version of rustfmt used can differ from the one we use in this repository (latest nightly). This change reduces the chance of a formatting error blocking rustc-pull.

It doesn't completely eliminate it as there's a chance that the formatting error is in generated code, in which case formatting it will break the checks that run the generator. In those cases we'd still need to make manual fixes to the sync branch.