### PR TITLE
Fix new Cargo lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,12 +218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +394,6 @@ name = "intrinsic-test"
 version = "0.1.0"
 dependencies = [
  "clap",
- "diff",
  "itertools",
  "log",
  "pretty_env_logger",
@@ -408,7 +401,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde-xml-rs",
  "serde_json",
 ]
 
@@ -727,18 +719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-xml-rs"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,26 +913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1168,12 +1128,6 @@ dependencies = [
  "unicode-xid",
  "wasmparser 0.244.0",
 ]
-
-[[package]]
-name = "xml"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
 
 [[package]]
 name = "yaml-rust"

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
 ]
 description = "`core::arch` - Rust's core library architecture-specific intrinsics."
-homepage = "https://github.com/rust-lang/stdarch"
 repository = "https://github.com/rust-lang/stdarch"
 keywords = ["core", "simd", "arch", "intrinsics"]
 categories = ["hardware-support", "no-std"]

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -9,7 +9,6 @@ authors = [
 description = "`core::arch` - Rust's core library architecture-specific intrinsics."
 homepage = "https://github.com/rust-lang/stdarch"
 repository = "https://github.com/rust-lang/stdarch"
-readme = "README.md"
 keywords = ["core", "simd", "arch", "intrinsics"]
 categories = ["hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"

--- a/crates/intrinsic-test/Cargo.toml
+++ b/crates/intrinsic-test/Cargo.toml
@@ -17,8 +17,6 @@ clap = { version = "4.4", features = ["derive"] }
 log = "0.4.11"
 pretty_env_logger = "0.5.0"
 rayon = "1.5.0"
-diff = "0.1.12"
 itertools = "0.15.0"
 quick-xml = { version = "0.37.5", features = ["serialize", "overlapped-lists"] }
-serde-xml-rs = "0.8.0"
 regex = "1.11.1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,8 +12,10 @@ default-run = "hex"
 
 [dependencies]
 core_arch = { path = "../crates/core_arch" }
-quickcheck = "1.0"
 rand = "0.9.3"
+
+[dev-dependencies]
+quickcheck = "1.0"
 
 [[bin]]
 name = "hex"


### PR DESCRIPTION
Cargo recently stabilised its linting system which caused a couple of warnings in `core_arch`'s manifest. We also had a few unused dependencies lurking around.

Tested with `TARGET=x86_64-unknown-linux-gnu cargo test --all`, no more warnings are printed.